### PR TITLE
fix: display source URL in mod show text output

### DIFF
--- a/cmd/lmm/mod.go
+++ b/cmd/lmm/mod.go
@@ -449,6 +449,9 @@ func runModShow(cmd *cobra.Command, args []string) error {
 	if mod.Category != "" {
 		fmt.Printf("Category: %s  Endorsements: %d\n", mod.Category, mod.Endorsements)
 	}
+	if mod.SourceURL != "" {
+		fmt.Printf("URL: %s\n", mod.SourceURL)
+	}
 	if mod.PictureURL != "" {
 		fmt.Printf("Image: %s\n", mod.PictureURL)
 	}

--- a/cmd/lmm/mod.go
+++ b/cmd/lmm/mod.go
@@ -447,7 +447,10 @@ func runModShow(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s\n", strings.Repeat("=", 60))
 	fmt.Printf("ID: %s  Version: %s  Author: %s\n", mod.ID, mod.Version, mod.Author)
 	if mod.Category != "" {
-		fmt.Printf("Category: %s  Endorsements: %d\n", mod.Category, mod.Endorsements)
+		fmt.Printf("Category: %s\n", mod.Category)
+	}
+	if mod.Endorsements > 0 {
+		fmt.Printf("Endorsements: %d\n", mod.Endorsements)
 	}
 	if mod.SourceURL != "" {
 		fmt.Printf("URL: %s\n", mod.SourceURL)


### PR DESCRIPTION
The `SourceURL` field was included in `--json` output but missing from the human-readable `lmm mod show` display.

Adds `URL: <url>` line to the text output when available, right after the category/endorsements line.