### PR TITLE
[codex] fix: make install and update flows failure-atomic

### DIFF
--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -434,20 +435,25 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	linkMethod := service.GetGameLinkMethod(game)
 	linker := service.GetLinker(linkMethod)
 	installer := core.NewInstaller(service.GetGameCache(game), linker, service.DB())
-	var reinstallSnapshot *reinstallCacheSnapshot
+	var reinstallTxn *reinstallCacheTransaction
+	downloadCache := service.GetGameCache(game)
 
 	// Check if mod is already installed so we can replace it atomically later.
 	existingMod, err := service.GetInstalledMod(installSource, mod.ID, gameID, profileName)
 	if err != nil {
+		if !errors.Is(err, domain.ErrModNotFound) {
+			return fmt.Errorf("checking existing installed mod: %w", err)
+		}
 		existingMod = nil
 	} else if existingMod.Version == mod.Version {
-		reinstallSnapshot, err = prepareReinstallCacheSnapshot(service.GetGameCache(game), gameID, existingMod.SourceID, existingMod.ID, existingMod.Version)
+		reinstallTxn, err = prepareReinstallCacheTransaction(service.GetGameCache(game), gameID, existingMod.SourceID, existingMod.ID, existingMod.Version)
 		if err != nil {
 			return fmt.Errorf("preparing reinstall cache: %w", err)
 		}
+		downloadCache = reinstallTxn.staged
 		defer func() {
-			if reinstallSnapshot != nil {
-				_ = reinstallSnapshot.Rollback()
+			if reinstallTxn != nil {
+				_ = reinstallTxn.Rollback()
 			}
 		}()
 	}
@@ -474,7 +480,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		downloadResult, err := service.DownloadMod(ctx, installSource, game, mod, selectedFile, progressFn)
+		downloadResult, err := service.DownloadModToCache(ctx, downloadCache, installSource, game, mod, selectedFile, progressFn)
 		if err != nil {
 			fmt.Println() // newline after progress
 			if strings.Contains(err.Error(), "third-party downloads") && mod.SourceURL != "" {
@@ -560,13 +566,22 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	fmt.Println("Deploying to game directory...")
 
 	if existingMod != nil {
+		if reinstallTxn != nil {
+			if err := reinstallTxn.Activate(); err != nil {
+				return fmt.Errorf("activating reinstall cache: %w", err)
+			}
+		}
 		var replaceErr error
-		if reinstallSnapshot != nil {
-			replaceErr = installer.ReplaceWithOldCache(ctx, game, reinstallSnapshot.snapshot, &existingMod.Mod, mod, profileName)
+		if reinstallTxn != nil {
+			replaceErr = installer.ReplaceWithOldCache(ctx, game, reinstallTxn.snapshot, &existingMod.Mod, mod, profileName)
 		} else {
 			replaceErr = installer.Replace(ctx, game, &existingMod.Mod, mod, profileName)
 		}
 		if replaceErr != nil {
+			if reinstallTxn != nil {
+				_ = reinstallTxn.RestoreLive()
+				_ = installer.ReplaceWithCaches(ctx, game, reinstallTxn.snapshot, service.GetGameCache(game), &existingMod.Mod, &existingMod.Mod, profileName)
+			}
 			return fmt.Errorf("deployment failed: %w", replaceErr)
 		}
 	} else if err := installer.Install(ctx, game, mod, profileName); err != nil {
@@ -586,8 +601,9 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 	if err := service.DB().SaveInstalledMod(installedMod); err != nil {
 		if existingMod != nil {
-			if reinstallSnapshot != nil {
-				_ = installer.ReplaceWithOldCache(ctx, game, reinstallSnapshot.snapshot, mod, &existingMod.Mod, profileName)
+			if reinstallTxn != nil {
+				_ = reinstallTxn.RestoreLive()
+				_ = installer.ReplaceWithCaches(ctx, game, reinstallTxn.staged, service.GetGameCache(game), mod, &existingMod.Mod, profileName)
 			} else {
 				_ = installer.Replace(ctx, game, mod, &existingMod.Mod, profileName)
 			}
@@ -596,11 +612,11 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		}
 		return fmt.Errorf("failed to save mod: %w", err)
 	}
-	if reinstallSnapshot != nil {
-		if err := reinstallSnapshot.Commit(); err != nil && verbose {
-			fmt.Printf("  Warning: could not finalize reinstall cache snapshot: %v\n", err)
+	if reinstallTxn != nil {
+		if err := reinstallTxn.Commit(); err != nil && verbose {
+			fmt.Printf("  Warning: could not finalize reinstall cache transaction: %v\n", err)
 		}
-		reinstallSnapshot = nil
+		reinstallTxn = nil
 	}
 
 	// Store checksums in database
@@ -678,33 +694,33 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-type reinstallCacheSnapshot struct {
-	live     *cache.Cache
-	snapshot *cache.Cache
-	tempDir  string
-	gameID   string
-	sourceID string
-	modID    string
-	version  string
+type reinstallCacheTransaction struct {
+	live      *cache.Cache
+	snapshot  *cache.Cache
+	staged    *cache.Cache
+	tempDir   string
+	gameID    string
+	sourceID  string
+	modID     string
+	version   string
+	activated bool
 }
 
-func prepareReinstallCacheSnapshot(live *cache.Cache, gameID, sourceID, modID, version string) (*reinstallCacheSnapshot, error) {
+func prepareReinstallCacheTransaction(live *cache.Cache, gameID, sourceID, modID, version string) (*reinstallCacheTransaction, error) {
 	tempDir, err := os.MkdirTemp("", "lmm-reinstall-cache-*")
 	if err != nil {
 		return nil, fmt.Errorf("creating cache snapshot: %w", err)
 	}
-	snapshot := cache.New(tempDir)
+	snapshot := cache.New(filepath.Join(tempDir, "snapshot"))
+	staged := cache.New(filepath.Join(tempDir, "staged"))
 	if err := live.CloneMod(snapshot, gameID, sourceID, modID, version); err != nil {
 		_ = os.RemoveAll(tempDir)
 		return nil, fmt.Errorf("snapshotting existing cache: %w", err)
 	}
-	if err := live.Delete(gameID, sourceID, modID, version); err != nil {
-		_ = os.RemoveAll(tempDir)
-		return nil, fmt.Errorf("preparing clean reinstall cache: %w", err)
-	}
-	return &reinstallCacheSnapshot{
+	return &reinstallCacheTransaction{
 		live:     live,
 		snapshot: snapshot,
+		staged:   staged,
 		tempDir:  tempDir,
 		gameID:   gameID,
 		sourceID: sourceID,
@@ -713,8 +729,25 @@ func prepareReinstallCacheSnapshot(live *cache.Cache, gameID, sourceID, modID, v
 	}, nil
 }
 
-func (s *reinstallCacheSnapshot) Rollback() error {
+func (s *reinstallCacheTransaction) Activate() error {
 	if s == nil {
+		return nil
+	}
+	if s.activated {
+		return nil
+	}
+	if err := s.live.Delete(s.gameID, s.sourceID, s.modID, s.version); err != nil {
+		return err
+	}
+	if err := s.staged.CloneMod(s.live, s.gameID, s.sourceID, s.modID, s.version); err != nil {
+		return err
+	}
+	s.activated = true
+	return nil
+}
+
+func (s *reinstallCacheTransaction) RestoreLive() error {
+	if s == nil || !s.activated {
 		return nil
 	}
 	if err := s.live.Delete(s.gameID, s.sourceID, s.modID, s.version); err != nil {
@@ -723,17 +756,28 @@ func (s *reinstallCacheSnapshot) Rollback() error {
 	if err := s.snapshot.CloneMod(s.live, s.gameID, s.sourceID, s.modID, s.version); err != nil {
 		return err
 	}
+	s.activated = false
+	return nil
+}
+
+func (s *reinstallCacheTransaction) Rollback() error {
+	if s == nil {
+		return nil
+	}
+	if err := s.RestoreLive(); err != nil {
+		return err
+	}
 	err := os.RemoveAll(s.tempDir)
-	*s = reinstallCacheSnapshot{}
+	*s = reinstallCacheTransaction{}
 	return err
 }
 
-func (s *reinstallCacheSnapshot) Commit() error {
+func (s *reinstallCacheTransaction) Commit() error {
 	if s == nil {
 		return nil
 	}
 	err := os.RemoveAll(s.tempDir)
-	*s = reinstallCacheSnapshot{}
+	*s = reinstallCacheTransaction{}
 	return err
 }
 

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
 
 	"github.com/spf13/cobra"
 )
@@ -433,23 +434,22 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	linkMethod := service.GetGameLinkMethod(game)
 	linker := service.GetLinker(linkMethod)
 	installer := core.NewInstaller(service.GetGameCache(game), linker, service.DB())
+	var reinstallSnapshot *reinstallCacheSnapshot
 
-	// Check if mod is already installed - if so, uninstall old files first
+	// Check if mod is already installed so we can replace it atomically later.
 	existingMod, err := service.GetInstalledMod(installSource, mod.ID, gameID, profileName)
-	if err == nil && existingMod != nil {
-		fmt.Println("\nRemoving previous installation...")
-		// Uninstall using the OLD version info to remove correct files
-		if err := installer.Uninstall(ctx, game, &existingMod.Mod, profileName); err != nil {
-			if verbose {
-				fmt.Printf("  Warning: could not remove old files: %v\n", err)
-			}
+	if err != nil {
+		existingMod = nil
+	} else if existingMod.Version == mod.Version {
+		reinstallSnapshot, err = prepareReinstallCacheSnapshot(service.GetGameCache(game), gameID, existingMod.SourceID, existingMod.ID, existingMod.Version)
+		if err != nil {
+			return fmt.Errorf("preparing reinstall cache: %w", err)
 		}
-		// Delete old cache for this mod/version to ensure clean slate
-		if err := service.GetGameCache(game).Delete(gameID, existingMod.SourceID, existingMod.ID, existingMod.Version); err != nil {
-			if verbose {
-				fmt.Printf("  Warning: could not clear old cache: %v\n", err)
+		defer func() {
+			if reinstallSnapshot != nil {
+				_ = reinstallSnapshot.Rollback()
 			}
-		}
+		}()
 	}
 
 	// Download each selected file
@@ -559,7 +559,17 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	// Deploy to game directory
 	fmt.Println("Deploying to game directory...")
 
-	if err := installer.Install(ctx, game, mod, profileName); err != nil {
+	if existingMod != nil {
+		var replaceErr error
+		if reinstallSnapshot != nil {
+			replaceErr = installer.ReplaceWithOldCache(ctx, game, reinstallSnapshot.snapshot, &existingMod.Mod, mod, profileName)
+		} else {
+			replaceErr = installer.Replace(ctx, game, &existingMod.Mod, mod, profileName)
+		}
+		if replaceErr != nil {
+			return fmt.Errorf("deployment failed: %w", replaceErr)
+		}
+	} else if err := installer.Install(ctx, game, mod, profileName); err != nil {
 		return fmt.Errorf("deployment failed: %w", err)
 	}
 
@@ -575,7 +585,22 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := service.DB().SaveInstalledMod(installedMod); err != nil {
+		if existingMod != nil {
+			if reinstallSnapshot != nil {
+				_ = installer.ReplaceWithOldCache(ctx, game, reinstallSnapshot.snapshot, mod, &existingMod.Mod, profileName)
+			} else {
+				_ = installer.Replace(ctx, game, mod, &existingMod.Mod, profileName)
+			}
+		} else {
+			_ = installer.Uninstall(ctx, game, mod, profileName)
+		}
 		return fmt.Errorf("failed to save mod: %w", err)
+	}
+	if reinstallSnapshot != nil {
+		if err := reinstallSnapshot.Commit(); err != nil && verbose {
+			fmt.Printf("  Warning: could not finalize reinstall cache snapshot: %v\n", err)
+		}
+		reinstallSnapshot = nil
 	}
 
 	// Store checksums in database
@@ -615,6 +640,12 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if existingMod != nil && existingMod.Version != mod.Version {
+		if err := service.GetGameCache(game).Delete(gameID, existingMod.SourceID, existingMod.ID, existingMod.Version); err != nil && verbose {
+			fmt.Printf("  Warning: could not clear old cache: %v\n", err)
+		}
+	}
+
 	// Run install.after_each hook
 	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Install.AfterEach != "" {
 		hookCtx.HookName = "install.after_each"
@@ -645,6 +676,65 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Added to profile: %s\n", profileName)
 
 	return nil
+}
+
+type reinstallCacheSnapshot struct {
+	live     *cache.Cache
+	snapshot *cache.Cache
+	tempDir  string
+	gameID   string
+	sourceID string
+	modID    string
+	version  string
+}
+
+func prepareReinstallCacheSnapshot(live *cache.Cache, gameID, sourceID, modID, version string) (*reinstallCacheSnapshot, error) {
+	tempDir, err := os.MkdirTemp("", "lmm-reinstall-cache-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating cache snapshot: %w", err)
+	}
+	snapshot := cache.New(tempDir)
+	if err := live.CloneMod(snapshot, gameID, sourceID, modID, version); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("snapshotting existing cache: %w", err)
+	}
+	if err := live.Delete(gameID, sourceID, modID, version); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("preparing clean reinstall cache: %w", err)
+	}
+	return &reinstallCacheSnapshot{
+		live:     live,
+		snapshot: snapshot,
+		tempDir:  tempDir,
+		gameID:   gameID,
+		sourceID: sourceID,
+		modID:    modID,
+		version:  version,
+	}, nil
+}
+
+func (s *reinstallCacheSnapshot) Rollback() error {
+	if s == nil {
+		return nil
+	}
+	if err := s.live.Delete(s.gameID, s.sourceID, s.modID, s.version); err != nil {
+		return err
+	}
+	if err := s.snapshot.CloneMod(s.live, s.gameID, s.sourceID, s.modID, s.version); err != nil {
+		return err
+	}
+	err := os.RemoveAll(s.tempDir)
+	*s = reinstallCacheSnapshot{}
+	return err
+}
+
+func (s *reinstallCacheSnapshot) Commit() error {
+	if s == nil {
+		return nil
+	}
+	err := os.RemoveAll(s.tempDir)
+	*s = reinstallCacheSnapshot{}
+	return err
 }
 
 // promptMultiSelection prompts the user to select one or more numbers

--- a/cmd/lmm/install_test.go
+++ b/cmd/lmm/install_test.go
@@ -260,22 +260,32 @@ func TestPromptMultiSelection_Cancel(t *testing.T) {
 	}
 }
 
-func TestReinstallCacheSnapshot_RollbackRestoresOriginalCache(t *testing.T) {
+func TestReinstallCacheTransaction_RollbackRestoresOriginalCache(t *testing.T) {
 	liveCache := cache.New(t.TempDir())
 	require.NoError(t, liveCache.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "main.esp", []byte("main")))
 	require.NoError(t, liveCache.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "optional.esp", []byte("optional")))
 
-	snapshot, err := prepareReinstallCacheSnapshot(liveCache, "skyrim-se", "nexusmods", "12345", "1.0.0")
+	txn, err := prepareReinstallCacheTransaction(liveCache, "skyrim-se", "nexusmods", "12345", "1.0.0")
 	require.NoError(t, err)
-
-	require.NoError(t, liveCache.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "main.esp", []byte("new-main")))
-	require.NoError(t, snapshot.Rollback())
 
 	files, err := liveCache.ListFiles("skyrim-se", "nexusmods", "12345", "1.0.0")
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"main.esp", "optional.esp"}, files)
 
-	_, err = os.Stat(snapshot.tempDir)
+	require.NoError(t, txn.staged.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "main.esp", []byte("new-main")))
+	require.NoError(t, txn.Activate())
+
+	files, err = liveCache.ListFiles("skyrim-se", "nexusmods", "12345", "1.0.0")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"main.esp"}, files)
+
+	require.NoError(t, txn.Rollback())
+
+	files, err = liveCache.ListFiles("skyrim-se", "nexusmods", "12345", "1.0.0")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"main.esp", "optional.esp"}, files)
+
+	_, err = os.Stat(txn.tempDir)
 	assert.True(t, os.IsNotExist(err), "snapshot temp dir should be cleaned up")
 }
 

--- a/cmd/lmm/install_test.go
+++ b/cmd/lmm/install_test.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestInstallCmd_Structure tests the install command structure
@@ -255,6 +258,25 @@ func TestPromptMultiSelection_Cancel(t *testing.T) {
 			assert.Nil(t, selections, "cancel should return nil selections")
 		})
 	}
+}
+
+func TestReinstallCacheSnapshot_RollbackRestoresOriginalCache(t *testing.T) {
+	liveCache := cache.New(t.TempDir())
+	require.NoError(t, liveCache.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "main.esp", []byte("main")))
+	require.NoError(t, liveCache.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "optional.esp", []byte("optional")))
+
+	snapshot, err := prepareReinstallCacheSnapshot(liveCache, "skyrim-se", "nexusmods", "12345", "1.0.0")
+	require.NoError(t, err)
+
+	require.NoError(t, liveCache.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "main.esp", []byte("new-main")))
+	require.NoError(t, snapshot.Rollback())
+
+	files, err := liveCache.ListFiles("skyrim-se", "nexusmods", "12345", "1.0.0")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"main.esp", "optional.esp"}, files)
+
+	_, err = os.Stat(snapshot.tempDir)
+	assert.True(t, os.IsNotExist(err), "snapshot temp dir should be cleaned up")
 }
 
 // TestPromptMultiSelection_Default tests that empty input returns default choice

--- a/cmd/lmm/update.go
+++ b/cmd/lmm/update.go
@@ -425,24 +425,6 @@ func applyUpdate(ctx context.Context, service *core.Service, game *domain.Game, 
 	linker := service.GetLinker(linkMethod)
 	installer := core.NewInstaller(service.GetGameCache(game), linker, service.DB())
 
-	if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
-		// Log but continue - files may have been manually removed
-		if verbose {
-			fmt.Printf("  Warning: failed to undeploy old version: %v\n", err)
-		}
-	}
-
-	// Run uninstall.after_each hook (after uninstalling old version)
-	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Uninstall.AfterEach != "" {
-		hookCtx.HookName = "uninstall.after_each"
-		hookCtx.ModID = mod.ID
-		hookCtx.ModName = mod.Name
-		hookCtx.ModVersion = mod.Version
-		if _, err := hookRunner.Run(ctx, resolvedHooks.Uninstall.AfterEach, hookCtx); err != nil {
-			hookErrors = append(hookErrors, fmt.Errorf("uninstall.after_each hook failed: %w", err))
-		}
-	}
-
 	// Run install.before_each hook (before installing new version)
 	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Install.BeforeEach != "" {
 		hookCtx.HookName = "install.before_each"
@@ -457,9 +439,20 @@ func applyUpdate(ctx context.Context, service *core.Service, game *domain.Game, 
 		}
 	}
 
-	// Deploy new version
-	if err := installer.Install(ctx, game, newMod, profileName); err != nil {
+	// Replace old version with the new version.
+	if err := installer.Replace(ctx, game, &mod.Mod, newMod, profileName); err != nil {
 		return fmt.Errorf("deploying update: %w", err)
+	}
+
+	// Run uninstall.after_each hook (after old files are no longer the active deployment)
+	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Uninstall.AfterEach != "" {
+		hookCtx.HookName = "uninstall.after_each"
+		hookCtx.ModID = mod.ID
+		hookCtx.ModName = mod.Name
+		hookCtx.ModVersion = mod.Version
+		if _, err := hookRunner.Run(ctx, resolvedHooks.Uninstall.AfterEach, hookCtx); err != nil {
+			hookErrors = append(hookErrors, fmt.Errorf("uninstall.after_each hook failed: %w", err))
+		}
 	}
 
 	// Run install.after_each hook (after installing new version)
@@ -476,8 +469,9 @@ func applyUpdate(ctx context.Context, service *core.Service, game *domain.Game, 
 	// Print hook warnings
 	printHookWarnings(hookErrors)
 
-	// Update database (preserves previous version for rollback)
-	if err := service.UpdateModVersion(mod.SourceID, mod.ID, game.ID, profileName, newVersion); err != nil {
+	// Update database (preserves rollback state and file IDs atomically).
+	if err := service.ApplyModUpdate(mod.SourceID, mod.ID, game.ID, profileName, newVersion, downloadedFileIDs); err != nil {
+		_ = installer.Replace(ctx, game, newMod, &mod.Mod, profileName)
 		return fmt.Errorf("updating database: %w", err)
 	}
 
@@ -485,13 +479,6 @@ func applyUpdate(ctx context.Context, service *core.Service, game *domain.Game, 
 	if err := service.SetModLinkMethod(mod.SourceID, mod.ID, game.ID, profileName, linkMethod); err != nil {
 		if verbose {
 			fmt.Printf("  Warning: could not update link method: %v\n", err)
-		}
-	}
-
-	// Update FileIDs in database
-	if err := service.SetModFileIDs(mod.SourceID, mod.ID, game.ID, profileName, downloadedFileIDs); err != nil {
-		if verbose {
-			fmt.Printf("  Warning: could not update file IDs: %v\n", err)
 		}
 	}
 
@@ -504,9 +491,9 @@ func applyUpdate(ctx context.Context, service *core.Service, game *domain.Game, 
 		FileIDs:  downloadedFileIDs,
 	}
 	if err := pm.UpsertMod(game.ID, profileName, modRef); err != nil {
-		if verbose {
-			fmt.Printf("  Warning: could not update profile: %v\n", err)
-		}
+		_ = service.RollbackModVersion(mod.SourceID, mod.ID, game.ID, profileName)
+		_ = installer.Replace(ctx, game, newMod, &mod.Mod, profileName)
+		return fmt.Errorf("updating profile: %w", err)
 	}
 
 	return nil
@@ -587,23 +574,6 @@ func runUpdateRollback(cmd *cobra.Command, args []string) error {
 	linker := service.GetLinker(linkMethod)
 	installer := core.NewInstaller(service.GetGameCache(game), linker, service.DB())
 
-	if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
-		if verbose {
-			fmt.Printf("  Warning: failed to undeploy current version: %v\n", err)
-		}
-	}
-
-	// Run uninstall.after_each hook (after uninstalling current version)
-	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Uninstall.AfterEach != "" {
-		hookCtx.HookName = "uninstall.after_each"
-		hookCtx.ModID = mod.ID
-		hookCtx.ModName = mod.Name
-		hookCtx.ModVersion = mod.Version
-		if _, err := hookRunner.Run(ctx, resolvedHooks.Uninstall.AfterEach, hookCtx); err != nil {
-			hookErrors = append(hookErrors, fmt.Errorf("uninstall.after_each hook failed: %w", err))
-		}
-	}
-
 	// Deploy previous version
 	prevMod := mod.Mod
 	prevMod.Version = mod.PreviousVersion
@@ -622,8 +592,19 @@ func runUpdateRollback(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := installer.Install(ctx, game, &prevMod, profileName); err != nil {
+	if err := installer.Replace(ctx, game, &mod.Mod, &prevMod, profileName); err != nil {
 		return fmt.Errorf("deploying previous version: %w", err)
+	}
+
+	// Run uninstall.after_each hook (after current version is no longer active)
+	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Uninstall.AfterEach != "" {
+		hookCtx.HookName = "uninstall.after_each"
+		hookCtx.ModID = mod.ID
+		hookCtx.ModName = mod.Name
+		hookCtx.ModVersion = mod.Version
+		if _, err := hookRunner.Run(ctx, resolvedHooks.Uninstall.AfterEach, hookCtx); err != nil {
+			hookErrors = append(hookErrors, fmt.Errorf("uninstall.after_each hook failed: %w", err))
+		}
 	}
 
 	// Run install.after_each hook (after installing previous version)
@@ -642,6 +623,7 @@ func runUpdateRollback(cmd *cobra.Command, args []string) error {
 
 	// Swap versions in database
 	if err := service.RollbackModVersion(mod.SourceID, mod.ID, game.ID, profileName); err != nil {
+		_ = installer.Replace(ctx, game, &prevMod, &mod.Mod, profileName)
 		return fmt.Errorf("updating database: %w", err)
 	}
 
@@ -650,6 +632,22 @@ func runUpdateRollback(cmd *cobra.Command, args []string) error {
 		if verbose {
 			fmt.Printf("  Warning: could not update link method: %v\n", err)
 		}
+	}
+
+	rolledBackMod, err := service.GetInstalledMod(mod.SourceID, mod.ID, game.ID, profileName)
+	if err != nil {
+		return fmt.Errorf("reloading rolled back mod: %w", err)
+	}
+	pm := getProfileManager(service)
+	if err := pm.UpsertMod(game.ID, profileName, domain.ModReference{
+		SourceID: rolledBackMod.SourceID,
+		ModID:    rolledBackMod.ID,
+		Version:  rolledBackMod.Version,
+		FileIDs:  rolledBackMod.FileIDs,
+	}); err != nil {
+		_ = service.RollbackModVersion(mod.SourceID, mod.ID, game.ID, profileName)
+		_ = installer.Replace(ctx, game, &prevMod, &mod.Mod, profileName)
+		return fmt.Errorf("updating profile: %w", err)
 	}
 
 	fmt.Printf("\n✓ Rolled back: %s %s → %s\n", mod.Name, mod.Version, mod.PreviousVersion)

--- a/internal/core/installer.go
+++ b/internal/core/installer.go
@@ -91,6 +91,11 @@ func (i *Installer) Replace(ctx context.Context, game *domain.Game, oldMod, newM
 	return i.replaceWithCaches(ctx, game, i.cache, i.cache, oldMod, newMod, profileName)
 }
 
+// ReplaceWithCaches swaps an existing deployment using explicit old and new caches.
+func (i *Installer) ReplaceWithCaches(ctx context.Context, game *domain.Game, oldCache, newCache *cache.Cache, oldMod, newMod *domain.Mod, profileName string) error {
+	return i.replaceWithCaches(ctx, game, oldCache, newCache, oldMod, newMod, profileName)
+}
+
 // ReplaceWithOldCache swaps an existing deployment using an alternate cache
 // snapshot for the old version.
 func (i *Installer) ReplaceWithOldCache(ctx context.Context, game *domain.Game, oldCache *cache.Cache, oldMod, newMod *domain.Mod, profileName string) error {
@@ -151,8 +156,16 @@ func (i *Installer) replaceWithCaches(ctx context.Context, game *domain.Game, ol
 		srcPath := newCache.GetFilePath(game.ID, newMod.SourceID, newMod.ID, newMod.Version, file)
 		dstPath := filepath.Join(game.ModPath, file)
 		if err := i.linker.Deploy(srcPath, dstPath); err != nil {
-			if rollbackErr := i.restoreOldFiles(oldCache, game, oldMod, removedOld, replacedOrAdded, oldSet); rollbackErr != nil {
+			cleanupErr := i.linker.Undeploy(dstPath)
+			rollbackFiles := append(append([]string(nil), replacedOrAdded...), file)
+			if rollbackErr := i.restoreOldFiles(oldCache, game, oldMod, removedOld, rollbackFiles, oldSet); rollbackErr != nil {
+				if cleanupErr != nil {
+					return fmt.Errorf("deploying %s: %w; cleanup failed: %v; rollback failed: %v", file, err, cleanupErr, rollbackErr)
+				}
 				return fmt.Errorf("deploying %s: %w; rollback failed: %v", file, err, rollbackErr)
+			}
+			if cleanupErr != nil {
+				return fmt.Errorf("deploying %s: %w; cleanup failed: %v", file, err, cleanupErr)
 			}
 			return fmt.Errorf("deploying %s: %w", file, err)
 		}

--- a/internal/core/installer.go
+++ b/internal/core/installer.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -81,6 +82,137 @@ func (i *Installer) Install(ctx context.Context, game *domain.Game, mod *domain.
 		}
 	}
 
+	return nil
+}
+
+// Replace swaps an existing deployment with a new cached version and restores
+// the old files if the replacement fails.
+func (i *Installer) Replace(ctx context.Context, game *domain.Game, oldMod, newMod *domain.Mod, profileName string) error {
+	return i.replaceWithCaches(ctx, game, i.cache, i.cache, oldMod, newMod, profileName)
+}
+
+// ReplaceWithOldCache swaps an existing deployment using an alternate cache
+// snapshot for the old version.
+func (i *Installer) ReplaceWithOldCache(ctx context.Context, game *domain.Game, oldCache *cache.Cache, oldMod, newMod *domain.Mod, profileName string) error {
+	return i.replaceWithCaches(ctx, game, oldCache, i.cache, oldMod, newMod, profileName)
+}
+
+func (i *Installer) replaceWithCaches(ctx context.Context, game *domain.Game, oldCache, newCache *cache.Cache, oldMod, newMod *domain.Mod, profileName string) error {
+	if !oldCache.Exists(game.ID, oldMod.SourceID, oldMod.ID, oldMod.Version) {
+		return fmt.Errorf("old mod not in cache: %s/%s@%s", oldMod.SourceID, oldMod.ID, oldMod.Version)
+	}
+	if !newCache.Exists(game.ID, newMod.SourceID, newMod.ID, newMod.Version) {
+		return fmt.Errorf("new mod not in cache: %s/%s@%s", newMod.SourceID, newMod.ID, newMod.Version)
+	}
+
+	oldFiles, err := oldCache.ListFiles(game.ID, oldMod.SourceID, oldMod.ID, oldMod.Version)
+	if err != nil {
+		return fmt.Errorf("listing old cached files: %w", err)
+	}
+	newFiles, err := newCache.ListFiles(game.ID, newMod.SourceID, newMod.ID, newMod.Version)
+	if err != nil {
+		return fmt.Errorf("listing new cached files: %w", err)
+	}
+
+	oldSet := make(map[string]bool, len(oldFiles))
+	for _, file := range oldFiles {
+		oldSet[file] = true
+	}
+	newSet := make(map[string]bool, len(newFiles))
+	for _, file := range newFiles {
+		newSet[file] = true
+	}
+
+	var removedOld []string
+	for _, file := range oldFiles {
+		if newSet[file] {
+			continue
+		}
+		if err := i.linker.Undeploy(filepath.Join(game.ModPath, file)); err != nil {
+			if rollbackErr := i.restoreOldFiles(oldCache, game, oldMod, removedOld, nil, oldSet); rollbackErr != nil {
+				return fmt.Errorf("removing obsolete file %s: %w; rollback failed: %v", file, err, rollbackErr)
+			}
+			return fmt.Errorf("removing obsolete file %s: %w", file, err)
+		}
+		removedOld = append(removedOld, file)
+	}
+
+	var replacedOrAdded []string
+	for _, file := range newFiles {
+		select {
+		case <-ctx.Done():
+			if rollbackErr := i.restoreOldFiles(oldCache, game, oldMod, removedOld, replacedOrAdded, oldSet); rollbackErr != nil {
+				return fmt.Errorf("%w; rollback failed: %v", ctx.Err(), rollbackErr)
+			}
+			return ctx.Err()
+		default:
+		}
+
+		srcPath := newCache.GetFilePath(game.ID, newMod.SourceID, newMod.ID, newMod.Version, file)
+		dstPath := filepath.Join(game.ModPath, file)
+		if err := i.linker.Deploy(srcPath, dstPath); err != nil {
+			if rollbackErr := i.restoreOldFiles(oldCache, game, oldMod, removedOld, replacedOrAdded, oldSet); rollbackErr != nil {
+				return fmt.Errorf("deploying %s: %w; rollback failed: %v", file, err, rollbackErr)
+			}
+			return fmt.Errorf("deploying %s: %w", file, err)
+		}
+		replacedOrAdded = append(replacedOrAdded, file)
+	}
+
+	if i.db != nil {
+		if err := i.db.DeleteDeployedFiles(game.ID, profileName, oldMod.SourceID, oldMod.ID); err != nil {
+			if rollbackErr := i.restoreOldFiles(oldCache, game, oldMod, removedOld, replacedOrAdded, oldSet); rollbackErr != nil {
+				return fmt.Errorf("resetting file tracking: %w; rollback failed: %v", err, rollbackErr)
+			}
+			return fmt.Errorf("resetting file tracking: %w", err)
+		}
+		for _, file := range newFiles {
+			if err := i.db.SaveDeployedFile(game.ID, profileName, file, newMod.SourceID, newMod.ID); err != nil {
+				_ = i.db.DeleteDeployedFiles(game.ID, profileName, newMod.SourceID, newMod.ID)
+				for _, oldFile := range oldFiles {
+					_ = i.db.SaveDeployedFile(game.ID, profileName, oldFile, oldMod.SourceID, oldMod.ID)
+				}
+				if rollbackErr := i.restoreOldFiles(oldCache, game, oldMod, removedOld, replacedOrAdded, oldSet); rollbackErr != nil {
+					return fmt.Errorf("tracking deployed file %s: %w; rollback failed: %v", file, err, rollbackErr)
+				}
+				return fmt.Errorf("tracking deployed file %s: %w", file, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (i *Installer) restoreOldFiles(oldCache *cache.Cache, game *domain.Game, oldMod *domain.Mod, removedOld, replacedOrAdded []string, oldSet map[string]bool) error {
+	var errs []error
+
+	for j := len(replacedOrAdded) - 1; j >= 0; j-- {
+		file := replacedOrAdded[j]
+		dstPath := filepath.Join(game.ModPath, file)
+		if oldSet[file] {
+			srcPath := oldCache.GetFilePath(game.ID, oldMod.SourceID, oldMod.ID, oldMod.Version, file)
+			if err := i.linker.Deploy(srcPath, dstPath); err != nil {
+				errs = append(errs, fmt.Errorf("restoring %s: %w", file, err))
+			}
+			continue
+		}
+		if err := i.linker.Undeploy(dstPath); err != nil {
+			errs = append(errs, fmt.Errorf("removing %s: %w", file, err))
+		}
+	}
+
+	for j := len(removedOld) - 1; j >= 0; j-- {
+		file := removedOld[j]
+		srcPath := oldCache.GetFilePath(game.ID, oldMod.SourceID, oldMod.ID, oldMod.Version, file)
+		dstPath := filepath.Join(game.ModPath, file)
+		if err := i.linker.Deploy(srcPath, dstPath); err != nil {
+			errs = append(errs, fmt.Errorf("restoring removed %s: %w", file, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
 	return nil
 }
 

--- a/internal/core/installer_test.go
+++ b/internal/core/installer_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
@@ -355,6 +356,23 @@ func (f *failingLinker) Deploy(src, dst string) error {
 	return f.Linker.Deploy(src, dst)
 }
 
+type conditionalFailingLinker struct {
+	linker.Linker
+	failSrcSubstring string
+	failAfter        int
+	matches          int
+}
+
+func (f *conditionalFailingLinker) Deploy(src, dst string) error {
+	if strings.Contains(src, f.failSrcSubstring) {
+		f.matches++
+		if f.matches > f.failAfter {
+			return fmt.Errorf("simulated deploy failure")
+		}
+	}
+	return f.Linker.Deploy(src, dst)
+}
+
 func TestInstaller_Install_DeployFailureRollsBackAndClearsDB(t *testing.T) {
 	// When Deploy fails after some files are deployed, roll back all deployed
 	// files and clear DB records so disk and DB stay consistent.
@@ -389,6 +407,77 @@ func TestInstaller_Install_DeployFailureRollsBackAndClearsDB(t *testing.T) {
 	paths, err := database.GetDeployedFilesForMod("g", "default", "src", "1")
 	require.NoError(t, err)
 	assert.Empty(t, paths, "DB should have no deployed file records for this mod")
+}
+
+func TestInstaller_Replace_DeployFailureRestoresOldFiles(t *testing.T) {
+	cacheDir := t.TempDir()
+	gameDir := t.TempDir()
+
+	modCache := cache.New(cacheDir)
+	require.NoError(t, modCache.Store("g", "src", "mod", "old", "same.esp", []byte("old-same")))
+	require.NoError(t, modCache.Store("g", "src", "mod", "old", "old-only.esp", []byte("old-only")))
+	require.NoError(t, modCache.Store("g", "src", "mod", "new", "same.esp", []byte("new-same")))
+	require.NoError(t, modCache.Store("g", "src", "mod", "new", "new-only.esp", []byte("new-only")))
+
+	game := &domain.Game{ID: "g", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	oldMod := &domain.Mod{ID: "mod", SourceID: "src", Version: "old", GameID: "g"}
+	newMod := &domain.Mod{ID: "mod", SourceID: "src", Version: "new", GameID: "g"}
+
+	baseLinker := linker.New(domain.LinkSymlink)
+	initialInstaller := core.NewInstaller(modCache, baseLinker, nil)
+	require.NoError(t, initialInstaller.Install(context.Background(), game, oldMod, "default"))
+
+	lnk := &conditionalFailingLinker{
+		Linker:           linker.New(domain.LinkSymlink),
+		failSrcSubstring: string(filepath.Separator) + "new" + string(filepath.Separator),
+		failAfter:        1,
+	}
+	installer := core.NewInstaller(modCache, lnk, nil)
+	err := installer.Replace(context.Background(), game, oldMod, newMod, "default")
+	require.Error(t, err)
+
+	samePath := filepath.Join(gameDir, "same.esp")
+	oldOnlyPath := filepath.Join(gameDir, "old-only.esp")
+	newOnlyPath := filepath.Join(gameDir, "new-only.esp")
+
+	sameTarget, err := os.Readlink(samePath)
+	require.NoError(t, err)
+	assert.Equal(t, modCache.GetFilePath("g", "src", "mod", "old", "same.esp"), sameTarget)
+
+	oldOnlyTarget, err := os.Readlink(oldOnlyPath)
+	require.NoError(t, err)
+	assert.Equal(t, modCache.GetFilePath("g", "src", "mod", "old", "old-only.esp"), oldOnlyTarget)
+
+	_, err = os.Lstat(newOnlyPath)
+	assert.True(t, os.IsNotExist(err), "new-only file should not remain after rollback")
+}
+
+func TestInstaller_ReplaceWithOldCache_SameVersionRemovesStaleFiles(t *testing.T) {
+	oldCacheDir := t.TempDir()
+	newCacheDir := t.TempDir()
+	gameDir := t.TempDir()
+
+	oldCache := cache.New(oldCacheDir)
+	newCache := cache.New(newCacheDir)
+	require.NoError(t, oldCache.Store("g", "src", "mod", "1.0", "main.esp", []byte("old-main")))
+	require.NoError(t, oldCache.Store("g", "src", "mod", "1.0", "optional.esp", []byte("old-optional")))
+	require.NoError(t, newCache.Store("g", "src", "mod", "1.0", "main.esp", []byte("new-main")))
+
+	game := &domain.Game{ID: "g", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	mod := &domain.Mod{ID: "mod", SourceID: "src", Version: "1.0", GameID: "g"}
+
+	initialInstaller := core.NewInstaller(oldCache, linker.New(domain.LinkSymlink), nil)
+	require.NoError(t, initialInstaller.Install(context.Background(), game, mod, "default"))
+
+	installer := core.NewInstaller(newCache, linker.New(domain.LinkSymlink), nil)
+	require.NoError(t, installer.ReplaceWithOldCache(context.Background(), game, oldCache, mod, mod, "default"))
+
+	mainTarget, err := os.Readlink(filepath.Join(gameDir, "main.esp"))
+	require.NoError(t, err)
+	assert.Equal(t, newCache.GetFilePath("g", "src", "mod", "1.0", "main.esp"), mainTarget)
+
+	_, err = os.Lstat(filepath.Join(gameDir, "optional.esp"))
+	assert.True(t, os.IsNotExist(err), "stale optional file should be removed")
 }
 
 func TestGetConflicts(t *testing.T) {

--- a/internal/core/profile.go
+++ b/internal/core/profile.go
@@ -240,7 +240,7 @@ func (pm *ProfileManager) Switch(ctx context.Context, game *domain.Game, newProf
 	if hadCurrentProfile && currentProfile.Name != newProfileName && len(currentProfile.Mods) > 0 {
 		for i, modRef := range currentProfile.Mods {
 			if err := pm.undeployModRefFailFast(ctx, game, modRef); err != nil {
-				rollbackErr := pm.rollbackRedeploy(ctx, game, currentProfile.Mods[:i])
+				rollbackErr := pm.rollbackRedeploy(ctx, game, currentProfile.Mods[:i+1])
 				return joinSwitchErr(fmt.Errorf("undeploy %s:%s: %w", modRef.SourceID, modRef.ModID, err), rollbackErr)
 			}
 		}
@@ -369,6 +369,7 @@ func (pm *ProfileManager) deployMod(ctx context.Context, game *domain.Game, modR
 		return fmt.Errorf("listing cached files: %w", err)
 	}
 
+	var deployed []string
 	// Deploy each file
 	for _, file := range files {
 		select {
@@ -381,8 +382,12 @@ func (pm *ProfileManager) deployMod(ctx context.Context, game *domain.Game, modR
 		dstPath := filepath.Join(game.ModPath, file)
 
 		if err := pm.linker.Deploy(srcPath, dstPath); err != nil {
+			for j := len(deployed) - 1; j >= 0; j-- {
+				_ = pm.linker.Undeploy(filepath.Join(game.ModPath, deployed[j]))
+			}
 			return fmt.Errorf("deploying %s: %w", file, err)
 		}
+		deployed = append(deployed, file)
 	}
 
 	return nil

--- a/internal/core/profile_test.go
+++ b/internal/core/profile_test.go
@@ -356,7 +356,8 @@ func TestProfileManager_Switch_UndeployFailure_Rollback(t *testing.T) {
 	assert.Contains(t, err.Error(), "profile switch failed")
 	assert.Contains(t, err.Error(), "undeploy nexusmods:222")
 
-	// Rollback redeploys only mods 0..i-1 (A). Mod B was never undeployed, so must not be redeployed.
+	// Rollback must restore the current profile completely, including the mod
+	// whose undeploy failed after partially mutating its files.
 	def, _ := pm.GetDefault("skyrim-se")
 	require.NotNil(t, def)
 	assert.Equal(t, "profile1", def.Name)
@@ -364,7 +365,7 @@ func TestProfileManager_Switch_UndeployFailure_Rollback(t *testing.T) {
 	require.NoError(t, err, "A should be redeployed")
 	infoB, err := os.Lstat(deployedB)
 	require.NoError(t, err)
-	assert.False(t, infoB.Mode()&os.ModeSymlink != 0, "B must still be regular file (never undeployed, rollback must not redeploy it)")
+	assert.True(t, infoB.Mode()&os.ModeSymlink != 0, "B should be restored to the original symlink deployment")
 }
 
 func TestProfileManager_Switch_OverridesFailure_Rollback(t *testing.T) {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -169,8 +169,11 @@ func (s *Service) GetDownloadURL(ctx context.Context, sourceID string, mod *doma
 // Returns the download result including files extracted and checksum.
 // Multiple files from the same mod can be downloaded to the same cache location.
 func (s *Service) DownloadMod(ctx context.Context, sourceID string, game *domain.Game, mod *domain.Mod, file *domain.DownloadableFile, progressFn ProgressFunc) (result *DownloadModResult, err error) {
-	// Get game-specific cache
-	gameCache := s.GetGameCache(game)
+	return s.DownloadModToCache(ctx, s.GetGameCache(game), sourceID, game, mod, file, progressFn)
+}
+
+// DownloadModToCache downloads a mod file, extracts it, and stores it in the provided cache.
+func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache, sourceID string, game *domain.Game, mod *domain.Mod, file *domain.DownloadableFile, progressFn ProgressFunc) (result *DownloadModResult, err error) {
 
 	// Note: We intentionally do NOT check if cache exists here.
 	// A mod can have multiple downloadable files (e.g., main mod + optional patches),
@@ -265,6 +268,8 @@ func commitStagedCache(cachePath, stagePath string) error {
 		if err := os.Rename(cachePath, backupPath); err != nil {
 			return fmt.Errorf("backing up existing cache: %w", err)
 		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking existing cache: %w", err)
 	}
 	if err := os.Rename(stagePath, cachePath); err != nil {
 		if _, statErr := os.Stat(backupPath); statErr == nil {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -203,15 +203,28 @@ func (s *Service) DownloadMod(ctx context.Context, sourceID string, game *domain
 
 	// Extract to cache location
 	cachePath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
+	stagePath := cachePath + ".staging"
+	if err := os.RemoveAll(stagePath); err != nil {
+		return nil, fmt.Errorf("clearing staging cache: %w", err)
+	}
+	defer os.RemoveAll(stagePath) //nolint:errcheck
+	if gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version) {
+		if err := copyDir(cachePath, stagePath); err != nil {
+			return nil, fmt.Errorf("staging existing cache: %w", err)
+		}
+	}
 	if game.DeployMode == domain.DeployCopy || !s.extractor.CanExtract(file.FileName) {
 		// Copy mode: game wants files as-is (e.g., Hytale .zip mods)
 		// Or not an archive - just copy to cache
-		if err := os.MkdirAll(cachePath, 0755); err != nil {
+		if err := os.MkdirAll(stagePath, 0755); err != nil {
 			return nil, fmt.Errorf("creating cache directory: %w", err)
 		}
-		destPath := filepath.Join(cachePath, file.FileName)
+		destPath := filepath.Join(stagePath, file.FileName)
 		if err := copyFileStreaming(archivePath, destPath); err != nil {
 			return nil, fmt.Errorf("copying to cache: %w", err)
+		}
+		if err := commitStagedCache(cachePath, stagePath); err != nil {
+			return nil, err
 		}
 		return &DownloadModResult{
 			FilesExtracted: 1,
@@ -219,8 +232,11 @@ func (s *Service) DownloadMod(ctx context.Context, sourceID string, game *domain
 		}, nil
 	}
 
-	if err := s.extractor.Extract(archivePath, cachePath); err != nil {
+	if err := s.extractor.Extract(archivePath, stagePath); err != nil {
 		return nil, fmt.Errorf("extracting mod: %w", err)
+	}
+	if err := commitStagedCache(cachePath, stagePath); err != nil {
+		return nil, err
 	}
 
 	// Count extracted files
@@ -233,6 +249,33 @@ func (s *Service) DownloadMod(ctx context.Context, sourceID string, game *domain
 		FilesExtracted: len(files),
 		Checksum:       downloadResult.Checksum,
 	}, nil
+}
+
+func commitStagedCache(cachePath, stagePath string) error {
+	parentDir := filepath.Dir(cachePath)
+	if err := os.MkdirAll(parentDir, 0755); err != nil {
+		return fmt.Errorf("creating cache parent directory: %w", err)
+	}
+
+	backupPath := cachePath + ".backup"
+	if err := os.RemoveAll(backupPath); err != nil {
+		return fmt.Errorf("clearing cache backup: %w", err)
+	}
+	if _, err := os.Stat(cachePath); err == nil {
+		if err := os.Rename(cachePath, backupPath); err != nil {
+			return fmt.Errorf("backing up existing cache: %w", err)
+		}
+	}
+	if err := os.Rename(stagePath, cachePath); err != nil {
+		if _, statErr := os.Stat(backupPath); statErr == nil {
+			_ = os.Rename(backupPath, cachePath)
+		}
+		return fmt.Errorf("activating staged cache: %w", err)
+	}
+	if err := os.RemoveAll(backupPath); err != nil {
+		return fmt.Errorf("removing old cache backup: %w", err)
+	}
+	return nil
 }
 
 // GetGame retrieves a game by ID
@@ -382,6 +425,11 @@ func (s *Service) IsSourceAuthenticated(sourceID string) bool {
 // UpdateModVersion updates the version of an installed mod, preserving the previous version for rollback
 func (s *Service) UpdateModVersion(sourceID, modID, gameID, profileName, newVersion string) error {
 	return s.db.UpdateModVersion(sourceID, modID, gameID, profileName, newVersion)
+}
+
+// ApplyModUpdate updates version and file IDs atomically, preserving rollback state.
+func (s *Service) ApplyModUpdate(sourceID, modID, gameID, profileName, newVersion string, fileIDs []string) error {
+	return s.db.ApplyModUpdate(sourceID, modID, gameID, profileName, newVersion, fileIDs)
 }
 
 // RollbackModVersion reverts a mod to its previous version

--- a/internal/domain/mod.go
+++ b/internal/domain/mod.go
@@ -83,6 +83,7 @@ type InstalledMod struct {
 	Enabled         bool       // User intent: wants this mod active
 	Deployed        bool       // Current state: files are in game directory
 	PreviousVersion string     // Version before last update (for rollback)
+	PreviousFileIDs []string   // File IDs before last update (for rollback)
 	LinkMethod      LinkMethod // How the mod was deployed (symlink, hardlink, copy)
 	FileIDs         []string   // Source-specific file IDs that were downloaded
 	ManualDownload  bool       // True if mod requires manual download (CurseForge restricted, etc.)

--- a/internal/storage/cache/cache.go
+++ b/internal/storage/cache/cache.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"fmt"
 	"io/fs"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -103,6 +104,25 @@ func (c *Cache) GetFilePath(gameID, sourceID, modID, version, relativePath strin
 	return filepath.Join(c.ModPath(gameID, sourceID, modID, version), relativePath)
 }
 
+// CloneMod copies a cached mod version into another cache.
+func (c *Cache) CloneMod(dest *Cache, gameID, sourceID, modID, version string) error {
+	files, err := c.ListFiles(gameID, sourceID, modID, version)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		srcPath := c.GetFilePath(gameID, sourceID, modID, version, file)
+		dstPath := dest.GetFilePath(gameID, sourceID, modID, version, file)
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+			return fmt.Errorf("creating destination dir: %w", err)
+		}
+		if err := copyFile(srcPath, dstPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Size returns the total size of cached files for a mod version
 func (c *Cache) Size(gameID, sourceID, modID, version string) (int64, error) {
 	modPath := c.ModPath(gameID, sourceID, modID, version)
@@ -128,4 +148,28 @@ func (c *Cache) Size(gameID, sourceID, modID, version string) (int64, error) {
 	}
 
 	return totalSize, nil
+}
+
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening source: %w", err)
+	}
+	defer srcFile.Close()
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("creating destination: %w", err)
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("copying file: %w", err)
+	}
+	return nil
 }

--- a/internal/storage/cache/cache_test.go
+++ b/internal/storage/cache/cache_test.go
@@ -97,3 +97,19 @@ func TestCache_Exists_ListFiles_GameScoped(t *testing.T) {
 	assert.Len(t, files, 1)
 	assert.Equal(t, "file.pak", files[0])
 }
+
+func TestCache_CloneMod(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	src := cache.New(srcDir)
+	dst := cache.New(dstDir)
+
+	require.NoError(t, src.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "main.esp", []byte("main")))
+	require.NoError(t, src.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "optional/patch.esp", []byte("patch")))
+
+	require.NoError(t, src.CloneMod(dst, "skyrim-se", "nexusmods", "12345", "1.0.0"))
+
+	files, err := dst.ListFiles("skyrim-se", "nexusmods", "12345", "1.0.0")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"main.esp", "optional/patch.esp"}, files)
+}

--- a/internal/storage/db/db_test.go
+++ b/internal/storage/db/db_test.go
@@ -199,6 +199,43 @@ func TestSwapModVersions(t *testing.T) {
 	assert.Equal(t, "2.0.0", retrieved.PreviousVersion)
 }
 
+func TestApplyModUpdateAndRollbackRestoresFileIDs(t *testing.T) {
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+
+	mod := &domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "12345",
+			SourceID: "nexusmods",
+			Name:     "Test Mod",
+			Version:  "1.0.0",
+			GameID:   "skyrim-se",
+		},
+		ProfileName: "default",
+		FileIDs:     []string{"old-main", "old-patch"},
+	}
+	require.NoError(t, database.SaveInstalledMod(mod))
+
+	require.NoError(t, database.ApplyModUpdate("nexusmods", "12345", "skyrim-se", "default", "2.0.0", []string{"new-main"}))
+
+	updated, err := database.GetInstalledMod("nexusmods", "12345", "skyrim-se", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", updated.Version)
+	assert.Equal(t, "1.0.0", updated.PreviousVersion)
+	assert.Equal(t, []string{"new-main"}, updated.FileIDs)
+	assert.Equal(t, []string{"old-main", "old-patch"}, updated.PreviousFileIDs)
+
+	require.NoError(t, database.SwapModVersions("nexusmods", "12345", "skyrim-se", "default"))
+
+	rolledBack, err := database.GetInstalledMod("nexusmods", "12345", "skyrim-se", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", rolledBack.Version)
+	assert.Equal(t, "2.0.0", rolledBack.PreviousVersion)
+	assert.Equal(t, []string{"old-main", "old-patch"}, rolledBack.FileIDs)
+	assert.Equal(t, []string{"new-main"}, rolledBack.PreviousFileIDs)
+}
+
 func TestSwapModVersions_NoPreviousVersion(t *testing.T) {
 	database, err := db.New(":memory:")
 	require.NoError(t, err)

--- a/internal/storage/db/migrations.go
+++ b/internal/storage/db/migrations.go
@@ -31,6 +31,7 @@ func (d *DB) migrate() error {
 		migrateV7,
 		migrateV8,
 		migrateV9,
+		migrateV10,
 	}
 
 	for i := version; i < len(migrations); i++ {
@@ -171,4 +172,9 @@ func migrateV9(d *DB) error {
 		}
 	}
 	return nil
+}
+
+func migrateV10(d *DB) error {
+	_, err := d.Exec(`ALTER TABLE installed_mods ADD COLUMN previous_file_ids TEXT DEFAULT '[]'`)
+	return err
 }

--- a/internal/storage/db/mods.go
+++ b/internal/storage/db/mods.go
@@ -2,12 +2,35 @@ package db
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 )
+
+func encodeFileIDs(fileIDs []string) (string, error) {
+	if len(fileIDs) == 0 {
+		return "[]", nil
+	}
+	data, err := json.Marshal(fileIDs)
+	if err != nil {
+		return "", fmt.Errorf("encoding file IDs: %w", err)
+	}
+	return string(data), nil
+}
+
+func decodeFileIDs(raw *string) ([]string, error) {
+	if raw == nil || *raw == "" {
+		return nil, nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(*raw), &out); err != nil {
+		return nil, fmt.Errorf("decoding file IDs: %w", err)
+	}
+	return out, nil
+}
 
 // SaveInstalledMod inserts or updates an installed mod record.
 // The mod upsert and file ID replacement are performed atomically within a transaction.
@@ -22,10 +45,14 @@ func (d *DB) SaveInstalledMod(mod *domain.InstalledMod) error {
 	if mod.PreviousVersion != "" {
 		prevVersion = &mod.PreviousVersion
 	}
+	prevFileIDs, err := encodeFileIDs(mod.PreviousFileIDs)
+	if err != nil {
+		return err
+	}
 
 	_, err = tx.Exec(`
-		INSERT INTO installed_mods (source_id, mod_id, game_id, profile_name, name, version, author, update_policy, enabled, deployed, installed_at, previous_version, link_method, manual_download, summary, source_url)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO installed_mods (source_id, mod_id, game_id, profile_name, name, version, author, update_policy, enabled, deployed, installed_at, previous_version, previous_file_ids, link_method, manual_download, summary, source_url)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(source_id, mod_id, game_id, profile_name) DO UPDATE SET
 			name = excluded.name,
 			version = excluded.version,
@@ -34,11 +61,12 @@ func (d *DB) SaveInstalledMod(mod *domain.InstalledMod) error {
 			enabled = excluded.enabled,
 			deployed = excluded.deployed,
 			previous_version = excluded.previous_version,
+			previous_file_ids = excluded.previous_file_ids,
 			link_method = excluded.link_method,
 			manual_download = excluded.manual_download,
 			summary = excluded.summary,
 			source_url = excluded.source_url
-	`, mod.SourceID, mod.ID, mod.GameID, mod.ProfileName, mod.Name, mod.Version, mod.Author, mod.UpdatePolicy, mod.Enabled, mod.Deployed, time.Now(), prevVersion, mod.LinkMethod, mod.ManualDownload, mod.Summary, mod.SourceURL)
+	`, mod.SourceID, mod.ID, mod.GameID, mod.ProfileName, mod.Name, mod.Version, mod.Author, mod.UpdatePolicy, mod.Enabled, mod.Deployed, time.Now(), prevVersion, prevFileIDs, mod.LinkMethod, mod.ManualDownload, mod.Summary, mod.SourceURL)
 	if err != nil {
 		return fmt.Errorf("saving installed mod: %w", err)
 	}
@@ -54,7 +82,7 @@ func (d *DB) SaveInstalledMod(mod *domain.InstalledMod) error {
 // GetInstalledMods returns all installed mods for a game/profile combination
 func (d *DB) GetInstalledMods(gameID, profileName string) (mods []domain.InstalledMod, err error) {
 	rows, err := d.Query(`
-		SELECT source_id, mod_id, game_id, profile_name, name, version, author, update_policy, enabled, deployed, installed_at, previous_version, link_method, manual_download, summary, source_url
+		SELECT source_id, mod_id, game_id, profile_name, name, version, author, update_policy, enabled, deployed, installed_at, previous_version, previous_file_ids, link_method, manual_download, summary, source_url
 		FROM installed_mods
 		WHERE game_id = ? AND profile_name = ?
 		ORDER BY installed_at ASC
@@ -71,10 +99,11 @@ func (d *DB) GetInstalledMods(gameID, profileName string) (mods []domain.Install
 	for rows.Next() {
 		var mod domain.InstalledMod
 		var prevVersion *string
+		var prevFileIDs *string
 		err := rows.Scan(
 			&mod.SourceID, &mod.ID, &mod.GameID, &mod.ProfileName,
 			&mod.Name, &mod.Version, &mod.Author, &mod.UpdatePolicy,
-			&mod.Enabled, &mod.Deployed, &mod.InstalledAt, &prevVersion, &mod.LinkMethod, &mod.ManualDownload,
+			&mod.Enabled, &mod.Deployed, &mod.InstalledAt, &prevVersion, &prevFileIDs, &mod.LinkMethod, &mod.ManualDownload,
 			&mod.Summary, &mod.SourceURL,
 		)
 		if err != nil {
@@ -82,6 +111,10 @@ func (d *DB) GetInstalledMods(gameID, profileName string) (mods []domain.Install
 		}
 		if prevVersion != nil {
 			mod.PreviousVersion = *prevVersion
+		}
+		mod.PreviousFileIDs, err = decodeFileIDs(prevFileIDs)
+		if err != nil {
+			return nil, err
 		}
 		mods = append(mods, mod)
 	}
@@ -207,16 +240,17 @@ func (d *DB) SetModDeployed(sourceID, modID, gameID, profileName string, deploye
 func (d *DB) GetInstalledMod(sourceID, modID, gameID, profileName string) (*domain.InstalledMod, error) {
 	var mod domain.InstalledMod
 	var prevVersion *string
+	var prevFileIDs *string
 	err := d.QueryRow(`
 		SELECT source_id, mod_id, game_id, profile_name, name, version, author,
-		       update_policy, enabled, deployed, installed_at, previous_version, link_method, manual_download,
+		       update_policy, enabled, deployed, installed_at, previous_version, previous_file_ids, link_method, manual_download,
 		       summary, source_url
 		FROM installed_mods
 		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
 	`, sourceID, modID, gameID, profileName).Scan(
 		&mod.SourceID, &mod.ID, &mod.GameID, &mod.ProfileName,
 		&mod.Name, &mod.Version, &mod.Author, &mod.UpdatePolicy,
-		&mod.Enabled, &mod.Deployed, &mod.InstalledAt, &prevVersion, &mod.LinkMethod, &mod.ManualDownload,
+		&mod.Enabled, &mod.Deployed, &mod.InstalledAt, &prevVersion, &prevFileIDs, &mod.LinkMethod, &mod.ManualDownload,
 		&mod.Summary, &mod.SourceURL,
 	)
 	if err != nil {
@@ -228,6 +262,10 @@ func (d *DB) GetInstalledMod(sourceID, modID, gameID, profileName string) (*doma
 
 	if prevVersion != nil {
 		mod.PreviousVersion = *prevVersion
+	}
+	mod.PreviousFileIDs, err = decodeFileIDs(prevFileIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	// Fetch file IDs
@@ -266,13 +304,46 @@ func (d *DB) GetModFileIDs(sourceID, modID, gameID, profileName string) (fileIDs
 	return fileIDs, rows.Err()
 }
 
-// UpdateModVersion updates a mod's version, preserving the previous version for rollback
+func getModFileIDsTx(tx *sql.Tx, sourceID, modID, gameID, profileName string) (fileIDs []string, err error) {
+	rows, err := tx.Query(`
+		SELECT file_id FROM installed_mod_files
+		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
+	`, sourceID, modID, gameID, profileName)
+	if err != nil {
+		return nil, fmt.Errorf("querying mod file IDs: %w", err)
+	}
+	defer func() {
+		if cerr := rows.Close(); err == nil && cerr != nil {
+			err = fmt.Errorf("closing rows: %w", cerr)
+		}
+	}()
+
+	for rows.Next() {
+		var fileID string
+		if err := rows.Scan(&fileID); err != nil {
+			return nil, fmt.Errorf("scanning file ID: %w", err)
+		}
+		fileIDs = append(fileIDs, fileID)
+	}
+
+	return fileIDs, rows.Err()
+}
+
+// UpdateModVersion updates a mod's version, preserving the previous version and file IDs for rollback.
 func (d *DB) UpdateModVersion(sourceID, modID, gameID, profileName, newVersion string) error {
+	currentFileIDs, err := d.GetModFileIDs(sourceID, modID, gameID, profileName)
+	if err != nil {
+		return err
+	}
+	prevFileIDs, err := encodeFileIDs(currentFileIDs)
+	if err != nil {
+		return err
+	}
 	result, err := d.Exec(`
 		UPDATE installed_mods
-		SET previous_version = version, version = ?
+		SET previous_version = version, previous_file_ids = ?, version = ?
 		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
-	`, newVersion, sourceID, modID, gameID, profileName)
+	`, prevFileIDs, newVersion, sourceID, modID, gameID, profileName)
 	if err != nil {
 		return fmt.Errorf("updating mod version: %w", err)
 	}
@@ -308,8 +379,53 @@ func (d *DB) SetModFileIDs(sourceID, modID, gameID, profileName string, fileIDs 
 	return d.replaceModFileIDs(sourceID, modID, gameID, profileName, fileIDs)
 }
 
+// ApplyModUpdate updates version and file IDs atomically while preserving rollback state.
+func (d *DB) ApplyModUpdate(sourceID, modID, gameID, profileName, newVersion string, newFileIDs []string) error {
+	tx, err := d.Begin()
+	if err != nil {
+		return fmt.Errorf("starting transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var currentVersion string
+	err = tx.QueryRow(`
+		SELECT version FROM installed_mods
+		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
+	`, sourceID, modID, gameID, profileName).Scan(&currentVersion)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.ErrModNotFound
+		}
+		return fmt.Errorf("checking current version: %w", err)
+	}
+
+	currentFileIDs, err := getModFileIDsTx(tx, sourceID, modID, gameID, profileName)
+	if err != nil {
+		return err
+	}
+	prevFileIDs, err := encodeFileIDs(currentFileIDs)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`
+		UPDATE installed_mods
+		SET previous_version = ?, previous_file_ids = ?, version = ?
+		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
+	`, currentVersion, prevFileIDs, newVersion, sourceID, modID, gameID, profileName)
+	if err != nil {
+		return fmt.Errorf("updating mod version: %w", err)
+	}
+
+	if err := replaceModFileIDsTx(tx, sourceID, modID, gameID, profileName, newFileIDs); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
 // SwapModVersions swaps version and previous_version (for rollback).
-// The read and write are performed atomically within a transaction.
+// The read/write and file ID restoration are performed atomically within a transaction.
 func (d *DB) SwapModVersions(sourceID, modID, gameID, profileName string) error {
 	tx, err := d.Begin()
 	if err != nil {
@@ -319,10 +435,11 @@ func (d *DB) SwapModVersions(sourceID, modID, gameID, profileName string) error 
 
 	var version string
 	var prevVersion *string
+	var prevFileIDsRaw *string
 	err = tx.QueryRow(`
-		SELECT version, previous_version FROM installed_mods
+		SELECT version, previous_version, previous_file_ids FROM installed_mods
 		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
-	`, sourceID, modID, gameID, profileName).Scan(&version, &prevVersion)
+	`, sourceID, modID, gameID, profileName).Scan(&version, &prevVersion, &prevFileIDsRaw)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return domain.ErrModNotFound
@@ -334,14 +451,29 @@ func (d *DB) SwapModVersions(sourceID, modID, gameID, profileName string) error 
 		return fmt.Errorf("no previous version available for rollback")
 	}
 	prevVal := *prevVersion
+	prevFileIDs, err := decodeFileIDs(prevFileIDsRaw)
+	if err != nil {
+		return err
+	}
+	currentFileIDs, err := getModFileIDsTx(tx, sourceID, modID, gameID, profileName)
+	if err != nil {
+		return err
+	}
+	currentFileIDsRaw, err := encodeFileIDs(currentFileIDs)
+	if err != nil {
+		return err
+	}
 
 	_, err = tx.Exec(`
 		UPDATE installed_mods
-		SET version = ?, previous_version = ?
+		SET version = ?, previous_version = ?, previous_file_ids = ?
 		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
-	`, prevVal, version, sourceID, modID, gameID, profileName)
+	`, prevVal, version, currentFileIDsRaw, sourceID, modID, gameID, profileName)
 	if err != nil {
 		return fmt.Errorf("swapping mod versions: %w", err)
+	}
+	if err := replaceModFileIDsTx(tx, sourceID, modID, gameID, profileName, prevFileIDs); err != nil {
+		return err
 	}
 
 	return tx.Commit()


### PR DESCRIPTION
## Summary
- make install, update, and rollback flows failure-atomic instead of uninstall-first
- stage cache changes transactionally and restore previous file IDs/profile state on rollback
- make same-version reinstall replace the selected file set exactly and restore the original cache if reinstall fails

## Validation
- go test ./...
- go vet ./...