### PR TITLE
feat: search picker pagination and cancel (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-02-11
+
+### Added
+
+- **Search pagination**: Search results are now paginated (10 per page) with `[n] Next page` and `[p] Previous page` navigation
+- **Cancel search**: Press `q` during mod selection to cancel without selecting (works in both single and multi-select modes)
+- **Total result count**: CurseForge searches show total available results; NexusMods gracefully handles unknown totals
+
+### Changed
+
+- `ModSource.Search()` now returns `SearchResult` struct with pagination metadata (`TotalCount`, `Page`, `PageSize`)
+- `Service.SearchMods()` accepts `page` and `pageSize` parameters for paginated queries
+
 ## [1.2.0] - 2026-02-10
 
 ### Added
@@ -543,7 +556,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.1.0...v1.2.0
 [1.0.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v0.12.0...v1.0.0
 [0.12.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v0.10.0...v0.11.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A terminal-based mod manager for Linux that provides a CLI interface for searchi
 - **Update Management**: Check for updates with configurable policies (auto, notify, pinned)
 - **Rollback Support**: Revert to previous mod versions when updates cause issues
 - **Flexible Deployment**: Symlink, hardlink, or copy mods to game directories
-- **Dependency Detection**: Fetches mod dependencies from NexusMods (automatic installation coming soon)
+- **Dependency Resolution**: Automatically fetches and installs mod dependencies
+- **Paginated Search**: Browse results page-by-page with clean cancel support
 - **Pure Go**: No CGO required, easy cross-compilation
 
 ## Installation

--- a/cmd/lmm/import.go
+++ b/cmd/lmm/import.go
@@ -576,11 +576,12 @@ func tryMatchCurseForge(ctx context.Context, service *core.Service, game *domain
 	}
 
 	// Search by mod name
-	mods, err := service.SearchMods(ctx, "curseforge", cfGameID, modName, "", nil)
+	searchResult, err := service.SearchMods(ctx, "curseforge", cfGameID, modName, "", nil, 0, 0)
 	if err != nil {
 		return nil, err
 	}
 
+	mods := searchResult.Mods
 	if len(mods) == 0 {
 		return nil, nil
 	}

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -228,7 +228,10 @@ func runInstall(cmd *cobra.Command, args []string) error {
 					if len(currentResult.Mods) == 0 {
 						fmt.Println("No more results.")
 						currentPage--
-						currentResult, _ = service.SearchMods(ctx, installSource, gameID, query, "", nil, currentPage, displayPageSize)
+						currentResult, err = service.SearchMods(ctx, installSource, gameID, query, "", nil, currentPage, displayPageSize)
+						if err != nil {
+							return fmt.Errorf("search failed: %w", err)
+						}
 					}
 					fmt.Println()
 					continue

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -43,7 +43,7 @@ func (s *serviceDepFetcher) GetDependencies(ctx context.Context, mod *domain.Mod
 	return s.svc.GetDependencies(ctx, s.sourceID, mod)
 }
 
-var ErrSearchCancelled = fmt.Errorf("search cancelled")
+var ErrSearchCancelled = ErrCancelled
 
 var (
 	installSource       string
@@ -217,7 +217,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				input = strings.TrimSpace(input)
 
 				if input == "q" || input == "Q" {
-					return fmt.Errorf("search cancelled")
+					return ErrCancelled
 				}
 				if (input == "n" || input == "N") && hasMore {
 					currentPage++

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -216,8 +216,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				input = strings.TrimSpace(input)
 
 				if input == "q" || input == "Q" {
-					fmt.Println("Search cancelled.")
-					return nil
+					return ErrCancelled
 				}
 				if (input == "n" || input == "N") && hasMore {
 					currentPage++
@@ -383,9 +382,6 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			if selections == nil {
-				return nil
-			}
 			for _, sel := range selections {
 				selectedFiles = append(selectedFiles, &files[sel-1])
 			}
@@ -489,7 +485,6 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				fmt.Printf("    1. Download from: %s\n", mod.SourceURL)
 				fmt.Printf("    2. Import:        lmm import <downloaded-file> --id %s\n", mod.ID)
 				fmt.Println()
-				cmd.SilenceUsage = true
 				return fmt.Errorf("download unavailable via API")
 			}
 			return fmt.Errorf("download failed: %w", err)
@@ -674,8 +669,7 @@ func promptMultiSelectionFrom(r io.Reader, prompt string, defaultChoice, max int
 			return []int{defaultChoice}, nil
 		}
 		if input == "q" || input == "Q" {
-			fmt.Println("Selection cancelled.")
-			return nil, nil
+			return nil, ErrCancelled
 		}
 
 		selections, err := parseRangeSelection(input, max)

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -43,6 +43,8 @@ func (s *serviceDepFetcher) GetDependencies(ctx context.Context, mod *domain.Mod
 	return s.svc.GetDependencies(ctx, s.sourceID, mod)
 }
 
+var ErrSearchCancelled = fmt.Errorf("search cancelled")
+
 var (
 	installSource       string
 	installProfile      string
@@ -147,7 +149,9 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		query := args[0]
 		fmt.Printf("Searching for \"%s\"...\n\n", query)
 
-		mods, err := service.SearchMods(ctx, installSource, gameID, query, "", nil)
+		const displayPageSize = 10
+
+		searchResult, err := service.SearchMods(ctx, installSource, gameID, query, "", nil, 0, displayPageSize)
 		if err != nil {
 			if errors.Is(err, domain.ErrAuthRequired) {
 				return fmt.Errorf("authentication required; run 'lmm auth login %s' to authenticate", installSource)
@@ -155,7 +159,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("search failed: %w", err)
 		}
 
-		if len(mods) == 0 {
+		if len(searchResult.Mods) == 0 {
 			return fmt.Errorf("no mods found matching \"%s\"", query)
 		}
 
@@ -169,34 +173,88 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Select the mod(s)
+		// Select the mod(s) with pagination
 		var selectedMods []*domain.Mod
-		if len(mods) == 1 || installYes {
-			selectedMods = []*domain.Mod{&mods[0]}
+		if len(searchResult.Mods) == 1 || installYes {
+			selectedMods = []*domain.Mod{&searchResult.Mods[0]}
 		} else {
-			// Show selection
-			maxDisplay := len(mods)
-			if maxDisplay > 10 {
-				maxDisplay = 10
-			}
-			for i := 0; i < maxDisplay; i++ {
-				m := mods[i]
-				installedMark := ""
-				if installedIDs[m.ID] {
-					installedMark = " [installed]"
-				}
-				fmt.Printf("  [%d] %s v%s by %s (ID: %s)%s\n", i+1, m.Name, m.Version, m.Author, m.ID, installedMark)
-			}
-			if len(mods) > 10 {
-				fmt.Printf("  ... and %d more\n", len(mods)-10)
-			}
+			currentPage := 0
+			currentResult := searchResult
+			reader := bufio.NewReader(os.Stdin)
 
-			selections, err := promptMultiSelection("Select mod(s) (e.g., 1 or 1,3,5 or 1-3)", 1, len(mods))
-			if err != nil {
-				return err
-			}
-			for _, sel := range selections {
-				selectedMods = append(selectedMods, &mods[sel-1])
+			for {
+				mods := currentResult.Mods
+				for i, m := range mods {
+					installedMark := ""
+					if installedIDs[m.ID] {
+						installedMark = " [installed]"
+					}
+					fmt.Printf("  [%d] %s v%s by %s (ID: %s)%s\n", i+1, m.Name, m.Version, m.Author, m.ID, installedMark)
+				}
+
+				// Pagination options
+				hasMore := false
+				if currentResult.TotalCount > 0 {
+					remaining := currentResult.TotalCount - (currentPage+1)*displayPageSize
+					if remaining > 0 {
+						hasMore = true
+						fmt.Printf("  [n] Next page (%d more)\n", remaining)
+					}
+				} else if len(mods) == displayPageSize {
+					hasMore = true
+					fmt.Printf("  [n] Next page\n")
+				}
+				if currentPage > 0 {
+					fmt.Printf("  [p] Previous page\n")
+				}
+				fmt.Printf("  [q] Cancel\n")
+
+				fmt.Printf("\nSelect mod(s) (e.g., 1 or 1,3,5 or 1-3) [1]: ")
+				input, err := reader.ReadString('\n')
+				if err != nil {
+					return fmt.Errorf("reading input: %w", err)
+				}
+				input = strings.TrimSpace(input)
+
+				if input == "q" || input == "Q" {
+					return fmt.Errorf("search cancelled")
+				}
+				if (input == "n" || input == "N") && hasMore {
+					currentPage++
+					currentResult, err = service.SearchMods(ctx, installSource, gameID, query, "", nil, currentPage, displayPageSize)
+					if err != nil {
+						return fmt.Errorf("search failed: %w", err)
+					}
+					if len(currentResult.Mods) == 0 {
+						fmt.Println("No more results.")
+						currentPage--
+						currentResult, _ = service.SearchMods(ctx, installSource, gameID, query, "", nil, currentPage, displayPageSize)
+					}
+					fmt.Println()
+					continue
+				}
+				if (input == "p" || input == "P") && currentPage > 0 {
+					currentPage--
+					currentResult, err = service.SearchMods(ctx, installSource, gameID, query, "", nil, currentPage, displayPageSize)
+					if err != nil {
+						return fmt.Errorf("search failed: %w", err)
+					}
+					fmt.Println()
+					continue
+				}
+
+				if input == "" {
+					input = "1"
+				}
+				selections, err := parseRangeSelection(input, len(mods))
+				if err != nil {
+					fmt.Printf("Invalid selection: %v\n", err)
+					continue
+				}
+				for _, sel := range selections {
+					selectedMods = append(selectedMods, &currentResult.Mods[sel-1])
+				}
+				break
 			}
 		}
 
@@ -594,7 +652,7 @@ func promptMultiSelection(prompt string, defaultChoice, max int) ([]int, error) 
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		fmt.Printf("\n%s [%d]: ", prompt, defaultChoice)
+		fmt.Printf("\n%s (q to cancel) [%d]: ", prompt, defaultChoice)
 		input, err := reader.ReadString('\n')
 		if err != nil {
 			return nil, fmt.Errorf("reading input: %w", err)
@@ -603,6 +661,9 @@ func promptMultiSelection(prompt string, defaultChoice, max int) ([]int, error) 
 		input = strings.TrimSpace(input)
 		if input == "" {
 			return []int{defaultChoice}, nil
+		}
+		if input == "q" || input == "Q" {
+			return nil, ErrSearchCancelled
 		}
 
 		selections, err := parseRangeSelection(input, max)

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strconv"
@@ -651,7 +652,12 @@ func runInstall(cmd *cobra.Command, args []string) error {
 // promptMultiSelection prompts the user to select one or more numbers
 // Accepts formats like: "1", "1,3,5", "1-3", "1..3", "1,3-5"
 func promptMultiSelection(prompt string, defaultChoice, max int) ([]int, error) {
-	reader := bufio.NewReader(os.Stdin)
+	return promptMultiSelectionFrom(os.Stdin, prompt, defaultChoice, max)
+}
+
+// promptMultiSelectionFrom is the testable core of promptMultiSelection
+func promptMultiSelectionFrom(r io.Reader, prompt string, defaultChoice, max int) ([]int, error) {
+	reader := bufio.NewReader(r)
 
 	for {
 		fmt.Printf("\n%s (q to cancel) [%d]: ", prompt, defaultChoice)

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -43,8 +43,6 @@ func (s *serviceDepFetcher) GetDependencies(ctx context.Context, mod *domain.Mod
 	return s.svc.GetDependencies(ctx, s.sourceID, mod)
 }
 
-var ErrSearchCancelled = ErrCancelled
-
 var (
 	installSource       string
 	installProfile      string
@@ -217,7 +215,8 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				input = strings.TrimSpace(input)
 
 				if input == "q" || input == "Q" {
-					return ErrCancelled
+					fmt.Println("Search cancelled.")
+					return nil
 				}
 				if (input == "n" || input == "N") && hasMore {
 					currentPage++
@@ -379,6 +378,9 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			selections, err := promptMultiSelection("Select file(s) (e.g., 1 or 1,3 or 1-3)", defaultChoice, len(files))
 			if err != nil {
 				return err
+			}
+			if selections == nil {
+				return nil
 			}
 			for _, sel := range selections {
 				selectedFiles = append(selectedFiles, &files[sel-1])
@@ -663,7 +665,8 @@ func promptMultiSelection(prompt string, defaultChoice, max int) ([]int, error) 
 			return []int{defaultChoice}, nil
 		}
 		if input == "q" || input == "Q" {
-			return nil, ErrSearchCancelled
+			fmt.Println("Selection cancelled.")
+			return nil, nil
 		}
 
 		selections, err := parseRangeSelection(input, max)

--- a/cmd/lmm/install_test.go
+++ b/cmd/lmm/install_test.go
@@ -251,7 +251,7 @@ func TestPromptMultiSelection_Cancel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := bytes.NewBufferString(tt.input)
 			selections, err := promptMultiSelectionFrom(r, "Select", 1, 10)
-			assert.NoError(t, err, "cancel should not return an error")
+			assert.ErrorIs(t, err, ErrCancelled, "cancel should return ErrCancelled")
 			assert.Nil(t, selections, "cancel should return nil selections")
 		})
 	}

--- a/cmd/lmm/install_test.go
+++ b/cmd/lmm/install_test.go
@@ -236,3 +236,47 @@ func TestParseRangeSelection(t *testing.T) {
 		})
 	}
 }
+
+// TestPromptMultiSelection_Cancel tests that 'q' cancels cleanly (no error)
+func TestPromptMultiSelection_Cancel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"lowercase q", "q\n"},
+		{"uppercase Q", "Q\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := bytes.NewBufferString(tt.input)
+			selections, err := promptMultiSelectionFrom(r, "Select", 1, 10)
+			assert.NoError(t, err, "cancel should not return an error")
+			assert.Nil(t, selections, "cancel should return nil selections")
+		})
+	}
+}
+
+// TestPromptMultiSelection_Default tests that empty input returns default choice
+func TestPromptMultiSelection_Default(t *testing.T) {
+	r := bytes.NewBufferString("\n")
+	selections, err := promptMultiSelectionFrom(r, "Select", 3, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{3}, selections)
+}
+
+// TestPromptMultiSelection_ValidSelection tests normal selection
+func TestPromptMultiSelection_ValidSelection(t *testing.T) {
+	r := bytes.NewBufferString("1,3,5\n")
+	selections, err := promptMultiSelectionFrom(r, "Select", 1, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{1, 3, 5}, selections)
+}
+
+// TestPromptMultiSelection_Range tests range selection
+func TestPromptMultiSelection_Range(t *testing.T) {
+	r := bytes.NewBufferString("2-4\n")
+	selections, err := promptMultiSelectionFrom(r, "Select", 1, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{2, 3, 4}, selections)
+}

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -19,7 +19,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.2.0"
+	version = "1.3.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -39,7 +39,8 @@ var rootCmd = &cobra.Command{
 updating, and managing game mods from various sources like NexusMods and CurseForge.
 
 Use subcommands for operations. Run 'lmm --help' for available commands.`,
-	Version: version,
+	Version:       version,
+	SilenceErrors: true,
 }
 
 func init() {
@@ -106,6 +107,8 @@ func Execute() {
 		}
 		if jsonOutput {
 			fmt.Printf(`{"error":%q}`+"\n", err.Error())
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
 		os.Exit(1)
 	}

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -39,7 +39,9 @@ var rootCmd = &cobra.Command{
 updating, and managing game mods from various sources like NexusMods and CurseForge.
 
 Use subcommands for operations. Run 'lmm --help' for available commands.`,
-	Version: version,
+	Version:       version,
+	SilenceUsage:  true, // Runtime errors should not print usage
+	SilenceErrors: true, // We handle error output in Execute()
 }
 
 func init() {
@@ -106,6 +108,8 @@ func Execute() {
 		}
 		if jsonOutput {
 			fmt.Printf(`{"error":%q}`+"\n", err.Error())
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
 		os.Exit(1)
 	}

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -19,7 +19,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.3.0"
+	version = "1.2.0"
 
 	// Global flags
 	configDir  string
@@ -39,8 +39,7 @@ var rootCmd = &cobra.Command{
 updating, and managing game mods from various sources like NexusMods and CurseForge.
 
 Use subcommands for operations. Run 'lmm --help' for available commands.`,
-	Version:       version,
-	SilenceErrors: true,
+	Version: version,
 }
 
 func init() {
@@ -107,8 +106,6 @@ func Execute() {
 		}
 		if jsonOutput {
 			fmt.Printf(`{"error":%q}`+"\n", err.Error())
-		} else {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
 		os.Exit(1)
 	}

--- a/cmd/lmm/search.go
+++ b/cmd/lmm/search.go
@@ -99,7 +99,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
-	mods, err := service.SearchMods(ctx, sourceToUse, gameID, query, searchCategory, searchTags)
+	searchResult, err := service.SearchMods(ctx, sourceToUse, gameID, query, searchCategory, searchTags, 0, 0)
 	if err != nil {
 		if errors.Is(err, domain.ErrAuthRequired) {
 			return fmt.Errorf("authentication required; run 'lmm auth login %s' to authenticate", sourceToUse)
@@ -107,6 +107,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("search failed: %w", err)
 	}
 
+	mods := searchResult.Mods
 	if len(mods) == 0 {
 		if jsonOutput {
 			enc := json.NewEncoder(os.Stdout)

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -100,10 +100,10 @@ func (s *Service) ListSources() []source.ModSource {
 }
 
 // SearchMods searches for mods in a source
-func (s *Service) SearchMods(ctx context.Context, sourceID, gameID, query string, category string, tags []string) ([]domain.Mod, error) {
+func (s *Service) SearchMods(ctx context.Context, sourceID, gameID, query string, category string, tags []string, page, pageSize int) (source.SearchResult, error) {
 	src, err := s.registry.Get(sourceID)
 	if err != nil {
-		return nil, err
+		return source.SearchResult{}, err
 	}
 
 	sourceGameID := gameID
@@ -118,6 +118,8 @@ func (s *Service) SearchMods(ctx context.Context, sourceID, gameID, query string
 		Query:    query,
 		Category: category,
 		Tags:     tags,
+		Page:     page,
+		PageSize: pageSize,
 	})
 }
 

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -35,14 +35,14 @@ func (m *mockSource) AuthURL() string { return "" }
 func (m *mockSource) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
 	return nil, nil
 }
-func (m *mockSource) Search(ctx context.Context, query source.SearchQuery) ([]domain.Mod, error) {
+func (m *mockSource) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
 	var results []domain.Mod
 	for _, mod := range m.mods {
 		if mod.GameID == query.GameID {
 			results = append(results, *mod)
 		}
 	}
-	return results, nil
+	return source.SearchResult{Mods: results}, nil
 }
 func (m *mockSource) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
 	key := gameID + "/" + modID
@@ -135,10 +135,10 @@ func TestService_SearchMods(t *testing.T) {
 	})
 	svc.RegisterSource(mock)
 
-	results, err := svc.SearchMods(context.Background(), "test", "skyrim", "test", "", nil)
+	searchResult, err := svc.SearchMods(context.Background(), "test", "skyrim", "test", "", nil, 0, 0)
 	require.NoError(t, err)
-	assert.Len(t, results, 1)
-	assert.Equal(t, "Test Mod", results[0].Name)
+	assert.Len(t, searchResult.Mods, 1)
+	assert.Equal(t, "Test Mod", searchResult.Mods[0].Name)
 }
 
 func TestService_GetMod(t *testing.T) {

--- a/internal/core/updater_test.go
+++ b/internal/core/updater_test.go
@@ -25,8 +25,8 @@ func (m *updateMockSource) AuthURL() string { return "" }
 func (m *updateMockSource) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
 	return nil, nil
 }
-func (m *updateMockSource) Search(ctx context.Context, query source.SearchQuery) ([]domain.Mod, error) {
-	return nil, nil
+func (m *updateMockSource) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	return source.SearchResult{}, nil
 }
 func (m *updateMockSource) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
 	if m.currentMod != nil && m.currentMod.ID == modID {

--- a/internal/source/curseforge/curseforge_test.go
+++ b/internal/source/curseforge/curseforge_test.go
@@ -64,6 +64,9 @@ func TestCurseForge_Search(t *testing.T) {
 		PageSize: 20,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, 1, result.TotalCount)
+	assert.Equal(t, 0, result.Page)
+	assert.Equal(t, 20, result.PageSize)
 	mods := result.Mods
 	require.Len(t, mods, 1)
 

--- a/internal/source/curseforge/curseforge_test.go
+++ b/internal/source/curseforge/curseforge_test.go
@@ -58,12 +58,13 @@ func TestCurseForge_Search(t *testing.T) {
 	cf := New(server.Client(), "test-api-key")
 	cf.client.baseURL = server.URL
 
-	mods, err := cf.Search(context.Background(), source.SearchQuery{
+	result, err := cf.Search(context.Background(), source.SearchQuery{
 		GameID:   "432",
 		Query:    "jei",
 		PageSize: 20,
 	})
 	require.NoError(t, err)
+	mods := result.Mods
 	require.Len(t, mods, 1)
 
 	assert.Equal(t, "238222", mods[0].ID)

--- a/internal/source/nexusmods/nexusmods.go
+++ b/internal/source/nexusmods/nexusmods.go
@@ -62,7 +62,7 @@ func (n *NexusMods) ExchangeToken(ctx context.Context, code string) (*source.Tok
 }
 
 // Search finds mods matching the query
-func (n *NexusMods) Search(ctx context.Context, query source.SearchQuery) ([]domain.Mod, error) {
+func (n *NexusMods) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
 	pageSize := query.PageSize
 	if pageSize == 0 {
 		pageSize = 20
@@ -71,7 +71,7 @@ func (n *NexusMods) Search(ctx context.Context, query source.SearchQuery) ([]dom
 
 	results, err := n.client.SearchMods(ctx, query.GameID, query.Query, query.Category, query.Tags, pageSize, offset)
 	if err != nil {
-		return nil, err
+		return source.SearchResult{}, err
 	}
 
 	mods := make([]domain.Mod, len(results))
@@ -79,7 +79,7 @@ func (n *NexusMods) Search(ctx context.Context, query source.SearchQuery) ([]dom
 		mods[i] = modDataToDomain(r, query.GameID)
 	}
 
-	return mods, nil
+	return source.SearchResult{Mods: mods, TotalCount: 0, Page: query.Page, PageSize: pageSize}, nil
 }
 
 // GetMod retrieves a specific mod

--- a/internal/source/registry_test.go
+++ b/internal/source/registry_test.go
@@ -19,8 +19,8 @@ func (m *mockSource) ID() string                                                
 func (m *mockSource) Name() string                                                 { return "Mock" }
 func (m *mockSource) AuthURL() string                                              { return "" }
 func (m *mockSource) ExchangeToken(context.Context, string) (*source.Token, error) { return nil, nil }
-func (m *mockSource) Search(context.Context, source.SearchQuery) ([]domain.Mod, error) {
-	return nil, nil
+func (m *mockSource) Search(context.Context, source.SearchQuery) (source.SearchResult, error) {
+	return source.SearchResult{}, nil
 }
 func (m *mockSource) GetMod(context.Context, string, string) (*domain.Mod, error) { return nil, nil }
 func (m *mockSource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) {

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -14,8 +14,7 @@ type Token struct {
 	ExpiresAt    time.Time
 }
 
-// SearchQuery parameters for searching mods
-// SearchResult contains paginated search results
+// SearchResult contains paginated search results.
 type SearchResult struct {
 	Mods       []domain.Mod
 	TotalCount int // Total results available (0 if unknown)
@@ -23,6 +22,7 @@ type SearchResult struct {
 	PageSize   int
 }
 
+// SearchQuery contains parameters for searching mods.
 type SearchQuery struct {
 	GameID   string
 	Query    string

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -15,6 +15,14 @@ type Token struct {
 }
 
 // SearchQuery parameters for searching mods
+// SearchResult contains paginated search results
+type SearchResult struct {
+	Mods       []domain.Mod
+	TotalCount int // Total results available (0 if unknown)
+	Page       int
+	PageSize   int
+}
+
 type SearchQuery struct {
 	GameID   string
 	Query    string
@@ -35,7 +43,7 @@ type ModSource interface {
 	ExchangeToken(ctx context.Context, code string) (*Token, error)
 
 	// Discovery
-	Search(ctx context.Context, query SearchQuery) ([]domain.Mod, error)
+	Search(ctx context.Context, query SearchQuery) (SearchResult, error)
 	GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error)
 	GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error)
 


### PR DESCRIPTION
## Summary

Implements #16 — paginated search results picker with clean exit.

## Changes

- **`internal/source/source.go`** — Added `SearchResult` struct with `Mods`, `TotalCount`, `Page`, `PageSize`. Updated `ModSource.Search` interface.
- **`internal/source/curseforge/curseforge.go`** — Returns `SearchResult` with `TotalCount` from CurseForge pagination API.
- **`internal/source/nexusmods/nexusmods.go`** — Returns `SearchResult` with `TotalCount: 0` (unavailable from GraphQL).
- **`internal/core/service.go`** — `SearchMods` accepts `page, pageSize int` params, returns `SearchResult`.
- **`cmd/lmm/install.go`** — Paginated mod picker (10 per page):
  - `[n] Next page (X more)` when more results available
  - `[p] Previous page` when not on page 1
  - `[q] Cancel` to exit without selecting
  - Graceful handling of unknown total count (NexusMods)
- **`cmd/lmm/search.go`**, **`cmd/lmm/import.go`** — Updated callers with default page/pageSize.
- **Test mocks** — Updated across 4 test files for new `Search` return type.
- **Version** bumped to `1.3.0`
- **CHANGELOG.md** and **README.md** updated.

## Testing

- `go build ./...` ✅
- `go test ./...` ✅

Closes #16