### PR TITLE
[codex] bump version for merged list output change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 2026-04-22
+
+### Changed
+
+- **List output defaults**: `lmm list` now shows a narrower default table (`ID`, `NAME`, `VERSION`, `AUTHOR`) and keeps operational fields like source, enabled state, deployment state, and link method behind verbose output
+
 ## [1.3.3] - 2026-04-21
 
 ### Fixed
@@ -576,7 +582,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.3...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.4...HEAD
+[1.3.4]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.1...v1.3.3
 [1.3.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.2.0...v1.3.0

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -19,7 +19,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.3.3"
+	version = "1.3.4"
 
 	// Global flags
 	configDir  string


### PR DESCRIPTION
## What changed

Bumps the CLI version to `1.3.4` and adds the matching changelog entry for the already-merged `lmm list` default-output change from PR #23.

## Why it changed

The list output change merged without a corresponding version/changelog update.

## Validation

- `go test ./cmd/lmm`
