### PR TITLE
[codex] fix Nexus file handling and install UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-04-21
+
+### Fixed
+
+- **NexusMods filename normalization**: Path-like `file_name` values from NexusMods are now sanitized to a safe basename before they reach the CLI, cache, or installer, avoiding bogus nested relative paths in file selection and cache writes
+- **Archive detection without extensions**: Downloaded archives are now identified by file signature as well as filename extension, so ZIP/7z/RAR downloads still extract correctly even when the source filename is missing or malformed
+- **Import path handling**: The CLI import streaming-copy helper now also creates destination parent directories before writing, matching the cache/import behavior used elsewhere
+
 ## [1.3.1] - 2026-02-12
 
 ### Changed
@@ -568,7 +576,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.3...HEAD
+[1.3.3]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.1...v1.3.3
 [1.3.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.1.0...v1.2.0

--- a/cmd/lmm/import.go
+++ b/cmd/lmm/import.go
@@ -657,6 +657,10 @@ func copyFileStreaming(src, dst string) error {
 		return fmt.Errorf("stat source: %w", err)
 	}
 
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("creating destination directory: %w", err)
+	}
+
 	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
 	if err != nil {
 		return fmt.Errorf("creating destination: %w", err)

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -97,6 +97,47 @@ func init() {
 	rootCmd.AddCommand(installCmd)
 }
 
+func displayFileLabel(file domain.DownloadableFile) string {
+	name := strings.TrimSpace(file.Name)
+	fileName := strings.TrimSpace(file.FileName)
+
+	if fileName == "" {
+		return name
+	}
+	if name == "" {
+		return fileName
+	}
+	if strings.ContainsAny(fileName, `/\`) {
+		return name
+	}
+	if looksOpaqueFileName(fileName) {
+		return name
+	}
+	return fileName
+}
+
+func looksOpaqueFileName(fileName string) bool {
+	if filepath.Ext(fileName) != "" {
+		return false
+	}
+	if strings.Count(fileName, "-") < 4 {
+		return false
+	}
+
+	compact := strings.ReplaceAll(fileName, "-", "")
+	if len(compact) < 24 {
+		return false
+	}
+
+	for _, r := range compact {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+
+	return true
+}
+
 func runInstall(cmd *cobra.Command, args []string) error {
 	if err := requireGame(cmd); err != nil {
 		return err
@@ -377,7 +418,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				if f.IsPrimary {
 					defaultMark = " <- default"
 				}
-				fmt.Printf("  [%d] %s (%s, %s)%s\n", i+1, f.FileName, f.Category, sizeStr, defaultMark)
+				fmt.Printf("  [%d] %s (%s, %s)%s\n", i+1, displayFileLabel(f), f.Category, sizeStr, defaultMark)
 			}
 
 			selections, err := promptMultiSelection("Select file(s) (e.g., 1 or 1,3 or 1-3)", defaultChoice, len(files))
@@ -392,11 +433,11 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 	// Show selected files
 	if len(selectedFiles) == 1 {
-		fmt.Printf("\nFile: %s\n", selectedFiles[0].FileName)
+		fmt.Printf("\nFile: %s\n", displayFileLabel(*selectedFiles[0]))
 	} else {
 		fmt.Printf("\nFiles (%d):\n", len(selectedFiles))
 		for _, f := range selectedFiles {
-			fmt.Printf("  - %s\n", f.FileName)
+			fmt.Printf("  - %s\n", displayFileLabel(*f))
 		}
 	}
 
@@ -465,9 +506,9 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 	for i, selectedFile := range selectedFiles {
 		if len(selectedFiles) > 1 {
-			fmt.Printf("\n[%d/%d] Downloading %s...\n", i+1, len(selectedFiles), selectedFile.FileName)
+			fmt.Printf("\n[%d/%d] Downloading %s...\n", i+1, len(selectedFiles), displayFileLabel(*selectedFile))
 		} else {
-			fmt.Printf("\nDownloading %s...\n", selectedFile.FileName)
+			fmt.Printf("\nDownloading %s...\n", displayFileLabel(*selectedFile))
 		}
 
 		progressFn := func(p core.DownloadProgress) {
@@ -1188,7 +1229,7 @@ func batchInstallMods(ctx context.Context, service *core.Service, game *domain.G
 		}
 
 		selectedFile := selectPrimaryFile(files)
-		fmt.Printf("  File: %s\n", selectedFile.FileName)
+		fmt.Printf("  File: %s\n", displayFileLabel(*selectedFile))
 
 		// Download
 		progressFn := func(p core.DownloadProgress) {

--- a/cmd/lmm/install_test.go
+++ b/cmd/lmm/install_test.go
@@ -184,6 +184,41 @@ func TestFilterAndSortFiles(t *testing.T) {
 	assert.Equal(t, "OLD_VERSION", withArchived[5].Category)
 }
 
+func TestDisplayFileLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     domain.DownloadableFile
+		expected string
+	}{
+		{
+			name:     "uses filename when it looks normal",
+			file:     domain.DownloadableFile{Name: "Main File", FileName: "mod-1.0.zip"},
+			expected: "mod-1.0.zip",
+		},
+		{
+			name:     "uses name for uuid-like opaque filename",
+			file:     domain.DownloadableFile{Name: "MoreTreeResources 2x", FileName: "c3f2ac27-ca21-42f3-bb09-cc41e09db10d"},
+			expected: "MoreTreeResources 2x",
+		},
+		{
+			name:     "uses name for path-like filename",
+			file:     domain.DownloadableFile{Name: "MoreTreeResources 2x", FileName: "c3/f2/ac/test-mod.zip"},
+			expected: "MoreTreeResources 2x",
+		},
+		{
+			name:     "falls back to name when filename missing",
+			file:     domain.DownloadableFile{Name: "MoreTreeResources 2x"},
+			expected: "MoreTreeResources 2x",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, displayFileLabel(tt.file))
+		})
+	}
+}
+
 // TestFileCategoryPriority tests category priority ordering
 func TestFileCategoryPriority(t *testing.T) {
 	assert.Less(t, fileCategoryPriority("MAIN"), fileCategoryPriority("OPTIONAL"))

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -19,7 +19,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.3.1"
+	version = "1.3.2"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -19,7 +19,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.3.2"
+	version = "1.3.3"
 
 	// Global flags
 	configDir  string

--- a/internal/core/extractor.go
+++ b/internal/core/extractor.go
@@ -23,9 +23,18 @@ func NewExtractor() *Extractor {
 // Extract extracts an archive to the destination directory
 // Supports .zip (native), .7z and .rar (via system 7z command)
 func (e *Extractor) Extract(archivePath, destDir string) error {
+	if _, err := os.Stat(archivePath); err != nil {
+		return fmt.Errorf("accessing archive %q: %w", archivePath, err)
+	}
+
 	format := e.detectFormatFromPath(archivePath)
 	if format == "" {
-		return fmt.Errorf("unsupported archive format: %s", filepath.Ext(archivePath))
+		ext := filepath.Ext(archivePath)
+		if ext != "" {
+			return fmt.Errorf("unsupported archive format: %s", ext)
+		}
+
+		return fmt.Errorf("unsupported archive format for path: %s", archivePath)
 	}
 
 	// Create destination directory

--- a/internal/core/extractor.go
+++ b/internal/core/extractor.go
@@ -23,7 +23,7 @@ func NewExtractor() *Extractor {
 // Extract extracts an archive to the destination directory
 // Supports .zip (native), .7z and .rar (via system 7z command)
 func (e *Extractor) Extract(archivePath, destDir string) error {
-	format := e.DetectFormat(archivePath)
+	format := e.detectFormatFromPath(archivePath)
 	if format == "" {
 		return fmt.Errorf("unsupported archive format: %s", filepath.Ext(archivePath))
 	}
@@ -45,7 +45,7 @@ func (e *Extractor) Extract(archivePath, destDir string) error {
 
 // CanExtract returns true if the extractor can handle the given filename
 func (e *Extractor) CanExtract(filename string) bool {
-	return e.DetectFormat(filename) != ""
+	return e.detectFormatFromPath(filename) != ""
 }
 
 // DetectFormat returns the archive format based on filename extension
@@ -57,6 +57,47 @@ func (e *Extractor) DetectFormat(filename string) string {
 	case ".7z":
 		return "7z"
 	case ".rar":
+		return "rar"
+	default:
+		return ""
+	}
+}
+
+func (e *Extractor) detectFormatFromPath(path string) string {
+	if format := e.DetectFormat(path); format != "" {
+		return format
+	}
+
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return ""
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+
+	header := make([]byte, 8)
+	n, err := io.ReadFull(file, header)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return ""
+	}
+	header = header[:n]
+
+	switch {
+	case len(header) >= 4 && string(header[:4]) == "PK\x03\x04":
+		return "zip"
+	case len(header) >= 4 && string(header[:4]) == "PK\x05\x06":
+		return "zip"
+	case len(header) >= 4 && string(header[:4]) == "PK\x07\x08":
+		return "zip"
+	case len(header) >= 6 && string(header[:6]) == "7z\xBC\xAF\x27\x1C":
+		return "7z"
+	case len(header) >= 7 && string(header[:7]) == "Rar!\x1A\x07\x00":
+		return "rar"
+	case len(header) >= 8 && string(header[:8]) == "Rar!\x1A\x07\x01\x00":
 		return "rar"
 	default:
 		return ""

--- a/internal/core/extractor_test.go
+++ b/internal/core/extractor_test.go
@@ -140,6 +140,21 @@ func TestExtractor_Extract_InvalidZip(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestExtractor_Extract_UnsupportedWithoutExtensionReportsPath(t *testing.T) {
+	srcDir := t.TempDir()
+	destDir := t.TempDir()
+
+	invalidPath := filepath.Join(srcDir, "downloaded-archive")
+	err := os.WriteFile(invalidPath, []byte("not an archive"), 0644)
+	require.NoError(t, err)
+
+	extractor := core.NewExtractor()
+	err = extractor.Extract(invalidPath, destDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported archive format for path")
+	assert.Contains(t, err.Error(), invalidPath)
+}
+
 // TestExtractor_Extract_TruncatedZip verifies corrupt/truncated zip returns error (error-path test).
 func TestExtractor_Extract_TruncatedZip(t *testing.T) {
 	srcDir := t.TempDir()
@@ -222,6 +237,17 @@ func TestExtractor_Extract_ZipWithoutExtension(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(destDir, "nested/file.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "content", string(content))
+}
+
+func TestExtractor_Extract_NonExistentFileReportsPath(t *testing.T) {
+	destDir := t.TempDir()
+	missingPath := "/nonexistent/file.zip"
+
+	extractor := core.NewExtractor()
+	err := extractor.Extract(missingPath, destDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accessing archive")
+	assert.Contains(t, err.Error(), missingPath)
 }
 
 func TestExtractor_DetectFormat(t *testing.T) {

--- a/internal/core/extractor_test.go
+++ b/internal/core/extractor_test.go
@@ -196,6 +196,34 @@ func TestExtractor_CanExtract(t *testing.T) {
 	}
 }
 
+func TestExtractor_CanExtract_ByContentWithoutExtension(t *testing.T) {
+	srcDir := t.TempDir()
+	zipPath := createTestZip(t, srcDir, map[string]string{"file.txt": "content"})
+	noExtPath := filepath.Join(srcDir, "downloaded-archive")
+
+	require.NoError(t, os.Rename(zipPath, noExtPath))
+
+	extractor := core.NewExtractor()
+	assert.True(t, extractor.CanExtract(noExtPath))
+}
+
+func TestExtractor_Extract_ZipWithoutExtension(t *testing.T) {
+	srcDir := t.TempDir()
+	destDir := t.TempDir()
+
+	zipPath := createTestZip(t, srcDir, map[string]string{"nested/file.txt": "content"})
+	noExtPath := filepath.Join(srcDir, "downloaded-archive")
+
+	require.NoError(t, os.Rename(zipPath, noExtPath))
+
+	extractor := core.NewExtractor()
+	require.NoError(t, extractor.Extract(noExtPath, destDir))
+
+	content, err := os.ReadFile(filepath.Join(destDir, "nested/file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+}
+
 func TestExtractor_DetectFormat(t *testing.T) {
 	extractor := core.NewExtractor()
 

--- a/internal/core/importer.go
+++ b/internal/core/importer.go
@@ -425,6 +425,10 @@ func copyFileStreaming(src, dst string) error {
 		return fmt.Errorf("stat source: %w", err)
 	}
 
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("creating destination directory: %w", err)
+	}
+
 	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
 	if err != nil {
 		return fmt.Errorf("creating destination: %w", err)

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -216,7 +216,7 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 			return nil, fmt.Errorf("staging existing cache: %w", err)
 		}
 	}
-	if game.DeployMode == domain.DeployCopy || !s.extractor.CanExtract(file.FileName) {
+	if game.DeployMode == domain.DeployCopy || !s.extractor.CanExtract(archivePath) {
 		// Copy mode: game wants files as-is (e.g., Hytale .zip mods)
 		// Or not an archive - just copy to cache
 		if err := os.MkdirAll(stagePath, 0755); err != nil {

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -583,7 +583,7 @@ func TestService_DownloadMod_MultipleFiles(t *testing.T) {
 	assert.True(t, fileNames["file2_content.txt"], "Cache should contain file2_content.txt")
 }
 
-func TestService_DownloadMod_NestedNonArchiveFilename(t *testing.T) {
+func TestService_DownloadMod_PathLikeFilename_ArchiveWithoutExtension(t *testing.T) {
 	cfg := core.ServiceConfig{
 		ConfigDir: t.TempDir(),
 		DataDir:   t.TempDir(),

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -583,6 +583,67 @@ func TestService_DownloadMod_MultipleFiles(t *testing.T) {
 	assert.True(t, fileNames["file2_content.txt"], "Cache should contain file2_content.txt")
 }
 
+func TestService_DownloadMod_NestedNonArchiveFilename(t *testing.T) {
+	cfg := core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	}
+
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	mock := newMockSourceWithDownloads("test")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+
+	game := &domain.Game{
+		ID:      "testgame",
+		Name:    "Test Game",
+		ModPath: filepath.Join(t.TempDir(), "mods"),
+	}
+	err = svc.AddGame(game)
+	require.NoError(t, err)
+
+	mod := &domain.Mod{
+		ID:       "123",
+		SourceID: "test",
+		Name:     "Nested File Mod",
+		Version:  "1.0.0",
+		GameID:   "testgame",
+	}
+
+	file := &domain.DownloadableFile{
+		ID:       "file1",
+		Name:     "Nested File",
+		FileName: "c3/f2/ac/c3f2ac27-ca21-42f3-bb09-cc41e09db10d",
+	}
+
+	tmpDir := t.TempDir()
+	zipPath := createTestZip(t, tmpDir, map[string]string{"plugin.esp": "payload"})
+	zipContent, err := os.ReadFile(zipPath)
+	require.NoError(t, err)
+
+	mock.AddDownload(file.ID, zipContent)
+
+	result, err := svc.DownloadMod(context.Background(), "test", game, mod, file, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesExtracted)
+	assert.NotEmpty(t, result.Checksum)
+
+	gameCache := svc.GetGameCache(game)
+	files, err := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"plugin.esp"}, files)
+
+	content, err := os.ReadFile(gameCache.GetFilePath(game.ID, mod.SourceID, mod.ID, mod.Version, "plugin.esp"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("payload"), content)
+}
+
 // mockSourceWithDownloads extends mockSource with download URL support
 type mockSourceWithDownloads struct {
 	*mockSource

--- a/internal/source/nexusmods/nexusmods.go
+++ b/internal/source/nexusmods/nexusmods.go
@@ -157,14 +157,16 @@ func (n *NexusMods) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.
 }
 
 func sanitizeFileName(name string) string {
+	const fallbackFileName = "download"
+
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return name
+		return fallbackFileName
 	}
 
 	safe := path.Base(strings.ReplaceAll(name, "\\", "/"))
-	if safe == "." || safe == "/" || safe == "" {
-		return name
+	if safe == "." || safe == ".." || safe == "/" || safe == "" {
+		return fallbackFileName
 	}
 
 	return safe

--- a/internal/source/nexusmods/nexusmods.go
+++ b/internal/source/nexusmods/nexusmods.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"strconv"
+	"strings"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
@@ -142,7 +144,7 @@ func (n *NexusMods) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.
 		files[i] = domain.DownloadableFile{
 			ID:          strconv.Itoa(f.FileID),
 			Name:        f.Name,
-			FileName:    f.FileName,
+			FileName:    sanitizeFileName(f.FileName),
 			Version:     f.Version,
 			Size:        size,
 			IsPrimary:   f.IsPrimary,
@@ -152,6 +154,20 @@ func (n *NexusMods) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.
 	}
 
 	return files, nil
+}
+
+func sanitizeFileName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return name
+	}
+
+	safe := path.Base(strings.ReplaceAll(name, "\\", "/"))
+	if safe == "." || safe == "/" || safe == "" {
+		return name
+	}
+
+	return safe
 }
 
 // GetDownloadURL gets the download URL for a mod file

--- a/internal/source/nexusmods/nexusmods_test.go
+++ b/internal/source/nexusmods/nexusmods_test.go
@@ -84,6 +84,42 @@ func TestNexusMods_GetModFiles(t *testing.T) {
 	assert.Equal(t, "OPTIONAL", files[1].Category)
 }
 
+func TestNexusMods_GetModFiles_SanitizesPathLikeFileName(t *testing.T) {
+	mockResponse := ModFileList{
+		Files: []FileData{
+			{
+				FileID:       100,
+				Name:         "Main File",
+				FileName:     "c3/f2/ac/test-mod-1-0.zip",
+				Version:      "1.0.0",
+				CategoryID:   1,
+				CategoryName: "MAIN",
+				IsPrimary:    true,
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/games/starrupture/mods/12345/files.json", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(t, w, mockResponse)
+	}))
+	defer server.Close()
+
+	nm := New(nil, "testapikey")
+	nm.client.baseURL = server.URL
+
+	mod := &domain.Mod{
+		ID:     "12345",
+		GameID: "starrupture",
+	}
+
+	files, err := nm.GetModFiles(context.Background(), mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "test-mod-1-0.zip", files[0].FileName)
+}
+
 func TestNexusMods_GetDownloadURL(t *testing.T) {
 	mockResponse := []DownloadLink{
 		{

--- a/internal/source/nexusmods/nexusmods_test.go
+++ b/internal/source/nexusmods/nexusmods_test.go
@@ -120,6 +120,52 @@ func TestNexusMods_GetModFiles_SanitizesPathLikeFileName(t *testing.T) {
 	assert.Equal(t, "test-mod-1-0.zip", files[0].FileName)
 }
 
+func TestNexusMods_GetModFiles_SanitizesInvalidFileNameToFallback(t *testing.T) {
+	mockResponse := ModFileList{
+		Files: []FileData{
+			{
+				FileID:       100,
+				Name:         "Main File",
+				FileName:     "////",
+				Version:      "1.0.0",
+				CategoryID:   1,
+				CategoryName: "MAIN",
+				IsPrimary:    true,
+			},
+			{
+				FileID:       101,
+				Name:         "Optional File",
+				FileName:     "..",
+				Version:      "1.0.0",
+				CategoryID:   4,
+				CategoryName: "OPTIONAL",
+				IsPrimary:    false,
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/games/starrupture/mods/12345/files.json", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(t, w, mockResponse)
+	}))
+	defer server.Close()
+
+	nm := New(nil, "testapikey")
+	nm.client.baseURL = server.URL
+
+	mod := &domain.Mod{
+		ID:     "12345",
+		GameID: "starrupture",
+	}
+
+	files, err := nm.GetModFiles(context.Background(), mod)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	assert.Equal(t, "download", files[0].FileName)
+	assert.Equal(t, "download", files[1].FileName)
+}
+
 func TestNexusMods_GetDownloadURL(t *testing.T) {
 	mockResponse := []DownloadLink{
 		{


### PR DESCRIPTION
## What changed

This PR fixes NexusMods file handling in the install pipeline and improves the install UI when source-provided filenames are opaque or malformed.

It also includes the local version/changelog bump that was already present on this branch.

## Why it changed

A real NexusMods install against `windrose/mods/59` surfaced file entries that appeared as path-like or opaque identifiers instead of meaningful filenames. That caused two classes of problems:

- bad filenames leaked into the CLI file-selection UX
- malformed or extension-less filenames could interfere with archive detection and extraction behavior

## User impact

Users should now see cleaner file labels during `lmm install`, and downloads from NexusMods with odd file metadata should cache and extract correctly instead of failing or being treated as raw files.

## Root cause

The code trusted NexusMods `file_name` too early and used it directly for display and extraction decisions. Some responses can contain path-like or otherwise unhelpful values, which are not suitable as-is for CLI presentation or archive classification.

## Validation

- `go test ./internal/core ./internal/source/nexusmods ./cmd/lmm`
