### PR TITLE
feat: user-defined custom mod sources (Phases 1-2: foundation + directory type)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User-defined source definitions loaded from `~/.config/lmm/sources/*.yaml`
 - Directory source type: use a local folder of mods as a first-class source
 
+### Fixed
+
+- **Hidden entries ignored by directory sources**: dot-prefixed entries (`.git`, etc.) under a directory source's path are no longer listed as installable mods
+- Negative `page` values in directory source search no longer panic; they clamp to the first page
+
 ## [1.5.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `lmm source list` — list built-in and user-defined mod sources
+- `lmm source validate <file>` — validate a user-defined source definition
+- User-defined source definitions loaded from `~/.config/lmm/sources/*.yaml`
+
 ## [1.5.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Directory source installs no longer orphaned**: mods found through a directory source mapped with the README-documented empty value (`sources: {my-mods: ""}`) now carry the correct game ID end-to-end, so `lmm list`/`update`/`uninstall` can see them after install
 - **Hidden entries ignored by directory sources**: dot-prefixed entries (`.git`, etc.) under a directory source's path are no longer listed as installable mods
+- **Local file ingest restricted to directory sources**: a `file://` download URL is now only trusted from directory sources, closing a path where any other source returning `file://` could pull arbitrary local files into the cache
 - Negative `page` values in directory source search no longer panic; they clamp to the first page
 
 ## [1.5.0] - 2026-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Hidden entries ignored by directory sources**: dot-prefixed entries (`.git`, etc.) under a directory source's path are no longer listed as installable mods
 - **Local file ingest restricted to directory sources**: a `file://` download URL is now only trusted from directory sources, closing a path where any other source returning `file://` could pull arbitrary local files into the cache
 - Negative `page` values in directory source search no longer panic; they clamp to the first page
+- **Archive mods now read embedded `ModInfo.xml` metadata**: a `.zip`/`.jar` mod in a directory source (e.g. `donovan-aio.zip` containing `donovan-aio/ModInfo.xml`) now resolves name/version/summary/author from the archived `ModInfo.xml` instead of saving an empty record with only a filename-derived name and version
 
 ## [1.5.0] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Directory source installs no longer orphaned**: mods found through a directory source mapped with the README-documented empty value (`sources: {my-mods: ""}`) now carry the correct game ID end-to-end, so `lmm list`/`update`/`uninstall` can see them after install
 - **Hidden entries ignored by directory sources**: dot-prefixed entries (`.git`, etc.) under a directory source's path are no longer listed as installable mods
 - Negative `page` values in directory source search no longer panic; they clamp to the first page
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Directory source installs no longer orphaned**: mods found through a directory source mapped with the README-documented empty value (`sources: {my-mods: ""}`) now carry the correct game ID end-to-end, so `lmm list`/`update`/`uninstall` can see them after install
+- **`lmm source list` shows every definition**: a definition whose source fails to construct (e.g. missing directory path) now shows as an `error` row instead of being silently dropped, and a definition colliding with a built-in source ID no longer relabels the built-in's row — the built-in stays `built-in` and the collision gets its own `error` row
 - **Hidden entries ignored by directory sources**: dot-prefixed entries (`.git`, etc.) under a directory source's path are no longer listed as installable mods
 - **Local file ingest restricted to directory sources**: a `file://` download URL is now only trusted from directory sources, closing a path where any other source returning `file://` could pull arbitrary local files into the cache
 - Negative `page` values in directory source search no longer panic; they clamp to the first page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-14
+
 ### Added
 
 - `lmm source list` — list built-in and user-defined mod sources
 - `lmm source validate <file>` — validate a user-defined source definition
 - User-defined source definitions loaded from `~/.config/lmm/sources/*.yaml`
+- Directory source type: use a local folder of mods as a first-class source
 
 ## [1.5.0] - 2026-07-13
 
@@ -662,7 +665,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.10...v1.4.0
 [1.3.10]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.9...v1.3.10

--- a/README.md
+++ b/README.md
@@ -226,6 +226,124 @@ The mod cache location is determined by:
 
 This allows you to store different games' mods on different drives (e.g., large games on HDD, frequently accessed games on SSD).
 
+## Custom Sources
+
+In addition to built-in mod sources (NexusMods, CurseForge), you can define custom sources declaratively in YAML files. This allows you to integrate local directories or remote mod repositories without any code changes.
+
+Custom source definitions are loaded from `~/.config/lmm/sources/*.yaml`. Each file must define exactly one source. Broken definition files are skipped with a warning — they never prevent lmm from starting.
+
+### Source Definition Format
+
+```yaml
+id: donovan-mods              # required; must match ^[a-z0-9-]+$ and be unique
+name: Donovan's 7D2D Modlets  # required display name
+type: directory               # required: directory (local folders) | manifest | api
+allow_http: false             # optional; permit http:// URLs (default false)
+
+# Type-specific configuration (one block required, must match type)
+directory:
+  path: ~/Projects/mods/7dtd/donovan-7d2d-modlets
+```
+
+### Common Fields
+
+| Field       | Type    | Required | Description                                                                         |
+| ----------- | ------- | -------- | ----------------------------------------------------------------------------------- |
+| `id`        | string  | yes      | Unique source identifier; must contain only lowercase letters, numbers, and hyphens |
+| `name`      | string  | yes      | Display name shown in source lists and commands                                     |
+| `type`      | string  | yes      | Source type: `directory` (v1), `manifest` (planned), `api` (planned)                |
+| `allow_http` | boolean | no       | If `true`, allow unencrypted http:// URLs (default `false`, HTTPS only)            |
+
+### Directory Source
+
+A directory source treats a local folder as a mod repository. Each subdirectory or archive file (`.zip`, `.jar`) is treated as a mod.
+
+```yaml
+id: my-local-mods
+name: My Local Mods
+type: directory
+directory:
+  path: ~/projects/my-mods    # ~ expands to home directory
+```
+
+**How it works:**
+
+- Mods are discovered by scanning the directory for subdirectories and archives
+- Mod metadata (name, version, author) is read from metadata files (e.g., `ModInfo.xml` for 7D2D) or inferred from the directory name
+- Mod ID is the directory or file base name (stable across versions)
+- Install/update/enable/disable work like any other source — the linker handles deployment to the game directory
+- Updates are detected by comparing installed version to current metadata version
+
+### Source Management Commands
+
+List all sources (built-in and custom):
+
+```bash
+lmm source list
+```
+
+Output:
+
+```
+ID          NAME        TYPE      AUTH  CAPABILITIES              ERROR
+nexusmods   Nexus Mods  built-in  yes   search,deps,updates,auth  
+curseforge  CurseForge  built-in  yes   search,deps,updates,auth  
+donovan-mods Donovan's 7D2D Modlets directory no search,updates
+```
+
+Validate a source definition file before use:
+
+```bash
+lmm source validate ~/.config/lmm/sources/my-source.yaml
+```
+
+On success:
+```
+~/.config/lmm/sources/my-source.yaml: valid (directory source "my-source")
+```
+
+On error (exits with code 1):
+```
+Error: invalid definition: id "my-bad-source!" must match ^[a-z0-9-]+$
+```
+
+### Adding a Custom Source
+
+1. Create `~/.config/lmm/sources/` if it doesn't exist:
+   ```bash
+   mkdir -p ~/.config/lmm/sources
+   ```
+
+2. Create a YAML file with your source definition:
+   ```bash
+   cat > ~/.config/lmm/sources/my-mods.yaml <<'EOF'
+   id: my-local-mods
+   name: My Local Mods
+   type: directory
+   directory:
+     path: ~/projects/mods
+   EOF
+   ```
+
+3. (Optional) Validate the definition:
+   ```bash
+   lmm source validate ~/.config/lmm/sources/my-mods.yaml
+   ```
+
+4. Add the source to your game's `sources` map in `~/.config/lmm/games.yaml`:
+   ```yaml
+   games:
+     my-game:
+       sources:
+         my-local-mods: ""  # empty string for directory sources (no game-specific ID)
+   ```
+
+5. Use the source with all standard commands:
+   ```bash
+   lmm search --source my-local-mods --game my-game
+   lmm install --source my-local-mods "mod-name" --game my-game
+   ```
+
 ## CLI Reference
 
 ### Global Flags
@@ -289,6 +407,8 @@ This allows you to store different games' mods on different drives (e.g., large 
 | `lmm deploy --purge`                   | Purge then deploy all mods                           |
 | `lmm purge`                            | Remove all mods from game directory                  |
 | `lmm conflicts`                        | Show file conflicts in current profile               |
+| `lmm source list`                      | List built-in and user-defined mod sources           |
+| `lmm source validate <file>`           | Validate a user-defined source definition           |
 
 ### Update check behavior
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ This allows you to store different games' mods on different drives (e.g., large 
 
 ## Custom Sources
 
-In addition to built-in mod sources (NexusMods, CurseForge), lmm lets you declare custom sources in YAML files instead of writing code. This release adds the definition format plus the `lmm source` commands for authoring and validating those files; using a custom source from `search`/`install` requires an implemented source type, and the first one (`directory`) ships in the next release.
+In addition to built-in mod sources (NexusMods, CurseForge), lmm lets you declare custom sources in YAML files instead of writing code. The `directory` type is fully implemented — point it at a local folder of mods and use it from `search`/`install` like any built-in source. `manifest` and `api` definitions parse and validate today, but their source types (fetching mods over HTTP) ship in later releases.
 
 Custom source definitions are loaded from `~/.config/lmm/sources/*.yaml` (or `*.yml`). Each file must define exactly one source. Broken definition files are skipped with a warning — they never prevent lmm from starting.
 
@@ -251,8 +251,47 @@ directory:
 | ----------- | ------- | -------- | ----------------------------------------------------------------------------------- |
 | `id`        | string  | yes      | Unique source identifier; must contain only lowercase letters, numbers, and hyphens |
 | `name`      | string  | yes      | Display name shown in source lists and commands                                     |
-| `type`      | string  | yes      | Source type: `directory`, `manifest`, or `api`. All three parse and validate today; `directory` support (search/install) ships in the next release, `manifest`/`api` in later releases. |
+| `type`      | string  | yes      | Source type: `directory`, `manifest`, or `api`. All three parse and validate today; `directory` support (search/install) is implemented now, `manifest`/`api` ship in later releases. |
 | `allow_http` | boolean | no       | If `true`, allow unencrypted http:// URLs (default `false`, HTTPS only)            |
+
+### Directory Sources
+
+A `directory` source scans a local folder every time it's queried — no indexing, no caching of the listing — so edits to the folder show up immediately without restarting lmm. Each entry directly under the configured path becomes one mod:
+
+- A **subdirectory** is a mod whose contents are used as-is.
+- A **`.zip` or `.jar` file** is a mod whose archive is extracted like any downloaded mod.
+- Anything else (loose files, `README.md`, `LICENSE.md`, other subfolders that aren't mods, etc.) is ignored by the scan but still shows up as a listed entry if it happens to be a directory — see the note on metadata fallback below.
+
+```yaml
+id: donovan-mods
+name: Donovan's 7D2D Modlets
+type: directory
+directory:
+  path: ~/Projects/mods/7dtd/donovan-7d2d-modlets
+```
+
+**Metadata resolution** — for each subdirectory, lmm resolves name/version/summary/author in this order:
+
+1. **`ModInfo.xml`** (7 Days to Die's mod metadata format), if present. Both layouts are supported:
+   - **V2**: fields directly under `<xml>` — `<xml><Name value="..."/><Version value="..."/>...</xml>`
+   - **V1**: fields nested in `<ModInfo>` — `<xml><ModInfo><Name value="..."/>...</ModInfo></xml>`
+2. **Dirname parsing**, if no `ModInfo.xml` (or it fails to parse): the directory name is split into a name and version, e.g. `PlainMod-0.5` → name `PlainMod`, version `0.5`. If no version-like suffix is found, the whole name is used as-is and the version is empty.
+
+Archive files (`.zip`/`.jar`) always use dirname-style parsing on the filename — there's no archive-metadata format supported yet.
+
+**The mod ID is the directory (or archive) name, verbatim.** There is no separate ID field — `BiggerBackpack/` is mod `BiggerBackpack`. This means **renaming the directory creates a new mod identity**: lmm has no way to know `BiggerBackpack/` and `Bigger-Backpack/` are the same mod, so a rename shows up as the old mod disappearing (update checks silently stop finding it) and a new, unrelated mod appearing. Keep directory names stable once you've installed from them.
+
+Directory sources support search, file listing, downloads (via local copy, no network), and update checks. They do not support dependency resolution (`GetDependencies` returns "not supported") since there's no manifest to declare dependencies from.
+
+To use a directory source with a specific game, map it under that game's `sources:` block in `games.yaml` (the value is ignored — directory sources apply to any game that maps them — but the key must be present):
+
+```yaml
+games:
+  7daystodie:
+    sources:
+      nexusmods: 7daystodie
+      donovan-mods: "" # directory sources ignore this value
+```
 
 ### Source Management Commands
 
@@ -265,9 +304,10 @@ lmm source list
 Output:
 
 ```
-ID          NAME        TYPE      AUTH  CAPABILITIES              ERROR
-nexusmods   Nexus Mods  built-in  yes   search,deps,updates,auth  
-curseforge  CurseForge  built-in  yes   search,deps,updates,auth  
+ID            NAME                    TYPE       AUTH  CAPABILITIES              ERROR
+nexusmods     Nexus Mods              built-in   yes   search,deps,updates,auth
+curseforge    CurseForge              built-in   yes   search,deps,updates,auth
+donovan-mods  Donovan's 7D2D Modlets  directory  n/a   search,updates
 ```
 
 Validate a source definition file before use:
@@ -309,7 +349,22 @@ Error: invalid definition: id "my-bad-source!" must match ^[a-z0-9-]+$
    lmm source validate ~/.config/lmm/sources/my-mods.yaml
    ```
 
-That's as far as this release goes. The definition loads and validates, and it will show up as an `error` row in `lmm source list` if it's ever broken — but no source type is implemented yet, so lmm skips it at startup with a warning, and `lmm search --source my-local-mods` / `lmm install --source my-local-mods` won't find it. Support for the `directory` type — the first source you can actually use — ships in the next release.
+4. Map it under the game(s) that should use it in `games.yaml` (see [Directory Sources](#directory-sources) above):
+   ```yaml
+   games:
+     skyrim-se:
+       sources:
+         nexusmods: skyrimspecialedition
+         my-local-mods: ""
+   ```
+
+5. Search and install from it like any built-in source:
+   ```bash
+   lmm search bigger -g skyrim-se --source my-local-mods
+   lmm install --source my-local-mods --id BiggerBackpack -g skyrim-se
+   ```
+
+A `directory` source now shows up with real capabilities in `lmm source list` (`search,updates`, `auth=n/a`), and it will show as an `error` row if the configured path is missing or not a directory.
 
 ## CLI Reference
 
@@ -413,11 +468,12 @@ internal/
 
 ## File Locations
 
-| Type      | Path                                  |
-| --------- | ------------------------------------- |
-| Config    | `~/.config/lmm/`                      |
-| Database  | `~/.local/share/lmm/lmm.db`           |
-| Mod Cache | `~/.local/share/lmm/cache/` (default) |
+| Type           | Path                                   |
+| -------------- | --------------------------------------- |
+| Config         | `~/.config/lmm/`                       |
+| Custom Sources | `~/.config/lmm/sources/*.yaml`         |
+| Database       | `~/.local/share/lmm/lmm.db`            |
+| Mod Cache      | `~/.local/share/lmm/cache/` (default)  |
 
 The mod cache location can be customized via `cache_path` in `config.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ A `directory` source scans a local folder every time it's queried — no indexin
 - A **subdirectory** is a mod whose contents are used as-is.
 - A **`.zip` or `.jar` file** is a mod whose archive is extracted like any downloaded mod.
 - Anything else (loose files, `README.md`, `LICENSE.md`, other subfolders that aren't mods, etc.) is ignored by the scan but still shows up as a listed entry if it happens to be a directory — see the note on metadata fallback below.
+- **Dot-prefixed entries** (`.git`, `.DS_Store`, dotfiles, ...) are always ignored, whether they're a directory or a file.
+
+Because every non-hidden subdirectory becomes an entry, point `directory.path` at a folder dedicated to mods (as in the example below) rather than something like a repository root that also holds unrelated project files — those would otherwise show up as listed (if harmless) entries in `search`/`lmm source list` output.
 
 ```yaml
 id: donovan-mods

--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ This allows you to store different games' mods on different drives (e.g., large 
 
 ## Custom Sources
 
-In addition to built-in mod sources (NexusMods, CurseForge), you can define custom sources declaratively in YAML files. This allows you to integrate local directories or remote mod repositories without any code changes.
+In addition to built-in mod sources (NexusMods, CurseForge), lmm lets you declare custom sources in YAML files instead of writing code. This release adds the definition format plus the `lmm source` commands for authoring and validating those files; using a custom source from `search`/`install` requires an implemented source type, and the first one (`directory`) ships in the next release.
 
-Custom source definitions are loaded from `~/.config/lmm/sources/*.yaml`. Each file must define exactly one source. Broken definition files are skipped with a warning — they never prevent lmm from starting.
+Custom source definitions are loaded from `~/.config/lmm/sources/*.yaml` (or `*.yml`). Each file must define exactly one source. Broken definition files are skipped with a warning — they never prevent lmm from starting.
 
 ### Source Definition Format
 
@@ -251,28 +251,8 @@ directory:
 | ----------- | ------- | -------- | ----------------------------------------------------------------------------------- |
 | `id`        | string  | yes      | Unique source identifier; must contain only lowercase letters, numbers, and hyphens |
 | `name`      | string  | yes      | Display name shown in source lists and commands                                     |
-| `type`      | string  | yes      | Source type: `directory` (v1), `manifest` (planned), `api` (planned)                |
+| `type`      | string  | yes      | Source type: `directory`, `manifest`, or `api`. All three parse and validate today; `directory` support (search/install) ships in the next release, `manifest`/`api` in later releases. |
 | `allow_http` | boolean | no       | If `true`, allow unencrypted http:// URLs (default `false`, HTTPS only)            |
-
-### Directory Source
-
-A directory source treats a local folder as a mod repository. Each subdirectory or archive file (`.zip`, `.jar`) is treated as a mod.
-
-```yaml
-id: my-local-mods
-name: My Local Mods
-type: directory
-directory:
-  path: ~/projects/my-mods    # ~ expands to home directory
-```
-
-**How it works:**
-
-- Mods are discovered by scanning the directory for subdirectories and archives
-- Mod metadata (name, version, author) is read from metadata files (e.g., `ModInfo.xml` for 7D2D) or inferred from the directory name
-- Mod ID is the directory or file base name (stable across versions)
-- Install/update/enable/disable work like any other source — the linker handles deployment to the game directory
-- Updates are detected by comparing installed version to current metadata version
 
 ### Source Management Commands
 
@@ -288,7 +268,6 @@ Output:
 ID          NAME        TYPE      AUTH  CAPABILITIES              ERROR
 nexusmods   Nexus Mods  built-in  yes   search,deps,updates,auth  
 curseforge  CurseForge  built-in  yes   search,deps,updates,auth  
-donovan-mods Donovan's 7D2D Modlets directory no search,updates
 ```
 
 Validate a source definition file before use:
@@ -325,24 +304,12 @@ Error: invalid definition: id "my-bad-source!" must match ^[a-z0-9-]+$
    EOF
    ```
 
-3. (Optional) Validate the definition:
+3. Validate the definition:
    ```bash
    lmm source validate ~/.config/lmm/sources/my-mods.yaml
    ```
 
-4. Add the source to your game's `sources` map in `~/.config/lmm/games.yaml`:
-   ```yaml
-   games:
-     my-game:
-       sources:
-         my-local-mods: ""  # empty string for directory sources (no game-specific ID)
-   ```
-
-5. Use the source with all standard commands:
-   ```bash
-   lmm search --source my-local-mods --game my-game
-   lmm install --source my-local-mods "mod-name" --game my-game
-   ```
+That's as far as this release goes. The definition loads and validates, and it will show up as an `error` row in `lmm source list` if it's ever broken — but no source type is implemented yet, so lmm skips it at startup with a warning, and `lmm search --source my-local-mods` / `lmm install --source my-local-mods` won't find it. Support for the `directory` type — the first source you can actually use — ships in the next release.
 
 ## CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Error: invalid definition: id "my-bad-source!" must match ^[a-z0-9-]+$
    lmm install --source my-local-mods --id BiggerBackpack -g skyrim-se
    ```
 
-A `directory` source now shows up with real capabilities in `lmm source list` (`search,updates`, `auth=n/a`), and it will show as an `error` row if the configured path is missing or not a directory.
+A `directory` source now shows up with real capabilities in `lmm source list` (`search,updates`, `auth=n/a`), and it will show as an `error` row if the configured path is missing or not a directory. A definition whose `id` collides with an already-registered source (a built-in, or another definition) also produces an `error` row (`id already in use`); the source that was already registered keeps its original row and type unchanged.
 
 ## CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ directory:
    - **V1**: fields nested in `<ModInfo>` — `<xml><ModInfo><Name value="..."/>...</ModInfo></xml>`
 2. **Dirname parsing**, if no `ModInfo.xml` (or it fails to parse): the directory name is split into a name and version, e.g. `PlainMod-0.5` → name `PlainMod`, version `0.5`. If no version-like suffix is found, the whole name is used as-is and the version is empty.
 
-Archive files (`.zip`/`.jar`) always use dirname-style parsing on the filename — there's no archive-metadata format supported yet.
+Archive files (`.zip`/`.jar`) get the same metadata resolution: lmm looks for `ModInfo.xml` inside the archive (at its root or exactly one directory deep, e.g. `donovan-aio.zip` containing `donovan-aio/ModInfo.xml`) before falling back to dirname-style parsing on the filename.
 
 **The mod ID is the directory (or archive) name, verbatim.** There is no separate ID field — `BiggerBackpack/` is mod `BiggerBackpack`. This means **renaming the directory creates a new mod identity**: lmm has no way to know `BiggerBackpack/` and `Bigger-Backpack/` are the same mod, so a rename shows up as the old mod disappearing (update checks silently stop finding it) and a new, unrelated mod appearing. Keep directory names stable once you've installed from them.
 

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -23,7 +23,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.5.0"
+	version = "1.6.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/curseforge"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/nexusmods"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 
@@ -153,13 +154,14 @@ func initService() (*core.Service, error) {
 	}
 
 	// Register mod sources
-	registerSources(svc)
+	registerSources(svc, cfg.ConfigDir)
 
 	return svc, nil
 }
 
-// registerSources registers all available mod sources with the service
-func registerSources(svc *core.Service) {
+// registerSources registers all available mod sources with the service.
+// Built-ins first, then user-defined sources from <configDir>/sources/.
+func registerSources(svc *core.Service, cfgDir string) {
 	// NexusMods
 	nexusKey := getSourceAPIKey(svc, "nexusmods", "NEXUSMODS_API_KEY")
 	svc.RegisterSource(nexusmods.New(nil, nexusKey))
@@ -167,6 +169,34 @@ func registerSources(svc *core.Service) {
 	// CurseForge
 	curseKey := getSourceAPIKey(svc, "curseforge", "CURSEFORGE_API_KEY")
 	svc.RegisterSource(curseforge.New(nil, curseKey))
+
+	registerCustomSources(svc, cfgDir)
+}
+
+// registerCustomSources loads user-defined source definitions and registers
+// the valid ones. Broken definitions warn on stderr and are skipped — a bad
+// file must never prevent lmm from starting.
+func registerCustomSources(svc *core.Service, cfgDir string) {
+	defs, loadErrs, err := config.LoadSourceDefinitions(cfgDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: loading custom sources: %v\n", err)
+		return
+	}
+	for _, le := range loadErrs {
+		fmt.Fprintf(os.Stderr, "warning: skipping source definition %v\n", le)
+	}
+	for _, def := range defs {
+		if _, err := svc.GetSource(def.ID); err == nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping source %q: id already in use\n", def.ID)
+			continue
+		}
+		src, err := custom.New(def)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping source %q: %v\n", def.ID, err)
+			continue
+		}
+		svc.RegisterSource(src)
+	}
 }
 
 // getSourceAPIKey retrieves an API key from environment or database

--- a/cmd/lmm/source.go
+++ b/cmd/lmm/source.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 	"github.com/spf13/cobra"
 )
@@ -43,16 +44,36 @@ var sourceListCmd = &cobra.Command{
 				return fmt.Errorf("loading source definitions: %w", err)
 			}
 
-			defTypes := make(map[string]string, len(defs))
+			// Reclassify each definition against what actually ended up registered
+			// (registerCustomSources may have skipped it on ID collision or
+			// construction failure) so the list reflects reality rather than just
+			// "a definition with this ID exists".
+			customTypes := make(map[string]string, len(defs)) // id -> def.Type, for defs that registered as custom
+			var errRows []sourceInfo
 			for _, d := range defs {
-				defTypes[d.ID] = d.Type
+				registered, err := svc.GetSource(d.ID)
+				switch {
+				case err == nil && isCustomSource(registered):
+					customTypes[d.ID] = d.Type
+				case err == nil:
+					// Something else (a built-in, or another def) already held this ID.
+					errRows = append(errRows, sourceInfo{ID: d.ID, Type: "error", Error: "id already in use"})
+				default:
+					// Nothing registered under this ID: construction must have failed.
+					// Re-run it to recover the actual error for display.
+					if _, cerr := custom.New(d); cerr != nil {
+						errRows = append(errRows, sourceInfo{ID: d.ID, Type: "error", Error: cerr.Error()})
+					}
+				}
 			}
 
 			var rows []sourceInfo
 			for _, src := range svc.ListSources() {
-				typ, isCustom := defTypes[src.ID()]
-				if !isCustom {
-					typ = "built-in"
+				typ := "built-in"
+				if isCustomSource(src) {
+					if t, ok := customTypes[src.ID()]; ok {
+						typ = t
+					}
 				}
 				rows = append(rows, sourceInfo{
 					ID:           src.ID(),
@@ -62,6 +83,7 @@ var sourceListCmd = &cobra.Command{
 					Capabilities: capabilitySummary(source.CapabilitiesOf(src)),
 				})
 			}
+			rows = append(rows, errRows...)
 			for _, le := range loadErrs {
 				rows = append(rows, sourceInfo{
 					ID:    le.File,
@@ -97,6 +119,18 @@ var sourceValidateCmd = &cobra.Command{
 		fmt.Fprintf(cmd.OutOrStdout(), "%s: valid (%s source %q)\n", args[0], def.Type, def.ID)
 		return nil
 	},
+}
+
+// isCustomSource reports whether src was constructed from a user-defined
+// source definition (as opposed to a built-in like NexusMods/CurseForge).
+// Extend this switch as new custom source types (manifest, api) ship.
+func isCustomSource(src source.ModSource) bool {
+	switch src.(type) {
+	case *custom.Directory:
+		return true
+	default:
+		return false
+	}
 }
 
 // authState reports a source's authentication status for display.

--- a/cmd/lmm/source.go
+++ b/cmd/lmm/source.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
+	"github.com/spf13/cobra"
+)
+
+var sourceCmd = &cobra.Command{
+	Use:   "source",
+	Short: "Manage mod sources",
+	Long:  "List registered mod sources and validate user-defined source definitions.",
+}
+
+// sourceInfo is one row of `lmm source list` output.
+type sourceInfo struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Type         string `json:"type"` // "built-in", "directory", "manifest", "api", or "error"
+	Auth         string `json:"auth"` // "yes", "no", "n/a"
+	Capabilities string `json:"capabilities"`
+	Error        string `json:"error,omitempty"`
+}
+
+var sourceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all mod sources",
+	Long:  "List built-in and user-defined mod sources, including definitions that failed to load.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return withService(cmd, func(ctx context.Context, svc *core.Service) error {
+			cfg, err := getServiceConfig()
+			if err != nil {
+				return err
+			}
+			defs, loadErrs, err := config.LoadSourceDefinitions(cfg.ConfigDir)
+			if err != nil {
+				return fmt.Errorf("loading source definitions: %w", err)
+			}
+
+			defTypes := make(map[string]string, len(defs))
+			for _, d := range defs {
+				defTypes[d.ID] = d.Type
+			}
+
+			var rows []sourceInfo
+			for _, src := range svc.ListSources() {
+				typ, isCustom := defTypes[src.ID()]
+				if !isCustom {
+					typ = "built-in"
+				}
+				rows = append(rows, sourceInfo{
+					ID:           src.ID(),
+					Name:         src.Name(),
+					Type:         typ,
+					Auth:         authState(src),
+					Capabilities: capabilitySummary(source.CapabilitiesOf(src)),
+				})
+			}
+			for _, le := range loadErrs {
+				rows = append(rows, sourceInfo{
+					ID:    le.File,
+					Type:  "error",
+					Error: le.Err.Error(),
+				})
+			}
+
+			if jsonOutput {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(rows)
+			}
+
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tNAME\tTYPE\tAUTH\tCAPABILITIES\tERROR")
+			for _, r := range rows {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", r.ID, r.Name, r.Type, r.Auth, r.Capabilities, r.Error)
+			}
+			return w.Flush()
+		})
+	},
+}
+
+var sourceValidateCmd = &cobra.Command{
+	Use:   "validate <file>",
+	Short: "Validate a source definition file",
+	Long:  "Parse and validate a user-defined source definition YAML file, reporting any problems.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		def, err := config.LoadSourceDefinitionFile(args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s: valid (%s source %q)\n", args[0], def.Type, def.ID)
+		return nil
+	},
+}
+
+// authState reports a source's authentication status for display.
+func authState(src source.ModSource) string {
+	if !source.CapabilitiesOf(src).Auth {
+		return "n/a"
+	}
+	if a, ok := src.(interface{ IsAuthenticated() bool }); ok {
+		if a.IsAuthenticated() {
+			return "yes"
+		}
+		return "no"
+	}
+	return "yes"
+}
+
+// capabilitySummary renders capabilities as a compact list, e.g. "search,updates".
+func capabilitySummary(c source.Capabilities) string {
+	out := ""
+	add := func(enabled bool, name string) {
+		if !enabled {
+			return
+		}
+		if out != "" {
+			out += ","
+		}
+		out += name
+	}
+	add(c.Search, "search")
+	add(c.Dependencies, "deps")
+	add(c.Updates, "updates")
+	add(c.Auth, "auth")
+	return out
+}
+
+func init() {
+	sourceCmd.AddCommand(sourceListCmd)
+	sourceCmd.AddCommand(sourceValidateCmd)
+	rootCmd.AddCommand(sourceCmd)
+}

--- a/cmd/lmm/source_test.go
+++ b/cmd/lmm/source_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceCmd_Structure(t *testing.T) {
+	assert.Equal(t, "source", sourceCmd.Use)
+	assert.NotEmpty(t, sourceCmd.Short)
+
+	names := make([]string, 0)
+	for _, c := range sourceCmd.Commands() {
+		names = append(names, c.Name())
+	}
+	assert.Contains(t, names, "list")
+	assert.Contains(t, names, "validate")
+}
+
+func TestSourceValidateCmd(t *testing.T) {
+	run := func(args ...string) (string, error) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.AddCommand(sourceCmd)
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		return buf.String(), err
+	}
+
+	t.Run("valid file passes", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "good.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+id: my-mods
+name: My Mods
+type: directory
+directory:
+  path: ~/mods
+`), 0644))
+
+		out, err := run("source", "validate", path)
+		assert.NoError(t, err)
+		assert.Contains(t, out, "valid")
+	})
+
+	t.Run("invalid file fails with reason", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bad.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+id: BAD_ID
+name: Bad
+type: directory
+directory:
+  path: ~/x
+`), 0644))
+
+		_, err := run("source", "validate", path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must match")
+	})
+
+	t.Run("missing argument errors", func(t *testing.T) {
+		_, err := run("source", "validate")
+		assert.Error(t, err)
+	})
+}

--- a/cmd/lmm/source_test.go
+++ b/cmd/lmm/source_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,5 +69,80 @@ directory:
 	t.Run("missing argument errors", func(t *testing.T) {
 		_, err := run("source", "validate")
 		assert.Error(t, err)
+	})
+}
+
+// TestSourceListCmd_ErrorRows is a regression test for final-review finding 2:
+// `lmm source list` must not silently drop a definition whose source failed to
+// construct, and must not relabel a built-in source's type just because a
+// custom definition collides with its ID.
+func TestSourceListCmd_ErrorRows(t *testing.T) {
+	runList := func(t *testing.T) []sourceInfo {
+		t.Helper()
+		cmd := &cobra.Command{Use: "test"}
+		cmd.AddCommand(sourceCmd)
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		cmd.SetArgs([]string{"source", "list"})
+
+		jsonOutput = true
+		t.Cleanup(func() { jsonOutput = false })
+
+		require.NoError(t, cmd.Execute())
+
+		var rows []sourceInfo
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &rows))
+		return rows
+	}
+
+	findRow := func(rows []sourceInfo, id, typ string) (sourceInfo, bool) {
+		for _, r := range rows {
+			if r.ID == id && r.Type == typ {
+				return r, true
+			}
+		}
+		return sourceInfo{}, false
+	}
+
+	t.Run("definition with missing path produces an error row", func(t *testing.T) {
+		configDir = t.TempDir()
+		dataDir = t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(configDir, "sources"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, "sources", "broken.yaml"), []byte(`
+id: broken-mods
+name: Broken Mods
+type: directory
+directory:
+  path: `+filepath.Join(t.TempDir(), "does-not-exist")+`
+`), 0644))
+
+		rows := runList(t)
+
+		row, found := findRow(rows, "broken-mods", "error")
+		require.True(t, found, "a definition whose source fails to construct must still produce a row: %+v", rows)
+		assert.NotEmpty(t, row.Error)
+	})
+
+	t.Run("definition colliding with a built-in id keeps the built-in row and adds an error row", func(t *testing.T) {
+		configDir = t.TempDir()
+		dataDir = t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(configDir, "sources"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, "sources", "collide.yaml"), []byte(`
+id: nexusmods
+name: Fake Nexus
+type: directory
+directory:
+  path: `+t.TempDir()+`
+`), 0644))
+
+		rows := runList(t)
+
+		_, builtinFound := findRow(rows, "nexusmods", "built-in")
+		assert.True(t, builtinFound, "a colliding custom definition must not relabel the built-in source's type: %+v", rows)
+
+		errRow, errFound := findRow(rows, "nexusmods", "error")
+		require.True(t, errFound, "an id collision must still produce an error row: %+v", rows)
+		assert.Contains(t, errRow.Error, "already in use")
 	})
 }

--- a/internal/core/importer.go
+++ b/internal/core/importer.go
@@ -60,7 +60,7 @@ func (i *Importer) Import(ctx context.Context, archivePath string, game *domain.
 		// Explicit linking provided
 		sourceID = opts.SourceID
 		modID = opts.ModID
-		version = extractVersionFromFilename(strings.TrimSuffix(filename, filepath.Ext(filename)))
+		version = domain.ExtractVersionFromName(strings.TrimSuffix(filename, filepath.Ext(filename)))
 		if version == "" {
 			version = "unknown"
 		}
@@ -74,7 +74,7 @@ func (i *Importer) Import(ctx context.Context, archivePath string, game *domain.
 		// No pattern - pure local mod
 		sourceID = domain.SourceLocal
 		modID = uuid.New().String()
-		version = extractVersionFromFilename(strings.TrimSuffix(filename, filepath.Ext(filename)))
+		version = domain.ExtractVersionFromName(strings.TrimSuffix(filename, filepath.Ext(filename)))
 		if version == "" {
 			version = "unknown"
 		}
@@ -378,7 +378,7 @@ func (i *Importer) detectModFromFilename(filename string, gameID string) *domain
 	baseName := strings.TrimSuffix(filename, filepath.Ext(filename))
 
 	// Try to extract version
-	version := extractVersionFromFilename(baseName)
+	version := domain.ExtractVersionFromName(baseName)
 
 	// Extract mod name (everything before the version)
 	name := baseName
@@ -397,19 +397,6 @@ func (i *Importer) detectModFromFilename(filename string, gameID string) *domain
 		Version:  version,
 		GameID:   gameID,
 	}
-}
-
-// extractVersionFromFilename extracts version from a filename using regex
-// versionRegexImporter matches semantic version patterns like 1.2.3, v1.2.3, etc.
-var versionRegexImporter = regexp.MustCompile(`[vV]?(\d+\.\d+(?:\.\d+)?(?:\.\d+)?(?:[-+][a-zA-Z][\w.]*)?)`)
-
-func extractVersionFromFilename(filename string) string {
-	// Match semantic version patterns
-	matches := versionRegexImporter.FindAllStringSubmatch(filename, -1)
-	if len(matches) > 0 {
-		return matches[len(matches)-1][1]
-	}
-	return ""
 }
 
 // copyFileStreaming copies a file using streaming to avoid loading it all into memory

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -113,7 +113,9 @@ func (s *Service) SearchMods(ctx context.Context, sourceID, gameID, query string
 
 	sourceGameID := gameID
 	if game, ok := s.games[gameID]; ok {
-		if id, ok := game.SourceIDs[sourceID]; ok {
+		// An empty mapping (e.g. directory sources: `donovan-mods: ""`) means
+		// "this source applies to any game" — it must not blank out the ID.
+		if id, ok := game.SourceIDs[sourceID]; ok && id != "" {
 			sourceGameID = id
 		}
 	}
@@ -135,10 +137,12 @@ func (s *Service) GetMod(ctx context.Context, sourceID, gameID, modID string) (*
 		return nil, err
 	}
 
-	// Get the source-specific game ID if we have a game configured
+	// Get the source-specific game ID if we have a game configured. An empty
+	// mapping (e.g. directory sources: `donovan-mods: ""`) means "this source
+	// applies to any game" — it must not blank out the ID.
 	sourceGameID := gameID
 	if game, ok := s.games[gameID]; ok {
-		if id, ok := game.SourceIDs[sourceID]; ok {
+		if id, ok := game.SourceIDs[sourceID]; ok && id != "" {
 			sourceGameID = id
 		}
 	}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/linker"
@@ -186,6 +187,10 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 		return nil, fmt.Errorf("getting download URL: %w", err)
 	}
 
+	if localPath, ok := strings.CutPrefix(url, "file://"); ok {
+		return s.ingestLocalToCache(gameCache, game, mod, file, localPath)
+	}
+
 	// Create temp directory for download
 	tempDir, err := os.MkdirTemp("", "lmm-download-*")
 	if err != nil {
@@ -252,6 +257,56 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 		FilesExtracted: len(files),
 		Checksum:       downloadResult.Checksum,
 	}, nil
+}
+
+// ingestLocalToCache copies a local mod (directory or archive) into the cache
+// using the same staging/commit flow as downloaded mods. Local ingests have no
+// download checksum, so DownloadModResult.Checksum is empty.
+func (s *Service) ingestLocalToCache(gameCache *cache.Cache, game *domain.Game, mod *domain.Mod, file *domain.DownloadableFile, localPath string) (*DownloadModResult, error) {
+	info, err := os.Stat(localPath)
+	if err != nil {
+		return nil, fmt.Errorf("local mod path: %w", err)
+	}
+
+	cachePath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
+	stagePath := cachePath + ".staging"
+	if err := os.RemoveAll(stagePath); err != nil {
+		return nil, fmt.Errorf("clearing staging cache: %w", err)
+	}
+	defer os.RemoveAll(stagePath) //nolint:errcheck
+	if gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version) {
+		if err := copyDir(cachePath, stagePath); err != nil {
+			return nil, fmt.Errorf("staging existing cache: %w", err)
+		}
+	}
+
+	switch {
+	case info.IsDir():
+		if err := copyDir(localPath, stagePath); err != nil {
+			return nil, fmt.Errorf("copying mod directory: %w", err)
+		}
+	case game.DeployMode == domain.DeployCopy || !s.extractor.CanExtract(localPath):
+		if err := os.MkdirAll(stagePath, 0755); err != nil {
+			return nil, fmt.Errorf("creating cache directory: %w", err)
+		}
+		if err := copyFileStreaming(localPath, filepath.Join(stagePath, filepath.Base(localPath))); err != nil {
+			return nil, fmt.Errorf("copying to cache: %w", err)
+		}
+	default:
+		if err := s.extractor.Extract(localPath, stagePath); err != nil {
+			return nil, fmt.Errorf("extracting mod: %w", err)
+		}
+	}
+
+	if err := commitStagedCache(cachePath, stagePath); err != nil {
+		return nil, err
+	}
+
+	files, err := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	if err != nil {
+		return nil, err
+	}
+	return &DownloadModResult{FilesExtracted: len(files)}, nil
 }
 
 func commitStagedCache(cachePath, stagePath string) error {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/linker"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/db"
@@ -185,13 +186,26 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 	// and each file should be downloaded and extracted to the cache.
 	// The cache directory may already exist from a previous file download.
 
-	// Get download URL
-	url, err := s.GetDownloadURL(ctx, sourceID, mod, file.ID)
+	// Get the source so we can gate the local-ingest branch below to sources
+	// that are actually allowed to serve local files.
+	src, err := s.registry.Get(sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("getting source: %w", err)
+	}
+
+	url, err := src.GetDownloadURL(ctx, mod, file.ID)
 	if err != nil {
 		return nil, fmt.Errorf("getting download URL: %w", err)
 	}
 
 	if localPath, ok := strings.CutPrefix(url, "file://"); ok {
+		// Only directory sources are allowed to serve local files. A remote
+		// source (NexusMods, CurseForge, a compromised custom API/manifest
+		// source, ...) returning file:// must never be trusted to read
+		// arbitrary paths off disk into the cache.
+		if _, isDirectorySource := src.(*custom.Directory); !isDirectorySource {
+			return nil, fmt.Errorf("source %q returned a local file:// URL but is not a directory source", sourceID)
+		}
 		return s.ingestLocalToCache(gameCache, game, mod, file, localPath)
 	}
 

--- a/internal/core/service_directory_source_test.go
+++ b/internal/core/service_directory_source_test.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectorySourceEndToEnd(t *testing.T) {
+	// A modlets directory with one mod.
+	root := t.TempDir()
+	modDir := filepath.Join(root, "BiggerBackpack")
+	require.NoError(t, os.MkdirAll(modDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "ModInfo.xml"), []byte(
+		`<?xml version="1.0"?><xml><Name value="BiggerBackpack"/><Version value="1.2.0"/></xml>`), 0644))
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "my-mods",
+		Name:      "My Mods",
+		Type:      custom.TypeDirectory,
+		Directory: &custom.DirectoryConfig{Path: root},
+	})
+	require.NoError(t, err)
+
+	svc := &Service{extractor: NewExtractor()}
+	gameCache := cache.New(t.TempDir())
+	game := &domain.Game{ID: "7dtd", DeployMode: domain.DeployExtract}
+	ctx := context.Background()
+
+	// Search finds the mod.
+	res, err := src.Search(ctx, sourceSearchQuery("backpack"))
+	require.NoError(t, err)
+	require.Len(t, res.Mods, 1)
+	mod := res.Mods[0]
+
+	// Files + download URL + local ingest land it in the cache.
+	files, err := src.GetModFiles(ctx, &mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	url, err := src.GetDownloadURL(ctx, &mod, files[0].ID)
+	require.NoError(t, err)
+
+	result, err := svc.ingestLocalToCache(gameCache, game, &mod, &files[0], url[len("file://"):])
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesExtracted)
+	assert.True(t, gameCache.Exists("7dtd", "my-mods", "BiggerBackpack", "1.2.0"))
+}
+
+func sourceSearchQuery(q string) source.SearchQuery {
+	return source.SearchQuery{Query: q, PageSize: 20}
+}

--- a/internal/core/service_directory_source_test.go
+++ b/internal/core/service_directory_source_test.go
@@ -35,11 +35,12 @@ func TestDirectorySourceEndToEnd(t *testing.T) {
 	game := &domain.Game{ID: "7dtd", DeployMode: domain.DeployExtract}
 	ctx := context.Background()
 
-	// Search finds the mod.
-	res, err := src.Search(ctx, sourceSearchQuery("backpack"))
+	// Search finds the mod and stamps GameID onto it for downstream identity.
+	res, err := src.Search(ctx, sourceSearchQuery("backpack", game.ID))
 	require.NoError(t, err)
 	require.Len(t, res.Mods, 1)
 	mod := res.Mods[0]
+	assert.Equal(t, game.ID, mod.GameID, "directory source must echo the queried GameID onto results")
 
 	// Files + download URL + local ingest land it in the cache.
 	files, err := src.GetModFiles(ctx, &mod)
@@ -55,6 +56,70 @@ func TestDirectorySourceEndToEnd(t *testing.T) {
 	assert.True(t, gameCache.Exists("7dtd", "my-mods", "BiggerBackpack", "1.2.0"))
 }
 
-func sourceSearchQuery(q string) source.SearchQuery {
-	return source.SearchQuery{Query: q, PageSize: 20}
+func sourceSearchQuery(q, gameID string) source.SearchQuery {
+	return source.SearchQuery{Query: q, GameID: gameID, PageSize: 20}
+}
+
+// TestDirectorySourceGameIDSurvivesEmptySourceMapping is a regression test for
+// the orphaned-install bug (final review finding 1): a directory source mapped
+// with the README-documented empty value (`sources: {my-mods: ""}`) must not
+// blank out the mod's GameID. It exercises both root causes together:
+// Directory.Search/GetMod echoing the gameID they're given, and
+// Service.SearchMods/GetMod only applying a mapped source-game-ID override when
+// it is non-empty. The key assertion is DB visibility: an install-shaped save
+// must show up via GetInstalledMods, which filters by game_id.
+func TestDirectorySourceGameIDSurvivesEmptySourceMapping(t *testing.T) {
+	root := t.TempDir()
+	modDir := filepath.Join(root, "BiggerBackpack")
+	require.NoError(t, os.MkdirAll(modDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "ModInfo.xml"), []byte(
+		`<?xml version="1.0"?><xml><Name value="BiggerBackpack"/><Version value="1.2.0"/></xml>`), 0644))
+
+	svc, err := NewService(ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "my-mods",
+		Name:      "My Mods",
+		Type:      custom.TypeDirectory,
+		Directory: &custom.DirectoryConfig{Path: root},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(src)
+
+	game := &domain.Game{
+		ID:         "7dtd",
+		Name:       "7 Days to Die",
+		SourceIDs:  map[string]string{"my-mods": ""}, // README-documented: directory sources ignore the value
+		DeployMode: domain.DeployExtract,
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	ctx := context.Background()
+
+	// SearchMods must return a mod carrying the lmm game's ID, not the blank override.
+	res, err := svc.SearchMods(ctx, "my-mods", game.ID, "backpack", "", nil, 0, 20)
+	require.NoError(t, err)
+	require.Len(t, res.Mods, 1)
+	assert.Equal(t, game.ID, res.Mods[0].GameID, "SearchMods must not blank GameID via an empty source mapping")
+
+	// GetMod must agree.
+	mod, err := svc.GetMod(ctx, "my-mods", game.ID, res.Mods[0].ID)
+	require.NoError(t, err)
+	assert.Equal(t, game.ID, mod.GameID, "GetMod must not blank GameID via an empty source mapping")
+
+	// The key assertion: an install-shaped save must be visible via GetInstalledMods,
+	// which filters by game_id — a blank GameID would silently orphan the row.
+	installed := &domain.InstalledMod{Mod: *mod, ProfileName: "default", Enabled: true}
+	require.NoError(t, svc.SaveInstalledMod(installed))
+
+	got, err := svc.GetInstalledMods(game.ID, "default")
+	require.NoError(t, err)
+	require.Len(t, got, 1, "installed mod must be visible under the game's own ID")
+	assert.Equal(t, mod.ID, got[0].ID)
 }

--- a/internal/core/service_download_local_test.go
+++ b/internal/core/service_download_local_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newLocalIngestService(t *testing.T) (*Service, *cache.Cache) {
+	t.Helper()
+	svc := &Service{extractor: NewExtractor()}
+	return svc, cache.New(t.TempDir())
+}
+
+func TestIngestLocalToCacheDirectory(t *testing.T) {
+	svc, gameCache := newLocalIngestService(t)
+
+	modDir := filepath.Join(t.TempDir(), "BiggerBackpack")
+	require.NoError(t, os.MkdirAll(filepath.Join(modDir, "Config"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "ModInfo.xml"), []byte("<xml/>"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "Config", "items.xml"), []byte("<items/>"), 0644))
+
+	game := &domain.Game{ID: "7dtd", DeployMode: domain.DeployExtract}
+	mod := &domain.Mod{ID: "BiggerBackpack", SourceID: "my-mods", Version: "1.2.0"}
+	file := &domain.DownloadableFile{ID: "main", FileName: "BiggerBackpack"}
+
+	result, err := svc.ingestLocalToCache(gameCache, game, mod, file, modDir)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.FilesExtracted)
+	assert.Empty(t, result.Checksum)
+
+	files, err := gameCache.ListFiles("7dtd", "my-mods", "BiggerBackpack", "1.2.0")
+	require.NoError(t, err)
+	assert.Len(t, files, 2)
+}
+
+func TestIngestLocalToCacheArchiveCopyMode(t *testing.T) {
+	svc, gameCache := newLocalIngestService(t)
+
+	archive := filepath.Join(t.TempDir(), "coolmod-2.0.zip")
+	require.NoError(t, os.WriteFile(archive, []byte("zipbytes"), 0644))
+
+	game := &domain.Game{ID: "hytale", DeployMode: domain.DeployCopy}
+	mod := &domain.Mod{ID: "coolmod-2.0", SourceID: "my-mods", Version: "2.0"}
+	file := &domain.DownloadableFile{ID: "main", FileName: "coolmod-2.0.zip"}
+
+	result, err := svc.ingestLocalToCache(gameCache, game, mod, file, archive)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesExtracted)
+
+	cached := gameCache.GetFilePath("hytale", "my-mods", "coolmod-2.0", "2.0", "coolmod-2.0.zip")
+	_, err = os.Stat(cached)
+	assert.NoError(t, err)
+}
+
+func TestIngestLocalToCacheMissingPath(t *testing.T) {
+	svc, gameCache := newLocalIngestService(t)
+
+	game := &domain.Game{ID: "7dtd"}
+	mod := &domain.Mod{ID: "x", SourceID: "my-mods", Version: "1.0"}
+	file := &domain.DownloadableFile{ID: "main", FileName: "x"}
+
+	_, err := svc.ingestLocalToCache(gameCache, game, mod, file, filepath.Join(t.TempDir(), "gone"))
+	assert.Error(t, err)
+}

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -644,6 +644,56 @@ func TestService_DownloadMod_PathLikeFilename_ArchiveWithoutExtension(t *testing
 	assert.Equal(t, []byte("payload"), content)
 }
 
+// TestService_DownloadMod_RejectsFileURLFromNonDirectorySource is a regression
+// test for final-review finding 3: a source.ModSource that is NOT a directory
+// source must never have its file:// download URL ingested by local copy. A
+// compromised or buggy remote source returning file:///etc/hostname (or any
+// other local path) must not let lmm read arbitrary files off disk into the
+// mod cache.
+func TestService_DownloadMod_RejectsFileURLFromNonDirectorySource(t *testing.T) {
+	cfg := core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	}
+
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("do not leak"), 0644))
+
+	mock := &mockSourceWithFileURL{mockSource: newMockSource("test"), fileURL: "file://" + secret}
+	svc.RegisterSource(mock)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir()}
+	require.NoError(t, svc.AddGame(game))
+
+	mod := &domain.Mod{ID: "123", SourceID: "test", Name: "Sneaky Mod", Version: "1.0.0", GameID: "testgame"}
+	file := &domain.DownloadableFile{ID: "file1", Name: "File", FileName: "file1.zip"}
+
+	_, err = svc.DownloadMod(context.Background(), "test", game, mod, file, nil)
+	require.Error(t, err)
+
+	gameCache := svc.GetGameCache(game)
+	assert.False(t, gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version),
+		"a file:// URL from a non-directory source must not be ingested into the cache")
+}
+
+// mockSourceWithFileURL returns a file:// download URL regardless of source
+// type, simulating a compromised or misbehaving remote source.
+type mockSourceWithFileURL struct {
+	*mockSource
+	fileURL string
+}
+
+func (m *mockSourceWithFileURL) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	return m.fileURL, nil
+}
+
 // mockSourceWithDownloads extends mockSource with download URL support
 type mockSourceWithDownloads struct {
 	*mockSource

--- a/internal/domain/mod.go
+++ b/internal/domain/mod.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -161,4 +162,20 @@ func parseVersionParts(v string) []int {
 	}
 
 	return result
+}
+
+// versionPattern matches version-like strings such as 1.2.3, v1.2.3, or
+// 1.0.0-beta2. The optional suffix must start with a letter so compound
+// strings like "1.20.1-15.3.0" parse as two versions, not one.
+var versionPattern = regexp.MustCompile(`[vV]?(\d+\.\d+(?:\.\d+)?(?:\.\d+)?(?:[-+][a-zA-Z][\w.]*)?)`)
+
+// ExtractVersionFromName extracts the last version-like pattern from a file or
+// directory name (mod version typically follows the game version in names like
+// "jei-1.20.1-15.3.0"). Returns "" when no version is present.
+func ExtractVersionFromName(name string) string {
+	matches := versionPattern.FindAllStringSubmatch(name, -1)
+	if len(matches) > 0 {
+		return matches[len(matches)-1][1]
+	}
+	return ""
 }

--- a/internal/domain/mod_test.go
+++ b/internal/domain/mod_test.go
@@ -1,6 +1,10 @@
 package domain
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestSourceLocal_IsExpectedValue(t *testing.T) {
 	if SourceLocal != "local" {
@@ -71,5 +75,24 @@ func TestIsNewerVersion(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("IsNewerVersion(%q, %q) = %v, want %v", tt.current, tt.new, got, tt.want)
 		}
+	}
+}
+
+func TestExtractVersionFromName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"simple", "BiggerBackpack-1.2.0", "1.2.0"},
+		{"v prefix", "cool-mod-v2.1", "2.1"},
+		{"last version wins", "jei-1.20.1-15.3.0", "15.3.0"},
+		{"prerelease suffix", "mod-1.0.0-beta2", "1.0.0-beta2"},
+		{"no version", "JustAName", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ExtractVersionFromName(tt.in))
+		})
 	}
 }

--- a/internal/source/custom/custom.go
+++ b/internal/source/custom/custom.go
@@ -11,6 +11,8 @@ import (
 // can warn-and-skip instead of failing.
 func New(def SourceDefinition) (source.ModSource, error) {
 	switch def.Type {
+	case TypeDirectory:
+		return NewDirectory(def)
 	default:
 		return nil, fmt.Errorf("source type %q is not yet supported", def.Type)
 	}

--- a/internal/source/custom/custom.go
+++ b/internal/source/custom/custom.go
@@ -1,0 +1,17 @@
+package custom
+
+import (
+	"fmt"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+)
+
+// New constructs a ModSource from a validated definition. It returns an error
+// for definition types whose implementation has not shipped yet, so startup
+// can warn-and-skip instead of failing.
+func New(def SourceDefinition) (source.ModSource, error) {
+	switch def.Type {
+	default:
+		return nil, fmt.Errorf("source type %q is not yet supported", def.Type)
+	}
+}

--- a/internal/source/custom/custom_test.go
+++ b/internal/source/custom/custom_test.go
@@ -7,8 +7,20 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Run("directory type constructs a source", func(t *testing.T) {
+		def := SourceDefinition{
+			ID:        "my-mods",
+			Name:      "My Mods",
+			Type:      TypeDirectory,
+			Directory: &DirectoryConfig{Path: t.TempDir()},
+		}
+		src, err := New(def)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-mods", src.ID())
+	})
+
 	t.Run("unimplemented types return a clear error", func(t *testing.T) {
-		for _, typ := range []string{TypeDirectory, TypeManifest, TypeAPI} {
+		for _, typ := range []string{TypeManifest, TypeAPI} {
 			def := SourceDefinition{ID: "x", Name: "X", Type: typ}
 			_, err := New(def)
 			assert.ErrorContains(t, err, "not yet supported", "type %s", typ)

--- a/internal/source/custom/custom_test.go
+++ b/internal/source/custom/custom_test.go
@@ -1,0 +1,17 @@
+package custom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("unimplemented types return a clear error", func(t *testing.T) {
+		for _, typ := range []string{TypeDirectory, TypeManifest, TypeAPI} {
+			def := SourceDefinition{ID: "x", Name: "X", Type: typ}
+			_, err := New(def)
+			assert.ErrorContains(t, err, "not yet supported", "type %s", typ)
+		}
+	})
+}

--- a/internal/source/custom/definition.go
+++ b/internal/source/custom/definition.go
@@ -1,0 +1,132 @@
+// Package custom implements user-defined mod sources configured declaratively
+// via YAML files in <configDir>/sources/. See the design doc:
+// docs/plans/2026-07-13-custom-sources-design.md
+package custom
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Source type identifiers for SourceDefinition.Type.
+const (
+	TypeDirectory = "directory"
+	TypeManifest  = "manifest"
+	TypeAPI       = "api"
+)
+
+// SourceDefinition is one user-defined source, parsed from a YAML file in
+// <configDir>/sources/. Exactly one of Directory/Manifest/API must be set,
+// matching Type.
+type SourceDefinition struct {
+	ID        string           `yaml:"id"`
+	Name      string           `yaml:"name"`
+	Type      string           `yaml:"type"`
+	AllowHTTP bool             `yaml:"allow_http"`
+	Directory *DirectoryConfig `yaml:"directory"`
+	Manifest  *ManifestConfig  `yaml:"manifest"`
+	API       *APIConfig       `yaml:"api"`
+}
+
+// DirectoryConfig configures a local-directory source.
+type DirectoryConfig struct {
+	Path string `yaml:"path"`
+}
+
+// ManifestConfig configures a manifest source (Phase 3).
+type ManifestConfig struct {
+	URL     string `yaml:"url"`
+	Refresh string `yaml:"refresh"` // Go duration string, e.g. "15m"; empty = default
+}
+
+// APIConfig configures a declarative REST source (expanded in Phase 4).
+type APIConfig struct {
+	BaseURL string `yaml:"base_url"`
+}
+
+var idPattern = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// Validate checks the definition for structural errors. It does not touch the
+// filesystem or network; existence checks happen when the source is constructed.
+func (d *SourceDefinition) Validate() error {
+	if d.ID == "" {
+		return errors.New("id is required")
+	}
+	if !idPattern.MatchString(d.ID) {
+		return fmt.Errorf("id %q must match ^[a-z0-9-]+$", d.ID)
+	}
+	if d.Name == "" {
+		return errors.New("name is required")
+	}
+	if d.Type == "" {
+		return errors.New("type is required")
+	}
+
+	blocks := 0
+	if d.Directory != nil {
+		blocks++
+	}
+	if d.Manifest != nil {
+		blocks++
+	}
+	if d.API != nil {
+		blocks++
+	}
+	if blocks > 1 {
+		return errors.New("exactly one of directory/manifest/api may be set")
+	}
+
+	switch d.Type {
+	case TypeDirectory:
+		if d.Directory == nil {
+			return fmt.Errorf(`type %q requires a "directory" block`, d.Type)
+		}
+		if d.Directory.Path == "" {
+			return errors.New("directory.path is required")
+		}
+	case TypeManifest:
+		if d.Manifest == nil {
+			return fmt.Errorf(`type %q requires a "manifest" block`, d.Type)
+		}
+		if d.Manifest.URL == "" {
+			return errors.New("manifest.url is required")
+		}
+		if err := d.checkURL(d.Manifest.URL); err != nil {
+			return fmt.Errorf("manifest.url: %w", err)
+		}
+		if d.Manifest.Refresh != "" {
+			if _, err := time.ParseDuration(d.Manifest.Refresh); err != nil {
+				return fmt.Errorf("manifest.refresh: %w", err)
+			}
+		}
+	case TypeAPI:
+		if d.API == nil {
+			return fmt.Errorf(`type %q requires an "api" block`, d.Type)
+		}
+		if d.API.BaseURL == "" {
+			return errors.New("api.base_url is required")
+		}
+		if !strings.HasPrefix(d.API.BaseURL, "https://") && !strings.HasPrefix(d.API.BaseURL, "http://") {
+			return errors.New("api.base_url must be an http(s) URL")
+		}
+		if err := d.checkURL(d.API.BaseURL); err != nil {
+			return fmt.Errorf("api.base_url: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown type %q (expected %s, %s, or %s)", d.Type, TypeDirectory, TypeManifest, TypeAPI)
+	}
+
+	return nil
+}
+
+// checkURL rejects plain-http URLs unless allow_http is set. Non-URL values
+// (local paths) pass through untouched.
+func (d *SourceDefinition) checkURL(u string) error {
+	if strings.HasPrefix(u, "http://") && !d.AllowHTTP {
+		return errors.New("plain http is disabled; use https or set allow_http: true")
+	}
+	return nil
+}

--- a/internal/source/custom/definition_test.go
+++ b/internal/source/custom/definition_test.go
@@ -1,0 +1,85 @@
+package custom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func validDirectoryDef() SourceDefinition {
+	return SourceDefinition{
+		ID:        "my-mods",
+		Name:      "My Mods",
+		Type:      TypeDirectory,
+		Directory: &DirectoryConfig{Path: "~/mods"},
+	}
+}
+
+func TestSourceDefinitionValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*SourceDefinition)
+		wantErr string // empty = valid
+	}{
+		{"valid directory", func(d *SourceDefinition) {}, ""},
+		{"missing id", func(d *SourceDefinition) { d.ID = "" }, "id is required"},
+		{"bad id chars", func(d *SourceDefinition) { d.ID = "My_Mods" }, "must match"},
+		{"missing name", func(d *SourceDefinition) { d.Name = "" }, "name is required"},
+		{"missing type", func(d *SourceDefinition) { d.Type = "" }, "type is required"},
+		{"unknown type", func(d *SourceDefinition) { d.Type = "ftp" }, "unknown type"},
+		{"directory without block", func(d *SourceDefinition) { d.Directory = nil }, `requires a "directory" block`},
+		{"directory with empty path", func(d *SourceDefinition) { d.Directory.Path = "" }, "directory.path is required"},
+		{"two type blocks", func(d *SourceDefinition) {
+			d.Manifest = &ManifestConfig{URL: "https://x.test/m.yaml"}
+		}, "exactly one"},
+		{"valid https manifest", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "https://x.test/m.yaml"}
+		}, ""},
+		{"valid local manifest path", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "~/mods/manifest.yaml"}
+		}, ""},
+		{"http manifest rejected", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "http://x.test/m.yaml"}
+		}, "https"},
+		{"http manifest allowed with allow_http", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.AllowHTTP = true
+			d.Manifest = &ManifestConfig{URL: "http://x.test/m.yaml"}
+		}, ""},
+		{"bad manifest refresh", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "https://x.test/m.yaml", Refresh: "soon"}
+		}, "refresh"},
+		{"valid api", func(d *SourceDefinition) {
+			d.Type = TypeAPI
+			d.Directory = nil
+			d.API = &APIConfig{BaseURL: "https://api.x.test"}
+		}, ""},
+		{"http api rejected", func(d *SourceDefinition) {
+			d.Type = TypeAPI
+			d.Directory = nil
+			d.API = &APIConfig{BaseURL: "http://api.x.test"}
+		}, "https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := validDirectoryDef()
+			tt.mutate(&def)
+			err := def.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/source/custom/directory.go
+++ b/internal/source/custom/directory.go
@@ -85,6 +85,9 @@ func (d *Directory) scan() ([]dirMod, error) {
 
 	var mods []dirMod
 	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue // hidden entries (.git, .DS_Store, dotfiles, ...) are never mods
+		}
 		entryPath := filepath.Join(d.path, entry.Name())
 
 		if entry.IsDir() {
@@ -188,6 +191,9 @@ func (d *Directory) Search(ctx context.Context, query source.SearchQuery) (sourc
 		pageSize = 20
 	}
 	start := query.Page * pageSize
+	if start < 0 {
+		start = 0
+	}
 	end := min(start+pageSize, len(matches))
 	if start > len(matches) {
 		start = len(matches)

--- a/internal/source/custom/directory.go
+++ b/internal/source/custom/directory.go
@@ -1,0 +1,296 @@
+package custom
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom/metadata"
+)
+
+// Directory is a ModSource backed by a local directory: each subdirectory (or
+// .zip/.jar archive) is one mod. The directory is rescanned on each operation
+// so edits show up without restarting lmm; scans are local and cheap.
+type Directory struct {
+	id   string
+	name string
+	path string // absolute, verified at construction
+}
+
+// NewDirectory constructs a directory source from a validated definition.
+// The configured path must exist and be a directory.
+func NewDirectory(def SourceDefinition) (*Directory, error) {
+	path := def.Directory.Path
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("expanding %q: %w", path, err)
+		}
+		path = filepath.Join(home, path[2:])
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %q: %w", path, err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("directory source path: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("directory source path %s is not a directory", abs)
+	}
+
+	return &Directory{id: def.ID, name: def.Name, path: abs}, nil
+}
+
+// ID implements source.ModSource.
+func (d *Directory) ID() string { return d.id }
+
+// Name implements source.ModSource.
+func (d *Directory) Name() string { return d.name }
+
+// AuthURL implements source.ModSource; directory sources need no auth.
+func (d *Directory) AuthURL() string { return "" }
+
+// ExchangeToken implements source.ModSource.
+func (d *Directory) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
+	return nil, fmt.Errorf("source %q: authentication: %w", d.id, source.ErrNotSupported)
+}
+
+// Capabilities implements source.CapabilityReporter.
+func (d *Directory) Capabilities() source.Capabilities {
+	return source.Capabilities{Search: true, Updates: true}
+}
+
+// dirMod pairs a scanned mod with its filesystem location.
+type dirMod struct {
+	mod       domain.Mod
+	path      string // absolute path to the mod directory or archive
+	isArchive bool
+	size      int64 // archive size in bytes; 0 for directories
+}
+
+// scan reads the source directory. Subdirectories are directory mods;
+// .zip/.jar files are archive mods; everything else is ignored.
+func (d *Directory) scan() ([]dirMod, error) {
+	entries, err := os.ReadDir(d.path)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: scanning %s: %w", d.id, d.path, err)
+	}
+
+	var mods []dirMod
+	for _, entry := range entries {
+		entryPath := filepath.Join(d.path, entry.Name())
+
+		if entry.IsDir() {
+			mods = append(mods, d.scanDir(entry.Name(), entryPath))
+			continue
+		}
+
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if ext != ".zip" && ext != ".jar" {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("source %q: stat %s: %w", d.id, entryPath, err)
+		}
+		base := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+		name, version := nameAndVersionFrom(base)
+		mods = append(mods, dirMod{
+			mod: domain.Mod{
+				ID:       base,
+				SourceID: d.id,
+				Name:     name,
+				Version:  version,
+			},
+			path:      entryPath,
+			isArchive: true,
+			size:      info.Size(),
+		})
+	}
+
+	return mods, nil
+}
+
+// scanDir builds a dirMod for a mod directory, preferring well-known metadata
+// files over dirname parsing.
+func (d *Directory) scanDir(dirName, dirPath string) dirMod {
+	mod := domain.Mod{ID: dirName, SourceID: d.id}
+
+	if info := metadata.Resolve(dirPath); info != nil {
+		mod.Name = info.DisplayName
+		if mod.Name == "" {
+			mod.Name = info.Name
+		}
+		mod.Version = info.Version
+		mod.Summary = info.Summary
+		mod.Description = info.Summary
+		mod.Author = info.Author
+	} else {
+		mod.Name, mod.Version = nameAndVersionFrom(dirName)
+	}
+
+	return dirMod{mod: mod, path: dirPath}
+}
+
+// nameAndVersionFrom splits a directory/file base name into a display name and
+// version ("PlainMod-0.5" -> "PlainMod", "0.5").
+func nameAndVersionFrom(base string) (string, string) {
+	version := domain.ExtractVersionFromName(base)
+	name := base
+	if version != "" {
+		if idx := strings.LastIndex(base, version); idx > 0 {
+			name = strings.TrimRight(base[:idx], "-_ vV")
+		}
+	}
+	return name, version
+}
+
+// Search implements source.ModSource with client-side matching: case-insensitive
+// substring on name and summary; name matches rank first, then alphabetical.
+// GameID is ignored — a directory source applies to any game that maps it.
+func (d *Directory) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	scanned, err := d.scan()
+	if err != nil {
+		return source.SearchResult{}, err
+	}
+
+	q := strings.ToLower(query.Query)
+	type ranked struct {
+		mod       domain.Mod
+		nameMatch bool
+	}
+	var matches []ranked
+	for _, dm := range scanned {
+		nameMatch := q == "" || strings.Contains(strings.ToLower(dm.mod.Name), q) || strings.Contains(strings.ToLower(dm.mod.ID), q)
+		summaryMatch := strings.Contains(strings.ToLower(dm.mod.Summary), q)
+		if !nameMatch && !summaryMatch {
+			continue
+		}
+		matches = append(matches, ranked{mod: dm.mod, nameMatch: nameMatch})
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].nameMatch != matches[j].nameMatch {
+			return matches[i].nameMatch
+		}
+		return matches[i].mod.Name < matches[j].mod.Name
+	})
+
+	pageSize := query.PageSize
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	start := query.Page * pageSize
+	end := min(start+pageSize, len(matches))
+	if start > len(matches) {
+		start = len(matches)
+	}
+
+	mods := make([]domain.Mod, 0, end-start)
+	for _, m := range matches[start:end] {
+		mods = append(mods, m.mod)
+	}
+
+	return source.SearchResult{
+		Mods:       mods,
+		TotalCount: len(matches),
+		Page:       query.Page,
+		PageSize:   pageSize,
+	}, nil
+}
+
+// GetMod implements source.ModSource. gameID is ignored (see Search).
+func (d *Directory) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	dm, err := d.find(modID)
+	if err != nil {
+		return nil, err
+	}
+	mod := dm.mod
+	return &mod, nil
+}
+
+// GetDependencies implements source.ModSource; directory mods declare none.
+func (d *Directory) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	return nil, fmt.Errorf("source %q: dependencies: %w", d.id, source.ErrNotSupported)
+}
+
+// GetModFiles implements source.ModSource: every mod has exactly one synthetic
+// file ("main") representing its directory or archive.
+func (d *Directory) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	dm, err := d.find(mod.ID)
+	if err != nil {
+		return nil, err
+	}
+	return []domain.DownloadableFile{{
+		ID:        "main",
+		Name:      dm.mod.Name,
+		FileName:  filepath.Base(dm.path),
+		Version:   dm.mod.Version,
+		Size:      dm.size,
+		IsPrimary: true,
+	}}, nil
+}
+
+// GetDownloadURL implements source.ModSource, returning a file:// URL that
+// Service.DownloadModToCache ingests by local copy instead of HTTP download.
+func (d *Directory) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	dm, err := d.find(mod.ID)
+	if err != nil {
+		return "", err
+	}
+	return "file://" + dm.path, nil
+}
+
+// CheckUpdates implements source.ModSource by comparing installed versions to
+// the current scan.
+func (d *Directory) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	scanned, err := d.scan()
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]domain.Mod, len(scanned))
+	for _, dm := range scanned {
+		byID[dm.mod.ID] = dm.mod
+	}
+
+	var updates []domain.Update
+	for _, inst := range installed {
+		select {
+		case <-ctx.Done():
+			return updates, ctx.Err()
+		default:
+		}
+		current, ok := byID[inst.ID]
+		if !ok {
+			continue // mod removed from the directory; nothing to offer
+		}
+		if domain.IsNewerVersion(inst.Version, current.Version) {
+			updates = append(updates, domain.Update{
+				InstalledMod: inst,
+				NewVersion:   current.Version,
+			})
+		}
+	}
+	return updates, nil
+}
+
+// find scans and returns the mod with the given ID.
+func (d *Directory) find(modID string) (dirMod, error) {
+	scanned, err := d.scan()
+	if err != nil {
+		return dirMod{}, err
+	}
+	for _, dm := range scanned {
+		if dm.mod.ID == modID {
+			return dm, nil
+		}
+	}
+	return dirMod{}, fmt.Errorf("source %q: mod not found: %s", d.id, modID)
+}

--- a/internal/source/custom/directory.go
+++ b/internal/source/custom/directory.go
@@ -157,7 +157,9 @@ func nameAndVersionFrom(base string) (string, string) {
 
 // Search implements source.ModSource with client-side matching: case-insensitive
 // substring on name and summary; name matches rank first, then alphabetical.
-// GameID is ignored — a directory source applies to any game that maps it.
+// GameID is accepted from any game (a directory source applies to any game that
+// maps it — it does not filter by GameID) but is echoed onto every returned mod
+// so downstream installs are attributed to the correct game.
 func (d *Directory) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
 	scanned, err := d.scan()
 	if err != nil {
@@ -201,7 +203,9 @@ func (d *Directory) Search(ctx context.Context, query source.SearchQuery) (sourc
 
 	mods := make([]domain.Mod, 0, end-start)
 	for _, m := range matches[start:end] {
-		mods = append(mods, m.mod)
+		mod := m.mod
+		mod.GameID = query.GameID
+		mods = append(mods, mod)
 	}
 
 	return source.SearchResult{
@@ -212,13 +216,16 @@ func (d *Directory) Search(ctx context.Context, query source.SearchQuery) (sourc
 	}, nil
 }
 
-// GetMod implements source.ModSource. gameID is ignored (see Search).
+// GetMod implements source.ModSource. gameID is accepted from any game and not
+// used to look up the mod (see Search); it is echoed onto the returned mod so
+// downstream installs are attributed to the correct game.
 func (d *Directory) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
 	dm, err := d.find(modID)
 	if err != nil {
 		return nil, err
 	}
 	mod := dm.mod
+	mod.GameID = gameID
 	return &mod, nil
 }
 

--- a/internal/source/custom/directory.go
+++ b/internal/source/custom/directory.go
@@ -104,14 +104,14 @@ func (d *Directory) scan() ([]dirMod, error) {
 			return nil, fmt.Errorf("source %q: stat %s: %w", d.id, entryPath, err)
 		}
 		base := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
-		name, version := nameAndVersionFrom(base)
+		mod := domain.Mod{ID: base, SourceID: d.id}
+		if meta := metadata.ResolveArchive(entryPath); meta != nil {
+			applyMetadata(&mod, meta)
+		} else {
+			mod.Name, mod.Version = nameAndVersionFrom(base)
+		}
 		mods = append(mods, dirMod{
-			mod: domain.Mod{
-				ID:       base,
-				SourceID: d.id,
-				Name:     name,
-				Version:  version,
-			},
+			mod:       mod,
 			path:      entryPath,
 			isArchive: true,
 			size:      info.Size(),
@@ -127,19 +127,27 @@ func (d *Directory) scanDir(dirName, dirPath string) dirMod {
 	mod := domain.Mod{ID: dirName, SourceID: d.id}
 
 	if info := metadata.Resolve(dirPath); info != nil {
-		mod.Name = info.DisplayName
-		if mod.Name == "" {
-			mod.Name = info.Name
-		}
-		mod.Version = info.Version
-		mod.Summary = info.Summary
-		mod.Description = info.Summary
-		mod.Author = info.Author
+		applyMetadata(&mod, info)
 	} else {
 		mod.Name, mod.Version = nameAndVersionFrom(dirName)
 	}
 
 	return dirMod{mod: mod, path: dirPath}
+}
+
+// applyMetadata copies well-known metadata fields onto mod, used by both
+// directory mods (metadata.Resolve) and archive mods (metadata.ResolveArchive)
+// so they share the same precedence: DisplayName wins, falling back to Name,
+// and metadata always wins over any filename-derived guess.
+func applyMetadata(mod *domain.Mod, info *metadata.Info) {
+	mod.Name = info.DisplayName
+	if mod.Name == "" {
+		mod.Name = info.Name
+	}
+	mod.Version = info.Version
+	mod.Summary = info.Summary
+	mod.Description = info.Summary
+	mod.Author = info.Author
 }
 
 // nameAndVersionFrom splits a directory/file base name into a display name and

--- a/internal/source/custom/directory_test.go
+++ b/internal/source/custom/directory_test.go
@@ -1,0 +1,170 @@
+package custom
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testModInfo = `<?xml version="1.0" encoding="UTF-8" ?>
+<xml>
+	<Name value="BiggerBackpack"/>
+	<DisplayName value="Bigger Backpack"/>
+	<Version value="1.2.0"/>
+	<Description value="Carry more stuff"/>
+	<Author value="Donovan"/>
+</xml>`
+
+// newTestDirectory builds a source over a temp dir containing:
+//
+//	BiggerBackpack/        (with ModInfo.xml)
+//	PlainMod-0.5/          (no metadata; version from dirname)
+//	archived-mod-2.0.zip   (archive mod)
+//	README.md              (ignored: not a dir or archive)
+func newTestDirectory(t *testing.T) *Directory {
+	t.Helper()
+	root := t.TempDir()
+
+	bb := filepath.Join(root, "BiggerBackpack")
+	require.NoError(t, os.MkdirAll(bb, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(bb, "ModInfo.xml"), []byte(testModInfo), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(bb, "readme.txt"), []byte("hi"), 0644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "PlainMod-0.5"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "archived-mod-2.0.zip"), []byte("zipbytes"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("ignored"), 0644))
+
+	def := SourceDefinition{
+		ID:        "my-mods",
+		Name:      "My Mods",
+		Type:      TypeDirectory,
+		Directory: &DirectoryConfig{Path: root},
+	}
+	d, err := NewDirectory(def)
+	require.NoError(t, err)
+	return d
+}
+
+func TestNewDirectoryValidation(t *testing.T) {
+	def := SourceDefinition{
+		ID:        "x",
+		Name:      "X",
+		Type:      TypeDirectory,
+		Directory: &DirectoryConfig{Path: filepath.Join(t.TempDir(), "missing")},
+	}
+	_, err := NewDirectory(def)
+	assert.ErrorContains(t, err, "missing")
+}
+
+func TestDirectoryIdentityAndCapabilities(t *testing.T) {
+	d := newTestDirectory(t)
+	assert.Equal(t, "my-mods", d.ID())
+	assert.Equal(t, "My Mods", d.Name())
+	assert.Equal(t, source.Capabilities{Search: true, Updates: true}, d.Capabilities())
+	assert.Empty(t, d.AuthURL())
+
+	_, err := d.ExchangeToken(context.Background(), "code")
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+
+	_, err = d.GetDependencies(context.Background(), nil)
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+}
+
+func TestDirectorySearch(t *testing.T) {
+	d := newTestDirectory(t)
+	ctx := context.Background()
+
+	t.Run("empty query returns all mods", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{GameID: "anything"})
+		require.NoError(t, err)
+		assert.Equal(t, 3, res.TotalCount)
+		require.Len(t, res.Mods, 3)
+	})
+
+	t.Run("metadata takes priority over dirname", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Query: "backpack"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		m := res.Mods[0]
+		assert.Equal(t, "BiggerBackpack", m.ID)
+		assert.Equal(t, "Bigger Backpack", m.Name)
+		assert.Equal(t, "1.2.0", m.Version)
+		assert.Equal(t, "Carry more stuff", m.Summary)
+		assert.Equal(t, "Donovan", m.Author)
+		assert.Equal(t, "my-mods", m.SourceID)
+	})
+
+	t.Run("fallback parses version from name", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Query: "plainmod"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		assert.Equal(t, "PlainMod-0.5", res.Mods[0].ID)
+		assert.Equal(t, "PlainMod", res.Mods[0].Name)
+		assert.Equal(t, "0.5", res.Mods[0].Version)
+	})
+
+	t.Run("summary matches rank after name matches", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Query: "stuff"}) // only in summary
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		assert.Equal(t, "BiggerBackpack", res.Mods[0].ID)
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Page: 0, PageSize: 2})
+		require.NoError(t, err)
+		assert.Len(t, res.Mods, 2)
+		assert.Equal(t, 3, res.TotalCount)
+
+		res, err = d.Search(ctx, source.SearchQuery{Page: 1, PageSize: 2})
+		require.NoError(t, err)
+		assert.Len(t, res.Mods, 1)
+	})
+}
+
+func TestDirectoryGetMod(t *testing.T) {
+	d := newTestDirectory(t)
+
+	mod, err := d.GetMod(context.Background(), "ignored", "BiggerBackpack")
+	require.NoError(t, err)
+	assert.Equal(t, "Bigger Backpack", mod.Name)
+
+	_, err = d.GetMod(context.Background(), "ignored", "nope")
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestDirectoryFilesAndDownloadURL(t *testing.T) {
+	d := newTestDirectory(t)
+	ctx := context.Background()
+
+	mod, err := d.GetMod(ctx, "", "BiggerBackpack")
+	require.NoError(t, err)
+
+	files, err := d.GetModFiles(ctx, mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "main", files[0].ID)
+	assert.Equal(t, "BiggerBackpack", files[0].FileName)
+	assert.True(t, files[0].IsPrimary)
+
+	url, err := d.GetDownloadURL(ctx, mod, files[0].ID)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(url, "file://"))
+	assert.True(t, strings.HasSuffix(url, "/BiggerBackpack"))
+
+	// Archive mods point at the archive file.
+	zipMod, err := d.GetMod(ctx, "", "archived-mod-2.0")
+	require.NoError(t, err)
+	zipFiles, err := d.GetModFiles(ctx, zipMod)
+	require.NoError(t, err)
+	require.Len(t, zipFiles, 1)
+	assert.Equal(t, "archived-mod-2.0.zip", zipFiles[0].FileName)
+	assert.Equal(t, int64(8), zipFiles[0].Size) // len("zipbytes")
+}

--- a/internal/source/custom/directory_test.go
+++ b/internal/source/custom/directory_test.go
@@ -29,6 +29,8 @@ const testModInfo = `<?xml version="1.0" encoding="UTF-8" ?>
 //	PlainMod-0.5/          (no metadata; version from dirname)
 //	archived-mod-2.0.zip   (archive mod)
 //	README.md              (ignored: not a dir or archive)
+//	.git/                  (ignored: dot-prefixed directory)
+//	.hidden-mod.zip        (ignored: dot-prefixed file, even though it's a .zip)
 func newTestDirectory(t *testing.T) *Directory {
 	t.Helper()
 	root := t.TempDir()
@@ -41,6 +43,10 @@ func newTestDirectory(t *testing.T) *Directory {
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "PlainMod-0.5"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "archived-mod-2.0.zip"), []byte("zipbytes"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("ignored"), 0644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".git", "config"), []byte("ignored"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".hidden-mod.zip"), []byte("zipbytes"), 0644))
 
 	def := SourceDefinition{
 		ID:        "my-mods",
@@ -127,6 +133,24 @@ func TestDirectorySearch(t *testing.T) {
 		res, err = d.Search(ctx, source.SearchQuery{Page: 1, PageSize: 2})
 		require.NoError(t, err)
 		assert.Len(t, res.Mods, 1)
+	})
+
+	t.Run("negative page clamps to the first page instead of panicking", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Page: -1, PageSize: 2})
+		require.NoError(t, err)
+		assert.Len(t, res.Mods, 2)
+		assert.Equal(t, 3, res.TotalCount)
+	})
+
+	t.Run("dot-prefixed entries are skipped", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{})
+		require.NoError(t, err)
+		assert.Equal(t, 3, res.TotalCount, "hidden .git dir and .hidden-mod.zip must not be listed as mods")
+		for _, m := range res.Mods {
+			assert.NotEqual(t, "config", m.ID)
+			assert.NotEqual(t, ".git", m.ID)
+			assert.NotEqual(t, ".hidden-mod", m.ID)
+		}
 	})
 }
 

--- a/internal/source/custom/directory_test.go
+++ b/internal/source/custom/directory_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -167,4 +168,20 @@ func TestDirectoryFilesAndDownloadURL(t *testing.T) {
 	require.Len(t, zipFiles, 1)
 	assert.Equal(t, "archived-mod-2.0.zip", zipFiles[0].FileName)
 	assert.Equal(t, int64(8), zipFiles[0].Size) // len("zipbytes")
+}
+
+func TestDirectoryCheckUpdates(t *testing.T) {
+	d := newTestDirectory(t) // BiggerBackpack is at 1.2.0
+
+	installed := []domain.InstalledMod{
+		{Mod: domain.Mod{ID: "BiggerBackpack", SourceID: "my-mods", Name: "Bigger Backpack", Version: "1.0.0"}},
+		{Mod: domain.Mod{ID: "PlainMod-0.5", SourceID: "my-mods", Name: "PlainMod", Version: "0.5"}},
+		{Mod: domain.Mod{ID: "Removed", SourceID: "my-mods", Name: "Removed", Version: "1.0"}},
+	}
+
+	updates, err := d.CheckUpdates(context.Background(), installed)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "BiggerBackpack", updates[0].InstalledMod.ID)
+	assert.Equal(t, "1.2.0", updates[0].NewVersion)
 }

--- a/internal/source/custom/directory_test.go
+++ b/internal/source/custom/directory_test.go
@@ -1,6 +1,7 @@
 package custom
 
 import (
+	"archive/zip"
 	"context"
 	"errors"
 	"os"
@@ -200,6 +201,68 @@ func TestDirectoryFilesAndDownloadURL(t *testing.T) {
 	require.Len(t, zipFiles, 1)
 	assert.Equal(t, "archived-mod-2.0.zip", zipFiles[0].FileName)
 	assert.Equal(t, int64(8), zipFiles[0].Size) // len("zipbytes")
+}
+
+// writeTestZip builds a real zip file at path containing entryPath -> content.
+func writeTestZip(t *testing.T, path, entryPath, content string) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	w := zip.NewWriter(f)
+	fw, err := w.Create(entryPath)
+	require.NoError(t, err)
+	_, err = fw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+}
+
+// TestDirectoryArchiveMetadata verifies that .zip mods with an embedded
+// ModInfo.xml (7 Days to Die's standard wrapper-folder layout) surface real
+// metadata instead of filename-derived guesses, while archives without
+// readable metadata still fall back to filename parsing.
+func TestDirectoryArchiveMetadata(t *testing.T) {
+	root := t.TempDir()
+
+	// Real zip: donovan-aio.zip containing donovan-aio/ModInfo.xml.
+	writeTestZip(t, filepath.Join(root, "donovan-aio.zip"), "donovan-aio/ModInfo.xml", testModInfo)
+
+	// Not a real zip (fake bytes) - must keep falling back to filename parsing.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "archived-mod-2.0.zip"), []byte("zipbytes"), 0644))
+
+	def := SourceDefinition{
+		ID:        "my-mods",
+		Name:      "My Mods",
+		Type:      TypeDirectory,
+		Directory: &DirectoryConfig{Path: root},
+	}
+	d, err := NewDirectory(def)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	t.Run("archive with embedded ModInfo.xml surfaces metadata", func(t *testing.T) {
+		mod, err := d.GetMod(ctx, "7dtd", "donovan-aio")
+		require.NoError(t, err)
+		assert.Equal(t, "donovan-aio", mod.ID, "mod ID stays the archive base name")
+		assert.Equal(t, "Bigger Backpack", mod.Name)
+		assert.Equal(t, "1.2.0", mod.Version)
+		assert.Equal(t, "Carry more stuff", mod.Summary)
+		assert.Equal(t, "Donovan", mod.Author)
+	})
+
+	t.Run("archive with no readable metadata falls back to filename parsing", func(t *testing.T) {
+		mod, err := d.GetMod(ctx, "7dtd", "archived-mod-2.0")
+		require.NoError(t, err)
+		assert.Equal(t, "archived-mod-2.0", mod.ID)
+		assert.Equal(t, "archived-mod", mod.Name)
+		assert.Equal(t, "2.0", mod.Version)
+
+		files, err := d.GetModFiles(ctx, mod)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		assert.Equal(t, int64(8), files[0].Size, `len("zipbytes")`)
+	})
 }
 
 func TestDirectoryCheckUpdates(t *testing.T) {

--- a/internal/source/custom/directory_test.go
+++ b/internal/source/custom/directory_test.go
@@ -142,6 +142,13 @@ func TestDirectorySearch(t *testing.T) {
 		assert.Equal(t, 3, res.TotalCount)
 	})
 
+	t.Run("GameID is echoed onto returned mods for identity, not used to filter", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Query: "backpack", GameID: "7dtd"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		assert.Equal(t, "7dtd", res.Mods[0].GameID)
+	})
+
 	t.Run("dot-prefixed entries are skipped", func(t *testing.T) {
 		res, err := d.Search(ctx, source.SearchQuery{})
 		require.NoError(t, err)
@@ -157,9 +164,10 @@ func TestDirectorySearch(t *testing.T) {
 func TestDirectoryGetMod(t *testing.T) {
 	d := newTestDirectory(t)
 
-	mod, err := d.GetMod(context.Background(), "ignored", "BiggerBackpack")
+	mod, err := d.GetMod(context.Background(), "7dtd", "BiggerBackpack")
 	require.NoError(t, err)
 	assert.Equal(t, "Bigger Backpack", mod.Name)
+	assert.Equal(t, "7dtd", mod.GameID, "GetMod must echo the gameID it was given so installs are attributed to the right game")
 
 	_, err = d.GetMod(context.Background(), "ignored", "nope")
 	assert.ErrorContains(t, err, "not found")

--- a/internal/source/custom/metadata/archive.go
+++ b/internal/source/custom/metadata/archive.go
@@ -1,0 +1,72 @@
+package metadata
+
+import (
+	"archive/zip"
+	"io"
+	"strings"
+)
+
+// modInfoFileName is the exact (case-sensitive) name Detect and
+// ResolveArchive look for; case-insensitive matching is tracked separately
+// (see issue #52).
+const modInfoFileName = "ModInfo.xml"
+
+// ResolveArchive extracts metadata from a .zip or .jar archive whose
+// ModInfo.xml lives at the archive root or exactly one directory deep - the
+// common "wrapper folder" layout used by 7 Days to Die mods (e.g. a
+// donovan-aio.zip containing donovan-aio/ModInfo.xml). Returns nil when the
+// archive can't be opened, has no ModInfo.xml, or the metadata is malformed;
+// callers fall back to filename-based detection, mirroring Resolve.
+func ResolveArchive(archivePath string) *Info {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return nil
+	}
+	defer r.Close()
+
+	target := findModInfoEntry(r.File)
+	if target == nil {
+		return nil
+	}
+
+	rc, err := target.Open()
+	if err != nil {
+		return nil
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil
+	}
+
+	info, err := parseModInfo(data)
+	if err != nil {
+		return nil // malformed metadata falls back, it doesn't fail the scan
+	}
+	return info
+}
+
+// findModInfoEntry locates ModInfo.xml at the archive root or exactly one
+// directory deep. A root-level match always wins over a nested one;
+// otherwise the first one-deep match in archive order is used.
+func findModInfoEntry(files []*zip.File) *zip.File {
+	var nested *zip.File
+	for _, f := range files {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		parts := strings.Split(f.Name, "/")
+		switch len(parts) {
+		case 1:
+			if parts[0] == modInfoFileName {
+				return f
+			}
+		case 2:
+			if nested == nil && parts[1] == modInfoFileName {
+				nested = f
+			}
+		}
+	}
+	return nested
+}

--- a/internal/source/custom/metadata/archive.go
+++ b/internal/source/custom/metadata/archive.go
@@ -11,6 +11,12 @@ import (
 // (see issue #52).
 const modInfoFileName = "ModInfo.xml"
 
+// maxModInfoSize is the maximum allowed size (in bytes) for a ModInfo.xml entry
+// when extracted from an archive. Real ModInfo.xml files are typically a few KB;
+// this limit prevents decompression bomb attacks where a small compressed entry
+// expands to gigabytes during extraction.
+const maxModInfoSize = 1 << 20 // 1 MiB
+
 // ResolveArchive extracts metadata from a .zip or .jar archive whose
 // ModInfo.xml lives at the archive root or exactly one directory deep - the
 // common "wrapper folder" layout used by 7 Days to Die mods (e.g. a
@@ -35,8 +41,13 @@ func ResolveArchive(archivePath string) *Info {
 	}
 	defer rc.Close()
 
-	data, err := io.ReadAll(rc)
+	data, err := io.ReadAll(io.LimitReader(rc, maxModInfoSize+1))
 	if err != nil {
+		return nil
+	}
+
+	// Reject entries larger than the cap to prevent decompression bombs
+	if len(data) > maxModInfoSize {
 		return nil
 	}
 

--- a/internal/source/custom/metadata/archive_test.go
+++ b/internal/source/custom/metadata/archive_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,4 +83,40 @@ func TestResolveArchiveFirstNestedMatchWinsInDeterministicOrder(t *testing.T) {
 	info := ResolveArchive(path)
 	require.NotNil(t, info)
 	assert.Equal(t, "BiggerBackpack", info.Name, "the first one-deep match in archive order should win")
+}
+
+func TestResolveArchiveTooDeepNesting(t *testing.T) {
+	path := writeZip(t, [][2]string{{"a/b/ModInfo.xml", modInfoV2}})
+	assert.Nil(t, ResolveArchive(path), "ModInfo.xml two directories deep must return nil")
+}
+
+func TestResolveArchiveDecompressionBomb(t *testing.T) {
+	// Create a zip with a ModInfo.xml entry that decompresses to >1 MiB.
+	// Use a valid XML structure but pad it with a multi-MiB comment to exceed the cap
+	// while remaining valid XML if fully read.
+	f, err := os.Create(filepath.Join(t.TempDir(), "bomb.zip"))
+	require.NoError(t, err)
+	defer f.Close()
+
+	w := zip.NewWriter(f)
+	// Create a large valid XML document with padding comment
+	header := `<?xml version="1.0" encoding="UTF-8" ?>
+<xml>
+	<Name value="BiggerBackpack"/>
+	<!-- `
+	footer := ` -->
+</xml>`
+	// Padding of ~1.1 MiB (spaces compress well in a zip)
+	padding := strings.Repeat("X", 1100000)
+	largeXML := header + padding + footer
+
+	fw, err := w.Create("ModInfo.xml")
+	require.NoError(t, err)
+	_, err = fw.Write([]byte(largeXML))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	// Should return nil because the decompressed size exceeds the cap
+	info := ResolveArchive(f.Name())
+	assert.Nil(t, info, "oversized ModInfo.xml must return nil to prevent decompression bomb")
 }

--- a/internal/source/custom/metadata/archive_test.go
+++ b/internal/source/custom/metadata/archive_test.go
@@ -1,0 +1,85 @@
+package metadata
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeZip builds a zip file in t.TempDir() containing entries in the given
+// order (order matters for tests asserting deterministic archive traversal).
+func writeZip(t *testing.T, entries [][2]string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "mod.zip")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	w := zip.NewWriter(f)
+	for _, entry := range entries {
+		fw, err := w.Create(entry[0])
+		require.NoError(t, err)
+		_, err = fw.Write([]byte(entry[1]))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	return path
+}
+
+func TestResolveArchiveWrapperFolder(t *testing.T) {
+	path := writeZip(t, [][2]string{{"donovan-aio/ModInfo.xml", modInfoV2}})
+	info := ResolveArchive(path)
+	require.NotNil(t, info)
+	assert.Equal(t, "BiggerBackpack", info.Name)
+	assert.Equal(t, "Bigger Backpack", info.DisplayName)
+	assert.Equal(t, "1.2.0", info.Version)
+	assert.Equal(t, "Carry more stuff", info.Summary)
+	assert.Equal(t, "Donovan", info.Author)
+}
+
+func TestResolveArchiveRootLevel(t *testing.T) {
+	path := writeZip(t, [][2]string{{"ModInfo.xml", modInfoV2}})
+	info := ResolveArchive(path)
+	require.NotNil(t, info)
+	assert.Equal(t, "BiggerBackpack", info.Name)
+}
+
+func TestResolveArchiveNoMetadata(t *testing.T) {
+	path := writeZip(t, [][2]string{{"readme.txt", "hi"}})
+	assert.Nil(t, ResolveArchive(path))
+}
+
+func TestResolveArchiveMalformedXML(t *testing.T) {
+	path := writeZip(t, [][2]string{{"ModInfo.xml", "<xml><unclosed"}})
+	assert.Nil(t, ResolveArchive(path))
+}
+
+func TestResolveArchiveNonZip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "garbage.zip")
+	require.NoError(t, os.WriteFile(path, []byte("not a zip file"), 0644))
+	assert.Nil(t, ResolveArchive(path))
+}
+
+func TestResolveArchiveRootWinsOverNested(t *testing.T) {
+	path := writeZip(t, [][2]string{
+		{"othername/ModInfo.xml", modInfoV1},
+		{"ModInfo.xml", modInfoV2},
+	})
+	info := ResolveArchive(path)
+	require.NotNil(t, info)
+	assert.Equal(t, "BiggerBackpack", info.Name, "root-level ModInfo.xml must win over a nested one")
+}
+
+func TestResolveArchiveFirstNestedMatchWinsInDeterministicOrder(t *testing.T) {
+	path := writeZip(t, [][2]string{
+		{"aaa/ModInfo.xml", modInfoV2},
+		{"bbb/ModInfo.xml", modInfoV1},
+	})
+	info := ResolveArchive(path)
+	require.NotNil(t, info)
+	assert.Equal(t, "BiggerBackpack", info.Name, "the first one-deep match in archive order should win")
+}

--- a/internal/source/custom/metadata/metadata_test.go
+++ b/internal/source/custom/metadata/metadata_test.go
@@ -1,0 +1,63 @@
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 7D2D "V2" layout: fields directly under <xml>.
+const modInfoV2 = `<?xml version="1.0" encoding="UTF-8" ?>
+<xml>
+	<Name value="BiggerBackpack"/>
+	<DisplayName value="Bigger Backpack"/>
+	<Version value="1.2.0"/>
+	<Description value="Carry more stuff"/>
+	<Author value="Donovan"/>
+</xml>`
+
+// 7D2D "V1" layout: fields nested in <ModInfo>.
+const modInfoV1 = `<?xml version="1.0" encoding="UTF-8" ?>
+<xml>
+	<ModInfo>
+		<Name value="OldMod"/>
+		<Version value="0.9"/>
+		<Description value="Legacy layout"/>
+		<Author value="Someone"/>
+	</ModInfo>
+</xml>`
+
+func writeModDir(t *testing.T, xml string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ModInfo.xml"), []byte(xml), 0644))
+	return dir
+}
+
+func TestResolveModInfoV2(t *testing.T) {
+	info := Resolve(writeModDir(t, modInfoV2))
+	require.NotNil(t, info)
+	assert.Equal(t, "BiggerBackpack", info.Name)
+	assert.Equal(t, "Bigger Backpack", info.DisplayName)
+	assert.Equal(t, "1.2.0", info.Version)
+	assert.Equal(t, "Carry more stuff", info.Summary)
+	assert.Equal(t, "Donovan", info.Author)
+}
+
+func TestResolveModInfoV1(t *testing.T) {
+	info := Resolve(writeModDir(t, modInfoV1))
+	require.NotNil(t, info)
+	assert.Equal(t, "OldMod", info.Name)
+	assert.Equal(t, "0.9", info.Version)
+}
+
+func TestResolveNoMetadata(t *testing.T) {
+	assert.Nil(t, Resolve(t.TempDir()))
+}
+
+func TestResolveMalformedXML(t *testing.T) {
+	assert.Nil(t, Resolve(writeModDir(t, "<xml><unclosed")))
+}

--- a/internal/source/custom/metadata/modinfo.go
+++ b/internal/source/custom/metadata/modinfo.go
@@ -44,6 +44,13 @@ func (ModInfoXML) Read(path string) (*Info, error) {
 		return nil, fmt.Errorf("reading ModInfo.xml: %w", err)
 	}
 
+	return parseModInfo(data)
+}
+
+// parseModInfo parses ModInfo.xml content shared by both the on-disk (Read)
+// and in-archive (ResolveArchive) paths, so file and archive mods use the
+// exact same V1/V2 layout handling.
+func parseModInfo(data []byte) (*Info, error) {
 	var doc modInfoDoc
 	if err := xml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parsing ModInfo.xml: %w", err)

--- a/internal/source/custom/metadata/modinfo.go
+++ b/internal/source/custom/metadata/modinfo.go
@@ -1,0 +1,67 @@
+package metadata
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ModInfoXML reads 7 Days to Die ModInfo.xml files. Two layouts exist:
+// V2 puts fields directly under <xml>; V1 nests them in <ModInfo>.
+type ModInfoXML struct{}
+
+// Detect implements Reader.
+func (ModInfoXML) Detect(modDir string) string {
+	path := filepath.Join(modDir, "ModInfo.xml")
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
+}
+
+type modInfoFields struct {
+	Name        attrValue `xml:"Name"`
+	DisplayName attrValue `xml:"DisplayName"`
+	Version     attrValue `xml:"Version"`
+	Description attrValue `xml:"Description"`
+	Author      attrValue `xml:"Author"`
+}
+
+type modInfoDoc struct {
+	modInfoFields
+	ModInfo *modInfoFields `xml:"ModInfo"`
+}
+
+type attrValue struct {
+	Value string `xml:"value,attr"`
+}
+
+// Read implements Reader.
+func (ModInfoXML) Read(path string) (*Info, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading ModInfo.xml: %w", err)
+	}
+
+	var doc modInfoDoc
+	if err := xml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing ModInfo.xml: %w", err)
+	}
+
+	fields := doc.modInfoFields
+	if doc.ModInfo != nil && doc.ModInfo.Name.Value != "" {
+		fields = *doc.ModInfo // V1 layout
+	}
+	if fields.Name.Value == "" {
+		return nil, fmt.Errorf("ModInfo.xml has no Name element")
+	}
+
+	return &Info{
+		Name:        fields.Name.Value,
+		DisplayName: fields.DisplayName.Value,
+		Version:     fields.Version.Value,
+		Summary:     fields.Description.Value,
+		Author:      fields.Author.Value,
+	}, nil
+}

--- a/internal/source/custom/metadata/reader.go
+++ b/internal/source/custom/metadata/reader.go
@@ -1,0 +1,43 @@
+// Package metadata extracts mod metadata from well-known files inside a mod
+// directory (e.g. 7 Days to Die's ModInfo.xml). Adding a format means adding
+// one Reader implementation and listing it in readers.
+package metadata
+
+// Info is metadata extracted from a well-known mod metadata file. Zero-value
+// fields mean the file did not provide them.
+type Info struct {
+	Name        string
+	DisplayName string
+	Version     string
+	Summary     string
+	Author      string
+}
+
+// Reader parses one well-known metadata file format.
+type Reader interface {
+	// Detect returns the metadata file path within modDir, or "" if absent.
+	Detect(modDir string) string
+	// Read parses the metadata file at path.
+	Read(path string) (*Info, error)
+}
+
+// readers lists all known formats in priority order.
+var readers = []Reader{ModInfoXML{}}
+
+// Resolve extracts metadata from modDir using the first matching reader.
+// Returns nil when no known metadata file exists or it cannot be parsed;
+// callers fall back to name-based detection.
+func Resolve(modDir string) *Info {
+	for _, r := range readers {
+		path := r.Detect(modDir)
+		if path == "" {
+			continue
+		}
+		info, err := r.Read(path)
+		if err != nil {
+			continue // malformed metadata falls back, it doesn't fail the scan
+		}
+		return info
+	}
+	return nil
+}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -53,4 +54,33 @@ type ModSource interface {
 
 	// Updates
 	CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error)
+}
+
+// ErrNotSupported indicates a source does not support the requested operation.
+// Callers should branch with errors.Is(err, ErrNotSupported) and degrade
+// gracefully (hide the action, show a notice) rather than treat it as a failure.
+var ErrNotSupported = errors.New("operation not supported by this source")
+
+// Capabilities reports which optional operations a source supports.
+type Capabilities struct {
+	Search       bool
+	Dependencies bool
+	Updates      bool
+	Auth         bool
+}
+
+// CapabilityReporter is implemented by sources that support only a subset of
+// ModSource operations. Sources that do not implement it are assumed fully
+// capable.
+type CapabilityReporter interface {
+	Capabilities() Capabilities
+}
+
+// CapabilitiesOf returns src's capabilities, assuming full capability for
+// sources that do not implement CapabilityReporter (all built-in sources).
+func CapabilitiesOf(src ModSource) Capabilities {
+	if cr, ok := src.(CapabilityReporter); ok {
+		return cr.Capabilities()
+	}
+	return Capabilities{Search: true, Dependencies: true, Updates: true, Auth: true}
 }

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -1,0 +1,52 @@
+package source
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+// fullSource implements ModSource but not CapabilityReporter.
+type fullSource struct{}
+
+func (fullSource) ID() string                                            { return "full" }
+func (fullSource) Name() string                                          { return "Full" }
+func (fullSource) AuthURL() string                                       { return "" }
+func (fullSource) ExchangeToken(context.Context, string) (*Token, error) { return nil, nil }
+func (fullSource) Search(context.Context, SearchQuery) (SearchResult, error) {
+	return SearchResult{}, nil
+}
+func (fullSource) GetMod(context.Context, string, string) (*domain.Mod, error) { return nil, nil }
+func (fullSource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) {
+	return nil, nil
+}
+func (fullSource) GetModFiles(context.Context, *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, nil
+}
+func (fullSource) GetDownloadURL(context.Context, *domain.Mod, string) (string, error) {
+	return "", nil
+}
+func (fullSource) CheckUpdates(context.Context, []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, nil
+}
+
+// partialSource additionally reports limited capabilities.
+type partialSource struct{ fullSource }
+
+func (partialSource) Capabilities() Capabilities {
+	return Capabilities{Search: true, Updates: true}
+}
+
+func TestCapabilitiesOf(t *testing.T) {
+	t.Run("defaults to fully capable", func(t *testing.T) {
+		caps := CapabilitiesOf(fullSource{})
+		assert.Equal(t, Capabilities{Search: true, Dependencies: true, Updates: true, Auth: true}, caps)
+	})
+
+	t.Run("uses CapabilityReporter when implemented", func(t *testing.T) {
+		caps := CapabilitiesOf(partialSource{})
+		assert.Equal(t, Capabilities{Search: true, Dependencies: false, Updates: true, Auth: false}, caps)
+	})
+}

--- a/internal/storage/cache/cache.go
+++ b/internal/storage/cache/cache.go
@@ -2,8 +2,8 @@ package cache
 
 import (
 	"fmt"
-	"io/fs"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 )

--- a/internal/storage/config/sources.go
+++ b/internal/storage/config/sources.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"gopkg.in/yaml.v3"
+)
+
+// SourceLoadError describes a source definition file that could not be loaded.
+// These are collected rather than returned as hard errors so one broken file
+// never prevents lmm from starting.
+type SourceLoadError struct {
+	File string // base filename within the sources directory
+	Err  error
+}
+
+func (e SourceLoadError) Error() string {
+	return fmt.Sprintf("%s: %v", e.File, e.Err)
+}
+
+// LoadSourceDefinitions reads and validates every *.yaml/*.yml file in
+// <configDir>/sources. A missing directory yields no definitions and no error.
+// Per-file parse/validation failures (including duplicate IDs) are returned as
+// SourceLoadErrors; the hard error is reserved for an unreadable directory.
+func LoadSourceDefinitions(configDir string) ([]custom.SourceDefinition, []SourceLoadError, error) {
+	dir := filepath.Join(configDir, "sources")
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading sources directory %s: %w", dir, err)
+	}
+
+	var defs []custom.SourceDefinition
+	var loadErrs []SourceLoadError
+	seen := make(map[string]string) // id -> filename that claimed it
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || (!strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml")) {
+			continue
+		}
+
+		def, err := LoadSourceDefinitionFile(filepath.Join(dir, name))
+		if err != nil {
+			loadErrs = append(loadErrs, SourceLoadError{File: name, Err: err})
+			continue
+		}
+		if prev, dup := seen[def.ID]; dup {
+			loadErrs = append(loadErrs, SourceLoadError{
+				File: name,
+				Err:  fmt.Errorf("duplicate source id %q (already defined in %s)", def.ID, prev),
+			})
+			continue
+		}
+		seen[def.ID] = name
+		defs = append(defs, def)
+	}
+
+	return defs, loadErrs, nil
+}
+
+// LoadSourceDefinitionFile reads and validates a single source definition file.
+func LoadSourceDefinitionFile(path string) (custom.SourceDefinition, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return custom.SourceDefinition{}, fmt.Errorf("reading definition: %w", err)
+	}
+
+	var def custom.SourceDefinition
+	if err := yaml.Unmarshal(data, &def); err != nil {
+		return custom.SourceDefinition{}, fmt.Errorf("parsing YAML: %w", err)
+	}
+	if err := def.Validate(); err != nil {
+		return custom.SourceDefinition{}, fmt.Errorf("invalid definition: %w", err)
+	}
+
+	return def, nil
+}

--- a/internal/storage/config/sources_test.go
+++ b/internal/storage/config/sources_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSourceFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644))
+}
+
+func TestLoadSourceDefinitions(t *testing.T) {
+	t.Run("missing sources dir is not an error", func(t *testing.T) {
+		defs, loadErrs, err := LoadSourceDefinitions(t.TempDir())
+		assert.NoError(t, err)
+		assert.Empty(t, defs)
+		assert.Empty(t, loadErrs)
+	})
+
+	t.Run("loads valid definitions and collects per-file errors", func(t *testing.T) {
+		configDir := t.TempDir()
+		srcDir := filepath.Join(configDir, "sources")
+		writeSourceFile(t, srcDir, "good.yaml", `
+id: my-mods
+name: My Mods
+type: directory
+directory:
+  path: ~/mods
+`)
+		writeSourceFile(t, srcDir, "bad-yaml.yaml", "id: [unclosed")
+		writeSourceFile(t, srcDir, "invalid.yaml", `
+id: BAD_ID
+name: Bad
+type: directory
+directory:
+  path: ~/x
+`)
+		writeSourceFile(t, srcDir, "notes.txt", "not yaml, ignored")
+
+		defs, loadErrs, err := LoadSourceDefinitions(configDir)
+		assert.NoError(t, err)
+		require.Len(t, defs, 1)
+		assert.Equal(t, "my-mods", defs[0].ID)
+		require.Len(t, loadErrs, 2)
+		files := []string{loadErrs[0].File, loadErrs[1].File}
+		assert.Contains(t, files, "bad-yaml.yaml")
+		assert.Contains(t, files, "invalid.yaml")
+	})
+
+	t.Run("duplicate ids across files are rejected", func(t *testing.T) {
+		configDir := t.TempDir()
+		srcDir := filepath.Join(configDir, "sources")
+		def := `
+id: dupe
+name: Dupe
+type: directory
+directory:
+  path: ~/mods
+`
+		writeSourceFile(t, srcDir, "a.yaml", def)
+		writeSourceFile(t, srcDir, "b.yaml", def)
+
+		defs, loadErrs, err := LoadSourceDefinitions(configDir)
+		assert.NoError(t, err)
+		assert.Len(t, defs, 1)
+		require.Len(t, loadErrs, 1)
+		assert.ErrorContains(t, loadErrs[0].Err, "duplicate")
+	})
+}
+
+func TestLoadSourceDefinitionFile(t *testing.T) {
+	dir := t.TempDir()
+	writeSourceFile(t, dir, "s.yaml", `
+id: my-mods
+name: My Mods
+type: directory
+directory:
+  path: ~/mods
+`)
+
+	def, err := LoadSourceDefinitionFile(filepath.Join(dir, "s.yaml"))
+	assert.NoError(t, err)
+	assert.Equal(t, "my-mods", def.ID)
+
+	_, err = LoadSourceDefinitionFile(filepath.Join(dir, "missing.yaml"))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Implements Phases 1–2 of the custom sources epic (#45): user-defined mod sources declared in `~/.config/lmm/sources/*.yaml`, with the `directory` type turning a local folder of mods (e.g. 7D2D modlets) into a first-class source — searchable, installable, and update-checked.

Closes #46
Closes #47

### Phase 1 — Foundation
- `source.Capabilities` / `source.ErrNotSupported` — partial sources degrade gracefully; sources not implementing `CapabilityReporter` are assumed fully capable
- `custom.SourceDefinition` YAML schema with validation (id regex `^[a-z0-9-]+$`, exactly-one type block, https enforcement with `allow_http` opt-in)
- Definition loader with warn-and-skip semantics — a broken definition file never prevents lmm from starting
- Startup registration with ID-collision guard (custom sources cannot clobber built-ins)
- New commands: `lmm source list` (table + `--json`, includes error rows for broken/colliding definitions) and `lmm source validate <file>`

### Phase 2 — Directory Source
- `metadata` package reading 7D2D `ModInfo.xml` (both V1 nested and V2 flat layouts), with dirname+version parsing fallback (`domain.ExtractVersionFromName`, promoted from the importer)
- `custom.Directory` implements `ModSource` over a local folder: each subdirectory or `.zip`/`.jar` archive is a mod; mod ID = directory name; client-side search with name-first ranking and local pagination; `CheckUpdates` against the live scan; hidden (dot-prefixed) entries skipped
- `file://` download URLs ingested into the mod cache via the existing staging/commit flow — gated to directory sources only (a remote source returning `file://` errors instead of reading local files)
- End-to-end test: definition → factory → search → files → download URL → cache ingest → DB visibility

### Final-review fixes (already included)
- **Critical:** directory-source installs previously saved `game_id=''`, making them invisible to `list`/`update`/`uninstall` — `Directory` now echoes the game ID and empty `sources:` mappings fall back to the lmm game ID (live-verified install→list→uninstall loop)
- `lmm source list` shows error rows for construction-failed and colliding definitions instead of dropping them / mislabeling built-ins
- Negative-page clamp in directory search; dot-entry skipping

### Docs & release
- README: Custom Sources section (definition format, directory sources, walkthrough); CHANGELOG 1.6.0; version bumped to 1.6.0

## Test plan
- [x] Full suite green (`go test ./...`, 17 packages), gofmt/vet clean, no new dependencies
- [x] TDD throughout (failing test first for every behavioral change; RED/GREEN evidence per task)
- [x] Live smoke test against the real modlets dir (`~/Projects/mods/7dtd/donovan-7d2d-modlets`): `source list` shows `donovan-mods` (directory, auth n/a); `~/.config/lmm/sources/donovan-mods.yaml` left in place
- [x] Live end-to-end verification of install→list→uninstall with an empty `sources:` mapping
- [ ] User smoke test: add `donovan-mods: ""` under the 7 Days to Die game's `sources:` in games.yaml (game ID is `7daystodie`), then `lmm search <modlet> -g 7daystodie --source donovan-mods` and install

🤖 Generated with [Claude Code](https://claude.com/claude-code)
