### PR TITLE
[codex] ignore .codex file as well as directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # AI assistant files
 .claude/
+.codex
 .codex/
 docs/plans
 


### PR DESCRIPTION
## What changed

Adds an ignore rule for `.codex` as a file, in addition to the existing `.codex/` directory rule.

## Why it changed

A local empty `.codex` file was still appearing in `git status` because `.codex/` only ignores a directory, not a file with the same name.
