### PR TITLE
[codex] ignore .codex workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # AI assistant files
 .claude/
+.codex/
 docs/plans
 
 # Go build artifacts


### PR DESCRIPTION
## What changed

Adds `.codex/` to `.gitignore`.

## Why it changed

The local Codex workspace directory was showing up as an untracked path in `git status` because it was not actually ignored in the repository's current `.gitignore`.

## Validation

- verified `.codex/` is now ignored by git once the updated `.gitignore` is present
