### PR TITLE
[codex] simplify default list output

### DIFF
--- a/cmd/lmm/list.go
+++ b/cmd/lmm/list.go
@@ -134,24 +134,24 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, mod := range mods {
-		enabled := "yes"
-		if !mod.Enabled {
-			enabled = "no"
-		}
-		deployed := "yes"
-		if !mod.Deployed {
-			deployed = "no"
-		}
-		sourceDisplay := mod.SourceID
-		if mod.SourceID == domain.SourceLocal {
-			sourceDisplay = "(local)"
-		}
 		author := mod.Author
 		if author == "" {
 			author = "-"
 		}
 		var row string
 		if verbose {
+			enabled := "yes"
+			if !mod.Enabled {
+				enabled = "no"
+			}
+			deployed := "yes"
+			if !mod.Deployed {
+				deployed = "no"
+			}
+			sourceDisplay := mod.SourceID
+			if mod.SourceID == domain.SourceLocal {
+				sourceDisplay = "(local)"
+			}
 			row = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s", mod.ID, truncate(mod.Name, 40), mod.Version, truncate(author, 20), sourceDisplay, enabled, deployed, mod.LinkMethod.String())
 		} else {
 			row = fmt.Sprintf("%s\t%s\t%s\t%s", mod.ID, truncate(mod.Name, 40), mod.Version, truncate(author, 20))

--- a/cmd/lmm/list.go
+++ b/cmd/lmm/list.go
@@ -120,8 +120,8 @@ func runList(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	header := "ID\tNAME\tVERSION\tSOURCE\tENABLED\tDEPLOYED\tMETHOD"
-	sep := "--\t----\t-------\t------\t-------\t--------\t------"
+	header := "ID\tNAME\tVERSION\tAUTHOR"
+	sep := "--\t----\t-------\t------"
 	if verbose {
 		header = "ID\tNAME\tVERSION\tAUTHOR\tSOURCE\tENABLED\tDEPLOYED\tMETHOD"
 		sep = "--\t----\t-------\t------\t------\t-------\t--------\t------"
@@ -146,15 +146,15 @@ func runList(cmd *cobra.Command, args []string) error {
 		if mod.SourceID == domain.SourceLocal {
 			sourceDisplay = "(local)"
 		}
+		author := mod.Author
+		if author == "" {
+			author = "-"
+		}
 		var row string
 		if verbose {
-			author := mod.Author
-			if author == "" {
-				author = "-"
-			}
 			row = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s", mod.ID, truncate(mod.Name, 40), mod.Version, truncate(author, 20), sourceDisplay, enabled, deployed, mod.LinkMethod.String())
 		} else {
-			row = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s", mod.ID, truncate(mod.Name, 40), mod.Version, sourceDisplay, enabled, deployed, mod.LinkMethod.String())
+			row = fmt.Sprintf("%s\t%s\t%s\t%s", mod.ID, truncate(mod.Name, 40), mod.Version, truncate(author, 20))
 		}
 		if _, err := fmt.Fprintln(w, row); err != nil {
 			return fmt.Errorf("writing row: %w", err)


### PR DESCRIPTION
## What changed

This PR trims the default `lmm list` table output so it only shows the core fields by default:

- `ID`
- `NAME`
- `VERSION`
- `AUTHOR`

The extended operational fields (`SOURCE`, `ENABLED`, `DEPLOYED`, `METHOD`) are still available in verbose mode.

## Why it changed

The default list view was showing too much operational detail for the common case, which made the output noisier than necessary for routine inspection.

## User impact

`lmm list` is easier to scan by default, while `lmm list -v` still exposes the full detailed view.

## Validation

- `go test ./cmd/lmm`
