### PR TITLE
chore(tui): Phase 2 close-out — snapshots, keymap wiring, menu single-sourcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Prototype TUI shell**: Added `lmm tui --prototype` with fake-data Dashboard, Installed Mods, Search, and Profiles screens, retro theme presets (`wizardry`, `amber`, `dos`, `green`), and keyboard navigation for early look-and-feel iteration. Prototype mode is intentionally side-effect-free: no DB writes, API calls, installs, updates, or deploys.
+- **TUI theme snapshots**: Committed ANSI captures of all four prototype themes at 80x24 and 120x36 under `docs/assets/tui/`, regenerable via `UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui -run TestGenerateThemeSnapshots`.
 
 ### Changed
 

--- a/cmd/lmm/tui_test.go
+++ b/cmd/lmm/tui_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunTUIRejectsRealModeUntilImplemented(t *testing.T) {
+	tuiOptions.prototype = false
+	t.Cleanup(func() { tuiOptions.prototype = false })
+
+	err := runTUI(tuiCmd, nil)
+	require.ErrorContains(t, err, "use --prototype")
+}
+
+func TestRunTUIRejectsUnknownTheme(t *testing.T) {
+	tuiOptions.prototype = true
+	tuiOptions.theme = "vaporwave"
+	t.Cleanup(func() {
+		tuiOptions.prototype = false
+		tuiOptions.theme = "wizardry"
+	})
+
+	err := runTUI(tuiCmd, nil)
+	require.ErrorContains(t, err, `unknown TUI theme "vaporwave"`)
+}

--- a/docs/assets/tui/amber-120x36.ansi
+++ b/docs/assets/tui/amber-120x36.ansi
@@ -1,0 +1,36 @@
+                                                                                                                        
+  LMM // Linux Mod Manager // Prototype Terminal                                                                        
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
+                                                                                                                        
+  ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮  
+  │ BOOT SEQUENCE // MOD GUILD TERMINAL                                                                              │  
+  │ > GAME     Skyrim Special Edition                                                                                │  
+  │ > PROFILE  survival                                                                                              │  
+  │ > MODS     42 INSTALLED / 39 ENABLED                                                                             │  
+  │ > ALERTS   3 UPDATES // 1 CONFLICT                                                                               │  
+  │                                                                                                                  │  
+  │ > RUN SPELLBOOK SCAN                                                                                             │  
+  │   QUERY ARCHIVE INDEX                                                                                            │  
+  │   LOAD PROFILE ROSTER                                                                                            │  
+  │   ASK CONFLICT ORACLE                                                                                            │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯  
+                                                                                                                        
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                                                           
+                                                                                                                        

--- a/docs/assets/tui/amber-80x24.ansi
+++ b/docs/assets/tui/amber-80x24.ansi
@@ -1,0 +1,24 @@
+                                                                                
+  LMM // Linux Mod Manager // Prototype Terminal                                
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
+                                                                                
+  ╭──────────────────────────────────────────────────────────────────────────╮  
+  │ BOOT SEQUENCE // MOD GUILD TERMINAL                                      │  
+  │ > GAME     Skyrim Special Edition                                        │  
+  │ > PROFILE  survival                                                      │  
+  │ > MODS     42 INSTALLED / 39 ENABLED                                     │  
+  │ > ALERTS   3 UPDATES // 1 CONFLICT                                       │  
+  │                                                                          │  
+  │ > RUN SPELLBOOK SCAN                                                     │  
+  │   QUERY ARCHIVE INDEX                                                    │  
+  │   LOAD PROFILE ROSTER                                                    │  
+  │   ASK CONFLICT ORACLE                                                    │  
+  │                                                                          │  
+  │                                                                          │  
+  │                                                                          │  
+  │                                                                          │  
+  │                                                                          │  
+  ╰──────────────────────────────────────────────────────────────────────────╯  
+                                                                                
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                   
+                                                                                

--- a/docs/assets/tui/dos-120x36.ansi
+++ b/docs/assets/tui/dos-120x36.ansi
@@ -7,7 +7,7 @@
   │ survival                                              │ │ > Installed Mods                                       │  
   │                                                       │ │   Search Archives                                      │  
   │ Game     Skyrim Special Edition                       │ │   Profiles                                             │  
-  │ Enabled  39                                           │ │   Conflict Oracle                                      │  
+  │ Enabled  39                                           │ │   Consult Conflict Oracle                              │  
   │ Updates  3                                            │ │                                                        │  
   │                                                       │ │                                                        │  
   │                                                       │ │                                                        │  

--- a/docs/assets/tui/dos-120x36.ansi
+++ b/docs/assets/tui/dos-120x36.ansi
@@ -1,0 +1,36 @@
+                                                                                                                        
+  LMM // Linux Mod Manager // Prototype Terminal                                                                        
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
+                                                                                                                        
+  ┌───────────────────────────────────────────────────────┐ ┌────────────────────────────────────────────────────────┐  
+  │ ACTIVE PROFILE                                        │ │ OPERATIONS                                             │  
+  │ survival                                              │ │ > Installed Mods                                       │  
+  │                                                       │ │   Search Archives                                      │  
+  │ Game     Skyrim Special Edition                       │ │   Profiles                                             │  
+  │ Enabled  39                                           │ │   Conflict Oracle                                      │  
+  │ Updates  3                                            │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  │                                                       │ │                                                        │  
+  └───────────────────────────────────────────────────────┘ └────────────────────────────────────────────────────────┘  
+                                                                                                                        
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                                                           
+                                                                                                                        

--- a/docs/assets/tui/dos-80x24.ansi
+++ b/docs/assets/tui/dos-80x24.ansi
@@ -1,0 +1,24 @@
+                                                                                
+  LMM // Linux Mod Manager // Prototype Terminal                                
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
+                                                                                
+  ┌───────────────────────────────────┐ ┌────────────────────────────────────┐  
+  │ ACTIVE PROFILE                    │ │ OPERATIONS                         │  
+  │ survival                          │ │ > Installed Mods                   │  
+  │                                   │ │   Search Archives                  │  
+  │ Game     Skyrim Special Edition   │ │   Profiles                         │  
+  │ Enabled  39                       │ │   Conflict Oracle                  │  
+  │ Updates  3                        │ │                                    │  
+  │                                   │ │                                    │  
+  │                                   │ │                                    │  
+  │                                   │ │                                    │  
+  │                                   │ │                                    │  
+  │                                   │ │                                    │  
+  │                                   │ │                                    │  
+  │                                   │ │                                    │  
+  │                                   │ │                                    │  
+  │                                   │ │                                    │  
+  └───────────────────────────────────┘ └────────────────────────────────────┘  
+                                                                                
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                   
+                                                                                

--- a/docs/assets/tui/dos-80x24.ansi
+++ b/docs/assets/tui/dos-80x24.ansi
@@ -7,7 +7,7 @@
   │ survival                          │ │ > Installed Mods                   │  
   │                                   │ │   Search Archives                  │  
   │ Game     Skyrim Special Edition   │ │   Profiles                         │  
-  │ Enabled  39                       │ │   Conflict Oracle                  │  
+  │ Enabled  39                       │ │   Consult Conflict Oracle          │  
   │ Updates  3                        │ │                                    │  
   │                                   │ │                                    │  
   │                                   │ │                                    │  

--- a/docs/assets/tui/green-120x36.ansi
+++ b/docs/assets/tui/green-120x36.ansi
@@ -1,0 +1,36 @@
+                                                                                                                        
+  LMM // Linux Mod Manager // Prototype Terminal                                                                        
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
+                                                                                                                        
+  ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮  
+  │ CRT STATUS STACK                                                                                                 │  
+  │ ▓ GAME       Skyrim Special Edition                                                                              │  
+  │ ▓ PROFILE    survival                                                                                            │  
+  │ ▓ MODS       39/42                                                                                               │  
+  │ ▓ SIGNAL     3 updates, 1 conflict                                                                               │  
+  │                                                                                                                  │  
+  │ > Installed Mods                                                                                                 │  
+  │   Search Archives                                                                                                │  
+  │   Profiles                                                                                                       │  
+  │   Consult Conflict Oracle                                                                                        │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯  
+                                                                                                                        
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                                                           
+                                                                                                                        

--- a/docs/assets/tui/green-80x24.ansi
+++ b/docs/assets/tui/green-80x24.ansi
@@ -1,0 +1,24 @@
+                                                                                
+  LMM // Linux Mod Manager // Prototype Terminal                                
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
+                                                                                
+  ╭──────────────────────────────────────────────────────────────────────────╮  
+  │ CRT STATUS STACK                                                         │  
+  │ ▓ GAME       Skyrim Special Edition                                      │  
+  │ ▓ PROFILE    survival                                                    │  
+  │ ▓ MODS       39/42                                                       │  
+  │ ▓ SIGNAL     3 updates, 1 conflict                                       │  
+  │                                                                          │  
+  │ > Installed Mods                                                         │  
+  │   Search Archives                                                        │  
+  │   Profiles                                                               │  
+  │   Consult Conflict Oracle                                                │  
+  │                                                                          │  
+  │                                                                          │  
+  │                                                                          │  
+  │                                                                          │  
+  │                                                                          │  
+  ╰──────────────────────────────────────────────────────────────────────────╯  
+                                                                                
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                   
+                                                                                

--- a/docs/assets/tui/wizardry-120x36.ansi
+++ b/docs/assets/tui/wizardry-120x36.ansi
@@ -1,0 +1,36 @@
+                                                                                                                        
+  LMM // Linux Mod Manager // Prototype Terminal                                                                        
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
+                                                                                                                        
+  ╭───────────────────────────────────────────────────────╮ ╭───────────────────────────────────────────────────────╮   
+  │ PARTY                                                 │ │ QUEST LOG                                             │   
+  │ Game:    Skyrim Special Edition                       │ │ 3 updates available                                   │   
+  │ Profile: survival                                     │ │ 1 file conflict                                       │   
+  │ Mods:    42 installed / 39 enabled                    │ │ Last deploy: 2h ago                                   │   
+  │                                                       │ │                                                       │   
+  │                                                       │ │                                                       │   
+  │                                                       │ │                                                       │   
+  │                                                       │ │                                                       │   
+  │                                                       │ │                                                       │   
+  │                                                       │ │                                                       │   
+  │                                                       │ │                                                       │   
+  │                                                       │ │                                                       │   
+  ╰───────────────────────────────────────────────────────╯ ╰───────────────────────────────────────────────────────╯   
+  ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮  
+  │ COMMANDS                                                                                                         │  
+  │ > Installed Mods                                                                                                 │  
+  │   Search Archives                                                                                                │  
+  │   Profiles                                                                                                       │  
+  │   Consult Conflict Oracle                                                                                        │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  │                                                                                                                  │  
+  ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯  
+                                                                                                                        
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                                                           
+                                                                                                                        

--- a/docs/assets/tui/wizardry-80x24.ansi
+++ b/docs/assets/tui/wizardry-80x24.ansi
@@ -1,0 +1,24 @@
+                                                                                
+  LMM // Linux Mod Manager // Prototype Terminal                                
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
+                                                                                
+  ╭───────────────────────────────────╮ ╭───────────────────────────────────╮   
+  │ PARTY                             │ │ QUEST LOG                         │   
+  │ Game:    Skyrim Special Edition   │ │ 3 updates available               │   
+  │ Profile: survival                 │ │ 1 file conflict                   │   
+  │ Mods:    42 installed / 39        │ │ Last deploy: 2h ago               │   
+  │ enabled                           │ │                                   │   
+  │                                   │ │                                   │   
+  ╰───────────────────────────────────╯ ╰───────────────────────────────────╯   
+  ╭──────────────────────────────────────────────────────────────────────────╮  
+  │ COMMANDS                                                                 │  
+  │ > Installed Mods                                                         │  
+  │   Search Archives                                                        │  
+  │   Profiles                                                               │  
+  │   Consult Conflict Oracle                                                │  
+  │                                                                          │  
+  │                                                                          │  
+  ╰──────────────────────────────────────────────────────────────────────────╯  
+                                                                                
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                   
+                                                                                

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -14,6 +14,14 @@ import (
 
 const defaultContentWidth = 76
 
+// menuItem is one dashboard menu entry. hasTarget is false for flavor-only
+// entries (like the Conflict Oracle) that have no screen yet.
+type menuItem struct {
+	label     string
+	target    Screen
+	hasTarget bool
+}
+
 // Layout describes the major panel arrangement for a prototype theme.
 type Layout string
 
@@ -65,6 +73,45 @@ func NewPrototypeModel(options Options) (Model, error) {
 	}, nil
 }
 
+func (m Model) dashboardMenu() []menuItem {
+	if m.layout == LayoutMonochromeTerminal {
+		return []menuItem{
+			{label: "RUN SPELLBOOK SCAN", target: ScreenInstalledMods, hasTarget: true},
+			{label: "QUERY ARCHIVE INDEX", target: ScreenSearch, hasTarget: true},
+			{label: "LOAD PROFILE ROSTER", target: ScreenProfiles, hasTarget: true},
+			{label: "ASK CONFLICT ORACLE"},
+		}
+	}
+	return []menuItem{
+		{label: "Installed Mods", target: ScreenInstalledMods, hasTarget: true},
+		{label: "Search Archives", target: ScreenSearch, hasTarget: true},
+		{label: "Profiles", target: ScreenProfiles, hasTarget: true},
+		{label: "Consult Conflict Oracle"},
+	}
+}
+
+func (m Model) dashboardMenuRows() []string {
+	items := m.dashboardMenu()
+	rows := make([]string, 0, len(items))
+	for i, item := range items {
+		rows = append(rows, m.row(i, item.label))
+	}
+	return rows
+}
+
+func (m Model) openSelectedMenuEntry() Model {
+	if m.screen != ScreenDashboard {
+		return m
+	}
+	items := m.dashboardMenu()
+	selected := m.selected[ScreenDashboard]
+	if selected >= len(items) || !items[selected].hasTarget {
+		return m
+	}
+	m.screen = items[selected].target
+	return m
+}
+
 func (m Model) Init() tea.Cmd {
 	return nil
 }
@@ -113,6 +160,8 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Down):
 		m.moveSelection(1)
 		return m, nil
+	case key.Matches(msg, m.keys.Select):
+		return m.openSelectedMenuEntry(), nil
 	default:
 		return m, nil
 	}
@@ -200,7 +249,7 @@ func (m Model) itemCount(screen Screen) int {
 	case ScreenProfiles:
 		return len(m.data.Profiles)
 	default:
-		return 4
+		return len(m.dashboardMenu())
 	}
 }
 
@@ -269,13 +318,9 @@ func (m Model) partyDashboardView() string {
 		"Last deploy: 2h ago",
 	}, "\n")
 
-	menu := strings.Join([]string{
-		m.theme.PanelTitle.Render("COMMANDS"),
-		m.row(0, "Installed Mods"),
-		m.row(1, "Search Archives"),
-		m.row(2, "Profiles"),
-		m.row(3, "Consult Conflict Oracle"),
-	}, "\n")
+	menu := strings.Join(
+		append([]string{m.theme.PanelTitle.Render("COMMANDS")}, m.dashboardMenuRows()...),
+		"\n")
 
 	return lipgloss.JoinHorizontal(lipgloss.Top,
 		m.panelWithHeight(panelWidth, topHeight).Render(party),
@@ -292,11 +337,8 @@ func (m Model) terminalDashboardView() string {
 		fmt.Sprintf("> MODS     %d INSTALLED / %d ENABLED", m.data.Stats.Installed, m.data.Stats.Enabled),
 		fmt.Sprintf("> ALERTS   %s UPDATES // %s CONFLICT", m.theme.WarningText.Render(fmt.Sprintf("%d", m.data.Stats.Updates)), m.theme.DangerText.Render(fmt.Sprintf("%d", m.data.Stats.Conflicts))),
 		"",
-		m.row(0, "RUN SPELLBOOK SCAN"),
-		m.row(1, "QUERY ARCHIVE INDEX"),
-		m.row(2, "LOAD PROFILE ROSTER"),
-		m.row(3, "ASK CONFLICT ORACLE"),
 	}
+	rows = append(rows, m.dashboardMenuRows()...)
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
 }
 
@@ -315,13 +357,9 @@ func (m Model) commanderDashboardView() string {
 		fmt.Sprintf("Enabled  %d", m.data.Stats.Enabled),
 		fmt.Sprintf("Updates  %d", m.data.Stats.Updates),
 	}, "\n")
-	right := strings.Join([]string{
-		m.theme.PanelTitle.Render("OPERATIONS"),
-		m.row(0, "Installed Mods"),
-		m.row(1, "Search Archives"),
-		m.row(2, "Profiles"),
-		m.row(3, "Conflict Oracle"),
-	}, "\n")
+	right := strings.Join(
+		append([]string{m.theme.PanelTitle.Render("OPERATIONS")}, m.dashboardMenuRows()...),
+		"\n")
 
 	return lipgloss.JoinHorizontal(lipgloss.Top,
 		m.panelWithHeight(leftWidth, height).Render(left),
@@ -338,11 +376,8 @@ func (m Model) crtDashboardView() string {
 		fmt.Sprintf("▓ %-10s %d/%d", "MODS", m.data.Stats.Enabled, m.data.Stats.Installed),
 		fmt.Sprintf("▓ %-10s %d updates, %d conflict", "SIGNAL", m.data.Stats.Updates, m.data.Stats.Conflicts),
 		"",
-		m.row(0, "Installed Mods"),
-		m.row(1, "Search Archives"),
-		m.row(2, "Profiles"),
-		m.row(3, "Consult Conflict Oracle"),
 	}
+	rows = append(rows, m.dashboardMenuRows()...)
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -264,8 +264,8 @@ func (m Model) partyDashboardView() string {
 
 	quest := strings.Join([]string{
 		m.theme.PanelTitle.Render("QUEST LOG"),
-		fmt.Sprintf("%s updates available", statusValue(m.data.Stats.Updates, m.theme.Warning)),
-		fmt.Sprintf("%s file conflict", statusValue(m.data.Stats.Conflicts, m.theme.Danger)),
+		fmt.Sprintf("%s updates available", m.theme.WarningText.Render(fmt.Sprintf("%d", m.data.Stats.Updates))),
+		fmt.Sprintf("%s file conflict", m.theme.DangerText.Render(fmt.Sprintf("%d", m.data.Stats.Conflicts))),
 		"Last deploy: 2h ago",
 	}, "\n")
 
@@ -290,7 +290,7 @@ func (m Model) terminalDashboardView() string {
 		fmt.Sprintf("> GAME     %s", m.data.Game.Name),
 		fmt.Sprintf("> PROFILE  %s", m.data.Profile.Name),
 		fmt.Sprintf("> MODS     %d INSTALLED / %d ENABLED", m.data.Stats.Installed, m.data.Stats.Enabled),
-		fmt.Sprintf("> ALERTS   %s UPDATES // %s CONFLICT", statusValue(m.data.Stats.Updates, m.theme.Warning), statusValue(m.data.Stats.Conflicts, m.theme.Danger)),
+		fmt.Sprintf("> ALERTS   %s UPDATES // %s CONFLICT", m.theme.WarningText.Render(fmt.Sprintf("%d", m.data.Stats.Updates)), m.theme.DangerText.Render(fmt.Sprintf("%d", m.data.Stats.Conflicts))),
 		"",
 		m.row(0, "RUN SPELLBOOK SCAN"),
 		m.row(1, "QUERY ARCHIVE INDEX"),
@@ -449,15 +449,4 @@ func layoutForTheme(name string) Layout {
 	default:
 		return LayoutPartySheet
 	}
-}
-
-func statusValue(value int, color lipgloss.Color) string {
-	return lipgloss.NewStyle().Foreground(color).Bold(true).Render(fmt.Sprintf("%d", value))
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -39,6 +40,7 @@ type Model struct {
 	showHelp bool
 	width    int
 	height   int
+	keys     KeyMap
 }
 
 // NewPrototypeModel creates a side-effect-free TUI model backed by fake data.
@@ -59,6 +61,7 @@ func NewPrototypeModel(options Options) (Model, error) {
 			ScreenSearch:        0,
 			ScreenProfiles:      0,
 		},
+		keys: DefaultKeyMap(),
 	}, nil
 }
 
@@ -80,34 +83,34 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "ctrl+c", "q":
+	switch {
+	case key.Matches(msg, m.keys.Quit):
 		return m, tea.Quit
-	case "?":
+	case key.Matches(msg, m.keys.Help):
 		m.showHelp = !m.showHelp
 		return m, nil
-	case "tab", "right", "l":
+	case key.Matches(msg, m.keys.NextScreen):
 		m.screen = screenAt((m.screenIndex() + 1) % len(screens))
 		return m, nil
-	case "shift+tab", "left", "h":
+	case key.Matches(msg, m.keys.PrevScreen):
 		m.screen = screenAt((m.screenIndex() - 1 + len(screens)) % len(screens))
 		return m, nil
-	case "1":
+	case key.Matches(msg, m.keys.Dashboard):
 		m.screen = ScreenDashboard
 		return m, nil
-	case "2":
+	case key.Matches(msg, m.keys.InstalledMods):
 		m.screen = ScreenInstalledMods
 		return m, nil
-	case "3", "/":
+	case key.Matches(msg, m.keys.Search):
 		m.screen = ScreenSearch
 		return m, nil
-	case "4":
+	case key.Matches(msg, m.keys.Profiles):
 		m.screen = ScreenProfiles
 		return m, nil
-	case "up", "k":
+	case key.Matches(msg, m.keys.Up):
 		m.moveSelection(-1)
 		return m, nil
-	case "down", "j":
+	case key.Matches(msg, m.keys.Down):
 		m.moveSelection(1)
 		return m, nil
 	default:

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -275,3 +275,44 @@ func TestNumberKeysJumpToScreens(t *testing.T) {
 		require.Equal(t, want, updateWithRunes(t, model, keyPress).CurrentScreen(), "key %q", keyPress)
 	}
 }
+
+func TestDashboardEnterOpensSelectedMenuEntry(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	// Initial selection is the first menu entry: Installed Mods.
+	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ScreenInstalledMods, opened.(Model).CurrentScreen())
+
+	// Second entry opens Search.
+	moved := updateWithRunes(t, model, "j")
+	opened, _ = moved.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ScreenSearch, opened.(Model).CurrentScreen())
+}
+
+func TestDashboardEnterOnOracleEntryStaysPut(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	// Move to the last entry (Conflict Oracle) — no screen exists for it yet.
+	for range 3 {
+		model = updateWithRunes(t, model, "j")
+	}
+	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ScreenDashboard, opened.(Model).CurrentScreen())
+}
+
+func TestEnterOutsideDashboardIsANoop(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+	model = updateWithRunes(t, model, "2")
+
+	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ScreenInstalledMods, opened.(Model).CurrentScreen())
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"testing"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
@@ -239,4 +240,38 @@ func updateWithMsg(t *testing.T, model Model, msg tea.KeyMsg) Model {
 	updatedModel, ok := updated.(Model)
 	require.True(t, ok)
 	return updatedModel
+}
+
+// TestUpdateKeyConsultsKeyMap proves key handling reads the KeyMap rather
+// than hard-coded strings: rebinding NextScreen must change which key cycles.
+func TestUpdateKeyConsultsKeyMap(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	model.keys.NextScreen = key.NewBinding(key.WithKeys("n"))
+
+	moved := updateWithRunes(t, model, "n")
+	require.Equal(t, ScreenInstalledMods, moved.CurrentScreen())
+
+	// The old default must no longer cycle once rebound away.
+	stay := updateWithRunes(t, model, "l")
+	require.Equal(t, ScreenDashboard, stay.CurrentScreen())
+}
+
+func TestNumberKeysJumpToScreens(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	for keyPress, want := range map[string]Screen{
+		"1": ScreenDashboard,
+		"2": ScreenInstalledMods,
+		"3": ScreenSearch,
+		"4": ScreenProfiles,
+	} {
+		require.Equal(t, want, updateWithRunes(t, model, keyPress).CurrentScreen(), "key %q", keyPress)
+	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -4,13 +4,16 @@ import "github.com/charmbracelet/bubbles/key"
 
 // KeyMap documents the prototype TUI keyboard contract.
 type KeyMap struct {
-	Quit       key.Binding
-	Help       key.Binding
-	NextScreen key.Binding
-	PrevScreen key.Binding
-	Up         key.Binding
-	Down       key.Binding
-	Search     key.Binding
+	Quit          key.Binding
+	Help          key.Binding
+	NextScreen    key.Binding
+	PrevScreen    key.Binding
+	Up            key.Binding
+	Down          key.Binding
+	Search        key.Binding
+	Dashboard     key.Binding
+	InstalledMods key.Binding
+	Profiles      key.Binding
 }
 
 // DefaultKeyMap returns the shared key bindings shown in help and used by tests.
@@ -43,6 +46,18 @@ func DefaultKeyMap() KeyMap {
 		Search: key.NewBinding(
 			key.WithKeys("/", "3"),
 			key.WithHelp("/", "search"),
+		),
+		Dashboard: key.NewBinding(
+			key.WithKeys("1"),
+			key.WithHelp("1", "dashboard"),
+		),
+		InstalledMods: key.NewBinding(
+			key.WithKeys("2"),
+			key.WithHelp("2", "installed mods"),
+		),
+		Profiles: key.NewBinding(
+			key.WithKeys("4"),
+			key.WithHelp("4", "profiles"),
 		),
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -14,6 +14,7 @@ type KeyMap struct {
 	Dashboard     key.Binding
 	InstalledMods key.Binding
 	Profiles      key.Binding
+	Select        key.Binding
 }
 
 // DefaultKeyMap returns the shared key bindings shown in help and used by tests.
@@ -58,6 +59,10 @@ func DefaultKeyMap() KeyMap {
 		Profiles: key.NewBinding(
 			key.WithKeys("4"),
 			key.WithHelp("4", "profiles"),
+		),
+		Select: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "open"),
 		),
 	}
 }

--- a/internal/tui/navigation_test.go
+++ b/internal/tui/navigation_test.go
@@ -1,0 +1,24 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScreenAtClampsOutOfRangeIndexes(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, ScreenDashboard, screenAt(-1))
+	require.Equal(t, ScreenProfiles, screenAt(len(screens)))
+	require.Equal(t, ScreenInstalledMods, screenAt(1))
+}
+
+func TestScreenStringNamesEveryScreen(t *testing.T) {
+	t.Parallel()
+
+	for _, s := range screens {
+		require.NotContains(t, s.String(), "Screen(", "screen %d needs a display name", int(s))
+	}
+	require.Equal(t, "Screen(99)", Screen(99).String())
+}

--- a/internal/tui/prototype/data_test.go
+++ b/internal/tui/prototype/data_test.go
@@ -1,0 +1,28 @@
+package prototype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadProvidesConsistentDemoData(t *testing.T) {
+	t.Parallel()
+
+	data := Load()
+
+	require.NotEmpty(t, data.InstalledMods)
+	require.NotEmpty(t, data.SearchResults)
+	require.NotEmpty(t, data.Profiles)
+
+	active := 0
+	for _, p := range data.Profiles {
+		if p.Active {
+			active++
+			require.Equal(t, data.Profile.Name, p.Name, "active roster entry must match the current profile")
+		}
+	}
+	require.Equal(t, 1, active, "exactly one profile should be active")
+
+	require.Equal(t, data.Stats.Installed, data.Profile.ModCount, "dashboard stats should agree with the profile mod count")
+}

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -1,0 +1,46 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateThemeSnapshots regenerates the committed theme captures under
+// docs/assets/tui. It only runs when UPDATE_TUI_SNAPSHOTS=1 so normal test
+// runs never write into the repo.
+//
+//	UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui -run TestGenerateThemeSnapshots
+func TestGenerateThemeSnapshots(t *testing.T) {
+	if os.Getenv("UPDATE_TUI_SNAPSHOTS") != "1" {
+		t.Skip("set UPDATE_TUI_SNAPSHOTS=1 to regenerate theme snapshots")
+	}
+
+	outDir := filepath.Join("..", "..", "docs", "assets", "tui")
+	require.NoError(t, os.MkdirAll(outDir, 0o755))
+
+	sizes := []struct{ width, height int }{{80, 24}, {120, 36}}
+	for _, themeName := range []string{"wizardry", "amber", "dos", "green"} {
+		for _, size := range sizes {
+			model, err := NewPrototypeModel(Options{Theme: themeName})
+			require.NoError(t, err)
+
+			// Run the init command if the model has one, so snapshots keep
+			// capturing loaded data once async loading lands (Phase 3).
+			if cmd := model.Init(); cmd != nil {
+				loaded, _ := model.Update(cmd())
+				model = loaded.(Model)
+			}
+
+			updated, _ := model.Update(tea.WindowSizeMsg{Width: size.width, Height: size.height})
+			view := updated.(Model).View()
+
+			name := fmt.Sprintf("%s-%dx%d.ansi", themeName, size.width, size.height)
+			require.NoError(t, os.WriteFile(filepath.Join(outDir, name), []byte(view+"\n"), 0o644))
+		}
+	}
+}

--- a/internal/tui/theme/theme.go
+++ b/internal/tui/theme/theme.go
@@ -18,14 +18,16 @@ type Theme struct {
 	Danger     lipgloss.Color
 	Success    lipgloss.Color
 
-	App        lipgloss.Style
-	Title      lipgloss.Style
-	Panel      lipgloss.Style
-	PanelTitle lipgloss.Style
-	Selected   lipgloss.Style
-	MutedText  lipgloss.Style
-	Help       lipgloss.Style
-	Badge      lipgloss.Style
+	App         lipgloss.Style
+	Title       lipgloss.Style
+	Panel       lipgloss.Style
+	PanelTitle  lipgloss.Style
+	Selected    lipgloss.Style
+	MutedText   lipgloss.Style
+	Help        lipgloss.Style
+	Badge       lipgloss.Style
+	WarningText lipgloss.Style
+	DangerText  lipgloss.Style
 }
 
 // ByName returns a named theme preset.
@@ -56,9 +58,6 @@ func base(name string, foreground, background, accent lipgloss.Color) Theme {
 		Foreground: foreground,
 		Accent:     accent,
 		Muted:      muted,
-		Warning:    warning,
-		Danger:     danger,
-		Success:    success,
 		App: lipgloss.NewStyle().
 			Foreground(foreground).
 			Padding(1, 2),
@@ -84,7 +83,7 @@ func base(name string, foreground, background, accent lipgloss.Color) Theme {
 			Padding(0, 1),
 	}
 
-	return t.withMuted(muted)
+	return t.withMuted(muted).withStatusColors(warning, danger, success)
 }
 
 func (t Theme) withMuted(muted lipgloss.Color) Theme {
@@ -96,11 +95,21 @@ func (t Theme) withMuted(muted lipgloss.Color) Theme {
 	return t
 }
 
+// withStatusColors sets the status palette and the derived text styles
+// together so they can never drift apart.
+func (t Theme) withStatusColors(warning, danger, success lipgloss.Color) Theme {
+	t.Warning = warning
+	t.Danger = danger
+	t.Success = success
+	t.WarningText = lipgloss.NewStyle().Foreground(warning).Background(t.Background).Bold(true)
+	t.DangerText = lipgloss.NewStyle().Foreground(danger).Background(t.Background).Bold(true)
+	return t
+}
+
 // Wizardry returns the default RPG party-sheet theme.
 func Wizardry() Theme {
 	t := base("wizardry", lipgloss.Color("230"), lipgloss.Color("0"), lipgloss.Color("141"))
-	t.Warning = lipgloss.Color("215")
-	t.Success = lipgloss.Color("150")
+	t = t.withStatusColors(lipgloss.Color("215"), t.Danger, lipgloss.Color("150"))
 	return t
 }
 

--- a/internal/tui/theme/theme_test.go
+++ b/internal/tui/theme/theme_test.go
@@ -82,3 +82,23 @@ func colorIndex(t *testing.T, color lipgloss.Color) int {
 	require.NoError(t, err)
 	return index
 }
+
+func TestStatusTextStylesMatchStatusColors(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"wizardry", "amber", "dos", "green"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			th, err := ByName(name)
+			require.NoError(t, err)
+
+			require.Equal(t, th.Warning, th.WarningText.GetForeground(), "WarningText foreground")
+			require.Equal(t, th.Danger, th.DangerText.GetForeground(), "DangerText foreground")
+			require.Equal(t, th.Background, th.WarningText.GetBackground(), "WarningText background")
+			require.Equal(t, th.Background, th.DangerText.GetBackground(), "DangerText background")
+			require.True(t, th.WarningText.GetBold())
+			require.True(t, th.DangerText.GetBold())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Committed ANSI captures of all four themes (80x24 and 120x36) with a regeneration-gated test — the last open acceptance criterion of #32.
- Key handling now flows through KeyMap (single source of truth); dashboard menu is defined once with Enter-to-open.
- Status text styles moved into the theme; hand-rolled max deleted (Go builtin takes over).
- Added the test files the TUI plan called for: cmd/lmm/tui_test.go, navigation_test.go, prototype/data_test.go.

Known cosmetic observation from the capture review: at 80x24 the wizardry PARTY panel wraps "Mods: 42 installed / 39 enabled" onto a second line (stays inside the panel border). Left as-is; worth revisiting if the dashboard copy changes.

Closes #32

## Test Plan
- [x] go test ./...
- [x] go vet ./...
- [x] Manual: ./lmm tui --prototype --theme wizardry (navigate, enter on menu, ?, q)

🤖 Generated with [Claude Code](https://claude.com/claude-code)