### PR TITLE
feat(tui): search and detail browsing (Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-13
+
+### Added
+
+- **TUI search** — Real source search from the TUI: query input with focus-aware key routing (`/` to focus on the Search screen, or jump there from other screens; `enter` to execute the search), per-source search with cancellation (stale results discarded), installed-result markers, detail panel for the selected result, CLI-parity pagination (`n`/`p` navigation), source cycling (`s` to switch between a game's configured sources), and first-class auth-required guidance (displays the login command needed).
+
+### Changed
+
+- **DataProvider boundary v2** — Single-fetch `Overview`, `Sources`, and `Search(ctx, source, query, page)` replace the Phase 3 read-only methods; the Bubble Tea program context now threads into all data loads.
+
 ## [1.4.0] - 2026-07-13
 
 ### Added
@@ -646,7 +656,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.10...v1.4.0
 [1.3.10]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.9...v1.3.10
 [1.3.9]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.8...v1.3.9

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ lmm mod set-update 12345 --game skyrim-se --pin
 
 ### Terminal UI
 
-Browse your configured game, installed mods, and profiles interactively:
+Browse your configured game, installed mods, and profiles interactively, and search mod sources:
 
 ```bash
 lmm tui                     # real data, read-only
@@ -153,9 +153,11 @@ lmm tui --theme amber       # themes: wizardry (default), amber, dos, green
 lmm tui --prototype         # demo mode with static fake data
 ```
 
-Keys: `tab`/`h`/`l` cycle screens, `1`–`4` jump, `↑↓`/`j`/`k` move, `enter` open,
-`/` search screen, `?` help, `q` quit. Browsing is read-only — install/update/deploy
-actions from the TUI arrive in a later release.
+Keys: `tab`/`h`/`l` cycle screens, `1`–`4` jump, `↑↓`/`j`/`k` move, `enter` open/select,
+`/` focus search (jumps to Search screen from other screens; type query, `enter` to search),
+`n`/`p` next/previous page, `s` cycle sources, `esc` cancel input, `?` help, `q` quit.
+Results mark already-installed mods; selecting a result shows a detail panel.
+Browsing and searching are read-only — install/update/deploy actions from the TUI arrive in a later release.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,11 @@ lmm tui --theme amber       # themes: wizardry (default), amber, dos, green
 lmm tui --prototype         # demo mode with static fake data
 ```
 
-Keys: `tab`/`h`/`l` cycle screens, `1`–`4` jump, `↑↓`/`j`/`k` move, `enter` open/select,
-`/` focus search (jumps to Search screen from other screens; type query, `enter` to search),
-`n`/`p` next/previous page, `s` cycle sources, `esc` cancel input, `?` help, `q` quit.
+Keys: `tab`/`h`/`l` cycle screens, `1`–`4` jump (`3` alone jumps to Search without
+focusing input), `↑↓`/`j`/`k` move, `enter` open/select,
+`/` searches from anywhere (jumps to the Search screen and focuses the input;
+type query, `enter` to search, `esc` returns to navigation),
+`n`/`p` next/previous page, `s` cycle sources, `?` help, `q` quit.
 Results mark already-installed mods; selecting a result shows a detail panel.
 Browsing and searching are read-only — install/update/deploy actions from the TUI arrive in a later release.
 

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -22,7 +22,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.4.0"
+	version = "1.5.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/tui.go
+++ b/cmd/lmm/tui.go
@@ -24,8 +24,9 @@ var tuiCmd = &cobra.Command{
 	Long: `Launch the interactive terminal UI.
 
 Shows the configured game's installed mods, profiles, and status using the
-same config, database, and game resolution as the CLI commands. Read-only:
-browsing never installs, updates, deploys, or deletes anything.
+same config, database, and game resolution as the CLI commands. Search mod
+sources interactively. Read-only: browsing and searching never install,
+update, deploy, or delete anything.
 
 Use --prototype for a demo mode backed by static fake data:
 

--- a/cmd/lmm/tui.go
+++ b/cmd/lmm/tui.go
@@ -41,7 +41,7 @@ func init() {
 
 func runTUI(cmd *cobra.Command, args []string) error {
 	if tuiOptions.prototype {
-		model, err := tui.NewModel(tui.Options{Theme: tuiOptions.theme, Provider: tui.NewPrototypeProvider()})
+		model, err := tui.NewModel(tui.Options{Theme: tuiOptions.theme, Provider: tui.NewPrototypeProvider(), Ctx: cmd.Context()})
 		if err != nil {
 			return err
 		}
@@ -62,6 +62,7 @@ func runTUI(cmd *cobra.Command, args []string) error {
 		model, err := tui.NewModel(tui.Options{
 			Theme:    tuiOptions.theme,
 			Provider: tui.NewCoreProvider(svc, game, profileName),
+			Ctx:      ctx,
 		})
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -18,7 +19,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -112,7 +112,7 @@ func NewModel(options Options) (Model, error) {
 		ctx:      options.Ctx,
 		state:    stateLoading,
 		screen:   ScreenDashboard,
-		search:   newSearchModel(options.Provider),
+		search:   newSearchModel(options.Provider, t.Panel.GetHorizontalFrameSize()),
 		selected: map[Screen]int{
 			ScreenDashboard:     0,
 			ScreenInstalledMods: 0,
@@ -221,6 +221,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.search.input.Width = searchInputWidthFor(m.availableWidth(), m.theme.Panel.GetHorizontalFrameSize())
 		return m, nil
 	case tea.KeyMsg:
 		return m.updateKey(msg)
@@ -285,6 +286,18 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.CycleSource):
 		if m.screen == ScreenSearch && len(m.search.sources) > 1 {
 			m.search.sourceIdx = (m.search.sourceIdx + 1) % len(m.search.sources)
+			// Cycling the target source must not leave the header, results,
+			// and pagination disagreeing about which source they describe:
+			// cancel any in-flight query for the old source, bump gen so a
+			// late result/failure for it is discarded as stale, and drop
+			// back to idle (keeping the typed query) so the user resubmits
+			// explicitly against the new source.
+			if m.search.cancel != nil {
+				m.search.cancel()
+				m.search.cancel = nil
+			}
+			m.search.gen++
+			m.search.state = searchIdle
 		}
 		return m, nil
 	case key.Matches(msg, m.keys.Profiles):
@@ -544,10 +557,19 @@ func (m Model) modsView() string {
 }
 
 // searchHeaderLines renders the two lines shared by every search state: the
-// panel title with the active source, and the query input itself.
+// panel title with the active source, and the query input itself. In
+// searchReady, the source label reflects m.search.page.Source (the source
+// the on-screen results actually came from) rather than m.search.source()
+// (the target of the next search), so cycling sources mid-view can never
+// make the header claim a source the results don't match. Every other state
+// has no results yet, so source() (the next search's target) is correct.
 func (m Model) searchHeaderLines() []string {
 	title := m.theme.PanelTitle.Render("ARCHIVE SEARCH")
-	meta := m.theme.MutedText.Render(fmt.Sprintf("[source: %s  (s cycles)]", m.search.source()))
+	source := m.search.source()
+	if m.search.state == searchReady {
+		source = m.search.page.Source
+	}
+	meta := m.theme.MutedText.Render(fmt.Sprintf("[source: %s  (s cycles)]", source))
 	return []string{title + "  " + meta, m.search.input.View()}
 }
 
@@ -757,7 +779,10 @@ func (m Model) helpView() string {
 		"tab / shift+tab     cycle top-level screens",
 		"1-4                 jump to a screen",
 		"/                   open search screen",
-		"/ focus · enter search · esc cancel · n/p pages · s source",
+		"enter               search",
+		"esc                 cancel input",
+		"n/p                 result pages",
+		"s                   cycle source",
 		"?                   toggle this help",
 		"q / ctrl+c           quit",
 		"",

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -267,10 +267,10 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = ScreenInstalledMods
 		return m, nil
 	case key.Matches(msg, m.keys.Search):
-		if m.screen == ScreenSearch {
-			m.search.input.Focus()
-			return m, textinput.Blink
-		}
+		m.screen = ScreenSearch
+		m.search.input.Focus()
+		return m, textinput.Blink
+	case key.Matches(msg, m.keys.SearchScreen):
 		m.screen = ScreenSearch
 		return m, nil
 	case key.Matches(msg, m.keys.NextPage):
@@ -778,7 +778,7 @@ func (m Model) helpView() string {
 		"arrows / hjkl       move or switch screens",
 		"tab / shift+tab     cycle top-level screens",
 		"1-4                 jump to a screen",
-		"/                   search screen / focus input",
+		"/                   search from anywhere (jumps + focuses input)",
 		"enter               search",
 		"esc                 cancel input",
 		"n/p                 result pages",

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2,13 +2,16 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/tui/theme"
 )
 
@@ -36,7 +39,9 @@ const (
 type Options struct {
 	Theme    string
 	Provider DataProvider
-	Ctx      context.Context
+	// Ctx seeds Model.ctx; see that field for why the context is stored
+	// rather than threaded as a parameter.
+	Ctx context.Context
 }
 
 // Model is the root Bubble Tea model for the lmm TUI.
@@ -45,7 +50,10 @@ type Model struct {
 	layout   Layout
 	keys     KeyMap
 	provider DataProvider
-	ctx      context.Context
+	// ctx deviates from "don't store contexts in structs": Bubble Tea's
+	// Init/Update/View take no context parameter, so commands (e.g.
+	// startSearch) close over m.ctx to reach it from goroutines.
+	ctx context.Context
 
 	state   loadState
 	loadErr error
@@ -53,6 +61,7 @@ type Model struct {
 	summary  Summary
 	mods     []ModItem
 	profiles []ProfileItem
+	search   searchModel
 
 	screen   Screen
 	selected map[Screen]int
@@ -102,6 +111,7 @@ func NewModel(options Options) (Model, error) {
 		ctx:      options.Ctx,
 		state:    stateLoading,
 		screen:   ScreenDashboard,
+		search:   newSearchModel(options.Provider),
 		selected: map[Screen]int{
 			ScreenDashboard:     0,
 			ScreenInstalledMods: 0,
@@ -187,6 +197,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state = stateFailed
 		m.loadErr = msg.err
 		return m, nil
+	case searchResultMsg:
+		if msg.gen != m.search.gen {
+			return m, nil
+		}
+		m.search.state = searchReady
+		m.search.page = msg.page
+		m.selected[ScreenSearch] = 0
+		return m, nil
+	case searchFailedMsg:
+		if msg.gen != m.search.gen {
+			return m, nil
+		}
+		if errors.Is(msg.err, domain.ErrAuthRequired) {
+			m.search.state = searchAuthRequired
+			m.search.authSource = msg.source
+			return m, nil
+		}
+		m.search.state = searchFailed
+		m.search.err = msg.err
+		return m, nil
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -199,6 +229,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.screen == ScreenSearch && m.search.input.Focused() {
+		switch {
+		case key.Matches(msg, m.keys.Quit) && msg.String() == "ctrl+c":
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.Blur):
+			m.search.input.Blur()
+			return m, nil
+		case key.Matches(msg, m.keys.Submit):
+			m.search.input.Blur()
+			return m.startSearch(m.search.input.Value(), 0)
+		default:
+			var cmd tea.Cmd
+			m.search.input, cmd = m.search.input.Update(msg)
+			return m, cmd
+		}
+	}
+
 	switch {
 	case key.Matches(msg, m.keys.Quit):
 		return m, tea.Quit
@@ -218,7 +265,26 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = ScreenInstalledMods
 		return m, nil
 	case key.Matches(msg, m.keys.Search):
+		if m.screen == ScreenSearch {
+			m.search.input.Focus()
+			return m, textinput.Blink
+		}
 		m.screen = ScreenSearch
+		return m, nil
+	case key.Matches(msg, m.keys.NextPage):
+		if m.screen == ScreenSearch && m.search.state == searchReady && m.search.hasNextPage() {
+			return m.startSearch(m.search.page.Query, m.search.page.Page+1)
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.PrevPage):
+		if m.screen == ScreenSearch && m.search.state == searchReady && m.search.page.Page > 0 {
+			return m.startSearch(m.search.page.Query, m.search.page.Page-1)
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.CycleSource):
+		if m.screen == ScreenSearch && len(m.search.sources) > 1 {
+			m.search.sourceIdx = (m.search.sourceIdx + 1) % len(m.search.sources)
+		}
 		return m, nil
 	case key.Matches(msg, m.keys.Profiles):
 		m.screen = ScreenProfiles
@@ -314,7 +380,7 @@ func (m Model) itemCount(screen Screen) int {
 	case ScreenInstalledMods:
 		return len(m.mods)
 	case ScreenSearch:
-		return 0 // Search results populated by Task 4
+		return len(m.search.page.Results)
 	case ScreenProfiles:
 		return len(m.profiles)
 	default:
@@ -478,6 +544,7 @@ func (m Model) modsView() string {
 
 func (m Model) searchView() string {
 	rows := []string{m.theme.PanelTitle.Render("ARCHIVE SEARCH")}
+	rows = append(rows, m.search.input.View())
 	rows = append(rows, m.theme.MutedText.Render("The archive index opens in a later chapter. (Search arrives in Phase 4.)"))
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -48,10 +48,9 @@ type Model struct {
 	state   loadState
 	loadErr error
 
-	summary       Summary
-	mods          []ModItem
-	searchResults []ModItem
-	profiles      []ProfileItem
+	summary  Summary
+	mods     []ModItem
+	profiles []ProfileItem
 
 	screen   Screen
 	selected map[Screen]int
@@ -71,10 +70,9 @@ const (
 
 // dataLoadedMsg carries data successfully loaded through a DataProvider.
 type dataLoadedMsg struct {
-	summary       Summary
-	mods          []ModItem
-	searchResults []ModItem
-	profiles      []ProfileItem
+	summary  Summary
+	mods     []ModItem
+	profiles []ProfileItem
 }
 
 // loadFailedMsg carries an error from a failed DataProvider load.
@@ -160,15 +158,7 @@ func (m Model) Init() tea.Cmd {
 func (m Model) loadData() tea.Msg {
 	ctx := context.Background()
 
-	summary, err := m.provider.Summary(ctx)
-	if err != nil {
-		return loadFailedMsg{err: err}
-	}
-	mods, err := m.provider.InstalledMods(ctx)
-	if err != nil {
-		return loadFailedMsg{err: err}
-	}
-	results, err := m.provider.SearchResults(ctx)
+	summary, mods, err := m.provider.Overview(ctx)
 	if err != nil {
 		return loadFailedMsg{err: err}
 	}
@@ -177,7 +167,7 @@ func (m Model) loadData() tea.Msg {
 		return loadFailedMsg{err: err}
 	}
 
-	return dataLoadedMsg{summary: summary, mods: mods, searchResults: results, profiles: profiles}
+	return dataLoadedMsg{summary: summary, mods: mods, profiles: profiles}
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -186,7 +176,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state = stateReady
 		m.summary = msg.summary
 		m.mods = msg.mods
-		m.searchResults = msg.searchResults
 		m.profiles = msg.profiles
 		return m, nil
 	case loadFailedMsg:
@@ -320,7 +309,7 @@ func (m Model) itemCount(screen Screen) int {
 	case ScreenInstalledMods:
 		return len(m.mods)
 	case ScreenSearch:
-		return len(m.searchResults)
+		return 0 // Search results populated by Task 4
 	case ScreenProfiles:
 		return len(m.profiles)
 	default:
@@ -484,12 +473,7 @@ func (m Model) modsView() string {
 
 func (m Model) searchView() string {
 	rows := []string{m.theme.PanelTitle.Render("ARCHIVE SEARCH")}
-	if len(m.searchResults) == 0 {
-		rows = append(rows, m.theme.MutedText.Render("The archive index opens in a later chapter. (Search arrives in Phase 4.)"))
-	}
-	for i, mod := range m.searchResults {
-		rows = append(rows, m.modRow(i, mod))
-	}
+	rows = append(rows, m.theme.MutedText.Render("The archive index opens in a later chapter. (Search arrives in Phase 4.)"))
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -542,11 +542,184 @@ func (m Model) modsView() string {
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
 }
 
+// searchHeaderLines renders the two lines shared by every search state: the
+// panel title with the active source, and the query input itself.
+func (m Model) searchHeaderLines() []string {
+	title := m.theme.PanelTitle.Render("ARCHIVE SEARCH")
+	meta := m.theme.MutedText.Render(fmt.Sprintf("[source: %s  (s cycles)]", m.search.source()))
+	return []string{title + "  " + meta, m.search.input.View()}
+}
+
+// searchSinglePanel wraps header+body lines in one full-bounds panel, used by
+// every search state except the ready-with-results two-pane layout.
+func (m Model) searchSinglePanel(lines []string) string {
+	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).
+		Render(strings.Join(lines, "\n"))
+}
+
 func (m Model) searchView() string {
-	rows := []string{m.theme.PanelTitle.Render("ARCHIVE SEARCH")}
-	rows = append(rows, m.search.input.View())
-	rows = append(rows, m.theme.MutedText.Render("The archive index opens in a later chapter. (Search arrives in Phase 4.)"))
-	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
+	header := m.searchHeaderLines()
+
+	switch m.search.state {
+	case searchLoading:
+		return m.searchSinglePanel(append(header, "Consulting the archive index..."))
+	case searchAuthRequired:
+		return m.searchSinglePanel(append(header,
+			m.theme.DangerText.Render(fmt.Sprintf("Authentication required for %s.", m.search.authSource)),
+			fmt.Sprintf("Run 'lmm auth login %s' in a shell, then search again.", m.search.authSource),
+		))
+	case searchFailed:
+		return m.searchSinglePanel(append(header, m.theme.DangerText.Render(m.search.err.Error())))
+	case searchReady:
+		if len(m.search.page.Results) == 0 {
+			return m.searchSinglePanel(append(header,
+				m.theme.MutedText.Render(fmt.Sprintf("No archives matched %q on %s.", m.search.page.Query, m.search.page.Source)),
+			))
+		}
+		return m.searchReadyView(header)
+	default: // searchIdle
+		return m.searchSinglePanel(append(header, m.theme.MutedText.Render("/ focus · enter search · s source")))
+	}
+}
+
+// searchReadyView renders the two-pane results/detail layout, mirroring
+// commanderDashboardView's width math so the panes plus a 1-column gap sum to
+// exactly availableWidth().
+func (m Model) searchReadyView(header []string) string {
+	width := m.availableWidth()
+	height := m.availableContentHeight()
+	footer := m.searchFooterLine()
+
+	paneHeight := max(height-len(header)-1, 1)
+	gap := 1
+	leftWidth := max((width-gap)/2, 1)
+	rightWidth := max(width-gap-leftWidth, 1)
+
+	// Panel content must never exceed paneContentHeight: lipgloss pads short
+	// content to a set Height() but does not clip content taller than it, so
+	// an unbounded row count or a long summary would silently grow the
+	// rendered block past paneHeight and break the exact-height invariant.
+	paneContentHeight := max(paneHeight-m.theme.Panel.GetVerticalBorderSize(), 1)
+
+	panes := lipgloss.JoinHorizontal(lipgloss.Top,
+		m.panelWithHeight(leftWidth, paneHeight).Render(m.searchResultsPane(leftWidth, paneContentHeight)),
+		" ",
+		m.panelWithHeight(rightWidth, paneHeight).Render(m.searchDetailPane(rightWidth, paneContentHeight)),
+	)
+
+	lines := append(append([]string{}, header...), panes, footer)
+	return strings.Join(lines, "\n")
+}
+
+// searchResultsPane renders the selectable result rows: name / version /
+// status, with "installed" statuses styled to pop. Column widths are derived
+// from the pane's actual content width (rather than fixed constants) and the
+// name column always absorbs whatever's left, so the three columns can never
+// sum past innerWidth. Overflowing values truncate instead of overflowing
+// into lipgloss's automatic line wrap, which would silently break the
+// exact-height layout invariant. Rows beyond maxLines are omitted for the
+// same reason (a full page of results can outnumber the available rows on a
+// short terminal).
+func (m Model) searchResultsPane(width, maxLines int) string {
+	const (
+		prefixWidth = 2 // m.row()'s "> "/"  " selection marker
+		gaps        = 2 // the two separating spaces between columns
+	)
+	innerWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
+	avail := max(innerWidth-prefixWidth-gaps, 3)
+	statusWidth := min(max(avail/4, 1), 9) // "installed"/"available" are 9 runes
+	versionWidth := min(max(avail/4, 1), 8)
+	nameWidth := max(avail-statusWidth-versionWidth, 1)
+
+	results := m.search.page.Results
+	if len(results) > maxLines {
+		results = results[:maxLines]
+	}
+
+	rows := make([]string, 0, len(results))
+	for i, item := range results {
+		status := fmt.Sprintf("%-*s", statusWidth, truncate(item.Status, statusWidth))
+		if item.Status == "installed" {
+			status = m.theme.WarningText.Render(status)
+		}
+		line := fmt.Sprintf("%-*s %-*s %s",
+			nameWidth, truncate(item.Name, nameWidth),
+			versionWidth, truncate(item.Version, versionWidth),
+			status)
+		rows = append(rows, m.row(i, line))
+	}
+	return strings.Join(rows, "\n")
+}
+
+// searchDetailPane renders the fields for the currently selected result.
+// Unknown endorsements render "?" (countLabel convention: never fake data).
+// Labels and free-text values are truncated to the pane's content width for
+// the same reason searchResultsPane truncates: overflow would trigger an
+// unpredictable automatic re-wrap inside the bordered panel. The summary is
+// clipped to whatever vertical budget remains after the fixed fields so a
+// long summary can never grow the pane past maxLines.
+func (m Model) searchDetailPane(width, maxLines int) string {
+	results := m.search.page.Results
+	idx := m.selected[ScreenSearch]
+	if idx < 0 || idx >= len(results) {
+		return m.theme.MutedText.Render("No selection.")
+	}
+	item := results[idx]
+
+	endorsements := "?"
+	if item.HasEndorsements {
+		endorsements = fmt.Sprintf("%d", item.Endorsements)
+	}
+
+	innerWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
+	labelWidth := min(13, max(innerWidth-1, 1)) // len("Endorsements ") == 13
+	valueWidth := max(innerWidth-labelWidth, 1)
+	field := func(label, value string) string {
+		return fmt.Sprintf("%-*s%s", labelWidth, truncate(label, labelWidth), truncate(value, valueWidth))
+	}
+
+	lines := []string{
+		m.theme.PanelTitle.Render("DETAIL"),
+		field("Name", item.Name),
+		field("Author", item.Author),
+		field("Version", item.Version),
+		field("Source", item.Source),
+		field("Status", item.Status),
+		field("Downloads", fmt.Sprintf("%d", item.Downloads)),
+		field("Endorsements", endorsements),
+	}
+
+	if summaryBudget := maxLines - len(lines) - 1; summaryBudget > 0 && item.Summary != "" {
+		lines = append(lines, "")
+		summary := strings.Split(m.theme.MutedText.Width(innerWidth).Render(item.Summary), "\n")
+		if len(summary) > summaryBudget {
+			summary = summary[:summaryBudget]
+			last := summaryBudget - 1
+			summary[last] = strings.TrimRight(summary[last], " ") + m.theme.MutedText.Render("…")
+		}
+		lines = append(lines, summary...)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// searchFooterLine renders pagination status. The total-pages figure only
+// appears when the source reports a TotalCount; otherwise only the current
+// page and (if available) the next-page hint are shown.
+func (m Model) searchFooterLine() string {
+	page := m.search.page
+	current := page.Page + 1
+
+	if page.TotalCount > 0 && page.PageSize > 0 {
+		totalPages := (page.TotalCount + page.PageSize - 1) / page.PageSize
+		return fmt.Sprintf("Page %d/%d (%d results) · n next · p prev", current, totalPages, page.TotalCount)
+	}
+
+	footer := fmt.Sprintf("Page %d", current)
+	if m.search.hasNextPage() {
+		footer += " · n next"
+	}
+	return footer
 }
 
 func (m Model) profilesView() string {
@@ -569,6 +742,7 @@ func (m Model) helpView() string {
 		"tab / shift+tab     cycle top-level screens",
 		"1-4                 jump to a screen",
 		"/                   open search screen",
+		"/ focus · enter search · esc cancel · n/p pages · s source",
 		"?                   toggle this help",
 		"q / ctrl+c           quit",
 		"",
@@ -630,6 +804,24 @@ func countLabel(n int) string {
 		return "?"
 	}
 	return fmt.Sprintf("%d", n)
+}
+
+// truncate returns s trimmed to at most width runes, marking a cut with a
+// trailing ellipsis. Used to keep fixed-width row/field values from
+// overflowing a panel's content width, which would otherwise trigger
+// lipgloss's automatic re-wrap and silently grow the rendered line count.
+func truncate(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= width {
+		return s
+	}
+	if width == 1 {
+		return string(runes[:1])
+	}
+	return string(runes[:width-1]) + "…"
 }
 
 func layoutForTheme(name string) Layout {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -36,6 +36,7 @@ const (
 type Options struct {
 	Theme    string
 	Provider DataProvider
+	Ctx      context.Context
 }
 
 // Model is the root Bubble Tea model for the lmm TUI.
@@ -44,6 +45,7 @@ type Model struct {
 	layout   Layout
 	keys     KeyMap
 	provider DataProvider
+	ctx      context.Context
 
 	state   loadState
 	loadErr error
@@ -88,11 +90,16 @@ func NewModel(options Options) (Model, error) {
 		return Model{}, err
 	}
 
+	if options.Ctx == nil {
+		options.Ctx = context.Background()
+	}
+
 	return Model{
 		theme:    t,
 		layout:   layoutForTheme(t.Name),
 		keys:     DefaultKeyMap(),
 		provider: options.Provider,
+		ctx:      options.Ctx,
 		state:    stateLoading,
 		screen:   ScreenDashboard,
 		selected: map[Screen]int{
@@ -156,13 +163,11 @@ func (m Model) Init() tea.Cmd {
 // loadData fetches all dashboard data through the configured DataProvider.
 // It runs as a Bubble Tea command, off the update loop.
 func (m Model) loadData() tea.Msg {
-	ctx := context.Background()
-
-	summary, mods, err := m.provider.Overview(ctx)
+	summary, mods, err := m.provider.Overview(m.ctx)
 	if err != nil {
 		return loadFailedMsg{err: err}
 	}
-	profiles, err := m.provider.Profiles(ctx)
+	profiles, err := m.provider.Profiles(m.ctx)
 	if err != nil {
 		return loadFailedMsg{err: err}
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/tui/theme"
@@ -584,7 +585,12 @@ func (m Model) searchView() string {
 
 // searchReadyView renders the two-pane results/detail layout, mirroring
 // commanderDashboardView's width math so the panes plus a 1-column gap sum to
-// exactly availableWidth().
+// exactly availableWidth(). Unlike the other search states, this view's
+// header and footer lines sit outside any Width()-constrained panel style,
+// so they are hard-capped to width here: lipgloss.Width of the whole view is
+// the max width across its lines, and the panes line already sums to exactly
+// width, but an unclamped header/footer line would push that max past width
+// and wrap the bordered panes onto separate output lines at narrow sizes.
 func (m Model) searchReadyView(header []string) string {
 	width := m.availableWidth()
 	height := m.availableContentHeight()
@@ -607,7 +613,11 @@ func (m Model) searchReadyView(header []string) string {
 		m.panelWithHeight(rightWidth, paneHeight).Render(m.searchDetailPane(rightWidth, paneContentHeight)),
 	)
 
-	lines := append(append([]string{}, header...), panes, footer)
+	lines := make([]string, 0, len(header)+2)
+	for _, line := range header {
+		lines = append(lines, truncate(line, width))
+	}
+	lines = append(lines, panes, truncate(footer, width))
 	return strings.Join(lines, "\n")
 }
 
@@ -705,19 +715,24 @@ func (m Model) searchDetailPane(width, maxLines int) string {
 
 // searchFooterLine renders pagination status. The total-pages figure only
 // appears when the source reports a TotalCount; otherwise only the current
-// page and (if available) the next-page hint are shown.
+// page is shown. In both cases, the "n next"/"p prev" hints only render when
+// the corresponding key would actually act, so a page-1 footer never shows a
+// dead "p prev" hint.
 func (m Model) searchFooterLine() string {
 	page := m.search.page
 	current := page.Page + 1
 
+	footer := fmt.Sprintf("Page %d", current)
 	if page.TotalCount > 0 && page.PageSize > 0 {
 		totalPages := (page.TotalCount + page.PageSize - 1) / page.PageSize
-		return fmt.Sprintf("Page %d/%d (%d results) · n next · p prev", current, totalPages, page.TotalCount)
+		footer = fmt.Sprintf("Page %d/%d (%d results)", current, totalPages, page.TotalCount)
 	}
 
-	footer := fmt.Sprintf("Page %d", current)
 	if m.search.hasNextPage() {
 		footer += " · n next"
+	}
+	if page.Page > 0 {
+		footer += " · p prev"
 	}
 	return footer
 }
@@ -806,22 +821,17 @@ func countLabel(n int) string {
 	return fmt.Sprintf("%d", n)
 }
 
-// truncate returns s trimmed to at most width runes, marking a cut with a
-// trailing ellipsis. Used to keep fixed-width row/field values from
+// truncate returns s trimmed to at most width display columns, marking a cut
+// with a trailing ellipsis. Used to keep fixed-width row/field values from
 // overflowing a panel's content width, which would otherwise trigger
 // lipgloss's automatic re-wrap and silently grow the rendered line count.
+// ansi.Truncate is display-width aware (wide runes such as CJK count as two
+// columns) and ANSI-escape safe, unlike a plain rune-count slice.
 func truncate(s string, width int) string {
 	if width <= 0 {
 		return ""
 	}
-	runes := []rune(s)
-	if len(runes) <= width {
-		return s
-	}
-	if width == 1 {
-		return string(runes[:1])
-	}
-	return string(runes[:width-1]) + "…"
+	return ansi.Truncate(s, width, "…")
 }
 
 func layoutForTheme(name string) Layout {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -778,7 +778,7 @@ func (m Model) helpView() string {
 		"arrows / hjkl       move or switch screens",
 		"tab / shift+tab     cycle top-level screens",
 		"1-4                 jump to a screen",
-		"/                   open search screen",
+		"/                   search screen / focus input",
 		"enter               search",
 		"esc                 cancel input",
 		"n/p                 result pages",

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -401,7 +401,7 @@ func TestEmptyStatesRenderHonestCopy(t *testing.T) {
 	require.Contains(t, model.View(), "No mods installed yet. 'lmm install <mod>' begins the quest.")
 
 	model = updateWithRunes(t, model, "3")
-	require.Contains(t, model.View(), "The archive index opens in a later chapter. (Search arrives in Phase 4.)")
+	require.Contains(t, model.View(), "/ focus · enter search · s source")
 }
 
 // recordingProvider wraps a delegate DataProvider and records the context

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -324,10 +324,14 @@ func TestEnterOutsideDashboardIsANoop(t *testing.T) {
 
 type failingProvider struct{ err error }
 
-func (f failingProvider) Summary(context.Context) (Summary, error)         { return Summary{}, f.err }
-func (f failingProvider) InstalledMods(context.Context) ([]ModItem, error) { return nil, f.err }
-func (f failingProvider) SearchResults(context.Context) ([]ModItem, error) { return nil, f.err }
-func (f failingProvider) Profiles(context.Context) ([]ProfileItem, error)  { return nil, f.err }
+func (f failingProvider) Overview(context.Context) (Summary, []ModItem, error) {
+	return Summary{}, nil, f.err
+}
+func (f failingProvider) Profiles(context.Context) ([]ProfileItem, error) { return nil, f.err }
+func (f failingProvider) Sources() []string                               { return []string{"nexusmods"} }
+func (f failingProvider) Search(context.Context, string, string, int) (SearchPage, error) {
+	return SearchPage{}, f.err
+}
 
 func TestModelShowsLoadingBeforeDataArrives(t *testing.T) {
 	t.Parallel()
@@ -375,10 +379,14 @@ func TestNewModelRequiresProvider(t *testing.T) {
 
 type emptyProvider struct{}
 
-func (emptyProvider) Summary(context.Context) (Summary, error)         { return Summary{}, nil }
-func (emptyProvider) InstalledMods(context.Context) ([]ModItem, error) { return nil, nil }
-func (emptyProvider) SearchResults(context.Context) ([]ModItem, error) { return nil, nil }
-func (emptyProvider) Profiles(context.Context) ([]ProfileItem, error)  { return nil, nil }
+func (emptyProvider) Overview(context.Context) (Summary, []ModItem, error) {
+	return Summary{}, nil, nil
+}
+func (emptyProvider) Profiles(context.Context) ([]ProfileItem, error) { return nil, nil }
+func (emptyProvider) Sources() []string                               { return []string{"nexusmods"} }
+func (emptyProvider) Search(context.Context, string, string, int) (SearchPage, error) {
+	return SearchPage{}, nil
+}
 
 func TestEmptyStatesRenderHonestCopy(t *testing.T) {
 	t.Parallel()

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -403,3 +403,47 @@ func TestEmptyStatesRenderHonestCopy(t *testing.T) {
 	model = updateWithRunes(t, model, "3")
 	require.Contains(t, model.View(), "The archive index opens in a later chapter. (Search arrives in Phase 4.)")
 }
+
+// recordingProvider wraps a delegate DataProvider and records the context
+// passed to Overview for test verification.
+type recordingProvider struct {
+	delegate   DataProvider
+	onOverview func(context.Context)
+}
+
+func (r recordingProvider) Overview(ctx context.Context) (Summary, []ModItem, error) {
+	if r.onOverview != nil {
+		r.onOverview(ctx)
+	}
+	return r.delegate.Overview(ctx)
+}
+
+func (r recordingProvider) Profiles(ctx context.Context) ([]ProfileItem, error) {
+	return r.delegate.Profiles(ctx)
+}
+
+func (r recordingProvider) Sources() []string {
+	return r.delegate.Sources()
+}
+
+func (r recordingProvider) Search(ctx context.Context, source, query string, page int) (SearchPage, error) {
+	return r.delegate.Search(ctx, source, query, page)
+}
+
+func TestModelUsesProvidedContext(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+
+	var seen context.Context
+	provider := recordingProvider{
+		delegate:   NewPrototypeProvider(),
+		onOverview: func(c context.Context) { seen = c },
+	}
+	model, err := NewModel(Options{Theme: "wizardry", Provider: provider, Ctx: ctx})
+	require.NoError(t, err)
+
+	model.Init()()
+	require.Equal(t, "marker", seen.Value(ctxKey{}))
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -11,6 +11,7 @@ type KeyMap struct {
 	Up            key.Binding
 	Down          key.Binding
 	Search        key.Binding
+	SearchScreen  key.Binding
 	Dashboard     key.Binding
 	InstalledMods key.Binding
 	Profiles      key.Binding
@@ -50,8 +51,12 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("↓/j", "down"),
 		),
 		Search: key.NewBinding(
-			key.WithKeys("/", "3"),
+			key.WithKeys("/"),
 			key.WithHelp("/", "search"),
+		),
+		SearchScreen: key.NewBinding(
+			key.WithKeys("3"),
+			key.WithHelp("3", "search screen"),
 		),
 		Dashboard: key.NewBinding(
 			key.WithKeys("1"),

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -15,6 +15,11 @@ type KeyMap struct {
 	InstalledMods key.Binding
 	Profiles      key.Binding
 	Select        key.Binding
+	Submit        key.Binding
+	Blur          key.Binding
+	NextPage      key.Binding
+	PrevPage      key.Binding
+	CycleSource   key.Binding
 }
 
 // DefaultKeyMap returns the shared key bindings shown in help and used by tests.
@@ -63,6 +68,26 @@ func DefaultKeyMap() KeyMap {
 		Select: key.NewBinding(
 			key.WithKeys("enter"),
 			key.WithHelp("enter", "open"),
+		),
+		Submit: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "search"),
+		),
+		Blur: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "cancel input"),
+		),
+		NextPage: key.NewBinding(
+			key.WithKeys("n"),
+			key.WithHelp("n", "next page"),
+		),
+		PrevPage: key.NewBinding(
+			key.WithKeys("p"),
+			key.WithHelp("p", "prev page"),
+		),
+		CycleSource: key.NewBinding(
+			key.WithKeys("s"),
+			key.WithHelp("s", "cycle source"),
 		),
 	}
 }

--- a/internal/tui/prototype/data.go
+++ b/internal/tui/prototype/data.go
@@ -29,11 +29,15 @@ type Stats struct {
 }
 
 type Mod struct {
-	Name    string
-	Source  string
-	Author  string
-	Version string
-	Status  string
+	Name            string
+	Source          string
+	Author          string
+	Version         string
+	Status          string
+	Summary         string
+	Downloads       int64
+	Endorsements    int64
+	HasEndorsements bool
 }
 
 // Load returns static demo data. It must never touch disk, network, DB, or APIs.
@@ -48,17 +52,17 @@ func Load() Data {
 			Conflicts: 1,
 		},
 		InstalledMods: []Mod{
-			{Name: "SkyUI", Source: "nexusmods", Author: "schlangster", Version: "5.2", Status: "installed"},
-			{Name: "USSEP", Source: "nexusmods", Author: "Arthmoor", Version: "4.3", Status: "update"},
-			{Name: "SKSE Address Library", Source: "nexusmods", Author: "meh321", Version: "11", Status: "installed"},
-			{Name: "Immersive Armors", Source: "nexusmods", Author: "hothtrooper44", Version: "8.1", Status: "conflict"},
-			{Name: "Alternate Start", Source: "nexusmods", Author: "Arthmoor", Version: "4.2", Status: "disabled"},
+			{Name: "SkyUI", Source: "nexusmods", Author: "schlangster", Version: "5.2", Status: "installed", Summary: "Immersive user interface overhaul.", Downloads: 12_500_000, Endorsements: 850_000, HasEndorsements: true},
+			{Name: "USSEP", Source: "nexusmods", Author: "Arthmoor", Version: "4.3", Status: "update", Summary: "Unofficial Skyrim Special Edition Patch.", Downloads: 11_000_000, Endorsements: 420_000, HasEndorsements: true},
+			{Name: "SKSE Address Library", Source: "nexusmods", Author: "meh321", Version: "11", Status: "installed", Summary: "Address library for SKSE plugins.", Downloads: 8_900_000, Endorsements: 150_000, HasEndorsements: true},
+			{Name: "Immersive Armors", Source: "nexusmods", Author: "hothtrooper44", Version: "8.1", Status: "conflict", Summary: "Adds hundreds of new armor variants.", Downloads: 6_700_000, Endorsements: 380_000, HasEndorsements: true},
+			{Name: "Alternate Start", Source: "nexusmods", Author: "Arthmoor", Version: "4.2", Status: "disabled", Summary: "Alternative character start scenarios.", Downloads: 5_200_000, Endorsements: 220_000, HasEndorsements: true},
 		},
 		SearchResults: []Mod{
-			{Name: "Campfire", Source: "nexusmods", Author: "Chesko", Version: "1.12", Status: "available"},
-			{Name: "Frostfall", Source: "nexusmods", Author: "Chesko", Version: "3.4", Status: "available"},
-			{Name: "Hunterborn", Source: "nexusmods", Author: "unuroboros", Version: "1.6", Status: "available"},
-			{Name: "Legacy of the Dragonborn", Source: "nexusmods", Author: "icecreamassassin", Version: "6.5", Status: "available"},
+			{Name: "Campfire", Source: "nexusmods", Author: "Chesko", Version: "1.12", Status: "available", Summary: "Camping and survival skill system.", Downloads: 4_200_000, Endorsements: 180_000, HasEndorsements: true},
+			{Name: "Frostfall", Source: "nexusmods", Author: "Chesko", Version: "3.4", Status: "available", Summary: "Hypothermia and survival overhaul.", Downloads: 3_800_000, Endorsements: 165_000, HasEndorsements: true},
+			{Name: "Hunterborn", Source: "nexusmods", Author: "unuroboros", Version: "1.6", Status: "available", Summary: "Hunting and harvesting overhaul.", Downloads: 2_900_000, Endorsements: 95_000, HasEndorsements: true},
+			{Name: "Legacy of the Dragonborn", Source: "nexusmods", Author: "icecreamassassin", Version: "6.5", Status: "available", Summary: "Museum and player home museum.", Downloads: 2_100_000, Endorsements: 78_000, HasEndorsements: true},
 		},
 		Profiles: []Profile{
 			{Name: "survival", Active: true, ModCount: 42},

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -1,0 +1,101 @@
+package tui
+
+import (
+	"context"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// searchState tracks where the search sub-model is in its async query
+// lifecycle.
+type searchState int
+
+const (
+	searchIdle searchState = iota
+	searchLoading
+	searchReady
+	searchFailed
+	searchAuthRequired
+)
+
+// searchModel is the Archive Search screen's sub-model: a focusable query
+// input, the currently selected source, and the state of the most recent
+// (or in-flight) search.
+type searchModel struct {
+	input      textinput.Model
+	sources    []string
+	sourceIdx  int
+	state      searchState
+	page       SearchPage
+	err        error
+	authSource string
+	gen        int
+	cancel     context.CancelFunc
+}
+
+// searchResultMsg carries a completed search page, tagged with the
+// generation of the query that produced it so stale results can be
+// discarded.
+type searchResultMsg struct {
+	gen  int
+	page SearchPage
+}
+
+// searchFailedMsg carries a failed search, tagged with the generation of the
+// query that produced it so stale failures can be discarded.
+type searchFailedMsg struct {
+	gen    int
+	err    error
+	source string
+}
+
+// newSearchModel builds the search sub-model, seeding its source list from
+// the DataProvider.
+func newSearchModel(provider DataProvider) searchModel {
+	input := textinput.New()
+	input.Placeholder = "search the archives"
+	input.CharLimit = 120
+	return searchModel{input: input, sources: provider.Sources()}
+}
+
+// source returns the currently selected source ID, or "" when the game has
+// no configured sources.
+func (s searchModel) source() string {
+	if len(s.sources) == 0 {
+		return ""
+	}
+	return s.sources[s.sourceIdx]
+}
+
+// hasNextPage reports whether another page of results is available for the
+// current search, mirroring the CLI picker's logic (see install.go).
+func (s searchModel) hasNextPage() bool {
+	if s.page.TotalCount > 0 {
+		return (s.page.Page+1)*s.page.PageSize < s.page.TotalCount
+	}
+	return len(s.page.Results) == s.page.PageSize // full page ⇒ maybe more
+}
+
+// startSearch cancels any in-flight search, bumps the generation, and returns
+// the model plus a command executing the new query.
+func (m Model) startSearch(query string, page int) (Model, tea.Cmd) {
+	if m.search.cancel != nil {
+		m.search.cancel()
+	}
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.search.cancel = cancel
+	m.search.gen++
+	m.search.state = searchLoading
+
+	gen := m.search.gen
+	provider := m.provider
+	source := m.search.source()
+	return m, func() tea.Msg {
+		result, err := provider.Search(ctx, source, query, page)
+		if err != nil {
+			return searchFailedMsg{gen: gen, err: err, source: source}
+		}
+		return searchResultMsg{gen: gen, page: result}
+	}
+}

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -102,6 +103,13 @@ func (s searchModel) hasNextPage() bool {
 // startSearch cancels any in-flight search, bumps the generation, and returns
 // the model plus a command executing the new query.
 func (m Model) startSearch(query string, page int) (Model, tea.Cmd) {
+	// Guard: no sources configured for this game
+	if m.search.source() == "" {
+		m.search.state = searchFailed
+		m.search.err = errors.New("no mod sources configured for this game; add one with 'lmm game add' or edit games.yaml")
+		return m, nil
+	}
+
 	if m.search.cancel != nil {
 		m.search.cancel()
 	}

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -50,12 +50,34 @@ type searchFailedMsg struct {
 	source string
 }
 
+// searchInputPromptAllowance reserves room for the query input's "> " prompt
+// plus its trailing cursor cell, so searchInputWidthFor's value-viewport
+// width keeps prompt+value+cursor inside the panel's content width. Without
+// this, a value near the viewport width can overflow by one cell and
+// word-wrap inside the width-set search panel instead of h-scrolling.
+const searchInputPromptAllowance = 4
+
+// searchInputWidthFor derives the query input's value-viewport width (see
+// textinput.Model.Width) from the content width available to the search
+// panel and that panel's horizontal frame size (border + padding), so a long
+// query scrolls horizontally within the input instead of word-wrapping
+// inside the width-set search panel and growing the view past
+// availableContentHeight.
+func searchInputWidthFor(availableWidth, panelHorizontalFrameSize int) int {
+	inner := availableWidth - panelHorizontalFrameSize
+	return max(inner-searchInputPromptAllowance, 10)
+}
+
 // newSearchModel builds the search sub-model, seeding its source list from
-// the DataProvider.
-func newSearchModel(provider DataProvider) searchModel {
+// the DataProvider. The input's Width defaults from defaultContentWidth (the
+// same zero-size fallback availableWidth uses) so the input stays bounded
+// even in tests that never send a tea.WindowSizeMsg; Update's
+// tea.WindowSizeMsg case recomputes it once real terminal dimensions arrive.
+func newSearchModel(provider DataProvider, panelHorizontalFrameSize int) searchModel {
 	input := textinput.New()
 	input.Placeholder = "search the archives"
 	input.CharLimit = 120
+	input.Width = searchInputWidthFor(defaultContentWidth, panelHorizontalFrameSize)
 	return searchModel{input: input, sources: provider.Sources()}
 }
 

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -110,6 +110,49 @@ func TestCycleSourceKey(t *testing.T) {
 	require.Equal(t, 0, model.search.sourceIdx, "cycling wraps")
 }
 
+func TestCycleSourceInvalidatesInFlightAndResults(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.sources = []string{"curseforge", "nexusmods"}
+	model.search.state = searchLoading
+	model.search.gen = 3
+
+	model = updateWithRunes(t, model, "s")
+	require.Equal(t, searchIdle, model.search.state, "cycling resets state")
+	require.Greater(t, model.search.gen, 3, "gen bumped so in-flight results are stale")
+
+	// The in-flight result from the old source must now be discarded.
+	updated, _ := model.Update(searchResultMsg{gen: 3, page: SearchPage{Source: "curseforge", Query: "x"}})
+	require.Equal(t, searchIdle, updated.(Model).search.state)
+}
+
+func TestReadyHeaderShowsResultSourceNotTarget(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.sources = []string{"curseforge", "nexusmods"}
+	model.search.state = searchReady
+	model.search.page = SearchPage{Query: "q", Source: "nexusmods", PageSize: 10, TotalCount: 1,
+		Results: []ModItem{{Name: "A", Status: "available"}}}
+	model.search.sourceIdx = 0 // target is curseforge, results are nexusmods
+
+	require.Contains(t, model.View(), "nexusmods", "ready view labels the results' actual source")
+}
+
+func TestLongQueryDoesNotBreakSearchHeightInvariant(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 80, 24)
+	model = updateWithRunes(t, model, "3")
+	model = updateWithRunes(t, model, "/")
+	for range 100 {
+		model = updateWithRunes(t, model, "x")
+	}
+	require.Equal(t, model.availableContentHeight(), lipgloss.Height(model.screenView()))
+	require.Equal(t, model.availableWidth(), lipgloss.Width(model.screenView()))
+}
+
 func TestPaginationKeysRequeryWithinBounds(t *testing.T) {
 	t.Parallel()
 
@@ -164,6 +207,16 @@ func TestSearchViewRendersStates(t *testing.T) {
 	require.Contains(t, view, "installed")
 	require.Contains(t, view, "Page 1/2")
 	require.Contains(t, view, "UI overhaul.", "detail panel shows the selected result's summary")
+
+	model.search.page.Results = append(model.search.page.Results,
+		ModItem{Name: "SkyUnknown", Author: "someone", Version: "0.1", Status: "available", HasEndorsements: false})
+	model.selected[ScreenSearch] = len(model.search.page.Results) - 1
+	view = model.View()
+	require.Contains(t, view, "Endorsements ?", "unknown endorsements render as ?")
+
+	model.search.page = SearchPage{Query: "nothing", Source: "nexusmods", PageSize: 10}
+	view = model.View()
+	require.Contains(t, view, "No archives matched", "zero-result state renders honest copy")
 }
 
 func TestSearchViewStaysWithinBounds(t *testing.T) {

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -143,14 +143,16 @@ func TestReadyHeaderShowsResultSourceNotTarget(t *testing.T) {
 func TestLongQueryDoesNotBreakSearchHeightInvariant(t *testing.T) {
 	t.Parallel()
 
-	model := sizedPrototypeModel(t, "wizardry", 80, 24)
-	model = updateWithRunes(t, model, "3")
-	model = updateWithRunes(t, model, "/")
-	for range 100 {
-		model = updateWithRunes(t, model, "x")
+	for _, width := range []int{44, 48, 60, 80} {
+		model := sizedPrototypeModel(t, "wizardry", width, 24)
+		model = updateWithRunes(t, model, "3")
+		model = updateWithRunes(t, model, "/")
+		for range 100 {
+			model = updateWithRunes(t, model, "x")
+		}
+		require.Equal(t, model.availableContentHeight(), lipgloss.Height(model.screenView()), "height at %d", width)
+		require.Equal(t, model.availableWidth(), lipgloss.Width(model.screenView()), "width at %d", width)
 	}
-	require.Equal(t, model.availableContentHeight(), lipgloss.Height(model.screenView()))
-	require.Equal(t, model.availableWidth(), lipgloss.Width(model.screenView()))
 }
 
 func TestPaginationKeysRequeryWithinBounds(t *testing.T) {

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -176,3 +176,25 @@ func TestSearchViewStaysWithinBounds(t *testing.T) {
 	require.Equal(t, model.availableWidth(), lipgloss.Width(model.screenView()))
 	require.Equal(t, model.availableContentHeight(), lipgloss.Height(model.screenView()))
 }
+
+func TestSearchReadyViewFitsNarrowTerminals(t *testing.T) {
+	t.Parallel()
+
+	for _, width := range []int{40, 48, 54, 80} {
+		model := sizedPrototypeModel(t, "wizardry", width, 24)
+		model = updateWithRunes(t, model, "3")
+		model.search.state = searchReady
+		model.search.page = SearchPage{
+			Query: "sky", Source: "nexusmods", Page: 0, PageSize: 10, TotalCount: 25,
+			Results: []ModItem{{Name: "SkyUI", Author: "schlangster", Version: "5.2", Status: "installed", Summary: "UI overhaul."}},
+		}
+		require.Equal(t, model.availableWidth(), lipgloss.Width(model.screenView()), "width %d", width)
+	}
+}
+
+func TestTruncateIsDisplayWidthAware(t *testing.T) {
+	t.Parallel()
+
+	require.LessOrEqual(t, lipgloss.Width(truncate("模组名称超长测试", 10)), 10)
+	require.Equal(t, "short", truncate("short", 10))
+}

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -32,6 +32,31 @@ func TestSlashFocusesSearchInputOnSearchScreen(t *testing.T) {
 	require.True(t, model.search.input.Focused())
 }
 
+func TestSlashFromAnyScreenJumpsAndFocuses(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 100, 30)
+	require.Equal(t, ScreenDashboard, model.CurrentScreen())
+
+	model = updateWithRunes(t, model, "/")
+	require.Equal(t, ScreenSearch, model.CurrentScreen())
+	require.True(t, model.search.input.Focused(), "single / must be enough to type")
+
+	for _, r := range "sky" {
+		model = updateWithRunes(t, model, string(r))
+	}
+	require.Equal(t, "sky", model.search.input.Value())
+}
+
+func TestNumberThreeJumpsWithoutFocusing(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 100, 30)
+	model = updateWithRunes(t, model, "3")
+	require.Equal(t, ScreenSearch, model.CurrentScreen())
+	require.False(t, model.search.input.Focused(), "3 is pure navigation")
+}
+
 func TestTypingWhileFocusedDoesNotTriggerGlobalKeys(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -253,3 +253,19 @@ func TestTruncateIsDisplayWidthAware(t *testing.T) {
 	require.LessOrEqual(t, lipgloss.Width(truncate("模组名称超长测试", 10)), 10)
 	require.Equal(t, "short", truncate("short", 10))
 }
+
+func TestSubmitWithNoConfiguredSourcesFailsClearly(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.sources = nil
+	model = updateWithRunes(t, model, "/")
+	for _, r := range "sky" {
+		model = updateWithRunes(t, model, string(r))
+	}
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m := updated.(Model)
+	require.Nil(t, cmd, "no search command without a source")
+	require.Equal(t, searchFailed, m.search.state)
+	require.Contains(t, m.View(), "no mod sources configured")
+}

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -1,0 +1,125 @@
+package tui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// keyRunes builds a KeyMsg carrying a single-character rune press, matching
+// the construction updateWithRunes uses internally.
+func keyRunes(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func searchScreenModel(t *testing.T) Model {
+	t.Helper()
+	model := sizedPrototypeModel(t, "wizardry", 100, 30)
+	return updateWithRunes(t, model, "3") // jump to search screen (blurred)
+}
+
+func TestSlashFocusesSearchInputOnSearchScreen(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model = updateWithRunes(t, model, "/")
+	require.True(t, model.search.input.Focused())
+}
+
+func TestTypingWhileFocusedDoesNotTriggerGlobalKeys(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model = updateWithRunes(t, model, "/")
+	for _, r := range "quest124" { // q would quit; 1/2/4 would jump screens
+		model = updateWithRunes(t, model, string(r))
+	}
+	require.Equal(t, ScreenSearch, model.CurrentScreen())
+	require.Equal(t, "quest124", model.search.input.Value())
+}
+
+func TestEscBlursSearchInput(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model = updateWithRunes(t, model, "/")
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.False(t, updated.(Model).search.input.Focused())
+}
+
+func TestEnterSubmitsSearchAndRendersResults(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model = updateWithRunes(t, model, "/")
+	for _, r := range "frost" {
+		model = updateWithRunes(t, model, string(r))
+	}
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.Equal(t, searchLoading, model.search.state)
+	require.NotNil(t, cmd)
+
+	result, _ := model.Update(cmd())
+	model = result.(Model)
+	require.Equal(t, searchReady, model.search.state)
+	require.Len(t, model.search.page.Results, 1)
+	require.Equal(t, "Frostfall", model.search.page.Results[0].Name)
+}
+
+func TestStaleSearchResultsAreDiscarded(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.gen = 5
+	model.search.state = searchLoading
+
+	updated, _ := model.Update(searchResultMsg{gen: 4, page: SearchPage{Query: "stale"}})
+	require.Equal(t, searchLoading, updated.(Model).search.state, "stale gen must be ignored")
+}
+
+func TestAuthRequiredBecomesFirstClassState(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.gen = 1
+	updated, _ := model.Update(searchFailedMsg{
+		gen:    1,
+		err:    fmt.Errorf("%w: key required", domain.ErrAuthRequired),
+		source: "nexusmods",
+	})
+	m := updated.(Model)
+	require.Equal(t, searchAuthRequired, m.search.state)
+	require.Equal(t, "nexusmods", m.search.authSource)
+}
+
+func TestCycleSourceKey(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.sources = []string{"curseforge", "nexusmods"}
+	model = updateWithRunes(t, model, "s")
+	require.Equal(t, 1, model.search.sourceIdx)
+	model = updateWithRunes(t, model, "s")
+	require.Equal(t, 0, model.search.sourceIdx, "cycling wraps")
+}
+
+func TestPaginationKeysRequeryWithinBounds(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.state = searchReady
+	model.search.page = SearchPage{Query: "q", Source: "nexusmods", Page: 0, PageSize: 10, TotalCount: 25}
+
+	updated, cmd := model.Update(keyRunes("n"))
+	require.NotNil(t, cmd, "next page issues a search command")
+	_ = updated
+
+	model.search.page.Page = 0
+	_, cmd = model.Update(keyRunes("p"))
+	require.Nil(t, cmd, "prev on page 0 is a no-op")
+}

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -1,10 +1,12 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -122,4 +124,55 @@ func TestPaginationKeysRequeryWithinBounds(t *testing.T) {
 	model.search.page.Page = 0
 	_, cmd = model.Update(keyRunes("p"))
 	require.Nil(t, cmd, "prev on page 0 is a no-op")
+}
+
+func TestCtrlCQuitsWhileSearchInputFocused(t *testing.T) {
+	t.Parallel()
+	model := searchScreenModel(t)
+	model = updateWithRunes(t, model, "/") // focus
+	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	require.NotNil(t, cmd)
+	require.Equal(t, tea.Quit(), cmd())
+}
+
+func TestSearchViewRendersStates(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+
+	require.Contains(t, model.View(), "search the archives", "idle shows the input placeholder")
+
+	model.search.state = searchAuthRequired
+	model.search.authSource = "nexusmods"
+	view := model.View()
+	require.Contains(t, view, "lmm auth login nexusmods")
+
+	model.search.state = searchFailed
+	model.search.err = errors.New("the aether is down")
+	require.Contains(t, model.View(), "the aether is down")
+
+	model.search.state = searchReady
+	model.search.page = SearchPage{
+		Query: "sky", Source: "nexusmods", Page: 0, PageSize: 10, TotalCount: 12,
+		Results: []ModItem{
+			{Name: "SkyUI", Author: "schlangster", Version: "5.2", Status: "installed", Summary: "UI overhaul.", Downloads: 1000, Endorsements: 50, HasEndorsements: true},
+			{Name: "SkyFresh", Author: "someone", Version: "1.0", Status: "available"},
+		},
+	}
+	view = model.View()
+	require.Contains(t, view, "SkyUI")
+	require.Contains(t, view, "installed")
+	require.Contains(t, view, "Page 1/2")
+	require.Contains(t, view, "UI overhaul.", "detail panel shows the selected result's summary")
+}
+
+func TestSearchViewStaysWithinBounds(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t) // 100x30
+	model.search.state = searchReady
+	model.search.page = SearchPage{Query: "q", Source: "nexusmods", PageSize: 10, TotalCount: 10,
+		Results: []ModItem{{Name: "A", Status: "available"}}}
+	require.Equal(t, model.availableWidth(), lipgloss.Width(model.screenView()))
+	require.Equal(t, model.availableContentHeight(), lipgloss.Height(model.screenView()))
 }

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -2,9 +2,12 @@ package tui
 
 import (
 	"context"
+	"strings"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
 )
+
+const SearchPageSize = 10
 
 // Summary is the dashboard header data.
 type Summary struct {
@@ -18,11 +21,15 @@ type Summary struct {
 
 // ModItem is one renderable mod row.
 type ModItem struct {
-	Name    string
-	Author  string
-	Version string
-	Source  string
-	Status  string
+	Name            string
+	Author          string
+	Version         string
+	Source          string
+	Status          string
+	Summary         string
+	Downloads       int64
+	Endorsements    int64
+	HasEndorsements bool
 }
 
 // ProfileItem is one renderable profile row.
@@ -32,14 +39,28 @@ type ProfileItem struct {
 	ModCount int
 }
 
+// SearchPage is one page of search results for one source/query.
+type SearchPage struct {
+	Results    []ModItem
+	Query      string
+	Source     string
+	Page       int // 0-based
+	PageSize   int
+	TotalCount int // 0 if the source doesn't report totals
+}
+
 // DataProvider is the narrow, read-only boundary between the TUI and app
 // data. Implementations must be safe to call from a Bubble Tea command
 // goroutine.
 type DataProvider interface {
-	Summary(ctx context.Context) (Summary, error)
-	InstalledMods(ctx context.Context) ([]ModItem, error)
-	SearchResults(ctx context.Context) ([]ModItem, error)
+	// Overview returns the dashboard summary and installed-mod rows from a
+	// single underlying fetch.
+	Overview(ctx context.Context) (Summary, []ModItem, error)
 	Profiles(ctx context.Context) ([]ProfileItem, error)
+	// Sources lists the game's configured source IDs, sorted; index 0 is the
+	// default (mirrors the CLI's resolveSource).
+	Sources() []string
+	Search(ctx context.Context, source, query string, page int) (SearchPage, error)
 }
 
 // prototypeProvider serves the static demo data set. It must never touch
@@ -54,7 +75,7 @@ func NewPrototypeProvider() DataProvider {
 	return prototypeProvider{data: prototype.Load()}
 }
 
-func (p prototypeProvider) Summary(_ context.Context) (Summary, error) {
+func (p prototypeProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 	return Summary{
 		GameName:    p.data.Game.Name,
 		ProfileName: p.data.Profile.Name,
@@ -62,15 +83,29 @@ func (p prototypeProvider) Summary(_ context.Context) (Summary, error) {
 		Enabled:     p.data.Stats.Enabled,
 		Updates:     p.data.Stats.Updates,
 		Conflicts:   p.data.Stats.Conflicts,
+	}, modItems(p.data.InstalledMods), nil
+}
+
+func (p prototypeProvider) Sources() []string {
+	return []string{"nexusmods"}
+}
+
+func (p prototypeProvider) Search(_ context.Context, source, query string, _ int) (SearchPage, error) {
+	all := modItems(p.data.SearchResults)
+	matched := make([]ModItem, 0, len(all))
+	for _, item := range all {
+		if strings.Contains(strings.ToLower(item.Name), strings.ToLower(query)) {
+			matched = append(matched, item)
+		}
+	}
+	return SearchPage{
+		Results:    matched,
+		Query:      query,
+		Source:     source,
+		Page:       0,
+		PageSize:   SearchPageSize,
+		TotalCount: len(matched),
 	}, nil
-}
-
-func (p prototypeProvider) InstalledMods(_ context.Context) ([]ModItem, error) {
-	return modItems(p.data.InstalledMods), nil
-}
-
-func (p prototypeProvider) SearchResults(_ context.Context) ([]ModItem, error) {
-	return modItems(p.data.SearchResults), nil
 }
 
 func (p prototypeProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
@@ -89,11 +124,15 @@ func modItems(mods []prototype.Mod) []ModItem {
 	items := make([]ModItem, 0, len(mods))
 	for _, mod := range mods {
 		items = append(items, ModItem{
-			Name:    mod.Name,
-			Author:  mod.Author,
-			Version: mod.Version,
-			Source:  mod.Source,
-			Status:  mod.Status,
+			Name:            mod.Name,
+			Author:          mod.Author,
+			Version:         mod.Version,
+			Source:          mod.Source,
+			Status:          mod.Status,
+			Summary:         mod.Summary,
+			Downloads:       mod.Downloads,
+			Endorsements:    mod.Endorsements,
+			HasEndorsements: mod.HasEndorsements,
 		})
 	}
 	return items

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
 )
 
+// SearchPageSize mirrors the CLI picker's displayPageSize (cmd/lmm/install.go).
 const SearchPageSize = 10
 
 // Summary is the dashboard header data.

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -21,10 +21,10 @@ func NewCoreProvider(svc *core.Service, game *domain.Game, profileName string) D
 	return &coreProvider{svc: svc, game: game, profile: profileName}
 }
 
-func (p *coreProvider) Summary(_ context.Context) (Summary, error) {
+func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 	mods, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
 	if err != nil {
-		return Summary{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
+		return Summary{}, nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
 	}
 
 	enabled := 0
@@ -32,22 +32,6 @@ func (p *coreProvider) Summary(_ context.Context) (Summary, error) {
 		if mod.Enabled {
 			enabled++
 		}
-	}
-
-	return Summary{
-		GameName:    p.game.Name,
-		ProfileName: p.profile,
-		Installed:   len(mods),
-		Enabled:     enabled,
-		Updates:     -1, // unknown: update checks are a Phase 6 workflow
-		Conflicts:   -1, // unknown: conflict detection is a Phase 6 workflow
-	}, nil
-}
-
-func (p *coreProvider) InstalledMods(_ context.Context) ([]ModItem, error) {
-	mods, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
-	if err != nil {
-		return nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
 	}
 
 	items := make([]ModItem, 0, len(mods))
@@ -60,13 +44,30 @@ func (p *coreProvider) InstalledMods(_ context.Context) ([]ModItem, error) {
 			Status:  installedModStatus(mod),
 		})
 	}
-	return items, nil
+
+	return Summary{
+		GameName:    p.game.Name,
+		ProfileName: p.profile,
+		Installed:   len(mods),
+		Enabled:     enabled,
+		Updates:     -1, // unknown: update checks are a Phase 6 workflow
+		Conflicts:   -1, // unknown: conflict detection is a Phase 6 workflow
+	}, items, nil
 }
 
-// SearchResults is an honest placeholder until Phase 4 wires real source
+func (p *coreProvider) Sources() []string {
+	return []string{"nexusmods"}
+}
+
+// Search is an honest placeholder until Phase 4 wires real source
 // search into the TUI.
-func (p *coreProvider) SearchResults(_ context.Context) ([]ModItem, error) {
-	return nil, nil
+func (p *coreProvider) Search(_ context.Context, source, query string, _ int) (SearchPage, error) {
+	return SearchPage{
+		Query:    query,
+		Source:   source,
+		Page:     0,
+		PageSize: SearchPageSize,
+	}, nil
 }
 
 func (p *coreProvider) Profiles(_ context.Context) ([]ProfileItem, error) {

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -56,7 +57,12 @@ func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 }
 
 func (p *coreProvider) Sources() []string {
-	return []string{"nexusmods"}
+	sources := make([]string, 0, len(p.game.SourceIDs))
+	for id := range p.game.SourceIDs {
+		sources = append(sources, id)
+	}
+	sort.Strings(sources)
+	return sources
 }
 
 // Search is an honest placeholder until Phase 4 wires real source

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -65,14 +65,52 @@ func (p *coreProvider) Sources() []string {
 	return sources
 }
 
-// Search is an honest placeholder until Phase 4 wires real source
-// search into the TUI.
-func (p *coreProvider) Search(_ context.Context, source, query string, _ int) (SearchPage, error) {
+// Search queries the given source and marks results already installed in
+// the active profile.
+func (p *coreProvider) Search(ctx context.Context, sourceID, query string, page int) (SearchPage, error) {
+	result, err := p.svc.SearchMods(ctx, sourceID, p.game.ID, query, "", nil, page, SearchPageSize)
+	if err != nil {
+		return SearchPage{}, fmt.Errorf("searching %s for %q: %w", sourceID, query, err)
+	}
+
+	installed, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
+	if err != nil {
+		return SearchPage{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
+	}
+	installedKeys := make(map[string]bool, len(installed))
+	for _, mod := range installed {
+		installedKeys[domain.ModKey(mod.SourceID, mod.ID)] = true
+	}
+
+	items := make([]ModItem, 0, len(result.Mods))
+	for _, mod := range result.Mods {
+		status := "available"
+		if installedKeys[domain.ModKey(mod.SourceID, mod.ID)] {
+			status = "installed"
+		}
+		item := ModItem{
+			Name:      mod.Name,
+			Author:    mod.Author,
+			Version:   mod.Version,
+			Source:    mod.SourceID,
+			Status:    status,
+			Summary:   mod.Summary,
+			Downloads: mod.Downloads,
+		}
+		if mod.Endorsements != nil {
+			item.Endorsements = *mod.Endorsements
+			item.HasEndorsements = true
+		}
+		items = append(items, item)
+	}
+
 	return SearchPage{
-		Query:    query,
-		Source:   source,
-		Page:     0,
-		PageSize: SearchPageSize,
+		Results:    items,
+		Query:      query,
+		Source:     sourceID,
+		Page:       page,
+		PageSize:   SearchPageSize,
+		TotalCount: result.TotalCount,
 	}, nil
 }
 

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -64,10 +64,10 @@ func newCoreProviderFixture(t *testing.T) (tui.DataProvider, *core.Service, *dom
 	return tui.NewCoreProvider(svc, game, "default"), svc, game
 }
 
-func TestCoreProviderSummary(t *testing.T) {
+func TestCoreProviderOverview(t *testing.T) {
 	provider, _, _ := newCoreProviderFixture(t)
 
-	summary, err := provider.Summary(context.Background())
+	summary, mods, err := provider.Overview(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "Test Game", summary.GameName)
 	require.Equal(t, "default", summary.ProfileName)
@@ -75,15 +75,8 @@ func TestCoreProviderSummary(t *testing.T) {
 	require.Equal(t, 1, summary.Enabled)
 	require.Equal(t, -1, summary.Updates, "updates are unknown until an update check runs")
 	require.Equal(t, -1, summary.Conflicts, "conflicts are unknown in the read-only phase")
-}
 
-func TestCoreProviderInstalledMods(t *testing.T) {
-	provider, _, _ := newCoreProviderFixture(t)
-
-	mods, err := provider.InstalledMods(context.Background())
-	require.NoError(t, err)
 	require.Len(t, mods, 2)
-
 	byName := map[string]tui.ModItem{}
 	for _, m := range mods {
 		byName[m.Name] = m
@@ -92,14 +85,6 @@ func TestCoreProviderInstalledMods(t *testing.T) {
 	require.Equal(t, "nexusmods", byName["SkyUI"].Source)
 	require.Equal(t, "5.2", byName["SkyUI"].Version)
 	require.Equal(t, "disabled", byName["USSEP"].Status)
-}
-
-func TestCoreProviderSearchResultsAreEmptyUntilPhase4(t *testing.T) {
-	provider, _, _ := newCoreProviderFixture(t)
-
-	results, err := provider.SearchResults(context.Background())
-	require.NoError(t, err)
-	require.Empty(t, results)
 }
 
 func TestCoreProviderProfiles(t *testing.T) {

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -182,6 +182,25 @@ func TestCoreProviderSearchMarksInstalled(t *testing.T) {
 	require.Equal(t, "available", byName["NewMod"].Status)
 }
 
+func TestCoreProviderSearchDoesNotCrossSourceMarkInstalled(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+	game.SourceIDs = map[string]string{"stub": "testgame"}
+	svc.RegisterSource(&stubSource{result: source.SearchResult{
+		Mods: []domain.Mod{
+			// Same mod ID as the fixture's nexusmods install, but from "stub" —
+			// ModKey(source, id) must keep these distinct.
+			{ID: "101", SourceID: "stub", Name: "SkyUI-Stub", Author: "a", Version: "5.2"},
+		},
+		TotalCount: 1, Page: 0, PageSize: 10,
+	}})
+
+	page, err := provider.Search(context.Background(), "stub", "sky", 0)
+	require.NoError(t, err)
+	require.Len(t, page.Results, 1)
+	require.Equal(t, "available", page.Results[0].Status,
+		"mod 101 is installed under nexusmods, not stub — no cross-source marking")
+}
+
 func TestCoreProviderSearchPropagatesAuthRequired(t *testing.T) {
 	provider, svc, game := newCoreProviderFixture(t)
 	game.SourceIDs = map[string]string{"stub": "testgame"}

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -107,3 +107,10 @@ func TestCoreProviderProfiles(t *testing.T) {
 	require.False(t, byName["hardcore"].Active)
 	require.Equal(t, 1, byName["hardcore"].ModCount, "ModCount should map from profile YAML mods, not the DB")
 }
+
+func TestCoreProviderSourcesAreSortedGameSources(t *testing.T) {
+	provider, _, game := newCoreProviderFixture(t)
+	game.SourceIDs = map[string]string{"nexusmods": "testgame", "curseforge": "testgame"}
+
+	require.Equal(t, []string{"curseforge", "nexusmods"}, provider.Sources())
+}

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -2,14 +2,50 @@ package tui_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/DonovanMods/linux-mod-manager/internal/tui"
 )
+
+// stubSource implements source.ModSource with canned search results.
+// Only Search and identity methods matter; the rest are unreachable in
+// these tests.
+type stubSource struct {
+	result source.SearchResult
+	err    error
+}
+
+func (s *stubSource) ID() string      { return "stub" }
+func (s *stubSource) Name() string    { return "Stub Source" }
+func (s *stubSource) AuthURL() string { return "" }
+func (s *stubSource) ExchangeToken(context.Context, string) (*source.Token, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubSource) Search(context.Context, source.SearchQuery) (source.SearchResult, error) {
+	return s.result, s.err
+}
+func (s *stubSource) GetMod(context.Context, string, string) (*domain.Mod, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubSource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubSource) GetModFiles(context.Context, *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubSource) GetDownloadURL(context.Context, *domain.Mod, string) (string, error) {
+	return "", errors.New("not implemented")
+}
+func (s *stubSource) CheckUpdates(context.Context, []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, errors.New("not implemented")
+}
 
 func newCoreProviderFixture(t *testing.T) (tui.DataProvider, *core.Service, *domain.Game) {
 	t.Helper()
@@ -113,4 +149,44 @@ func TestCoreProviderSourcesAreSortedGameSources(t *testing.T) {
 	game.SourceIDs = map[string]string{"nexusmods": "testgame", "curseforge": "testgame"}
 
 	require.Equal(t, []string{"curseforge", "nexusmods"}, provider.Sources())
+}
+
+func TestCoreProviderSearchMarksInstalled(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+	game.SourceIDs = map[string]string{"stub": "testgame"}
+	svc.RegisterSource(&stubSource{result: source.SearchResult{
+		Mods: []domain.Mod{
+			{ID: "101", SourceID: "stub", Name: "SkyUI-Stub", Author: "a", Version: "5.2"},
+			{ID: "999", SourceID: "stub", Name: "NewMod", Author: "b", Version: "1.0"},
+		},
+		TotalCount: 2, Page: 0, PageSize: 10,
+	}})
+	// Fixture installed mod 101 under sourceID "nexusmods"; install one under "stub" too:
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:         domain.Mod{ID: "101", SourceID: "stub", GameID: game.ID, Name: "SkyUI-Stub", Version: "5.2"},
+		ProfileName: "default", Enabled: true,
+	}))
+
+	page, err := provider.Search(context.Background(), "stub", "sky", 0)
+	require.NoError(t, err)
+	require.Equal(t, "sky", page.Query)
+	require.Equal(t, "stub", page.Source)
+	require.Equal(t, 2, page.TotalCount)
+	require.Len(t, page.Results, 2)
+
+	byName := map[string]tui.ModItem{}
+	for _, r := range page.Results {
+		byName[r.Name] = r
+	}
+	require.Equal(t, "installed", byName["SkyUI-Stub"].Status)
+	require.Equal(t, "available", byName["NewMod"].Status)
+}
+
+func TestCoreProviderSearchPropagatesAuthRequired(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+	game.SourceIDs = map[string]string{"stub": "testgame"}
+	svc.RegisterSource(&stubSource{err: fmt.Errorf("%w: key required", domain.ErrAuthRequired)})
+
+	_, err := provider.Search(context.Background(), "stub", "x", 0)
+	require.ErrorIs(t, err, domain.ErrAuthRequired)
 }

--- a/internal/tui/service_test.go
+++ b/internal/tui/service_test.go
@@ -9,31 +9,52 @@ import (
 	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
 )
 
-func TestPrototypeProviderMirrorsFakeData(t *testing.T) {
+func TestPrototypeProviderOverviewMirrorsFakeData(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	provider := NewPrototypeProvider()
 	data := prototype.Load()
 
-	summary, err := provider.Summary(ctx)
+	summary, mods, err := provider.Overview(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data.Game.Name, summary.GameName)
-	require.Equal(t, data.Profile.Name, summary.ProfileName)
 	require.Equal(t, data.Stats.Installed, summary.Installed)
-	require.Equal(t, data.Stats.Enabled, summary.Enabled)
-	require.Equal(t, data.Stats.Updates, summary.Updates)
-	require.Equal(t, data.Stats.Conflicts, summary.Conflicts)
-
-	mods, err := provider.InstalledMods(ctx)
-	require.NoError(t, err)
 	require.Len(t, mods, len(data.InstalledMods))
 	require.Equal(t, data.InstalledMods[0].Name, mods[0].Name)
-	require.Equal(t, data.InstalledMods[0].Status, mods[0].Status)
+}
 
-	results, err := provider.SearchResults(ctx)
+func TestPrototypeProviderSources(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"nexusmods"}, NewPrototypeProvider().Sources())
+}
+
+func TestPrototypeProviderSearchFiltersCannedResults(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	provider := NewPrototypeProvider()
+
+	page, err := provider.Search(ctx, "nexusmods", "frost", 0)
 	require.NoError(t, err)
-	require.Len(t, results, len(data.SearchResults))
+	require.Equal(t, "frost", page.Query)
+	require.Equal(t, "nexusmods", page.Source)
+	require.Len(t, page.Results, 1)
+	require.Equal(t, "Frostfall", page.Results[0].Name)
+	require.Equal(t, 1, page.TotalCount)
+
+	all, err := provider.Search(ctx, "nexusmods", "", 0)
+	require.NoError(t, err)
+	require.Len(t, all.Results, len(prototype.Load().SearchResults), "empty query returns everything")
+}
+
+func TestPrototypeProviderProfiles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	provider := NewPrototypeProvider()
+	data := prototype.Load()
 
 	profiles, err := provider.Profiles(ctx)
 	require.NoError(t, err)

--- a/internal/tui/service_test.go
+++ b/internal/tui/service_test.go
@@ -47,6 +47,11 @@ func TestPrototypeProviderSearchFiltersCannedResults(t *testing.T) {
 	all, err := provider.Search(ctx, "nexusmods", "", 0)
 	require.NoError(t, err)
 	require.Len(t, all.Results, len(prototype.Load().SearchResults), "empty query returns everything")
+
+	none, err := provider.Search(ctx, "nexusmods", "zzz-nothing", 0)
+	require.NoError(t, err)
+	require.Empty(t, none.Results, "no match returns an empty page")
+	require.Equal(t, 0, none.TotalCount)
 }
 
 func TestPrototypeProviderProfiles(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Real source search from the TUI**: focus-aware query input (`/` focuses; typing never triggers global keys; `esc` cancels, `enter` searches), per-source search through `core.SearchMods` with cancellation — every query carries a generation tag, new queries cancel in-flight contexts, and stale results/errors are discarded.
- **Results and details**: installed mods are marked (cross-source-safe via ModKey, pinned by test), two-pane layout with a detail panel that follows the selection, CLI-parity pagination (`n`/`p`, page size 10), and source cycling (`s`) that invalidates stale searches so header/results/pagination can never disagree.
- **First-class states**: loading, error, and auth-required (with the exact `lmm auth login <source>` remedy) render inside exact terminal bounds — including 40-column terminals (display-width-safe truncation via `ansi.Truncate`; bounded input width so long queries h-scroll).
- **DataProvider v2**: single-fetch `Overview`, `Sources`, and `Search(ctx, source, query, page)` replace the Phase 3 placeholders; the Bubble Tea program context threads into all data loads.
- Docs (README/help), CHANGELOG, and version **1.5.0**.

Design decisions (from the pre-plan blindspot pass): enter-to-search only (no live search — httpclient has no 429 handling), single source per search with the CLI's default-source semantics, detail from result fields only, no category/tag filters this phase.

Two review-fix commits are included from the branch's internal review loop (source-cycle invalidation + narrow-width bounds; CoreProvider sources from game config).

Closes #40

## Test Plan
- [x] go test ./... / go vet ./... / gofmt (touched files); focus-routing and cancellation paths -race clean
- [x] CoreProvider search tested against a real temp-dir core.Service with a stubbed source through the real registry
- [x] Width/height invariants swept at 40/44/48/54/60/80 columns
- [ ] Interactive smoke test (needs a TTY — see below)

**Smoke test before merging:** `go build -o lmm ./cmd/lmm && ./lmm tui` with a configured game and an authenticated source — press `/`, type a query, enter; check installed markers, `n`/`p` paging, `s` source cycling, and the auth-required message with a logged-out source. `./lmm tui --prototype` still works offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)