### PR TITLE
feat(tui): read-only service-backed TUI (Phase 3)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -29,6 +29,8 @@ Interactive terminal interface using Bubble Tea framework. Removed to focus on C
 - Settings view
 - Configurable keybindings (vim and standard modes)
 
-**Status:** Code removed, to be reimplemented once CLI is stable.
+**Status:** Reimplemented. Prototype shell (v1.3.x, #31/#32) and read-only
+service-backed TUI (v1.4.0) are done; search, mutations, and workflows are
+tracked by the Phase 4-6 sections of docs/plans/2026-04-28-tui-implementation.md.
 
 **Original implementation:** See git history before commit that removed TUI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-13
+
 ### Added
 
-- **Prototype TUI shell**: Added `lmm tui --prototype` with fake-data Dashboard, Installed Mods, Search, and Profiles screens, retro theme presets (`wizardry`, `amber`, `dos`, `green`), and keyboard navigation for early look-and-feel iteration. Prototype mode is intentionally side-effect-free: no DB writes, API calls, installs, updates, or deploys.
-- **TUI theme snapshots**: Committed ANSI captures of all four prototype themes at 80x24 and 120x36 under `docs/assets/tui/`, regenerable via `UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui -run TestGenerateThemeSnapshots`.
+- **`lmm tui` (read-only)**: The TUI now runs against real app data — Dashboard, Installed Mods, and Profiles views load the configured game, default profile, and installed mods through a narrow read-only provider. Search shows an honest placeholder until source search is wired in. `--prototype` remains as a side-effect-free demo mode.
+- **TUI theme snapshots**: Committed ANSI captures of all four themes at 80x24 and 120x36 under `docs/assets/tui/`, regenerable with `UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui -run TestGenerateThemeSnapshots`.
+- **Dashboard enter-to-open**: The dashboard menu is defined once, and Enter opens the selected entry's screen.
 
 ### Changed
 
-- **Prototype TUI visual pass**: The TUI now expands to the current terminal size, uses more readable muted colors on dark terminals, assigns each retro theme its own dashboard layout rather than only swapping colors, stretches screen panels/sections to use the available content area instead of rendering as fixed-size islands, avoids painting non-selected chrome backgrounds so terminal themes do not show stray ANSI blocks, documents `wizardry` as the selected default theme while retaining `amber`, `dos`, and `green` as alternates, and records that the implementation phase should let users configure their own default TUI theme.
+- **TUI internals**: Key handling flows through the shared KeyMap; status text styles live in the theme; the TUI uses the terminal's alternate screen.
 
 ## [1.3.10] - 2026-04-26
 
@@ -643,7 +646,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.10...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.10...v1.4.0
 [1.3.10]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.9...v1.3.10
 [1.3.9]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.8...v1.3.9
 [1.3.8]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.7...v1.3.8

--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ lmm mod set-update 12345 --game skyrim-se --notify
 lmm mod set-update 12345 --game skyrim-se --pin
 ```
 
+### Terminal UI
+
+Browse your configured game, installed mods, and profiles interactively:
+
+```bash
+lmm tui                     # real data, read-only
+lmm tui --theme amber       # themes: wizardry (default), amber, dos, green
+lmm tui --prototype         # demo mode with static fake data
+```
+
+Keys: `tab`/`h`/`l` cycle screens, `1`–`4` jump, `↑↓`/`j`/`k` move, `enter` open,
+`/` search screen, `?` help, `q` quit. Browsing is read-only — install/update/deploy
+actions from the TUI arrive in a later release.
+
 ## Configuration
 
 Configuration files are stored in `~/.config/lmm/`:

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -22,7 +22,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.3.10"
+	version = "1.4.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/tui.go
+++ b/cmd/lmm/tui.go
@@ -49,8 +49,8 @@ func runTUI(cmd *cobra.Command, args []string) error {
 	}
 
 	return withGameService(cmd, func(ctx context.Context, svc *core.Service, game *domain.Game) error {
-		// Match the CLI's behavior (profileOrDefault): fall back to the
-		// literal "default" profile when none exists yet, so a fresh setup
+		// Fall back to the CLI's default-profile convention (cf.
+		// profileOrDefault) when no profile exists yet, so a fresh setup
 		// opens an empty TUI instead of erroring.
 		profileName := "default"
 		if profile, err := svc.NewProfileManager().GetDefault(game.ID); err == nil {

--- a/cmd/lmm/tui.go
+++ b/cmd/lmm/tui.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/tui"
 )
 
@@ -19,9 +23,13 @@ var tuiCmd = &cobra.Command{
 	Short: "Launch the interactive terminal UI",
 	Long: `Launch the interactive terminal UI.
 
-The TUI is currently available as a safe prototype backed by static fake data:
+Shows the configured game's installed mods, profiles, and status using the
+same config, database, and game resolution as the CLI commands. Read-only:
+browsing never installs, updates, deploys, or deletes anything.
 
-  lmm tui --prototype --theme wizardry`,
+Use --prototype for a demo mode backed by static fake data:
+
+  lmm tui --prototype --theme amber`,
 	RunE: runTUI,
 }
 
@@ -32,17 +40,38 @@ func init() {
 }
 
 func runTUI(cmd *cobra.Command, args []string) error {
-	if !tuiOptions.prototype {
-		return fmt.Errorf("real TUI mode is not implemented yet; use --prototype")
+	if tuiOptions.prototype {
+		model, err := tui.NewModel(tui.Options{Theme: tuiOptions.theme, Provider: tui.NewPrototypeProvider()})
+		if err != nil {
+			return err
+		}
+		return runTUIProgram(cmd.Context(), model)
 	}
 
-	model, err := tui.NewModel(tui.Options{Theme: tuiOptions.theme, Provider: tui.NewPrototypeProvider()})
-	if err != nil {
-		return err
-	}
+	return withGameService(cmd, func(ctx context.Context, svc *core.Service, game *domain.Game) error {
+		// Match the CLI's behavior (profileOrDefault): fall back to the
+		// literal "default" profile when none exists yet, so a fresh setup
+		// opens an empty TUI instead of erroring.
+		profileName := "default"
+		if profile, err := svc.NewProfileManager().GetDefault(game.ID); err == nil {
+			profileName = profile.Name
+		} else if !errors.Is(err, domain.ErrProfileNotFound) {
+			return fmt.Errorf("resolving default profile for %s: %w", game.ID, err)
+		}
 
-	_, err = tea.NewProgram(model, tea.WithContext(cmd.Context())).Run()
-	if err != nil {
+		model, err := tui.NewModel(tui.Options{
+			Theme:    tuiOptions.theme,
+			Provider: tui.NewCoreProvider(svc, game, profileName),
+		})
+		if err != nil {
+			return err
+		}
+		return runTUIProgram(ctx, model)
+	})
+}
+
+func runTUIProgram(ctx context.Context, model tui.Model) error {
+	if _, err := tea.NewProgram(model, tea.WithContext(ctx), tea.WithAltScreen()).Run(); err != nil {
 		return fmt.Errorf("running TUI: %w", err)
 	}
 	return nil

--- a/cmd/lmm/tui.go
+++ b/cmd/lmm/tui.go
@@ -36,7 +36,7 @@ func runTUI(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("real TUI mode is not implemented yet; use --prototype")
 	}
 
-	model, err := tui.NewPrototypeModel(tui.Options{Theme: tuiOptions.theme, Prototype: true})
+	model, err := tui.NewModel(tui.Options{Theme: tuiOptions.theme, Provider: tui.NewPrototypeProvider()})
 	if err != nil {
 		return err
 	}

--- a/cmd/lmm/tui_test.go
+++ b/cmd/lmm/tui_test.go
@@ -6,12 +6,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRunTUIRejectsRealModeUntilImplemented(t *testing.T) {
+// TestRunTUIRealModeRequiresAGame tests that real mode (no --prototype) goes
+// through the same game-resolution path as other CLI commands, failing
+// before the TUI program starts when no game is specified.
+func TestRunTUIRealModeRequiresAGame(t *testing.T) {
 	tuiOptions.prototype = false
-	t.Cleanup(func() { tuiOptions.prototype = false })
+	tuiOptions.theme = "wizardry"
+	// Reset flags. configDir must point at an empty tempdir so requireGame
+	// does not pick up a default-game from the user's real ~/.config/lmm.
+	gameID = ""
+	configDir = t.TempDir()
+	t.Cleanup(func() {
+		tuiOptions.prototype = false
+		tuiOptions.theme = "wizardry"
+	})
 
 	err := runTUI(tuiCmd, nil)
-	require.ErrorContains(t, err, "use --prototype")
+	require.ErrorContains(t, err, "no game specified")
 }
 
 func TestRunTUIRejectsUnknownTheme(t *testing.T) {

--- a/docs/assets/tui/amber-120x36.ansi
+++ b/docs/assets/tui/amber-120x36.ansi
@@ -1,5 +1,5 @@
                                                                                                                         
-  LMM // Linux Mod Manager // Prototype Terminal                                                                        
+  LMM // Linux Mod Manager                                                                                              
   [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
                                                                                                                         
   ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮  

--- a/docs/assets/tui/amber-80x24.ansi
+++ b/docs/assets/tui/amber-80x24.ansi
@@ -1,5 +1,5 @@
                                                                                 
-  LMM // Linux Mod Manager // Prototype Terminal                                
+  LMM // Linux Mod Manager                                                      
   [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
                                                                                 
   ╭──────────────────────────────────────────────────────────────────────────╮  

--- a/docs/assets/tui/dos-120x36.ansi
+++ b/docs/assets/tui/dos-120x36.ansi
@@ -1,5 +1,5 @@
                                                                                                                         
-  LMM // Linux Mod Manager // Prototype Terminal                                                                        
+  LMM // Linux Mod Manager                                                                                              
   [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
                                                                                                                         
   ┌───────────────────────────────────────────────────────┐ ┌────────────────────────────────────────────────────────┐  

--- a/docs/assets/tui/dos-80x24.ansi
+++ b/docs/assets/tui/dos-80x24.ansi
@@ -1,5 +1,5 @@
                                                                                 
-  LMM // Linux Mod Manager // Prototype Terminal                                
+  LMM // Linux Mod Manager                                                      
   [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
                                                                                 
   ┌───────────────────────────────────┐ ┌────────────────────────────────────┐  

--- a/docs/assets/tui/green-120x36.ansi
+++ b/docs/assets/tui/green-120x36.ansi
@@ -1,5 +1,5 @@
                                                                                                                         
-  LMM // Linux Mod Manager // Prototype Terminal                                                                        
+  LMM // Linux Mod Manager                                                                                              
   [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
                                                                                                                         
   ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮  

--- a/docs/assets/tui/green-80x24.ansi
+++ b/docs/assets/tui/green-80x24.ansi
@@ -1,5 +1,5 @@
                                                                                 
-  LMM // Linux Mod Manager // Prototype Terminal                                
+  LMM // Linux Mod Manager                                                      
   [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
                                                                                 
   ╭──────────────────────────────────────────────────────────────────────────╮  

--- a/docs/assets/tui/wizardry-120x36.ansi
+++ b/docs/assets/tui/wizardry-120x36.ansi
@@ -1,12 +1,12 @@
                                                                                                                         
-  LMM // Linux Mod Manager // Prototype Terminal                                                                        
+  LMM // Linux Mod Manager                                                                                              
   [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
                                                                                                                         
   ╭───────────────────────────────────────────────────────╮ ╭───────────────────────────────────────────────────────╮   
   │ PARTY                                                 │ │ QUEST LOG                                             │   
   │ Game:    Skyrim Special Edition                       │ │ 3 updates available                                   │   
   │ Profile: survival                                     │ │ 1 file conflict                                       │   
-  │ Mods:    42 installed / 39 enabled                    │ │ Last deploy: 2h ago                                   │   
+  │ Mods:    42 installed / 39 enabled                    │ │ Last deploy: ?                                        │   
   │                                                       │ │                                                       │   
   │                                                       │ │                                                       │   
   │                                                       │ │                                                       │   

--- a/docs/assets/tui/wizardry-80x24.ansi
+++ b/docs/assets/tui/wizardry-80x24.ansi
@@ -1,12 +1,12 @@
                                                                                 
-  LMM // Linux Mod Manager // Prototype Terminal                                
+  LMM // Linux Mod Manager                                                      
   [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
                                                                                 
   ╭───────────────────────────────────╮ ╭───────────────────────────────────╮   
   │ PARTY                             │ │ QUEST LOG                         │   
   │ Game:    Skyrim Special Edition   │ │ 3 updates available               │   
   │ Profile: survival                 │ │ 1 file conflict                   │   
-  │ Mods:    42 installed / 39        │ │ Last deploy: 2h ago               │   
+  │ Mods:    42 installed / 39        │ │ Last deploy: ?                    │   
   │ enabled                           │ │                                   │   
   │                                   │ │                                   │   
   ╰───────────────────────────────────╯ ╰───────────────────────────────────╯   

--- a/docs/plans/2026-04-28-tui-implementation.md
+++ b/docs/plans/2026-04-28-tui-implementation.md
@@ -581,3 +581,54 @@ Acceptance criteria:
 Per `CLAUDE.md`, a full TUI is a new feature and should be a **MINOR** release when completed. Prototype-only work can live under `[Unreleased]` until the service-backed TUI is useful enough to ship.
 
 Do the version bump and `CHANGELOG.md` update as a separate release commit at the end of the shippable TUI milestone, not after every visual-prototype tweak.
+
+---
+
+## CLI-parity coverage and roadmap gaps
+
+**Added:** 2026-07-13, after the Phase 3 (read-only service-backed) milestone shipped as v1.4.0.
+
+This section audits every CLI capability against the TUI and the phases above, so nothing is missing from the roadmap by omission. Items marked *planned* were already covered by a phase; items marked **added** were roadmap gaps discovered in this audit and are now assigned; items marked *CLI-only for now* are deliberate deferrals, not oversights.
+
+### Covered by the shipped TUI (v1.4.0, read-only)
+
+| CLI capability | TUI status |
+| --- | --- |
+| `status` (game/profile/mod counts) | Dashboard summary; update/conflict counts render `?` until Phase 6 |
+| `list` (installed mods) | Installed Mods view (read-only) |
+| `list --profiles` | Profile roster (read-only, active marker) |
+| Game selection at launch | Works today via the global `-g/--game` flag (`lmm tui -g skyrim-se`) |
+
+### Already planned (no change)
+
+| CLI capability | Phase |
+| --- | --- |
+| `search`, `show` (details), auth-required messaging | Phase 4 |
+| `install`, `enable`, `disable`, `deploy`, `profile switch`, `update` (check/apply) | Phase 5 |
+| `conflicts`, `profile reorder` (load order), `profile export`/`import` entry points, update changelogs, respecting per-mod policies | Phase 6 |
+
+### Roadmap gaps — **added** to phases by this audit
+
+| Capability | Assigned | Rationale |
+| --- | --- | --- |
+| `uninstall <mod-id>` | **Phase 5** (add to the initial action set) | Same confirmation/async machinery as install; its omission from the P5 list was an oversight |
+| `update rollback <mod-id>` | **Phase 6** (update workflow) | Belongs beside apply-updates; rollback is the safety net the update view should surface |
+| `mod set-update` (notify/auto/pin) | **Phase 6** (update workflow) | P6 only *respects* policies; editing them from the update list is the natural affordance |
+| In-TUI game selector/switcher | **Phase 6** | Original BACKLOG feature ("Game selector view") dropped when this plan was drafted; multi-game users otherwise must restart the TUI. Switching only — game add/detect/set-default stay CLI-only |
+| `purge` | **Phase 6** | Destructive; requires the P5 confirmation view, and pairs with the deploy workflow |
+| `files <mod-id>` (deployed file listing) | **Phase 6** (fold into conflict/detail panels) | The P6 conflict view already renders per-file data; a per-mod file panel reuses it |
+| `profile create` / `profile delete` | **Phase 6** (profile management affordances) | P6 has switch/reorder/export/import; create/delete complete the management loop |
+
+### Deliberately CLI-only for now (revisit post-Phase 6)
+
+| Capability | Reason |
+| --- | --- |
+| `auth login`/`logout`/`status` | Login requires API-key entry and browser round-trips; Phase 4 shows clear "run `lmm auth login <source>`" instructions instead. Revisit if/when the NexusMods OAuth flow (currently deferred in TODO.local.md) lands |
+| `import` (local archives / mod_path scan) | Interactive file-picking in a TUI is heavy; the CLI flow includes fuzzy matching prompts (#27) that don't map cleanly yet |
+| `verify` (cache checksums) | Maintenance task with long runtime and rare use; no interactive benefit over the CLI |
+| `mod edit` (metadata fixes) | Rare corrective surgery; form-style editing needs widgets none of the planned views require |
+| `profile sync` / `profile apply` | Power-user reconciliation commands; semantics are easier to express (and audit) as explicit CLI invocations |
+| `game add` / `game detect` / `game set-default` / `game clear-default` | Setup-time operations, usually once per machine; keep setup in the CLI, browsing/management in the TUI |
+| Settings view; configurable keybindings (vim/standard) | Original BACKLOG wish-list items; post-v1 TUI polish once the workflows above exist. Theme is already configurable per the Phase 2 decision note |
+
+Track execution of the **added** items in the corresponding phase issues as those phases begin; this table is the checklist to copy from.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -22,7 +22,7 @@ type menuItem struct {
 	hasTarget bool
 }
 
-// Layout describes the major panel arrangement for a prototype theme.
+// Layout describes the major panel arrangement for a theme.
 type Layout string
 
 const (
@@ -245,7 +245,7 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) View() string {
 	var b strings.Builder
 
-	b.WriteString(m.theme.Title.Render("LMM // Linux Mod Manager // Prototype Terminal"))
+	b.WriteString(m.theme.Title.Render("LMM // Linux Mod Manager"))
 	b.WriteString("\n")
 	b.WriteString(m.nav())
 	b.WriteString("\n\n")
@@ -404,7 +404,7 @@ func (m Model) partyDashboardView() string {
 		m.theme.PanelTitle.Render("QUEST LOG"),
 		fmt.Sprintf("%s updates available", m.theme.WarningText.Render(countLabel(m.summary.Updates))),
 		fmt.Sprintf("%s file conflict", m.theme.DangerText.Render(countLabel(m.summary.Conflicts))),
-		"Last deploy: 2h ago",
+		"Last deploy: ?",
 	}, "\n")
 
 	menu := strings.Join(
@@ -472,7 +472,7 @@ func (m Model) crtDashboardView() string {
 
 func (m Model) modsView() string {
 	rows := []string{m.theme.PanelTitle.Render("SPELLBOOK: INSTALLED MODS")}
-	rows = append(rows, "[E] Enable  [D] Disable  [U] Update  [/] Search")
+	rows = append(rows, "[/] Search")
 	if len(m.mods) == 0 {
 		rows = append(rows, m.theme.MutedText.Render("No mods installed yet. 'lmm install <mod>' begins the quest."))
 	}
@@ -484,7 +484,6 @@ func (m Model) modsView() string {
 
 func (m Model) searchView() string {
 	rows := []string{m.theme.PanelTitle.Render("ARCHIVE SEARCH")}
-	rows = append(rows, "Query: survival mods_")
 	if len(m.searchResults) == 0 {
 		rows = append(rows, m.theme.MutedText.Render("The archive index opens in a later chapter. (Search arrives in Phase 4.)"))
 	}
@@ -517,7 +516,7 @@ func (m Model) helpView() string {
 		"?                   toggle this help",
 		"q / ctrl+c           quit",
 		"",
-		"Prototype mode uses static fake data only. No DB, API, install, update, or deploy actions run here.",
+		"Browsing is read-only. Nothing is installed, updated, or deployed from this screen.",
 	}, "\n"))
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
 	"github.com/DonovanMods/linux-mod-manager/internal/tui/theme"
 )
 
@@ -34,43 +34,82 @@ const (
 
 // Options configures the TUI app.
 type Options struct {
-	Theme     string
-	Prototype bool
+	Theme    string
+	Provider DataProvider
 }
 
 // Model is the root Bubble Tea model for the lmm TUI.
 type Model struct {
 	theme    theme.Theme
 	layout   Layout
-	data     prototype.Data
+	keys     KeyMap
+	provider DataProvider
+
+	state   loadState
+	loadErr error
+
+	summary       Summary
+	mods          []ModItem
+	searchResults []ModItem
+	profiles      []ProfileItem
+
 	screen   Screen
 	selected map[Screen]int
 	showHelp bool
 	width    int
 	height   int
-	keys     KeyMap
 }
 
-// NewPrototypeModel creates a side-effect-free TUI model backed by fake data.
-func NewPrototypeModel(options Options) (Model, error) {
+// loadState tracks where the Model is in its async data-load lifecycle.
+type loadState int
+
+const (
+	stateLoading loadState = iota
+	stateReady
+	stateFailed
+)
+
+// dataLoadedMsg carries data successfully loaded through a DataProvider.
+type dataLoadedMsg struct {
+	summary       Summary
+	mods          []ModItem
+	searchResults []ModItem
+	profiles      []ProfileItem
+}
+
+// loadFailedMsg carries an error from a failed DataProvider load.
+type loadFailedMsg struct{ err error }
+
+// NewModel creates the TUI model backed by the given DataProvider.
+func NewModel(options Options) (Model, error) {
+	if options.Provider == nil {
+		return Model{}, fmt.Errorf("TUI options: provider is required")
+	}
 	t, err := theme.ByName(options.Theme)
 	if err != nil {
 		return Model{}, err
 	}
 
 	return Model{
-		theme:  t,
-		layout: layoutForTheme(t.Name),
-		data:   prototype.Load(),
-		screen: ScreenDashboard,
+		theme:    t,
+		layout:   layoutForTheme(t.Name),
+		keys:     DefaultKeyMap(),
+		provider: options.Provider,
+		state:    stateLoading,
+		screen:   ScreenDashboard,
 		selected: map[Screen]int{
 			ScreenDashboard:     0,
 			ScreenInstalledMods: 0,
 			ScreenSearch:        0,
 			ScreenProfiles:      0,
 		},
-		keys: DefaultKeyMap(),
 	}, nil
+}
+
+// NewPrototypeModel creates a side-effect-free TUI model backed by fake data.
+func NewPrototypeModel(options Options) (Model, error) {
+	options.Provider = NewPrototypeProvider()
+	return NewModel(options)
 }
 
 func (m Model) dashboardMenu() []menuItem {
@@ -113,11 +152,47 @@ func (m Model) openSelectedMenuEntry() Model {
 }
 
 func (m Model) Init() tea.Cmd {
-	return nil
+	return m.loadData
+}
+
+// loadData fetches all dashboard data through the configured DataProvider.
+// It runs as a Bubble Tea command, off the update loop.
+func (m Model) loadData() tea.Msg {
+	ctx := context.Background()
+
+	summary, err := m.provider.Summary(ctx)
+	if err != nil {
+		return loadFailedMsg{err: err}
+	}
+	mods, err := m.provider.InstalledMods(ctx)
+	if err != nil {
+		return loadFailedMsg{err: err}
+	}
+	results, err := m.provider.SearchResults(ctx)
+	if err != nil {
+		return loadFailedMsg{err: err}
+	}
+	profiles, err := m.provider.Profiles(ctx)
+	if err != nil {
+		return loadFailedMsg{err: err}
+	}
+
+	return dataLoadedMsg{summary: summary, mods: mods, searchResults: results, profiles: profiles}
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case dataLoadedMsg:
+		m.state = stateReady
+		m.summary = msg.summary
+		m.mods = msg.mods
+		m.searchResults = msg.searchResults
+		m.profiles = msg.profiles
+		return m, nil
+	case loadFailedMsg:
+		m.state = stateFailed
+		m.loadErr = msg.err
+		return m, nil
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -243,11 +318,11 @@ func (m Model) moveSelection(delta int) {
 func (m Model) itemCount(screen Screen) int {
 	switch screen {
 	case ScreenInstalledMods:
-		return len(m.data.InstalledMods)
+		return len(m.mods)
 	case ScreenSearch:
-		return len(m.data.SearchResults)
+		return len(m.searchResults)
 	case ScreenProfiles:
-		return len(m.data.Profiles)
+		return len(m.profiles)
 	default:
 		return len(m.dashboardMenu())
 	}
@@ -268,6 +343,20 @@ func (m Model) nav() string {
 }
 
 func (m Model) screenView() string {
+	switch m.state {
+	case stateLoading:
+		return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).
+			Render(m.theme.PanelTitle.Render("Consulting the archives..."))
+	case stateFailed:
+		return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).
+			Render(strings.Join([]string{
+				m.theme.PanelTitle.Render("THE RITUAL FAILED"),
+				m.theme.DangerText.Render(m.loadErr.Error()),
+				"",
+				m.theme.MutedText.Render("q: quit"),
+			}, "\n"))
+	}
+
 	switch m.screen {
 	case ScreenDashboard:
 		return m.dashboardView()
@@ -306,15 +395,15 @@ func (m Model) partyDashboardView() string {
 
 	party := strings.Join([]string{
 		m.theme.PanelTitle.Render("PARTY"),
-		fmt.Sprintf("Game:    %s", m.data.Game.Name),
-		fmt.Sprintf("Profile: %s", m.data.Profile.Name),
-		fmt.Sprintf("Mods:    %d installed / %d enabled", m.data.Stats.Installed, m.data.Stats.Enabled),
+		fmt.Sprintf("Game:    %s", m.summary.GameName),
+		fmt.Sprintf("Profile: %s", m.summary.ProfileName),
+		fmt.Sprintf("Mods:    %d installed / %d enabled", m.summary.Installed, m.summary.Enabled),
 	}, "\n")
 
 	quest := strings.Join([]string{
 		m.theme.PanelTitle.Render("QUEST LOG"),
-		fmt.Sprintf("%s updates available", m.theme.WarningText.Render(fmt.Sprintf("%d", m.data.Stats.Updates))),
-		fmt.Sprintf("%s file conflict", m.theme.DangerText.Render(fmt.Sprintf("%d", m.data.Stats.Conflicts))),
+		fmt.Sprintf("%s updates available", m.theme.WarningText.Render(countLabel(m.summary.Updates))),
+		fmt.Sprintf("%s file conflict", m.theme.DangerText.Render(countLabel(m.summary.Conflicts))),
 		"Last deploy: 2h ago",
 	}, "\n")
 
@@ -332,10 +421,10 @@ func (m Model) partyDashboardView() string {
 func (m Model) terminalDashboardView() string {
 	rows := []string{
 		m.theme.PanelTitle.Render("BOOT SEQUENCE // MOD GUILD TERMINAL"),
-		fmt.Sprintf("> GAME     %s", m.data.Game.Name),
-		fmt.Sprintf("> PROFILE  %s", m.data.Profile.Name),
-		fmt.Sprintf("> MODS     %d INSTALLED / %d ENABLED", m.data.Stats.Installed, m.data.Stats.Enabled),
-		fmt.Sprintf("> ALERTS   %s UPDATES // %s CONFLICT", m.theme.WarningText.Render(fmt.Sprintf("%d", m.data.Stats.Updates)), m.theme.DangerText.Render(fmt.Sprintf("%d", m.data.Stats.Conflicts))),
+		fmt.Sprintf("> GAME     %s", m.summary.GameName),
+		fmt.Sprintf("> PROFILE  %s", m.summary.ProfileName),
+		fmt.Sprintf("> MODS     %d INSTALLED / %d ENABLED", m.summary.Installed, m.summary.Enabled),
+		fmt.Sprintf("> ALERTS   %s UPDATES // %s CONFLICT", m.theme.WarningText.Render(countLabel(m.summary.Updates)), m.theme.DangerText.Render(countLabel(m.summary.Conflicts))),
 		"",
 	}
 	rows = append(rows, m.dashboardMenuRows()...)
@@ -351,11 +440,11 @@ func (m Model) commanderDashboardView() string {
 
 	left := strings.Join([]string{
 		m.theme.PanelTitle.Render("ACTIVE PROFILE"),
-		m.data.Profile.Name,
+		m.summary.ProfileName,
 		"",
-		fmt.Sprintf("Game     %s", m.data.Game.Name),
-		fmt.Sprintf("Enabled  %d", m.data.Stats.Enabled),
-		fmt.Sprintf("Updates  %d", m.data.Stats.Updates),
+		fmt.Sprintf("Game     %s", m.summary.GameName),
+		fmt.Sprintf("Enabled  %d", m.summary.Enabled),
+		fmt.Sprintf("Updates  %d", m.summary.Updates),
 	}, "\n")
 	right := strings.Join(
 		append([]string{m.theme.PanelTitle.Render("OPERATIONS")}, m.dashboardMenuRows()...),
@@ -371,10 +460,10 @@ func (m Model) commanderDashboardView() string {
 func (m Model) crtDashboardView() string {
 	rows := []string{
 		m.theme.PanelTitle.Render("CRT STATUS STACK"),
-		fmt.Sprintf("▓ %-10s %s", "GAME", m.data.Game.Name),
-		fmt.Sprintf("▓ %-10s %s", "PROFILE", m.data.Profile.Name),
-		fmt.Sprintf("▓ %-10s %d/%d", "MODS", m.data.Stats.Enabled, m.data.Stats.Installed),
-		fmt.Sprintf("▓ %-10s %d updates, %d conflict", "SIGNAL", m.data.Stats.Updates, m.data.Stats.Conflicts),
+		fmt.Sprintf("▓ %-10s %s", "GAME", m.summary.GameName),
+		fmt.Sprintf("▓ %-10s %s", "PROFILE", m.summary.ProfileName),
+		fmt.Sprintf("▓ %-10s %d/%d", "MODS", m.summary.Enabled, m.summary.Installed),
+		fmt.Sprintf("▓ %-10s %d updates, %d conflict", "SIGNAL", m.summary.Updates, m.summary.Conflicts),
 		"",
 	}
 	rows = append(rows, m.dashboardMenuRows()...)
@@ -384,7 +473,7 @@ func (m Model) crtDashboardView() string {
 func (m Model) modsView() string {
 	rows := []string{m.theme.PanelTitle.Render("SPELLBOOK: INSTALLED MODS")}
 	rows = append(rows, "[E] Enable  [D] Disable  [U] Update  [/] Search")
-	for i, mod := range m.data.InstalledMods {
+	for i, mod := range m.mods {
 		rows = append(rows, m.modRow(i, mod))
 	}
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
@@ -393,7 +482,7 @@ func (m Model) modsView() string {
 func (m Model) searchView() string {
 	rows := []string{m.theme.PanelTitle.Render("ARCHIVE SEARCH")}
 	rows = append(rows, "Query: survival mods_")
-	for i, mod := range m.data.SearchResults {
+	for i, mod := range m.searchResults {
 		rows = append(rows, m.modRow(i, mod))
 	}
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
@@ -401,7 +490,7 @@ func (m Model) searchView() string {
 
 func (m Model) profilesView() string {
 	rows := []string{m.theme.PanelTitle.Render("PROFILE ROSTER")}
-	for i, profile := range m.data.Profiles {
+	for i, profile := range m.profiles {
 		active := " "
 		if profile.Active {
 			active = "*"
@@ -435,7 +524,7 @@ func (m Model) row(index int, label string) string {
 	return prefix + label
 }
 
-func (m Model) modRow(index int, mod prototype.Mod) string {
+func (m Model) modRow(index int, mod ModItem) string {
 	line := fmt.Sprintf("%-28s %-11s %-16s %7s", mod.Name, mod.Status, mod.Author, mod.Version)
 	return m.row(index, line)
 }
@@ -471,6 +560,15 @@ func (m Model) contentChromeHeight() int {
 
 	const titleNavAndSpacerHeight = 4 // title, nav, and the spacer lines around content.
 	return titleNavAndSpacerHeight + footerHeight
+}
+
+// countLabel renders n, or "?" when n is negative (unknown, e.g. no update
+// check has run yet).
+func countLabel(n int) string {
+	if n < 0 {
+		return "?"
+	}
+	return fmt.Sprintf("%d", n)
 }
 
 func layoutForTheme(name string) Layout {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -444,7 +444,7 @@ func (m Model) commanderDashboardView() string {
 		"",
 		fmt.Sprintf("Game     %s", m.summary.GameName),
 		fmt.Sprintf("Enabled  %d", m.summary.Enabled),
-		fmt.Sprintf("Updates  %d", m.summary.Updates),
+		fmt.Sprintf("Updates  %s", countLabel(m.summary.Updates)),
 	}, "\n")
 	right := strings.Join(
 		append([]string{m.theme.PanelTitle.Render("OPERATIONS")}, m.dashboardMenuRows()...),
@@ -463,7 +463,7 @@ func (m Model) crtDashboardView() string {
 		fmt.Sprintf("▓ %-10s %s", "GAME", m.summary.GameName),
 		fmt.Sprintf("▓ %-10s %s", "PROFILE", m.summary.ProfileName),
 		fmt.Sprintf("▓ %-10s %d/%d", "MODS", m.summary.Enabled, m.summary.Installed),
-		fmt.Sprintf("▓ %-10s %d updates, %d conflict", "SIGNAL", m.summary.Updates, m.summary.Conflicts),
+		fmt.Sprintf("▓ %-10s %s updates, %s conflict", "SIGNAL", countLabel(m.summary.Updates), countLabel(m.summary.Conflicts)),
 		"",
 	}
 	rows = append(rows, m.dashboardMenuRows()...)
@@ -473,6 +473,9 @@ func (m Model) crtDashboardView() string {
 func (m Model) modsView() string {
 	rows := []string{m.theme.PanelTitle.Render("SPELLBOOK: INSTALLED MODS")}
 	rows = append(rows, "[E] Enable  [D] Disable  [U] Update  [/] Search")
+	if len(m.mods) == 0 {
+		rows = append(rows, m.theme.MutedText.Render("No mods installed yet. 'lmm install <mod>' begins the quest."))
+	}
 	for i, mod := range m.mods {
 		rows = append(rows, m.modRow(i, mod))
 	}
@@ -482,6 +485,9 @@ func (m Model) modsView() string {
 func (m Model) searchView() string {
 	rows := []string{m.theme.PanelTitle.Render("ARCHIVE SEARCH")}
 	rows = append(rows, "Query: survival mods_")
+	if len(m.searchResults) == 0 {
+		rows = append(rows, m.theme.MutedText.Render("The archive index opens in a later chapter. (Search arrives in Phase 4.)"))
+	}
 	for i, mod := range m.searchResults {
 		rows = append(rows, m.modRow(i, mod))
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -372,3 +372,26 @@ func TestNewModelRequiresProvider(t *testing.T) {
 	_, err := NewModel(Options{Theme: "wizardry"})
 	require.ErrorContains(t, err, "provider")
 }
+
+type emptyProvider struct{}
+
+func (emptyProvider) Summary(context.Context) (Summary, error)         { return Summary{}, nil }
+func (emptyProvider) InstalledMods(context.Context) ([]ModItem, error) { return nil, nil }
+func (emptyProvider) SearchResults(context.Context) ([]ModItem, error) { return nil, nil }
+func (emptyProvider) Profiles(context.Context) ([]ProfileItem, error)  { return nil, nil }
+
+func TestEmptyStatesRenderHonestCopy(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(Options{Theme: "wizardry", Provider: emptyProvider{}})
+	require.NoError(t, err)
+
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+
+	model = updateWithRunes(t, model, "2")
+	require.Contains(t, model.View(), "No mods installed yet. 'lmm install <mod>' begins the quest.")
+
+	model = updateWithRunes(t, model, "3")
+	require.Contains(t, model.View(), "The archive index opens in a later chapter. (Search arrives in Phase 4.)")
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -12,7 +14,7 @@ import (
 func TestNewPrototypeModelDefaultsToDashboard(t *testing.T) {
 	t.Parallel()
 
-	model, err := NewPrototypeModel(Options{Theme: "wizardry", Prototype: true})
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
 	require.NoError(t, err)
 	require.Equal(t, ScreenDashboard, model.CurrentScreen())
 }
@@ -20,14 +22,14 @@ func TestNewPrototypeModelDefaultsToDashboard(t *testing.T) {
 func TestNewPrototypeModelRejectsInvalidTheme(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewPrototypeModel(Options{Theme: "bogus", Prototype: true})
+	_, err := NewPrototypeModel(Options{Theme: "bogus"})
 	require.Error(t, err)
 }
 
 func TestNumberKeysNavigateScreens(t *testing.T) {
 	t.Parallel()
 
-	model, err := NewPrototypeModel(Options{Theme: "wizardry", Prototype: true})
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
 	require.NoError(t, err)
 
 	updated := updateWithRunes(t, model, "2")
@@ -46,7 +48,7 @@ func TestNumberKeysNavigateScreens(t *testing.T) {
 func TestTabCyclesScreens(t *testing.T) {
 	t.Parallel()
 
-	model, err := NewPrototypeModel(Options{Theme: "wizardry", Prototype: true})
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
 	require.NoError(t, err)
 
 	updated := updateWithKeyType(t, model, tea.KeyTab)
@@ -59,7 +61,7 @@ func TestTabCyclesScreens(t *testing.T) {
 func TestArrowAndVimKeysNavigateScreens(t *testing.T) {
 	t.Parallel()
 
-	model, err := NewPrototypeModel(Options{Theme: "wizardry", Prototype: true})
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
 	require.NoError(t, err)
 
 	model = updateWithKeyType(t, model, tea.KeyRight)
@@ -78,8 +80,10 @@ func TestArrowAndVimKeysNavigateScreens(t *testing.T) {
 func TestSelectionMovementIsClamped(t *testing.T) {
 	t.Parallel()
 
-	model, err := NewPrototypeModel(Options{Theme: "wizardry", Prototype: true})
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
 	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
 	model = updateWithRunes(t, model, "2")
 
 	model = updateWithRunes(t, model, "j")
@@ -103,7 +107,7 @@ func TestSelectionMovementIsClamped(t *testing.T) {
 func TestSearchAndQuitBindings(t *testing.T) {
 	t.Parallel()
 
-	model, err := NewPrototypeModel(Options{Theme: "wizardry", Prototype: true})
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
 	require.NoError(t, err)
 
 	model = updateWithRunes(t, model, "/")
@@ -116,7 +120,7 @@ func TestSearchAndQuitBindings(t *testing.T) {
 func TestHelpToggle(t *testing.T) {
 	t.Parallel()
 
-	model, err := NewPrototypeModel(Options{Theme: "wizardry", Prototype: true})
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
 	require.NoError(t, err)
 
 	model = updateWithRunes(t, model, "?")
@@ -129,7 +133,7 @@ func TestHelpToggle(t *testing.T) {
 func TestWindowSizeExpandsViewToTerminalBounds(t *testing.T) {
 	t.Parallel()
 
-	model, err := NewPrototypeModel(Options{Theme: "wizardry", Prototype: true})
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
 	require.NoError(t, err)
 
 	updated, _ := model.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
@@ -202,7 +206,7 @@ func TestThemesUseDistinctLayouts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.themeName, func(t *testing.T) {
-			model, err := NewPrototypeModel(Options{Theme: tt.themeName, Prototype: true})
+			model, err := NewPrototypeModel(Options{Theme: tt.themeName})
 			require.NoError(t, err)
 			require.Equal(t, tt.want, model.Layout())
 		})
@@ -212,10 +216,11 @@ func TestThemesUseDistinctLayouts(t *testing.T) {
 func sizedPrototypeModel(t *testing.T, themeName string, width, height int) Model {
 	t.Helper()
 
-	model, err := NewPrototypeModel(Options{Theme: themeName, Prototype: true})
+	model, err := NewPrototypeModel(Options{Theme: themeName})
 	require.NoError(t, err)
 
-	updated, _ := model.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	loaded, _ := model.Update(model.Init()())
+	updated, _ := loaded.Update(tea.WindowSizeMsg{Width: width, Height: height})
 	updatedModel, ok := updated.(Model)
 	require.True(t, ok)
 	return updatedModel
@@ -315,4 +320,55 @@ func TestEnterOutsideDashboardIsANoop(t *testing.T) {
 
 	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	require.Equal(t, ScreenInstalledMods, opened.(Model).CurrentScreen())
+}
+
+type failingProvider struct{ err error }
+
+func (f failingProvider) Summary(context.Context) (Summary, error)         { return Summary{}, f.err }
+func (f failingProvider) InstalledMods(context.Context) ([]ModItem, error) { return nil, f.err }
+func (f failingProvider) SearchResults(context.Context) ([]ModItem, error) { return nil, f.err }
+func (f failingProvider) Profiles(context.Context) ([]ProfileItem, error)  { return nil, f.err }
+
+func TestModelShowsLoadingBeforeDataArrives(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(Options{Theme: "wizardry", Provider: NewPrototypeProvider()})
+	require.NoError(t, err)
+
+	require.Contains(t, model.View(), "Consulting the archives")
+}
+
+func TestInitLoadsDataThroughProvider(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(Options{Theme: "wizardry", Provider: NewPrototypeProvider()})
+	require.NoError(t, err)
+
+	msg := model.Init()()
+	updated, _ := model.Update(msg)
+	view := updated.(Model).View()
+
+	require.Contains(t, view, "Skyrim Special Edition")
+	require.NotContains(t, view, "Consulting the archives")
+}
+
+func TestLoadFailureRendersErrorState(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(Options{Theme: "wizardry", Provider: failingProvider{err: errors.New("the archive door is sealed")}})
+	require.NoError(t, err)
+
+	msg := model.Init()()
+	updated, _ := model.Update(msg)
+	view := updated.(Model).View()
+
+	require.Contains(t, view, "the archive door is sealed")
+	require.Contains(t, view, "q: quit")
+}
+
+func TestNewModelRequiresProvider(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewModel(Options{Theme: "wizardry"})
+	require.ErrorContains(t, err, "provider")
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -2,7 +2,7 @@ package tui
 
 import "github.com/charmbracelet/bubbles/key"
 
-// KeyMap documents the prototype TUI keyboard contract.
+// KeyMap documents the TUI keyboard contract.
 type KeyMap struct {
 	Quit          key.Binding
 	Help          key.Binding

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -1,0 +1,100 @@
+package tui
+
+import (
+	"context"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
+)
+
+// Summary is the dashboard header data.
+type Summary struct {
+	GameName    string
+	ProfileName string
+	Installed   int
+	Enabled     int
+	Updates     int // -1 = unknown (no update check has run)
+	Conflicts   int // -1 = unknown
+}
+
+// ModItem is one renderable mod row.
+type ModItem struct {
+	Name    string
+	Author  string
+	Version string
+	Source  string
+	Status  string
+}
+
+// ProfileItem is one renderable profile row.
+type ProfileItem struct {
+	Name     string
+	Active   bool
+	ModCount int
+}
+
+// DataProvider is the narrow, read-only boundary between the TUI and app
+// data. Implementations must be safe to call from a Bubble Tea command
+// goroutine.
+type DataProvider interface {
+	Summary(ctx context.Context) (Summary, error)
+	InstalledMods(ctx context.Context) ([]ModItem, error)
+	SearchResults(ctx context.Context) ([]ModItem, error)
+	Profiles(ctx context.Context) ([]ProfileItem, error)
+}
+
+// prototypeProvider serves the static demo data set. It must never touch
+// disk, network, DB, or APIs.
+type prototypeProvider struct {
+	data prototype.Data
+}
+
+// NewPrototypeProvider returns the side-effect-free demo DataProvider used
+// by --prototype mode and tests.
+func NewPrototypeProvider() DataProvider {
+	return prototypeProvider{data: prototype.Load()}
+}
+
+func (p prototypeProvider) Summary(_ context.Context) (Summary, error) {
+	return Summary{
+		GameName:    p.data.Game.Name,
+		ProfileName: p.data.Profile.Name,
+		Installed:   p.data.Stats.Installed,
+		Enabled:     p.data.Stats.Enabled,
+		Updates:     p.data.Stats.Updates,
+		Conflicts:   p.data.Stats.Conflicts,
+	}, nil
+}
+
+func (p prototypeProvider) InstalledMods(_ context.Context) ([]ModItem, error) {
+	return modItems(p.data.InstalledMods), nil
+}
+
+func (p prototypeProvider) SearchResults(_ context.Context) ([]ModItem, error) {
+	return modItems(p.data.SearchResults), nil
+}
+
+func (p prototypeProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
+	items := make([]ProfileItem, 0, len(p.data.Profiles))
+	for _, profile := range p.data.Profiles {
+		items = append(items, ProfileItem{
+			Name:     profile.Name,
+			Active:   profile.Active,
+			ModCount: profile.ModCount,
+		})
+	}
+	return items, nil
+}
+
+func modItems(mods []prototype.Mod) []ModItem {
+	items := make([]ModItem, 0, len(mods))
+	for _, mod := range mods {
+		items = append(items, ModItem{
+			Name:    mod.Name,
+			Author:  mod.Author,
+			Version: mod.Version,
+			Source:  mod.Source,
+			Status:  mod.Status,
+		})
+	}
+	return items
+}

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// coreProvider adapts *core.Service to the read-only DataProvider boundary.
+type coreProvider struct {
+	svc     *core.Service
+	game    *domain.Game
+	profile string
+}
+
+// NewCoreProvider returns a DataProvider backed by the real app service for
+// one game/profile pair.
+func NewCoreProvider(svc *core.Service, game *domain.Game, profileName string) DataProvider {
+	return &coreProvider{svc: svc, game: game, profile: profileName}
+}
+
+func (p *coreProvider) Summary(_ context.Context) (Summary, error) {
+	mods, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
+	if err != nil {
+		return Summary{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
+	}
+
+	enabled := 0
+	for _, mod := range mods {
+		if mod.Enabled {
+			enabled++
+		}
+	}
+
+	return Summary{
+		GameName:    p.game.Name,
+		ProfileName: p.profile,
+		Installed:   len(mods),
+		Enabled:     enabled,
+		Updates:     -1, // unknown: update checks are a Phase 6 workflow
+		Conflicts:   -1, // unknown: conflict detection is a Phase 6 workflow
+	}, nil
+}
+
+func (p *coreProvider) InstalledMods(_ context.Context) ([]ModItem, error) {
+	mods, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
+	if err != nil {
+		return nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
+	}
+
+	items := make([]ModItem, 0, len(mods))
+	for _, mod := range mods {
+		items = append(items, ModItem{
+			Name:    mod.Name,
+			Author:  mod.Author,
+			Version: mod.Version,
+			Source:  mod.SourceID,
+			Status:  installedModStatus(mod),
+		})
+	}
+	return items, nil
+}
+
+// SearchResults is an honest placeholder until Phase 4 wires real source
+// search into the TUI.
+func (p *coreProvider) SearchResults(_ context.Context) ([]ModItem, error) {
+	return nil, nil
+}
+
+func (p *coreProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
+	profiles, err := p.svc.NewProfileManager().List(p.game.ID)
+	if err != nil {
+		return nil, fmt.Errorf("listing profiles for %s: %w", p.game.ID, err)
+	}
+
+	items := make([]ProfileItem, 0, len(profiles))
+	for _, profile := range profiles {
+		items = append(items, ProfileItem{
+			Name:     profile.Name,
+			Active:   profile.Name == p.profile,
+			ModCount: len(profile.Mods),
+		})
+	}
+	return items, nil
+}
+
+func installedModStatus(mod domain.InstalledMod) string {
+	switch {
+	case mod.Enabled && mod.Deployed:
+		return "deployed"
+	case mod.Enabled:
+		return "enabled"
+	default:
+		return "disabled"
+	}
+}

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -105,8 +105,10 @@ func TestCoreProviderSearchResultsAreEmptyUntilPhase4(t *testing.T) {
 func TestCoreProviderProfiles(t *testing.T) {
 	provider, svc, game := newCoreProviderFixture(t)
 
-	_, err := svc.NewProfileManager().Create(game.ID, "hardcore")
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "hardcore")
 	require.NoError(t, err)
+	require.NoError(t, pm.AddMod(game.ID, "hardcore", domain.ModReference{SourceID: "nexusmods", ModID: "101"}))
 
 	profiles, err := provider.Profiles(context.Background())
 	require.NoError(t, err)
@@ -118,4 +120,5 @@ func TestCoreProviderProfiles(t *testing.T) {
 	}
 	require.True(t, byName["default"].Active)
 	require.False(t, byName["hardcore"].Active)
+	require.Equal(t, 1, byName["hardcore"].ModCount, "ModCount should map from profile YAML mods, not the DB")
 }

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -1,0 +1,121 @@
+package tui_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/tui"
+)
+
+func newCoreProviderFixture(t *testing.T) (tui.DataProvider, *core.Service, *domain.Game) {
+	t.Helper()
+
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{
+		ID:          "test-game",
+		Name:        "Test Game",
+		InstallPath: t.TempDir(),
+		ModPath:     t.TempDir(),
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "101",
+			SourceID: "nexusmods",
+			GameID:   game.ID,
+			Name:     "SkyUI",
+			Author:   "schlangster",
+			Version:  "5.2",
+		},
+		ProfileName: "default",
+		Enabled:     true,
+		Deployed:    true,
+	}))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "102",
+			SourceID: "nexusmods",
+			GameID:   game.ID,
+			Name:     "USSEP",
+			Author:   "Arthmoor",
+			Version:  "4.3",
+		},
+		ProfileName: "default",
+		Enabled:     false,
+	}))
+
+	return tui.NewCoreProvider(svc, game, "default"), svc, game
+}
+
+func TestCoreProviderSummary(t *testing.T) {
+	provider, _, _ := newCoreProviderFixture(t)
+
+	summary, err := provider.Summary(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Test Game", summary.GameName)
+	require.Equal(t, "default", summary.ProfileName)
+	require.Equal(t, 2, summary.Installed)
+	require.Equal(t, 1, summary.Enabled)
+	require.Equal(t, -1, summary.Updates, "updates are unknown until an update check runs")
+	require.Equal(t, -1, summary.Conflicts, "conflicts are unknown in the read-only phase")
+}
+
+func TestCoreProviderInstalledMods(t *testing.T) {
+	provider, _, _ := newCoreProviderFixture(t)
+
+	mods, err := provider.InstalledMods(context.Background())
+	require.NoError(t, err)
+	require.Len(t, mods, 2)
+
+	byName := map[string]tui.ModItem{}
+	for _, m := range mods {
+		byName[m.Name] = m
+	}
+	require.Equal(t, "deployed", byName["SkyUI"].Status)
+	require.Equal(t, "nexusmods", byName["SkyUI"].Source)
+	require.Equal(t, "5.2", byName["SkyUI"].Version)
+	require.Equal(t, "disabled", byName["USSEP"].Status)
+}
+
+func TestCoreProviderSearchResultsAreEmptyUntilPhase4(t *testing.T) {
+	provider, _, _ := newCoreProviderFixture(t)
+
+	results, err := provider.SearchResults(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, results)
+}
+
+func TestCoreProviderProfiles(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+
+	_, err := svc.NewProfileManager().Create(game.ID, "hardcore")
+	require.NoError(t, err)
+
+	profiles, err := provider.Profiles(context.Background())
+	require.NoError(t, err)
+	require.Len(t, profiles, 2)
+
+	byName := map[string]tui.ProfileItem{}
+	for _, p := range profiles {
+		byName[p.Name] = p
+	}
+	require.True(t, byName["default"].Active)
+	require.False(t, byName["hardcore"].Active)
+}

--- a/internal/tui/service_test.go
+++ b/internal/tui/service_test.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
+)
+
+func TestPrototypeProviderMirrorsFakeData(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	provider := NewPrototypeProvider()
+	data := prototype.Load()
+
+	summary, err := provider.Summary(ctx)
+	require.NoError(t, err)
+	require.Equal(t, data.Game.Name, summary.GameName)
+	require.Equal(t, data.Profile.Name, summary.ProfileName)
+	require.Equal(t, data.Stats.Installed, summary.Installed)
+	require.Equal(t, data.Stats.Enabled, summary.Enabled)
+	require.Equal(t, data.Stats.Updates, summary.Updates)
+	require.Equal(t, data.Stats.Conflicts, summary.Conflicts)
+
+	mods, err := provider.InstalledMods(ctx)
+	require.NoError(t, err)
+	require.Len(t, mods, len(data.InstalledMods))
+	require.Equal(t, data.InstalledMods[0].Name, mods[0].Name)
+	require.Equal(t, data.InstalledMods[0].Status, mods[0].Status)
+
+	results, err := provider.SearchResults(ctx)
+	require.NoError(t, err)
+	require.Len(t, results, len(data.SearchResults))
+
+	profiles, err := provider.Profiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, profiles, len(data.Profiles))
+	require.Equal(t, data.Profiles[0].Name, profiles[0].Name)
+	require.True(t, profiles[0].Active)
+}


### PR DESCRIPTION
## Summary
- Narrow read-only DataProvider boundary between the TUI and core.Service, with prototype and real implementations.
- `lmm tui` initializes config/service via withGameService, resolves the default profile (falling back to "default" on fresh setups), and browses real installed mods and profiles.
- Async load with explicit loading/error states; honest placeholders for search (Phase 4) and update/conflict counts (Phase 6, rendered as "?").
- Final-review polish: prototype-era chrome (fake deploy timestamp, fake query, dead E/D/U hints, "Prototype Terminal" banner) removed from views shared with real mode; theme snapshots regenerated.
- Docs (README/BACKLOG/CHANGELOG) and version 1.4.0.

Closes #35

## Test Plan
- [x] go test ./... / go vet ./... / gofmt (touched files)
- [x] CoreProvider exercised against a real temp-dir core.Service (no mocks)
- [x] Real-mode wiring verified to reach the terminal boundary without a TTY; loading/failed/empty states covered by tests
- [ ] Interactive smoke test on a real terminal (see note below)

**Note:** the sandbox has no TTY, so please run the interactive smoke test before merging: `go build -o lmm ./cmd/lmm && ./lmm tui` (with a configured game), plus `./lmm tui --prototype` and one alternate theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)