### PR TITLE
feat: manifest custom source type (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Manifest source type: publish a JSON/YAML mod list (https URL or local file) and use it as a full source — search, install, within-source dependencies, and update checks
+- Declared `sha256` checksums in manifests are verified on download
+- API-key authentication for custom sources (`auth.api_key` in the definition; `LMM_<ID>_API_KEY` env var or `lmm auth login <id>`)
+
 ## [1.6.0] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-07-14
+
 ### Added
 
 - Manifest source type: publish a JSON/YAML mod list (https URL or local file) and use it as a full source — search, install, within-source dependencies, and update checks
@@ -680,7 +682,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.3.10...v1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Declared `sha256` checksums in manifests are verified on download
 - API-key authentication for custom sources (`auth.api_key` in the definition; `LMM_<ID>_API_KEY` env var or `lmm auth login <id>`)
 
+### Fixed
+
+- **Manifest source installs no longer orphaned**: mods found through a source mapped to a non-empty, different value under a game's `sources:` block (the README-documented pattern for manifest `game_ids` filtering, e.g. `my-repo: skyrim`) now save with the correct game ID, so `lmm list`/`update`/`uninstall` can see them after install
+- **Query-mode API keys no longer leak into error output**: a manifest source or file download using query-string authentication (`auth.api_key.in: query`) could print the API key in plain text as part of a network-failure error message; failures now redact the key
+- **Honest `lmm auth login` feedback for custom sources**: custom sources no longer show a fabricated "Validating... done" (they have no generic validation endpoint) — they now report "Stored (validated on first use)." instead. The rejection for an unrecognized source name now also mentions that a registered custom source with auth declared is an option
+
 ## [1.6.0] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ manifest:
   1. The `LMM_<ID>_API_KEY` environment variable, with the source's `id` uppercased and `-` replaced by `_` (source `my-repo` → `LMM_MY_REPO_API_KEY`).
   2. A key saved with `lmm auth login <id>` — this works for any registered source whose definition declares `auth`, not just NexusMods/CurseForge, and stores the key in the same local token store.
 - The resolved key is attached to **both** the manifest fetch and every file download from that source, using the same `in`/`name` the definition declares.
-- Keys are never printed or logged; `lmm source list` only reports whether one is configured (`AUTH` column: `yes` / `no` / `n/a`), and `lmm auth login` masks stored keys to their first/last 3 characters. (`lmm auth status` currently only reports on built-in sources — nexusmods and curseforge.)
+- Keys are never printed or logged; `lmm source list` only reports whether one is configured (`AUTH` column: `yes` / `no` / `n/a`), and `lmm auth status` masks stored keys to their first/last 3 characters. (`lmm auth status` currently only reports on built-in sources — nexusmods and curseforge.)
 
 ### Source Management Commands
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ This allows you to store different games' mods on different drives (e.g., large 
 
 ## Custom Sources
 
-In addition to built-in mod sources (NexusMods, CurseForge), lmm lets you declare custom sources in YAML files instead of writing code. The `directory` type is fully implemented — point it at a local folder of mods and use it from `search`/`install` like any built-in source. `manifest` and `api` definitions parse and validate today, but their source types (fetching mods over HTTP) ship in later releases.
+In addition to built-in mod sources (NexusMods, CurseForge), lmm lets you declare custom sources in YAML files instead of writing code. Two types are fully implemented: `directory` (a local folder of mods) and `manifest` (a JSON/YAML mod list you publish, over `https://` or as a local file) — both work from `search`/`install`/`update` like any built-in source, and `manifest` sources also support optional API-key authentication. `api` definitions parse and validate today, but the declarative-REST source type itself ships in a later release.
 
 Custom source definitions are loaded from `~/.config/lmm/sources/*.yaml` (or `*.yml`). Each file must define exactly one source. Broken definition files are skipped with a warning — they never prevent lmm from starting.
 
@@ -251,7 +251,7 @@ directory:
 | ----------- | ------- | -------- | ----------------------------------------------------------------------------------- |
 | `id`        | string  | yes      | Unique source identifier; must contain only lowercase letters, numbers, and hyphens |
 | `name`      | string  | yes      | Display name shown in source lists and commands                                     |
-| `type`      | string  | yes      | Source type: `directory`, `manifest`, or `api`. All three parse and validate today; `directory` support (search/install) is implemented now, `manifest`/`api` ship in later releases. |
+| `type`      | string  | yes      | Source type: `directory`, `manifest`, or `api`. All three parse and validate today; `directory` and `manifest` are fully supported (search/install/updates), `api` is planned for a later release. |
 | `allow_http` | boolean | no       | If `true`, allow unencrypted http:// URLs (default `false`, HTTPS only)            |
 
 ### Directory Sources
@@ -296,6 +296,107 @@ games:
       donovan-mods: "" # directory sources ignore this value
 ```
 
+### Manifest Sources
+
+A `manifest` source treats a JSON or YAML document you publish — an `https://` URL, or a local file path — as a full mod list: search, install, within-source dependency resolution, and update checks all work against it, the same as a built-in source.
+
+```yaml
+id: my-repo
+name: My Mod Repo
+type: manifest
+manifest:
+  url: https://example.com/mods.yaml   # https:// URL, or a local path (~ expanded)
+  refresh: 15m                         # optional cache TTL for remote URLs (default 15m)
+```
+
+- **Remote URLs** (`https://...`) are fetched on demand and cached in memory for `refresh` — a Go duration string like `30s`, `15m`, or `2h` (default `15m` when omitted). **Local file paths** are read fresh on every operation instead of being cached, so edits show up immediately.
+- Fetch/parse problems (unreachable URL, malformed document, unsupported `version`) surface as an operation error naming the source and the manifest URL; a bad manifest *document* does not stop lmm from starting — only a broken *definition* file does that (see above).
+- `https://` is required for the manifest `url`, and for every file `url` inside the document, unless the definition sets `allow_http: true`; local paths are exempt.
+
+The manifest document itself:
+
+```yaml
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    author: someone
+    summary: Makes things cooler
+    game_ids: [skyrimspecialedition]         # matched against this source's mapped `sources:` value
+    url: https://example.com/mods/cool-mod   # optional web page
+    updated_at: 2026-07-01T00:00:00Z         # optional, RFC 3339
+    dependencies: [other-mod]                # optional, IDs of other mods in this manifest
+    files:
+      - id: main
+        name: Main File
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        size: 123456
+        url: https://example.com/files/cool-mod-1.2.0.zip
+        sha256: <hex digest>                 # optional; verified on download if present
+        primary: true
+```
+
+`version: 1` is the only manifest version lmm understands today; any other value is rejected.
+
+**`mods[]` fields:**
+
+| Field          | Type     | Required | Description                                                                                                                                                                                            |
+| -------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`           | string   | **yes**  | Unique mod ID within this manifest; also its dependency-reference ID                                                                                                                                  |
+| `name`         | string   | **yes**  | Display name                                                                                                                                                                                            |
+| `version`      | string   | no       | Compared against installed versions for update checks                                                                                                                                                  |
+| `author`       | string   | no       | —                                                                                                                                                                                                        |
+| `summary`      | string   | no       | Shown in search results                                                                                                                                                                                 |
+| `game_ids`     | []string | no       | Restricts the mod to specific games, matched against the value that game maps for this source under its `sources:` block in `games.yaml` (same convention as NexusMods/CurseForge IDs); omitted or empty matches every game that maps this source |
+| `url`          | string   | no       | Web page for the mod (informational only)                                                                                                                                                              |
+| `updated_at`   | string   | no       | RFC 3339 timestamp; an unparseable value is silently treated as unset rather than an error                                                                                                             |
+| `dependencies` | []string | no       | Other mods' `id`s within this same manifest; resolved automatically like NexusMods dependencies                                                                                                        |
+| `files`        | []object | no       | Downloadable files for this mod, see below                                                                                                                                                              |
+
+**`files[]` fields:**
+
+| Field      | Type    | Required | Description                                                                                                                 |
+| ---------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `id`       | string  | **yes**  | File ID, used to request a download                                                                                         |
+| `filename` | string  | **yes**  | Name given to the downloaded/cached file                                                                                    |
+| `url`      | string  | **yes**  | Download URL (`https://` unless `allow_http: true`)                                                                         |
+| `name`     | string  | no       | Display name                                                                                                                 |
+| `version`  | string  | no       | —                                                                                                                             |
+| `size`     | integer | no       | Size in bytes                                                                                                                |
+| `sha256`   | string  | no       | Hex-encoded SHA-256 checksum; when present, lmm verifies it after download and **aborts the install if it doesn't match**   |
+| `primary`  | boolean | no       | Marks the default file when a mod publishes more than one                                                                    |
+
+To use a manifest source with a game, map it under that game's `sources:` block in `games.yaml`, the same as any built-in source — the mapped value should match the IDs used in the manifest's `game_ids` (unlike `directory` sources, this value is not ignored):
+
+```yaml
+games:
+  skyrim-se:
+    sources:
+      nexusmods: skyrimspecialedition
+      my-repo: skyrimspecialedition
+```
+
+### Authentication
+
+A custom source can require an API key, attached to every request as either a header or a query parameter. Today this is available to `manifest` sources (`directory` sources need no auth; `api` sources will reuse the same block when they ship):
+
+```yaml
+manifest:
+  url: https://example.com/mods.yaml
+  auth:
+    api_key:
+      in: header      # "header" or "query"
+      name: X-API-Key # header name, or query parameter name, the key is sent as
+```
+
+- **Key resolution**, checked in order:
+  1. The `LMM_<ID>_API_KEY` environment variable, with the source's `id` uppercased and `-` replaced by `_` (source `my-repo` → `LMM_MY_REPO_API_KEY`).
+  2. A key saved with `lmm auth login <id>` — this works for any registered source whose definition declares `auth`, not just NexusMods/CurseForge, and stores the key in the same local token store.
+- The resolved key is attached to **both** the manifest fetch and every file download from that source, using the same `in`/`name` the definition declares.
+- Keys are never printed or logged; `lmm source list` only reports whether one is configured (`AUTH` column: `yes` / `no` / `n/a`), and `lmm auth login`/`status` mask stored keys to their first/last 3 characters.
+
 ### Source Management Commands
 
 List all sources (built-in and custom):
@@ -311,6 +412,7 @@ ID            NAME                    TYPE       AUTH  CAPABILITIES             
 nexusmods     Nexus Mods              built-in   yes   search,deps,updates,auth
 curseforge    CurseForge              built-in   yes   search,deps,updates,auth
 donovan-mods  Donovan's 7D2D Modlets  directory  n/a   search,updates
+my-repo       My Mod Repo             manifest   no    search,deps,updates,auth
 ```
 
 Validate a source definition file before use:
@@ -367,7 +469,7 @@ Error: invalid definition: id "my-bad-source!" must match ^[a-z0-9-]+$
    lmm install --source my-local-mods --id BiggerBackpack -g skyrim-se
    ```
 
-A `directory` source now shows up with real capabilities in `lmm source list` (`search,updates`, `auth=n/a`), and it will show as an `error` row if the configured path is missing or not a directory. A definition whose `id` collides with an already-registered source (a built-in, or another definition) also produces an `error` row (`id already in use`); the source that was already registered keeps its original row and type unchanged.
+A `directory` source now shows up with real capabilities in `lmm source list` (`search,updates`, `auth=n/a`), and it will show as an `error` row if the configured path is missing or not a directory. A `manifest` source shows `search,deps,updates` (plus `auth` if the definition declares one, with the `AUTH` column reporting `yes`/`no` once a key is or isn't configured). Either type will show as an `error` row if construction fails (e.g. a directory source's path doesn't exist). A definition whose `id` collides with an already-registered source (a built-in, or another definition) also produces an `error` row (`id already in use`); the source that was already registered keeps its original row and type unchanged.
 
 ## CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ manifest:
 ```
 
 - **Remote URLs** (`https://...`) are fetched on demand and cached in memory for `refresh` — a Go duration string like `30s`, `15m`, or `2h` (default `15m` when omitted). **Local file paths** are read fresh on every operation instead of being cached, so edits show up immediately.
-- Fetch/parse problems (unreachable URL, malformed document, unsupported `version`) surface as an operation error naming the source and the manifest URL; a bad manifest *document* does not stop lmm from starting — only a broken *definition* file does that (see above).
+- Fetch/parse problems (unreachable URL, malformed document, unsupported `version`) surface as an operation error naming the source and the manifest URL, at the point something actually uses the source. This is different from a broken *definition* file, which is caught at load time and skipped with a warning before lmm ever starts (see above).
 - `https://` is required for the manifest `url`, and for every file `url` inside the document, unless the definition sets `allow_http: true`; local paths are exempt.
 
 The manifest document itself:
@@ -395,7 +395,7 @@ manifest:
   1. The `LMM_<ID>_API_KEY` environment variable, with the source's `id` uppercased and `-` replaced by `_` (source `my-repo` → `LMM_MY_REPO_API_KEY`).
   2. A key saved with `lmm auth login <id>` — this works for any registered source whose definition declares `auth`, not just NexusMods/CurseForge, and stores the key in the same local token store.
 - The resolved key is attached to **both** the manifest fetch and every file download from that source, using the same `in`/`name` the definition declares.
-- Keys are never printed or logged; `lmm source list` only reports whether one is configured (`AUTH` column: `yes` / `no` / `n/a`), and `lmm auth login`/`status` mask stored keys to their first/last 3 characters.
+- Keys are never printed or logged; `lmm source list` only reports whether one is configured (`AUTH` column: `yes` / `no` / `n/a`), and `lmm auth login` masks stored keys to their first/last 3 characters. (`lmm auth status` currently only reports on built-in sources — nexusmods and curseforge.)
 
 ### Source Management Commands
 

--- a/cmd/lmm/auth.go
+++ b/cmd/lmm/auth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/curseforge"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/nexusmods"
 
@@ -109,7 +110,7 @@ func promptForSource() (string, error) {
 
 func runAuthLogin(cmd *cobra.Command, args []string) error {
 	return withService(cmd, func(ctx context.Context, service *core.Service) error {
-		sourceID, err := selectAuthSource(args)
+		sourceID, err := selectAuthSource(service, args)
 		if err != nil {
 			return err
 		}
@@ -140,11 +141,13 @@ func runAuthLogin(cmd *cobra.Command, args []string) error {
 	})
 }
 
-// selectAuthSource resolves the source from args or prompts the user.
-func selectAuthSource(args []string) (string, error) {
+// selectAuthSource resolves the source from args or prompts the user. The
+// service is used to recognize registered custom sources that declare auth
+// support; the interactive prompt path only ever offers built-ins.
+func selectAuthSource(service *core.Service, args []string) (string, error) {
 	if len(args) > 0 {
 		sourceID := args[0]
-		if !isSupportedSource(sourceID) {
+		if !isAuthCapableSource(service, sourceID) {
 			return "", fmt.Errorf("unsupported source: %s (supported: %s)", sourceID, strings.Join(supportedSources, ", "))
 		}
 		return sourceID, nil
@@ -157,9 +160,23 @@ func selectAuthSource(args []string) (string, error) {
 	return sourceID, nil
 }
 
+// isAuthCapableSource reports whether sourceID can hold an API key: either a
+// built-in from supportedSources, or a registered custom source whose
+// definition declares auth.
+func isAuthCapableSource(service *core.Service, sourceID string) bool {
+	if isSupportedSource(sourceID) {
+		return true
+	}
+	src, err := service.GetSource(sourceID)
+	if err != nil {
+		return false
+	}
+	return source.CapabilitiesOf(src).Auth
+}
+
 func runAuthLogout(cmd *cobra.Command, args []string) error {
 	return withService(cmd, func(ctx context.Context, service *core.Service) error {
-		sourceID, err := selectAuthSource(args)
+		sourceID, err := selectAuthSource(service, args)
 		if err != nil {
 			return err
 		}
@@ -242,6 +259,9 @@ func printAuthInstructions(sourceID string) {
 		fmt.Println("1. Visit https://console.curseforge.com/")
 		fmt.Println("2. Create a project and generate an API key")
 		fmt.Println("3. Copy your API key")
+	default:
+		fmt.Printf("Enter the API key for %s.\n", sourceID)
+		fmt.Printf("(Alternatively, set the %s environment variable.)\n", envKeyForSourceID(sourceID))
 	}
 	fmt.Println()
 }
@@ -261,7 +281,10 @@ func validateAPIKey(ctx context.Context, sourceID, apiKey string) error {
 		}
 		return nil
 	default:
-		return fmt.Errorf("unknown source: %s", sourceID)
+		// Custom sources have no generic validation endpoint. By the time we
+		// get here the source has already passed isAuthCapableSource, so the
+		// key is simply stored and exercised on first fetch.
+		return nil
 	}
 }
 
@@ -273,8 +296,14 @@ func getEnvKeyForSource(sourceID string) string {
 	case "curseforge":
 		return "CURSEFORGE_API_KEY"
 	default:
-		return ""
+		return envKeyForSourceID(sourceID)
 	}
+}
+
+// envKeyForSourceID derives the env var that can supply a custom source's API
+// key: LMM_<ID>_API_KEY with the ID uppercased and dashes as underscores.
+func envKeyForSourceID(sourceID string) string {
+	return "LMM_" + strings.ReplaceAll(strings.ToUpper(sourceID), "-", "_") + "_API_KEY"
 }
 
 // readAPIKey prompts for and reads an API key from the terminal

--- a/cmd/lmm/auth.go
+++ b/cmd/lmm/auth.go
@@ -139,8 +139,7 @@ func runAuthLogin(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("saving token: %w", err)
 		}
 		printLoginResult(os.Stdout, sourceID)
-
-		fmt.Printf("Successfully authenticated with %s!\n", getSourceDisplayName(sourceID))
+		printAuthLoginSuccess(os.Stdout, sourceID)
 		return nil
 	})
 }
@@ -157,6 +156,20 @@ func printLoginResult(w io.Writer, sourceID string) {
 		return
 	}
 	fmt.Fprintln(w, "Stored (validated on first use).")
+}
+
+// printAuthLoginSuccess prints the final confirmation line for a completed
+// login. Built-in sources were actively validated via a real API call
+// earlier in the flow ("Validating... done"), so "Successfully
+// authenticated" is accurate. Custom sources have no generic validation
+// endpoint — printing that same claim would fabricate a result that never
+// happened, so they get an honest "stored" message instead.
+func printAuthLoginSuccess(w io.Writer, sourceID string) {
+	if isSupportedSource(sourceID) {
+		fmt.Fprintf(w, "Successfully authenticated with %s!\n", getSourceDisplayName(sourceID))
+		return
+	}
+	fmt.Fprintf(w, "API key stored for %s.\n", sourceID)
 }
 
 // selectAuthSource resolves the source from args or prompts the user. The

--- a/cmd/lmm/auth.go
+++ b/cmd/lmm/auth.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -125,20 +126,37 @@ func runAuthLogin(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("API key cannot be empty")
 		}
 
-		fmt.Print("Validating... ")
-		if err := validateAPIKey(ctx, sourceID, apiKey); err != nil {
-			fmt.Println("failed")
-			return fmt.Errorf("invalid API key: %w", err)
+		if isSupportedSource(sourceID) {
+			fmt.Print("Validating... ")
+			if err := validateAPIKey(ctx, sourceID, apiKey); err != nil {
+				fmt.Println("failed")
+				return fmt.Errorf("invalid API key: %w", err)
+			}
+			fmt.Println("done")
 		}
-		fmt.Println("done")
 
 		if err := service.SaveSourceToken(sourceID, apiKey); err != nil {
 			return fmt.Errorf("saving token: %w", err)
 		}
+		printLoginResult(os.Stdout, sourceID)
 
 		fmt.Printf("Successfully authenticated with %s!\n", getSourceDisplayName(sourceID))
 		return nil
 	})
+}
+
+// printLoginResult reports the outcome of storing credentials for sourceID.
+// Built-in sources (nexusmods, curseforge) were actively validated via a real
+// API call just above ("Validating... done"), so nothing more is needed here.
+// Custom sources have no generic validation endpoint (validateAPIKey is a
+// no-op for them) — printing the same "Validating... done" sequence would be
+// a fabricated result, so they get an honest message instead: the key is
+// simply stored and will be exercised on first use.
+func printLoginResult(w io.Writer, sourceID string) {
+	if isSupportedSource(sourceID) {
+		return
+	}
+	fmt.Fprintln(w, "Stored (validated on first use).")
 }
 
 // selectAuthSource resolves the source from args or prompts the user. The
@@ -148,7 +166,7 @@ func selectAuthSource(service *core.Service, args []string) (string, error) {
 	if len(args) > 0 {
 		sourceID := args[0]
 		if !isAuthCapableSource(service, sourceID) {
-			return "", fmt.Errorf("unsupported source: %s (supported: %s)", sourceID, strings.Join(supportedSources, ", "))
+			return "", fmt.Errorf("unsupported source: %s (supported: %s, or a registered custom source with auth declared)", sourceID, strings.Join(supportedSources, ", "))
 		}
 		return sourceID, nil
 	}

--- a/cmd/lmm/auth_test.go
+++ b/cmd/lmm/auth_test.go
@@ -379,3 +379,29 @@ func TestPrintLoginResult(t *testing.T) {
 		assert.NotContains(t, buf.String(), "Validating", "must not fabricate a validation step that never ran")
 	})
 }
+
+// TestPrintAuthLoginSuccess pins the re-review fix for finding 4: custom
+// sources have no generic validation endpoint, so runAuthLogin's final line
+// must not claim "Successfully authenticated" for them — that's a fabricated
+// result. Built-ins were actively validated earlier in the flow and keep the
+// original message; non-built-ins get an honest "stored" message instead.
+func TestPrintAuthLoginSuccess(t *testing.T) {
+	t.Run("built-in source keeps the authenticated message", func(t *testing.T) {
+		var buf bytes.Buffer
+		printAuthLoginSuccess(&buf, "nexusmods")
+		assert.Equal(t, "Successfully authenticated with NexusMods!\n", buf.String())
+	})
+
+	t.Run("curseforge keeps the authenticated message", func(t *testing.T) {
+		var buf bytes.Buffer
+		printAuthLoginSuccess(&buf, "curseforge")
+		assert.Equal(t, "Successfully authenticated with CurseForge!\n", buf.String())
+	})
+
+	t.Run("custom source prints an honest stored message", func(t *testing.T) {
+		var buf bytes.Buffer
+		printAuthLoginSuccess(&buf, "my-repo")
+		assert.Equal(t, "API key stored for my-repo.\n", buf.String())
+		assert.NotContains(t, buf.String(), "Successfully authenticated", "must not fabricate a validation result that never happened")
+	})
+}

--- a/cmd/lmm/auth_test.go
+++ b/cmd/lmm/auth_test.go
@@ -139,6 +139,29 @@ func TestAuthLoginCmd_UnsupportedSource(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported source")
 }
 
+// TestAuthLoginCmd_UnsupportedSourceMentionsCustomSources pins final-review
+// finding 4: the rejection for an unrecognized source must not read like
+// only nexusmods/curseforge are ever possible — a registered custom source
+// with auth declared is also a valid `lmm auth login <id>` target.
+func TestAuthLoginCmd_UnsupportedSourceMentionsCustomSources(t *testing.T) {
+	configDir = t.TempDir()
+	dataDir = t.TempDir()
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.AddCommand(authCmd)
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"auth", "login", "unsupported-source"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nexusmods")
+	assert.Contains(t, err.Error(), "curseforge")
+	assert.Contains(t, err.Error(), "registered custom source with auth declared")
+}
+
 // TestAuthLogoutCmd_UnsupportedSource tests logout with unsupported source
 func TestAuthLogoutCmd_UnsupportedSource(t *testing.T) {
 	// Use temp directories
@@ -328,4 +351,31 @@ func TestAuthLogoutCmd_DefaultSource(t *testing.T) {
 func TestEnvKeyForSourceID(t *testing.T) {
 	assert.Equal(t, "LMM_DONOVAN_MODS_API_KEY", envKeyForSourceID("donovan-mods"))
 	assert.Equal(t, "LMM_MY_REPO_API_KEY", envKeyForSourceID("my-repo"))
+}
+
+// TestPrintLoginResult pins final-review finding 4: custom sources have no
+// generic validation endpoint (validateAPIKey is a no-op for them), so
+// runAuthLogin must not print the built-in "Validating... done" sequence for
+// them — that's a fabricated result. Built-ins are actively validated
+// earlier in the flow and need no extra message here; non-built-ins get an
+// honest "stored, checked on first use" message instead.
+func TestPrintLoginResult(t *testing.T) {
+	t.Run("built-in source prints nothing extra", func(t *testing.T) {
+		var buf bytes.Buffer
+		printLoginResult(&buf, "nexusmods")
+		assert.Empty(t, buf.String(), "built-ins are validated via the Validating...done sequence above")
+	})
+
+	t.Run("curseforge prints nothing extra", func(t *testing.T) {
+		var buf bytes.Buffer
+		printLoginResult(&buf, "curseforge")
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("custom source prints an honest stored message", func(t *testing.T) {
+		var buf bytes.Buffer
+		printLoginResult(&buf, "my-repo")
+		assert.Equal(t, "Stored (validated on first use).\n", buf.String())
+		assert.NotContains(t, buf.String(), "Validating", "must not fabricate a validation step that never ran")
+	})
 }

--- a/cmd/lmm/auth_test.go
+++ b/cmd/lmm/auth_test.go
@@ -65,14 +65,14 @@ func TestGetEnvKeyForSource(t *testing.T) {
 			expected: "NEXUSMODS_API_KEY",
 		},
 		{
-			name:     "unknown source",
+			name:     "unknown source falls back to the derived LMM_*_API_KEY name",
 			sourceID: "unknown",
-			expected: "",
+			expected: "LMM_UNKNOWN_API_KEY",
 		},
 		{
 			name:     "empty source",
 			sourceID: "",
-			expected: "",
+			expected: "LMM__API_KEY",
 		},
 	}
 
@@ -323,4 +323,9 @@ func TestAuthLoginCmd_DefaultSource(t *testing.T) {
 func TestAuthLogoutCmd_DefaultSource(t *testing.T) {
 	// Similar to login, verify it accepts 0 or 1 args
 	assert.NotNil(t, authLogoutCmd.Args, "Args validator should be set")
+}
+
+func TestEnvKeyForSourceID(t *testing.T) {
+	assert.Equal(t, "LMM_DONOVAN_MODS_API_KEY", envKeyForSourceID("donovan-mods"))
+	assert.Equal(t, "LMM_MY_REPO_API_KEY", envKeyForSourceID("my-repo"))
 }

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -642,7 +642,11 @@ func doInstall(ctx context.Context, service *core.Service, game *domain.Game, ar
 		return fmt.Errorf("deployment failed: %w", err)
 	}
 
-	// Save to database
+	// Save to database. Normalize GameID to the lmm game (not the
+	// source-mapped value Service.SearchMods/GetMod stamped onto mod.GameID
+	// for querying the source) so every DB read, which queries by the lmm
+	// game ID, can find this row again (see issue: non-empty sources:
+	// mappings otherwise orphan the install).
 	installedMod := &domain.InstalledMod{
 		Mod:          *mod,
 		ProfileName:  profileName,
@@ -652,6 +656,7 @@ func doInstall(ctx context.Context, service *core.Service, game *domain.Game, ar
 		LinkMethod:   linkMethod,
 		FileIDs:      downloadedFileIDs,
 	}
+	installedMod.Mod.GameID = game.ID
 
 	if err := service.SaveInstalledMod(installedMod); err != nil {
 		if existingMod != nil {
@@ -1277,7 +1282,8 @@ func batchInstallMods(ctx context.Context, service *core.Service, game *domain.G
 			continue
 		}
 
-		// Save to database
+		// Save to database. Normalize GameID to the lmm game (see comment on
+		// the single-mod save site above for why).
 		installedMod := &domain.InstalledMod{
 			Mod:          *mod,
 			ProfileName:  profileName,
@@ -1287,6 +1293,7 @@ func batchInstallMods(ctx context.Context, service *core.Service, game *domain.G
 			LinkMethod:   linkMethod,
 			FileIDs:      []string{selectedFile.ID},
 		}
+		installedMod.Mod.GameID = game.ID
 		if err := service.SaveInstalledMod(installedMod); err != nil {
 			fmt.Printf("  Error: failed to save mod: %v\n", err)
 			failed = append(failed, mod.Name)

--- a/cmd/lmm/install_gameid_test.go
+++ b/cmd/lmm/install_gameid_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDoInstall_VisibleUnderLMMGameIDWhenSourceMappingDiffers reproduces the
+// install-orphan bug (final-review finding 1): when a game's `sources:`
+// mapping points a source at a value different from the lmm game ID (the
+// README-documented pattern for manifest game_ids filtering, e.g.
+// `my-repo: skyrim` under game `testgame`), the search/GetMod path correctly
+// stamps the source-mapped value onto mod.GameID for querying the source —
+// but that same value must NOT leak into the persisted InstalledMod. Before
+// the fix, doInstall saved *mod as-is, so the row landed under GameID
+// "skyrim" while every other DB read (list/update/uninstall) queries by the
+// lmm game ID "testgame", orphaning the install.
+func TestDoInstall_VisibleUnderLMMGameIDWhenSourceMappingDiffers(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    summary: Makes things cooler
+    game_ids: [skyrim]
+    files:
+      - id: main
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        url: %s/files/cool-mod-1.2.0.zip
+        primary: true
+`, srv.URL)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	mux.HandleFunc("/files/", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("archive bytes")) })
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "e2e-repo",
+		Name:      "E2E Repo",
+		Type:      custom.TypeManifest,
+		AllowHTTP: true, // httptest serves plain http
+		Manifest:  &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(src)
+
+	// Game "testgame" maps the manifest source to a DIFFERENT, non-empty
+	// value ("skyrim") — the README-documented pattern for game_ids filtering.
+	game := &domain.Game{
+		ID:         "testgame",
+		Name:       "Test Game",
+		ModPath:    t.TempDir(),
+		DeployMode: domain.DeployCopy,
+		SourceIDs:  map[string]string{"e2e-repo": "skyrim"},
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	// Drive the same package-level flags runInstall would set, skipping
+	// interactive prompts so the real doInstall save path executes.
+	origInstallSource, origInstallProfile, origInstallModID := installSource, installProfile, installModID
+	origInstallFileID, origInstallYes, origInstallShowArchived := installFileID, installYes, installShowArchived
+	origSkipVerify, origInstallForce, origInstallNoDeps := skipVerify, installForce, installNoDeps
+	origNoHooks := noHooks
+	t.Cleanup(func() {
+		installSource, installProfile, installModID = origInstallSource, origInstallProfile, origInstallModID
+		installFileID, installYes, installShowArchived = origInstallFileID, origInstallYes, origInstallShowArchived
+		skipVerify, installForce, installNoDeps = origSkipVerify, origInstallForce, origInstallNoDeps
+		noHooks = origNoHooks
+	})
+
+	installSource = ""
+	installProfile = ""
+	installModID = "cool-mod"
+	installFileID = ""
+	installYes = true
+	installShowArchived = false
+	skipVerify = true
+	installForce = true
+	installNoDeps = true
+	noHooks = true
+
+	require.NoError(t, doInstall(context.Background(), svc, game, nil))
+
+	installed, err := svc.GetInstalledMods(game.ID, "default")
+	require.NoError(t, err)
+	require.Len(t, installed, 1, "installed mod must be visible under the lmm game ID after install")
+	assert.Equal(t, "cool-mod", installed[0].ID)
+	assert.Equal(t, "testgame", installed[0].GameID, "persisted GameID must be normalized to the lmm game, not the source-mapped value")
+
+	orphaned, err := svc.GetInstalledMods("skyrim", "default")
+	require.NoError(t, err)
+	assert.Empty(t, orphaned, "installed mod must not be filed under the source-mapped game ID")
+}
+
+// TestBatchInstallMods_VisibleUnderLMMGameIDWhenSourceMappingDiffers covers
+// the second install-orphan save site (batchInstallMods, used by both
+// multi-select search installs and dependency-resolved installs). Same bug,
+// same fix: the persisted GameID must be normalized to the lmm game.
+func TestBatchInstallMods_VisibleUnderLMMGameIDWhenSourceMappingDiffers(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    game_ids: [skyrim]
+    files:
+      - id: main
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        url: %s/files/cool-mod-1.2.0.zip
+        primary: true
+`, srv.URL)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	mux.HandleFunc("/files/", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("archive bytes")) })
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "e2e-repo",
+		Name:      "E2E Repo",
+		Type:      custom.TypeManifest,
+		AllowHTTP: true,
+		Manifest:  &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(src)
+
+	game := &domain.Game{
+		ID:         "testgame",
+		Name:       "Test Game",
+		ModPath:    t.TempDir(),
+		DeployMode: domain.DeployCopy,
+		SourceIDs:  map[string]string{"e2e-repo": "skyrim"},
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	origInstallShowArchived, origSkipVerify, origInstallForce := installShowArchived, skipVerify, installForce
+	origNoHooks := noHooks
+	t.Cleanup(func() {
+		installShowArchived, skipVerify, installForce = origInstallShowArchived, origSkipVerify, origInstallForce
+		noHooks = origNoHooks
+	})
+	installShowArchived = false
+	skipVerify = true
+	installForce = true
+	noHooks = true
+
+	ctx := context.Background()
+	mod, err := svc.GetMod(ctx, "e2e-repo", game.ID, "cool-mod")
+	require.NoError(t, err)
+	require.Equal(t, "skyrim", mod.GameID, "GetMod stamps the source-mapped GameID for querying the source")
+
+	require.NoError(t, batchInstallMods(ctx, svc, game, []*domain.Mod{mod}, "default"))
+
+	installed, err := svc.GetInstalledMods(game.ID, "default")
+	require.NoError(t, err)
+	require.Len(t, installed, 1, "installed mod must be visible under the lmm game ID after batch install")
+	assert.Equal(t, "cool-mod", installed[0].ID)
+	assert.Equal(t, "testgame", installed[0].GameID)
+
+	orphaned, err := svc.GetInstalledMods("skyrim", "default")
+	require.NoError(t, err)
+	assert.Empty(t, orphaned, "installed mod must not be filed under the source-mapped game ID")
+}

--- a/cmd/lmm/profile.go
+++ b/cmd/lmm/profile.go
@@ -492,7 +492,10 @@ func doProfileSwitch(ctx context.Context, service *core.Service, game *domain.Ga
 				continue
 			}
 
-			// Save to DB
+			// Save to DB. Normalize GameID to the lmm game (not the
+			// source-mapped value Service.GetMod stamped onto mod.GameID for
+			// querying the source) so every DB read, which queries by the
+			// lmm game ID, can find this row again.
 			installedMod := &domain.InstalledMod{
 				Mod:          *mod,
 				ProfileName:  targetName,
@@ -500,6 +503,7 @@ func doProfileSwitch(ctx context.Context, service *core.Service, game *domain.Ga
 				Enabled:      true,
 				FileIDs:      downloadedFileIDs,
 			}
+			installedMod.Mod.GameID = game.ID
 			if err := service.SaveInstalledMod(installedMod); err != nil {
 				fmt.Printf("    Error: save failed: %v\n", err)
 				continue
@@ -749,7 +753,8 @@ func doProfileImport(ctx context.Context, service *core.Service, game *domain.Ga
 			continue
 		}
 
-		// Save to DB
+		// Save to DB. Normalize GameID to the lmm game (see comment on the
+		// doProfileSwitch save site for why).
 		installedMod := &domain.InstalledMod{
 			Mod:          *mod,
 			ProfileName:  profile.Name,
@@ -757,6 +762,7 @@ func doProfileImport(ctx context.Context, service *core.Service, game *domain.Ga
 			Enabled:      true,
 			FileIDs:      downloadedFileIDs,
 		}
+		installedMod.Mod.GameID = game.ID
 		if err := service.SaveInstalledMod(installedMod); err != nil {
 			fmt.Printf("    Error: save failed: %v\n", err)
 			failedCount++
@@ -1302,7 +1308,8 @@ func doProfileApply(ctx context.Context, service *core.Service, game *domain.Gam
 				continue
 			}
 
-			// Save to DB
+			// Save to DB. Normalize GameID to the lmm game (see comment on
+			// the doProfileSwitch save site for why).
 			installedMod := &domain.InstalledMod{
 				Mod:          *mod,
 				ProfileName:  profileName,
@@ -1310,6 +1317,7 @@ func doProfileApply(ctx context.Context, service *core.Service, game *domain.Gam
 				Enabled:      true,
 				FileIDs:      downloadedFileIDs,
 			}
+			installedMod.Mod.GameID = game.ID
 			if err := service.SaveInstalledMod(installedMod); err != nil {
 				fmt.Printf("    Error: save failed: %v\n", err)
 				continue

--- a/cmd/lmm/profile_gameid_test.go
+++ b/cmd/lmm/profile_gameid_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDoProfileApply_VisibleUnderLMMGameIDWhenSourceMappingDiffers reproduces
+// the same install-orphan bug (re-review finding: same class as commit
+// 4b3154e) for the profile.go "install missing mods" save site in
+// doProfileApply. When a game's `sources:` mapping points a source at a
+// value different from the lmm game ID (the README-documented pattern for
+// manifest game_ids filtering, e.g. `my-repo: skyrim` under game
+// `testgame`), Service.GetMod correctly stamps the source-mapped value onto
+// mod.GameID for querying the source — but that value must NOT leak into
+// the persisted InstalledMod. Before the fix, doProfileApply saved *mod
+// as-is, so the row landed under GameID "skyrim" while every other DB read
+// (list/update/uninstall) queries by the lmm game ID "testgame", orphaning
+// the install even though it was deployed to disk.
+func TestDoProfileApply_VisibleUnderLMMGameIDWhenSourceMappingDiffers(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    summary: Makes things cooler
+    game_ids: [skyrim]
+    files:
+      - id: main
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        url: %s/files/cool-mod-1.2.0.zip
+        primary: true
+`, srv.URL)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	mux.HandleFunc("/files/", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("archive bytes")) })
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "e2e-repo",
+		Name:      "E2E Repo",
+		Type:      custom.TypeManifest,
+		AllowHTTP: true, // httptest serves plain http
+		Manifest:  &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(src)
+
+	// Game "testgame" maps the manifest source to a DIFFERENT, non-empty
+	// value ("skyrim") — the README-documented pattern for game_ids filtering.
+	game := &domain.Game{
+		ID:         "testgame",
+		Name:       "Test Game",
+		ModPath:    t.TempDir(),
+		DeployMode: domain.DeployCopy,
+		SourceIDs:  map[string]string{"e2e-repo": "skyrim"},
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	pm := getProfileManager(svc)
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{
+		SourceID: "e2e-repo",
+		ModID:    "cool-mod",
+		Version:  "1.2.0",
+	}))
+
+	// Auto-confirm the "Proceed?" prompt so the real save path executes
+	// without needing to fake stdin.
+	origProfileApplyYes := profileApplyYes
+	t.Cleanup(func() { profileApplyYes = origProfileApplyYes })
+	profileApplyYes = true
+
+	require.NoError(t, doProfileApply(context.Background(), svc, game, []string{"default"}))
+
+	installed, err := svc.GetInstalledMods(game.ID, "default")
+	require.NoError(t, err)
+	require.Len(t, installed, 1, "installed mod must be visible under the lmm game ID after profile apply")
+	assert.Equal(t, "cool-mod", installed[0].ID)
+	assert.Equal(t, "testgame", installed[0].GameID, "persisted GameID must be normalized to the lmm game, not the source-mapped value")
+
+	orphaned, err := svc.GetInstalledMods("skyrim", "default")
+	require.NoError(t, err)
+	assert.Empty(t, orphaned, "installed mod must not be filed under the source-mapped game ID")
+}

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -195,6 +195,11 @@ func registerCustomSources(svc *core.Service, cfgDir string) {
 			fmt.Fprintf(os.Stderr, "warning: skipping source %q: %v\n", def.ID, err)
 			continue
 		}
+		if a, ok := src.(interface{ SetAPIKey(string) }); ok {
+			if key := getSourceAPIKey(svc, def.ID, envKeyForSourceID(def.ID)); key != "" {
+				a.SetAPIKey(key)
+			}
+		}
 		svc.RegisterSource(src)
 	}
 }

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -23,7 +23,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.6.0"
+	version = "1.7.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/source.go
+++ b/cmd/lmm/source.go
@@ -126,7 +126,7 @@ var sourceValidateCmd = &cobra.Command{
 // Extend this switch as new custom source types (manifest, api) ship.
 func isCustomSource(src source.ModSource) bool {
 	switch src.(type) {
-	case *custom.Directory:
+	case *custom.Directory, *custom.Manifest:
 		return true
 	default:
 		return false

--- a/internal/core/downloader.go
+++ b/internal/core/downloader.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -148,6 +149,20 @@ func (d *Downloader) downloadOnce(ctx context.Context, url, destPath string, hea
 
 	resp, err := d.httpClient.Do(req)
 	if err != nil {
+		// *url.Error's Error() embeds the request URL verbatim, which for
+		// query-mode auth (custom sources' GetDownloadURL) contains the API
+		// key. Unwrap to the transport error and report a query-stripped URL
+		// instead — %w still wraps the inner net error so isRetryableNet's
+		// errors.As(err, &netErr) keeps working for retry classification.
+		var uerr *neturl.Error
+		if errors.As(err, &uerr) {
+			reportURL := uerr.URL
+			if parsed, perr := neturl.Parse(uerr.URL); perr == nil {
+				parsed.RawQuery = ""
+				reportURL = parsed.String()
+			}
+			return nil, fmt.Errorf("executing request to %s: %w", reportURL, uerr.Err)
+		}
 		return nil, fmt.Errorf("executing request: %w", err)
 	}
 	defer func() {

--- a/internal/core/downloader.go
+++ b/internal/core/downloader.go
@@ -78,14 +78,21 @@ func isRetryableNet(err error) bool {
 	return false
 }
 
-// Download fetches a file from the URL and saves it to destPath, with retries on transient
-// failures (exponential backoff). Progress updates are sent to the optional progressFn callback.
+// Download fetches a file from the URL and saves it to destPath, with retries
+// on transient failures (exponential backoff). Progress updates are sent to
+// the optional progressFn callback.
 func (d *Downloader) Download(ctx context.Context, url, destPath string, progressFn ProgressFunc) (*DownloadResult, error) {
+	return d.DownloadWithHeaders(ctx, url, destPath, nil, progressFn)
+}
+
+// DownloadWithHeaders is Download with extra request headers applied to every
+// attempt — used for authenticated file downloads from custom sources.
+func (d *Downloader) DownloadWithHeaders(ctx context.Context, url, destPath string, headers map[string]string, progressFn ProgressFunc) (*DownloadResult, error) {
 	var lastErr error
 	backoff := defaultInitialBackoff
 
 	for attempt := 1; attempt <= defaultMaxAttempts; attempt++ {
-		result, err := d.downloadOnce(ctx, url, destPath, progressFn)
+		result, err := d.downloadOnce(ctx, url, destPath, headers, progressFn)
 		if err == nil {
 			return result, nil
 		}
@@ -130,10 +137,13 @@ func (e *httpStatusError) Error() string {
 }
 
 // downloadOnce performs a single download attempt (no retries).
-func (d *Downloader) downloadOnce(ctx context.Context, url, destPath string, progressFn ProgressFunc) (result *DownloadResult, err error) {
+func (d *Downloader) downloadOnce(ctx context.Context, url, destPath string, headers map[string]string, progressFn ProgressFunc) (result *DownloadResult, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	for name, value := range headers {
+		req.Header.Set(name, value)
 	}
 
 	resp, err := d.httpClient.Do(req)

--- a/internal/core/downloader_test.go
+++ b/internal/core/downloader_test.go
@@ -3,6 +3,7 @@ package core_test
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -405,6 +406,63 @@ func TestDownloadWithHeadersSetsHeaders(t *testing.T) {
 	_, err := d.DownloadWithHeaders(context.Background(), srv.URL, dest, map[string]string{"X-API-Key": "sekrit"}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "sekrit", got)
+}
+
+// TestDownloadWithHeaders_ErrorDoesNotLeakQueryParam pins final-review
+// finding 2's download-path leak: GetDownloadURL bakes an auth key into the
+// URL's query string for query-mode custom sources, and httpClient.Do's
+// *url.Error embeds that full authenticated URL in its Error() string.
+// downloadOnce must not report the raw transport error verbatim.
+func TestDownloadWithHeaders_ErrorDoesNotLeakQueryParam(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close()) // now unreachable: connection refused
+
+	url := "http://" + addr + "/file.zip?api_key=LEAKME123"
+
+	d := core.NewDownloader(nil)
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	_, err = d.DownloadWithHeaders(context.Background(), url, dest, nil, nil)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "LEAKME123", "error must not leak the query-auth API key")
+	assert.NotContains(t, err.Error(), "api_key=", "error must not leak the query parameter at all")
+}
+
+// fakeTimeoutError is a minimal net.Error that reports Timeout()==true but is
+// distinct from context.DeadlineExceeded, so it exercises the
+// isRetryableNet "known-transient net error" branch rather than the
+// context-deadline exclusion.
+type fakeTimeoutError struct{}
+
+func (fakeTimeoutError) Error() string   { return "fake i/o timeout" }
+func (fakeTimeoutError) Timeout() bool   { return true }
+func (fakeTimeoutError) Temporary() bool { return true }
+
+// fakeTimeoutRoundTripper always fails with fakeTimeoutError, simulating a
+// transport-level timeout. http.Client.Do wraps RoundTripper errors in
+// *url.Error, which is exactly the wrapping downloadOnce must see through.
+type fakeTimeoutRoundTripper struct{ calls int }
+
+func (f *fakeTimeoutRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.calls++
+	return nil, fakeTimeoutError{}
+}
+
+// TestDownloadWithHeaders_RetriesOnWrappedNetTimeout proves the *url.Error
+// unwrap in downloadOnce still preserves the wrapped net.Error chain that
+// isRetryableNet depends on (errors.As(err, &netErr) && netErr.Timeout()) —
+// retries must not silently break as a side effect of redacting the URL.
+func TestDownloadWithHeaders_RetriesOnWrappedNetTimeout(t *testing.T) {
+	rt := &fakeTimeoutRoundTripper{}
+	client := &http.Client{Transport: rt}
+	d := core.NewDownloader(client)
+	dest := filepath.Join(t.TempDir(), "out.bin")
+
+	_, err := d.DownloadWithHeaders(context.Background(), "http://example.invalid/file.zip?api_key=LEAKME123", dest, nil, nil)
+	require.Error(t, err)
+	assert.GreaterOrEqual(t, rt.calls, 2, "a wrapped net timeout error must still be retried after the url.Error unwrap")
+	assert.NotContains(t, err.Error(), "LEAKME123")
 }
 
 func BenchmarkDownloader_Download(b *testing.B) {

--- a/internal/core/downloader_test.go
+++ b/internal/core/downloader_test.go
@@ -392,6 +392,21 @@ func TestDownloader_Download_WriteTempFirst(t *testing.T) {
 	assert.Equal(t, content, data)
 }
 
+func TestDownloadWithHeadersSetsHeaders(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-API-Key")
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer srv.Close()
+
+	d := core.NewDownloader(nil)
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	_, err := d.DownloadWithHeaders(context.Background(), srv.URL, dest, map[string]string{"X-API-Key": "sekrit"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "sekrit", got)
+}
+
 func BenchmarkDownloader_Download(b *testing.B) {
 	// Create 1MB of content
 	content := make([]byte, 1024*1024)

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -2,7 +2,10 @@ package core
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -227,6 +230,12 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 		return nil, fmt.Errorf("downloading mod: %w", err)
 	}
 
+	if file.SHA256 != "" {
+		if err := verifyFileSHA256(archivePath, file.SHA256); err != nil {
+			return nil, fmt.Errorf("verifying download of %s: %w", file.FileName, err)
+		}
+	}
+
 	// Extract to cache location
 	cachePath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
 	stagePath := cachePath + ".staging"
@@ -275,6 +284,27 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 		FilesExtracted: len(files),
 		Checksum:       downloadResult.Checksum,
 	}, nil
+}
+
+// verifyFileSHA256 streams path and compares its SHA-256 against expectedHex
+// (case-insensitive). Sources that publish expected checksums (manifest
+// sha256) set DownloadableFile.SHA256; built-in sources leave it empty and
+// skip this entirely.
+func verifyFileSHA256(path, expectedHex string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening downloaded file: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hashing downloaded file: %w", err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, expectedHex) {
+		return fmt.Errorf("sha256 mismatch: source declares %s, downloaded file is %s", expectedHex, got)
+	}
+	return nil
 }
 
 // ingestLocalToCache copies a local mod (directory or archive) into the cache

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -225,7 +225,11 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 
 	// Download the file
 	archivePath := filepath.Join(tempDir, file.FileName)
-	downloadResult, err := s.downloader.Download(ctx, url, archivePath, progressFn)
+	var headers map[string]string
+	if hp, ok := src.(source.DownloadHeaderProvider); ok {
+		headers = hp.DownloadHeaders()
+	}
+	downloadResult, err := s.downloader.DownloadWithHeaders(ctx, url, archivePath, headers, progressFn)
 	if err != nil {
 		return nil, fmt.Errorf("downloading mod: %w", err)
 	}

--- a/internal/core/service_manifest_source_test.go
+++ b/internal/core/service_manifest_source_test.go
@@ -1,0 +1,162 @@
+package core_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManifestSourceEndToEnd drives the full loop against a static file
+// server: manifest fetch -> search -> files (sha256) -> download+verify ->
+// cache, plus dependency resolution and update checks (issue #48 acceptance).
+func TestManifestSourceEndToEnd(t *testing.T) {
+	archive := []byte("mod payload bytes")
+	sum := sha256.Sum256(archive)
+	archiveSHA := hex.EncodeToString(sum[:])
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    summary: Makes things cooler
+    dependencies: [dep-mod]
+    files:
+      - id: main
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        url: %s/files/cool-mod-1.2.0.zip
+        sha256: %s
+        primary: true
+  - id: dep-mod
+    name: Dep Mod
+    version: 0.5.0
+    files:
+      - id: main
+        filename: dep-mod.zip
+        url: %s/files/dep-mod.zip
+`, srv.URL, archiveSHA, srv.URL)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	mux.HandleFunc("/files/", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(archive) })
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "e2e-repo",
+		Name:      "E2E Repo",
+		Type:      custom.TypeManifest,
+		AllowHTTP: true, // httptest serves plain http
+		Manifest:  &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(src)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), DeployMode: domain.DeployCopy}
+	require.NoError(t, svc.AddGame(game))
+	ctx := context.Background()
+
+	// Search finds the mod and stamps identity.
+	res, err := src.Search(ctx, source.SearchQuery{Query: "cool", GameID: "testgame", PageSize: 20})
+	require.NoError(t, err)
+	require.Len(t, res.Mods, 1)
+	mod := res.Mods[0]
+	assert.Equal(t, "e2e-repo", mod.SourceID)
+	assert.Equal(t, "testgame", mod.GameID)
+
+	// Dependencies resolve within the source.
+	deps, err := src.GetDependencies(ctx, &mod)
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, domain.ModReference{SourceID: "e2e-repo", ModID: "dep-mod"}, deps[0])
+
+	// Files carry the declared sha256; download verifies it and lands in cache.
+	files, err := src.GetModFiles(ctx, &mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, archiveSHA, files[0].SHA256)
+
+	result, err := svc.DownloadMod(ctx, "e2e-repo", game, &mod, &files[0], nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesExtracted)
+	gameCache := svc.GetGameCache(game)
+	assert.True(t, gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version))
+
+	// Update checks: installed 1.0.0 -> manifest 1.2.0 offers an update.
+	installed := []domain.InstalledMod{{Mod: domain.Mod{ID: "cool-mod", SourceID: "e2e-repo", Version: "1.0.0"}}}
+	updates, err := src.CheckUpdates(ctx, installed)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "1.2.0", updates[0].NewVersion)
+}
+
+// TestManifestSourceEndToEndCorruptDownload pins acceptance criterion 2 of
+// the sha256 wiring: a server whose file bytes don't match the declared hash
+// must fail the install and leave the cache empty.
+func TestManifestSourceEndToEndCorruptDownload(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	wrongSHA := strings.Repeat("de", 32) // 64 hex chars that won't match the served bytes
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: bad-mod
+    name: Bad Mod
+    version: 1.0.0
+    files:
+      - id: main
+        filename: bad-mod.zip
+        url: %s/files/bad-mod.zip
+        sha256: %s
+`, srv.URL, wrongSHA)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	mux.HandleFunc("/files/", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("tampered content")) })
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID: "bad-repo", Name: "Bad Repo", Type: custom.TypeManifest, AllowHTTP: true,
+		Manifest: &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(src)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), DeployMode: domain.DeployCopy}
+	require.NoError(t, svc.AddGame(game))
+	ctx := context.Background()
+
+	mod, err := src.GetMod(ctx, "testgame", "bad-mod")
+	require.NoError(t, err)
+	files, err := src.GetModFiles(ctx, mod)
+	require.NoError(t, err)
+
+	_, err = svc.DownloadMod(ctx, "bad-repo", game, mod, &files[0], nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sha256 mismatch")
+	gameCache := svc.GetGameCache(game)
+	assert.False(t, gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version))
+}

--- a/internal/core/service_sha256_test.go
+++ b/internal/core/service_sha256_test.go
@@ -1,0 +1,74 @@
+package core_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// downloadWithSHA256 runs one DownloadMod through a mock source serving
+// content, with expectedSHA declared on the file. Returns the error.
+func downloadWithSHA256(t *testing.T, content []byte, expectedSHA string) (error, *domain.Game, *domain.Mod, func() bool) {
+	t.Helper()
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	mock := newMockSourceWithDownloads("test")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: filepath.Join(t.TempDir(), "mods"), DeployMode: domain.DeployCopy}
+	require.NoError(t, svc.AddGame(game))
+
+	mod := &domain.Mod{ID: "m1", SourceID: "test", Name: "Mod", Version: "1.0.0", GameID: "testgame"}
+	file := &domain.DownloadableFile{ID: "file1", Name: "File", FileName: "m1.zip", SHA256: expectedSHA}
+
+	mock.AddDownload(file.ID, content)
+
+	_, err = svc.DownloadMod(context.Background(), "test", game, mod, file, nil)
+	gameCache := svc.GetGameCache(game)
+	cached := func() bool { return gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version) }
+	return err, game, mod, cached
+}
+
+func TestDownloadModVerifiesDeclaredSHA256(t *testing.T) {
+	content := []byte("mod archive bytes")
+	sum := sha256.Sum256(content)
+	good := hex.EncodeToString(sum[:])
+
+	t.Run("matching hash passes", func(t *testing.T) {
+		err, _, _, cached := downloadWithSHA256(t, content, good)
+		require.NoError(t, err)
+		assert.True(t, cached())
+	})
+
+	t.Run("uppercase hash passes (case-insensitive)", func(t *testing.T) {
+		err, _, _, cached := downloadWithSHA256(t, content, strings.ToUpper(good))
+		require.NoError(t, err)
+		assert.True(t, cached())
+	})
+
+	t.Run("mismatched hash fails and nothing is cached", func(t *testing.T) {
+		err, _, _, cached := downloadWithSHA256(t, content, strings.Repeat("ab", 32))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sha256 mismatch")
+		assert.False(t, cached())
+	})
+
+	t.Run("empty hash skips verification", func(t *testing.T) {
+		err, _, _, cached := downloadWithSHA256(t, content, "")
+		require.NoError(t, err)
+		assert.True(t, cached())
+	})
+}

--- a/internal/domain/mod.go
+++ b/internal/domain/mod.go
@@ -45,6 +45,7 @@ type DownloadableFile struct {
 	IsPrimary   bool   // Whether this is the primary/main file
 	Category    string // Category: "MAIN", "OPTIONAL", "UPDATE", etc.
 	Description string // File description
+	SHA256      string // Expected SHA-256 of the download (hex); empty = source declares no checksum
 }
 
 // ModReference is a pointer to a mod (used in profiles, dependencies)

--- a/internal/source/custom/custom.go
+++ b/internal/source/custom/custom.go
@@ -13,6 +13,8 @@ func New(def SourceDefinition) (source.ModSource, error) {
 	switch def.Type {
 	case TypeDirectory:
 		return NewDirectory(def)
+	case TypeManifest:
+		return NewManifest(def)
 	default:
 		return nil, fmt.Errorf("source type %q is not yet supported", def.Type)
 	}

--- a/internal/source/custom/custom_test.go
+++ b/internal/source/custom/custom_test.go
@@ -19,11 +19,21 @@ func TestNew(t *testing.T) {
 		assert.Equal(t, "my-mods", src.ID())
 	})
 
-	t.Run("unimplemented types return a clear error", func(t *testing.T) {
-		for _, typ := range []string{TypeManifest, TypeAPI} {
-			def := SourceDefinition{ID: "x", Name: "X", Type: typ}
-			_, err := New(def)
-			assert.ErrorContains(t, err, "not yet supported", "type %s", typ)
+	t.Run("manifest type constructs a source", func(t *testing.T) {
+		def := SourceDefinition{
+			ID:       "my-repo",
+			Name:     "My Repo",
+			Type:     TypeManifest,
+			Manifest: &ManifestConfig{URL: "https://x.test/mods.yaml"},
 		}
+		src, err := New(def)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-repo", src.ID())
+	})
+
+	t.Run("unimplemented types return a clear error", func(t *testing.T) {
+		def := SourceDefinition{ID: "x", Name: "X", Type: TypeAPI}
+		_, err := New(def)
+		assert.ErrorContains(t, err, "not yet supported")
 	})
 }

--- a/internal/source/custom/definition.go
+++ b/internal/source/custom/definition.go
@@ -38,8 +38,22 @@ type DirectoryConfig struct {
 
 // ManifestConfig configures a manifest source (Phase 3).
 type ManifestConfig struct {
-	URL     string `yaml:"url"`
-	Refresh string `yaml:"refresh"` // Go duration string, e.g. "15m"; empty = default
+	URL     string      `yaml:"url"`
+	Refresh string      `yaml:"refresh"` // Go duration string, e.g. "15m"; empty = default
+	Auth    *AuthConfig `yaml:"auth"`
+}
+
+// AuthConfig configures optional API-key authentication for a custom source.
+// The key itself is never stored in the definition; it comes from the
+// LMM_<ID>_API_KEY env var or the DB token store at startup.
+type AuthConfig struct {
+	APIKey *APIKeyConfig `yaml:"api_key"`
+}
+
+// APIKeyConfig says where the API key is attached on requests.
+type APIKeyConfig struct {
+	In   string `yaml:"in"`   // "header" or "query"
+	Name string `yaml:"name"` // header name or query parameter name
 }
 
 // APIConfig configures a declarative REST source (expanded in Phase 4).
@@ -48,6 +62,24 @@ type APIConfig struct {
 }
 
 var idPattern = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// validateAuth checks an optional auth block. Shared by manifest (Phase 3)
+// and api (Phase 4) validation.
+func validateAuth(a *AuthConfig) error {
+	if a == nil {
+		return nil
+	}
+	if a.APIKey == nil {
+		return errors.New("auth.api_key is required when auth is set")
+	}
+	if a.APIKey.In != "header" && a.APIKey.In != "query" {
+		return fmt.Errorf(`auth.api_key.in must be "header" or "query", got %q`, a.APIKey.In)
+	}
+	if a.APIKey.Name == "" {
+		return errors.New("auth.api_key.name is required")
+	}
+	return nil
+}
 
 // Validate checks the definition for structural errors. It does not touch the
 // filesystem or network; existence checks happen when the source is constructed.
@@ -101,6 +133,9 @@ func (d *SourceDefinition) Validate() error {
 			if _, err := time.ParseDuration(d.Manifest.Refresh); err != nil {
 				return fmt.Errorf("manifest.refresh: %w", err)
 			}
+		}
+		if err := validateAuth(d.Manifest.Auth); err != nil {
+			return fmt.Errorf("manifest: %w", err)
 		}
 	case TypeAPI:
 		if d.API == nil {

--- a/internal/source/custom/definition.go
+++ b/internal/source/custom/definition.go
@@ -129,6 +129,10 @@ func (d *SourceDefinition) Validate() error {
 		if err := d.checkURL(d.Manifest.URL); err != nil {
 			return fmt.Errorf("manifest.url: %w", err)
 		}
+		if strings.Contains(d.Manifest.URL, "://") &&
+			!strings.HasPrefix(d.Manifest.URL, "http://") && !strings.HasPrefix(d.Manifest.URL, "https://") {
+			return errors.New("manifest.url: unsupported scheme (use https://, http:// with allow_http, or a local path)")
+		}
 		if d.Manifest.Refresh != "" {
 			if _, err := time.ParseDuration(d.Manifest.Refresh); err != nil {
 				return fmt.Errorf("manifest.refresh: %w", err)

--- a/internal/source/custom/definition_test.go
+++ b/internal/source/custom/definition_test.go
@@ -53,6 +53,11 @@ func TestSourceDefinitionValidate(t *testing.T) {
 			d.AllowHTTP = true
 			d.Manifest = &ManifestConfig{URL: "http://x.test/m.yaml"}
 		}, ""},
+		{"ftp manifest url rejected", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "ftp://x.test/m.yaml"}
+		}, "unsupported scheme"},
 		{"bad manifest refresh", func(d *SourceDefinition) {
 			d.Type = TypeManifest
 			d.Directory = nil

--- a/internal/source/custom/definition_test.go
+++ b/internal/source/custom/definition_test.go
@@ -68,6 +68,43 @@ func TestSourceDefinitionValidate(t *testing.T) {
 			d.Directory = nil
 			d.API = &APIConfig{BaseURL: "http://api.x.test"}
 		}, "https"},
+		{"valid manifest auth header", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{
+				URL:  "https://x.test/m.yaml",
+				Auth: &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}},
+			}
+		}, ""},
+		{"valid manifest auth query", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{
+				URL:  "https://x.test/m.yaml",
+				Auth: &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}},
+			}
+		}, ""},
+		{"auth without api_key block", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "https://x.test/m.yaml", Auth: &AuthConfig{}}
+		}, "auth.api_key is required"},
+		{"auth bad in", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{
+				URL:  "https://x.test/m.yaml",
+				Auth: &AuthConfig{APIKey: &APIKeyConfig{In: "body", Name: "k"}},
+			}
+		}, `auth.api_key.in must be "header" or "query"`},
+		{"auth missing name", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{
+				URL:  "https://x.test/m.yaml",
+				Auth: &AuthConfig{APIKey: &APIKeyConfig{In: "header"}},
+			}
+		}, "auth.api_key.name is required"},
 	}
 
 	for _, tt := range tests {

--- a/internal/source/custom/directory.go
+++ b/internal/source/custom/directory.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -173,55 +172,11 @@ func (d *Directory) Search(ctx context.Context, query source.SearchQuery) (sourc
 	if err != nil {
 		return source.SearchResult{}, err
 	}
-
-	q := strings.ToLower(query.Query)
-	type ranked struct {
-		mod       domain.Mod
-		nameMatch bool
-	}
-	var matches []ranked
+	mods := make([]domain.Mod, 0, len(scanned))
 	for _, dm := range scanned {
-		nameMatch := q == "" || strings.Contains(strings.ToLower(dm.mod.Name), q) || strings.Contains(strings.ToLower(dm.mod.ID), q)
-		summaryMatch := strings.Contains(strings.ToLower(dm.mod.Summary), q)
-		if !nameMatch && !summaryMatch {
-			continue
-		}
-		matches = append(matches, ranked{mod: dm.mod, nameMatch: nameMatch})
+		mods = append(mods, dm.mod)
 	}
-
-	sort.SliceStable(matches, func(i, j int) bool {
-		if matches[i].nameMatch != matches[j].nameMatch {
-			return matches[i].nameMatch
-		}
-		return matches[i].mod.Name < matches[j].mod.Name
-	})
-
-	pageSize := query.PageSize
-	if pageSize <= 0 {
-		pageSize = 20
-	}
-	start := query.Page * pageSize
-	if start < 0 {
-		start = 0
-	}
-	end := min(start+pageSize, len(matches))
-	if start > len(matches) {
-		start = len(matches)
-	}
-
-	mods := make([]domain.Mod, 0, end-start)
-	for _, m := range matches[start:end] {
-		mod := m.mod
-		mod.GameID = query.GameID
-		mods = append(mods, mod)
-	}
-
-	return source.SearchResult{
-		Mods:       mods,
-		TotalCount: len(matches),
-		Page:       query.Page,
-		PageSize:   pageSize,
-	}, nil
+	return searchMods(mods, query), nil
 }
 
 // GetMod implements source.ModSource. gameID is accepted from any game and not

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -381,5 +381,15 @@ func (m *Manifest) CheckUpdates(ctx context.Context, installed []domain.Installe
 	return updates, nil
 }
 
+// DownloadHeaders implements source.DownloadHeaderProvider: header-mode auth
+// applies the same key to file downloads as to manifest fetches (design §6).
+func (m *Manifest) DownloadHeaders() map[string]string {
+	if m.auth == nil || m.auth.APIKey.In != "header" || m.apiKey == "" {
+		return nil
+	}
+	return map[string]string{m.auth.APIKey.Name: m.apiKey}
+}
+
 var _ source.ModSource = (*Manifest)(nil)
 var _ source.CapabilityReporter = (*Manifest)(nil)
+var _ source.DownloadHeaderProvider = (*Manifest)(nil)

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -334,14 +334,51 @@ func (m *Manifest) findMod(ctx context.Context, modID string) (*manifestMod, err
 	return nil, fmt.Errorf("source %q: mod not found: %s", m.id, modID)
 }
 
-// GetDependencies is implemented in the dependencies task (replaces this stub).
+// GetDependencies implements source.ModSource: manifest dependencies are IDs
+// within this source, returned as ModReferences for the resolver.
 func (m *Manifest) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
-	return nil, fmt.Errorf("source %q: dependencies: %w", m.id, source.ErrNotSupported)
+	mm, err := m.findMod(ctx, mod.ID)
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]domain.ModReference, 0, len(mm.Dependencies))
+	for _, dep := range mm.Dependencies {
+		refs = append(refs, domain.ModReference{SourceID: m.id, ModID: dep})
+	}
+	return refs, nil
 }
 
-// CheckUpdates is implemented in the update-check task (replaces this stub).
+// CheckUpdates implements source.ModSource by comparing installed versions to
+// the current manifest.
 func (m *Manifest) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
-	return nil, fmt.Errorf("source %q: update checks: %w", m.id, source.ErrNotSupported)
+	doc, err := m.fetch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]manifestMod, len(doc.Mods))
+	for _, mm := range doc.Mods {
+		byID[mm.ID] = mm
+	}
+
+	var updates []domain.Update
+	for _, inst := range installed {
+		select {
+		case <-ctx.Done():
+			return updates, ctx.Err()
+		default:
+		}
+		current, ok := byID[inst.ID]
+		if !ok {
+			continue // mod removed from the manifest; nothing to offer
+		}
+		if domain.IsNewerVersion(inst.Version, current.Version) {
+			updates = append(updates, domain.Update{
+				InstalledMod: inst,
+				NewVersion:   current.Version,
+			})
+		}
+	}
+	return updates, nil
 }
 
 var _ source.ModSource = (*Manifest)(nil)

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
 )
 
 // defaultManifestRefresh is the remote-manifest cache TTL when the definition
@@ -189,3 +192,157 @@ func addQueryParam(rawURL, name, value string) (string, error) {
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }
+
+// AuthURL implements source.ModSource; manifest sources use API keys, not OAuth.
+func (m *Manifest) AuthURL() string { return "" }
+
+// ExchangeToken implements source.ModSource.
+func (m *Manifest) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
+	return nil, fmt.Errorf("source %q: authentication: %w", m.id, source.ErrNotSupported)
+}
+
+// Capabilities implements source.CapabilityReporter. Auth reflects whether the
+// definition declares an auth block.
+func (m *Manifest) Capabilities() source.Capabilities {
+	return source.Capabilities{Search: true, Dependencies: true, Updates: true, Auth: m.auth != nil}
+}
+
+// toMod converts a manifest entry to a domain.Mod. GameID is stamped by
+// searchMods / the callers, not here.
+func (m *Manifest) toMod(mm manifestMod) domain.Mod {
+	mod := domain.Mod{
+		ID:          mm.ID,
+		SourceID:    m.id,
+		Name:        mm.Name,
+		Version:     mm.Version,
+		Author:      mm.Author,
+		Summary:     mm.Summary,
+		Description: mm.Summary,
+		SourceURL:   mm.URL,
+	}
+	if mm.UpdatedAt != "" {
+		if ts, err := time.Parse(time.RFC3339, mm.UpdatedAt); err == nil {
+			mod.UpdatedAt = ts // unparseable -> zero value, by design
+		}
+	}
+	for _, dep := range mm.Dependencies {
+		mod.Dependencies = append(mod.Dependencies, domain.ModReference{SourceID: m.id, ModID: dep})
+	}
+	return mod
+}
+
+// gameMatches reports whether a manifest entry applies to gameID: an empty
+// game_ids list matches every game, and an empty gameID matches every entry.
+func gameMatches(mm manifestMod, gameID string) bool {
+	if len(mm.GameIDs) == 0 || gameID == "" {
+		return true
+	}
+	for _, g := range mm.GameIDs {
+		if g == gameID {
+			return true
+		}
+	}
+	return false
+}
+
+// Search implements source.ModSource with the shared client-side semantics
+// (design §5), filtered by the manifest's per-mod game_ids.
+func (m *Manifest) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	doc, err := m.fetch(ctx)
+	if err != nil {
+		return source.SearchResult{}, err
+	}
+	mods := make([]domain.Mod, 0, len(doc.Mods))
+	for _, mm := range doc.Mods {
+		if !gameMatches(mm, query.GameID) {
+			continue
+		}
+		mods = append(mods, m.toMod(mm))
+	}
+	return searchMods(mods, query), nil
+}
+
+// GetMod implements source.ModSource. gameID does not filter (install-by-ID
+// works from any game); it is echoed onto the returned mod for attribution.
+func (m *Manifest) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	mm, err := m.findMod(ctx, modID)
+	if err != nil {
+		return nil, err
+	}
+	mod := m.toMod(*mm)
+	mod.GameID = gameID
+	return &mod, nil
+}
+
+// GetModFiles implements source.ModSource, mapping manifest file entries —
+// including declared sha256 checksums — onto DownloadableFiles.
+func (m *Manifest) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	mm, err := m.findMod(ctx, mod.ID)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]domain.DownloadableFile, 0, len(mm.Files))
+	for _, f := range mm.Files {
+		files = append(files, domain.DownloadableFile{
+			ID:        f.ID,
+			Name:      f.Name,
+			FileName:  f.Filename,
+			Version:   f.Version,
+			Size:      f.Size,
+			IsPrimary: f.Primary,
+			SHA256:    f.SHA256,
+		})
+	}
+	return files, nil
+}
+
+// GetDownloadURL implements source.ModSource. Query-mode auth is appended
+// here; header-mode auth rides via DownloadHeaders (see DownloadHeaderProvider).
+func (m *Manifest) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	mm, err := m.findMod(ctx, mod.ID)
+	if err != nil {
+		return "", err
+	}
+	for _, f := range mm.Files {
+		if f.ID != fileID {
+			continue
+		}
+		u := f.URL
+		if m.auth != nil && m.auth.APIKey.In == "query" && m.apiKey != "" {
+			withKey, err := addQueryParam(u, m.auth.APIKey.Name, m.apiKey)
+			if err != nil {
+				return "", fmt.Errorf("source %q: file %q: %w", m.id, fileID, err)
+			}
+			u = withKey
+		}
+		return u, nil
+	}
+	return "", fmt.Errorf("source %q: mod %q: file not found: %s", m.id, mod.ID, fileID)
+}
+
+// findMod fetches the manifest and returns the entry with the given ID.
+func (m *Manifest) findMod(ctx context.Context, modID string) (*manifestMod, error) {
+	doc, err := m.fetch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range doc.Mods {
+		if doc.Mods[i].ID == modID {
+			return &doc.Mods[i], nil
+		}
+	}
+	return nil, fmt.Errorf("source %q: mod not found: %s", m.id, modID)
+}
+
+// GetDependencies is implemented in the dependencies task (replaces this stub).
+func (m *Manifest) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	return nil, fmt.Errorf("source %q: dependencies: %w", m.id, source.ErrNotSupported)
+}
+
+// CheckUpdates is implemented in the update-check task (replaces this stub).
+func (m *Manifest) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, fmt.Errorf("source %q: update checks: %w", m.id, source.ErrNotSupported)
+}
+
+var _ source.ModSource = (*Manifest)(nil)
+var _ source.CapabilityReporter = (*Manifest)(nil)

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -2,6 +2,7 @@ package custom
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -157,6 +158,14 @@ func (m *Manifest) fetchRemote(ctx context.Context) (*manifestDoc, error) {
 
 	resp, err := m.httpClient.Do(req)
 	if err != nil {
+		// *url.Error's Error() embeds the request URL verbatim, which for
+		// query-mode auth contains the API key. Unwrap to the transport
+		// error before reporting so the key never reaches the message; the
+		// (unauthenticated) m.url is still named via the format string.
+		var uerr *url.Error
+		if errors.As(err, &uerr) {
+			err = uerr.Err
+		}
 		return nil, fmt.Errorf("source %q: fetching manifest %s: %w", m.id, m.url, err)
 	}
 	defer resp.Body.Close() //nolint:errcheck

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -1,0 +1,191 @@
+package custom
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultManifestRefresh is the remote-manifest cache TTL when the definition
+// does not set manifest.refresh.
+const defaultManifestRefresh = 15 * time.Minute
+
+// maxManifestSize bounds how much of a remote manifest we read into memory.
+// Real manifests are KBs; 10 MiB is generous and prevents a hostile or broken
+// server from exhausting memory.
+const maxManifestSize = 10 << 20 // 10 MiB
+
+// Manifest is a ModSource backed by a published mod-list document (design §3).
+// Remote manifests are fetched on demand and cached in memory for the
+// configured TTL; local paths are read on every operation (cheap).
+// Construction is pure: a valid definition always registers, and fetch/parse
+// problems surface as operation errors naming the manifest URL.
+type Manifest struct {
+	id        string
+	name      string
+	url       string // https URL, or absolute local path (~ expanded)
+	isRemote  bool
+	refresh   time.Duration
+	allowHTTP bool
+	auth      *AuthConfig
+
+	apiKey     string
+	httpClient *http.Client
+	now        func() time.Time // injectable for TTL tests
+
+	mu        sync.Mutex
+	cached    *manifestDoc
+	fetchedAt time.Time
+}
+
+// NewManifest constructs a manifest source from a validated definition. It
+// performs no I/O — the manifest is first fetched when an operation needs it.
+func NewManifest(def SourceDefinition) (*Manifest, error) {
+	cfg := def.Manifest
+
+	refresh := defaultManifestRefresh
+	if cfg.Refresh != "" {
+		d, err := time.ParseDuration(cfg.Refresh)
+		if err != nil {
+			return nil, fmt.Errorf("manifest.refresh: %w", err) // unreachable after Validate, kept for safety
+		}
+		refresh = d
+	}
+
+	u := cfg.URL
+	isRemote := strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")
+	if !isRemote {
+		if strings.HasPrefix(u, "~/") {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil, fmt.Errorf("expanding %q: %w", u, err)
+			}
+			u = filepath.Join(home, u[2:])
+		}
+		abs, err := filepath.Abs(u)
+		if err != nil {
+			return nil, fmt.Errorf("resolving %q: %w", u, err)
+		}
+		u = abs
+	}
+
+	return &Manifest{
+		id:         def.ID,
+		name:       def.Name,
+		url:        u,
+		isRemote:   isRemote,
+		refresh:    refresh,
+		allowHTTP:  def.AllowHTTP,
+		auth:       cfg.Auth,
+		httpClient: http.DefaultClient,
+		now:        time.Now,
+	}, nil
+}
+
+// ID returns the source ID.
+func (m *Manifest) ID() string { return m.id }
+
+// Name returns the source name.
+func (m *Manifest) Name() string { return m.name }
+
+// SetAPIKey provides the API key resolved at startup (env var or token store).
+func (m *Manifest) SetAPIKey(key string) { m.apiKey = key }
+
+// IsAuthenticated reports whether an API key is configured. Only meaningful
+// when the definition declares auth (Capabilities().Auth).
+func (m *Manifest) IsAuthenticated() bool { return m.apiKey != "" }
+
+// fetch returns the parsed manifest, honoring the TTL cache for remote URLs.
+// Errors name the source and manifest URL so users can act on them.
+func (m *Manifest) fetch(ctx context.Context) (*manifestDoc, error) {
+	if !m.isRemote {
+		data, err := os.ReadFile(m.url)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: reading manifest %s: %w", m.id, m.url, err)
+		}
+		doc, err := parseManifest(data, m.allowHTTP)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: manifest %s: %w", m.id, m.url, err)
+		}
+		return doc, nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.cached != nil && m.now().Sub(m.fetchedAt) < m.refresh {
+		return m.cached, nil
+	}
+
+	doc, err := m.fetchRemote(ctx)
+	if err != nil {
+		return nil, err
+	}
+	m.cached = doc
+	m.fetchedAt = m.now()
+	return doc, nil
+}
+
+// fetchRemote downloads and parses the manifest document. Callers hold m.mu.
+func (m *Manifest) fetchRemote(ctx context.Context) (*manifestDoc, error) {
+	reqURL := m.url
+	if m.auth != nil && m.auth.APIKey.In == "query" && m.apiKey != "" {
+		u, err := addQueryParam(reqURL, m.auth.APIKey.Name, m.apiKey)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: manifest %s: %w", m.id, m.url, err)
+		}
+		reqURL = u
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: manifest %s: %w", m.id, m.url, err)
+	}
+	if m.auth != nil && m.auth.APIKey.In == "header" && m.apiKey != "" {
+		req.Header.Set(m.auth.APIKey.Name, m.apiKey)
+	}
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: fetching manifest %s: %w", m.id, m.url, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("source %q: fetching manifest %s: HTTP %d", m.id, m.url, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("source %q: reading manifest %s: %w", m.id, m.url, err)
+	}
+	if len(data) > maxManifestSize {
+		return nil, fmt.Errorf("source %q: manifest %s exceeds %d bytes", m.id, m.url, maxManifestSize)
+	}
+
+	doc, err := parseManifest(data, m.allowHTTP)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: manifest %s: %w", m.id, m.url, err)
+	}
+	return doc, nil
+}
+
+// addQueryParam returns rawURL with name=value appended to its query string,
+// preserving existing parameters. Values are URL-escaped.
+func addQueryParam(rawURL, name, value string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing URL: %w", err)
+	}
+	q := u.Query()
+	q.Set(name, value)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -326,3 +326,27 @@ func TestManifestCheckUpdates(t *testing.T) {
 	assert.Equal(t, "cool-mod", updates[0].InstalledMod.ID)
 	assert.Equal(t, "1.2.0", updates[0].NewVersion)
 }
+
+func TestManifestDownloadHeaders(t *testing.T) {
+	t.Run("header auth with key", func(t *testing.T) {
+		def := manifestDef("https://x.test/mods.yaml")
+		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, m.DownloadHeaders())
+	})
+
+	t.Run("query auth or no key yields nil", func(t *testing.T) {
+		def := manifestDef("https://x.test/mods.yaml")
+		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Nil(t, m.DownloadHeaders())
+
+		noKey, err := NewManifest(manifestDef("https://x.test/mods.yaml"))
+		require.NoError(t, err)
+		assert.Nil(t, noKey.DownloadHeaders())
+	})
+}

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -2,6 +2,7 @@ package custom
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -183,4 +185,110 @@ func TestManifestIsAuthenticated(t *testing.T) {
 	assert.False(t, m.IsAuthenticated())
 	m.SetAPIKey("k")
 	assert.True(t, m.IsAuthenticated())
+}
+
+func TestManifestIdentityAndCapabilities(t *testing.T) {
+	m := newLocalManifest(t)
+	assert.Equal(t, source.Capabilities{Search: true, Dependencies: true, Updates: true, Auth: false}, m.Capabilities())
+	assert.Empty(t, m.AuthURL())
+
+	_, err := m.ExchangeToken(context.Background(), "code")
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+
+	def := manifestDef("https://x.test/mods.yaml")
+	def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+	authed, err := NewManifest(def)
+	require.NoError(t, err)
+	assert.True(t, authed.Capabilities().Auth)
+}
+
+func TestManifestSearch(t *testing.T) {
+	m := newLocalManifest(t)
+	ctx := context.Background()
+
+	t.Run("empty query returns all mods for a matching game", func(t *testing.T) {
+		res, err := m.Search(ctx, source.SearchQuery{GameID: "skyrim"})
+		require.NoError(t, err)
+		assert.Equal(t, 2, res.TotalCount) // cool-mod matches game_ids; other-mod has no game_ids (all games)
+	})
+
+	t.Run("game_ids filters non-matching games", func(t *testing.T) {
+		res, err := m.Search(ctx, source.SearchQuery{GameID: "othergame"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1) // only other-mod (no game_ids = all games)
+		assert.Equal(t, "other-mod", res.Mods[0].ID)
+	})
+
+	t.Run("empty GameID matches everything", func(t *testing.T) {
+		res, err := m.Search(ctx, source.SearchQuery{})
+		require.NoError(t, err)
+		assert.Equal(t, 2, res.TotalCount)
+	})
+
+	t.Run("query matches and mod fields map", func(t *testing.T) {
+		res, err := m.Search(ctx, source.SearchQuery{Query: "cool", GameID: "skyrim"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		mod := res.Mods[0]
+		assert.Equal(t, "cool-mod", mod.ID)
+		assert.Equal(t, "my-repo", mod.SourceID)
+		assert.Equal(t, "Cool Mod", mod.Name)
+		assert.Equal(t, "1.2.0", mod.Version)
+		assert.Equal(t, "someone", mod.Author)
+		assert.Equal(t, "Makes things cooler", mod.Summary)
+		assert.Equal(t, "skyrim", mod.GameID)
+	})
+}
+
+func TestManifestGetMod(t *testing.T) {
+	m := newLocalManifest(t)
+	mod, err := m.GetMod(context.Background(), "skyrim", "cool-mod")
+	require.NoError(t, err)
+	assert.Equal(t, "Cool Mod", mod.Name)
+	assert.Equal(t, "skyrim", mod.GameID)
+
+	_, err = m.GetMod(context.Background(), "skyrim", "nope")
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestManifestFilesAndDownloadURL(t *testing.T) {
+	m := newLocalManifest(t)
+	ctx := context.Background()
+
+	mod, err := m.GetMod(ctx, "skyrim", "cool-mod")
+	require.NoError(t, err)
+
+	files, err := m.GetModFiles(ctx, mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	f := files[0]
+	assert.Equal(t, "main", f.ID)
+	assert.Equal(t, "cool-mod-1.2.0.zip", f.FileName)
+	assert.Equal(t, "1.2.0", f.Version)
+	assert.Equal(t, int64(4), f.Size)
+	assert.Equal(t, "aabbcc", f.SHA256)
+	assert.True(t, f.IsPrimary)
+
+	u, err := m.GetDownloadURL(ctx, mod, "main")
+	require.NoError(t, err)
+	assert.Equal(t, "https://files.test/cool-mod-1.2.0.zip", u)
+
+	_, err = m.GetDownloadURL(ctx, mod, "nope")
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestManifestDownloadURLQueryAuth(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mods.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(testManifest), 0644))
+	def := manifestDef(path)
+	def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+	m.SetAPIKey("sekrit")
+
+	mod, err := m.GetMod(context.Background(), "skyrim", "cool-mod")
+	require.NoError(t, err)
+	u, err := m.GetDownloadURL(context.Background(), mod, "main")
+	require.NoError(t, err)
+	assert.Equal(t, "https://files.test/cool-mod-1.2.0.zip?api_key=sekrit", u)
 }

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -33,7 +33,7 @@ mods:
         version: 1.2.0
         size: 4
         url: https://files.test/cool-mod-1.2.0.zip
-        sha256: aabbcc
+        sha256: aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd
         primary: true
   - id: other-mod
     name: Other Mod
@@ -71,6 +71,16 @@ func TestNewManifestIsPure(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "my-repo", m.ID())
 	assert.Equal(t, "My Repo", m.Name())
+}
+
+// TestNewManifestLocalPathNoScheme is a defensive proof that a schemeless
+// local path still constructs: SourceDefinition.Validate rejects unsupported
+// URL schemes (e.g. ftp://) before a definition ever reaches NewManifest, so
+// NewManifest itself only needs to treat non-http(s) values as local paths.
+func TestNewManifestLocalPathNoScheme(t *testing.T) {
+	m, err := NewManifest(manifestDef("relative/mods.yaml"))
+	require.NoError(t, err)
+	assert.False(t, m.isRemote)
 }
 
 func TestManifestFetchLocal(t *testing.T) {
@@ -296,7 +306,7 @@ func TestManifestFilesAndDownloadURL(t *testing.T) {
 	assert.Equal(t, "cool-mod-1.2.0.zip", f.FileName)
 	assert.Equal(t, "1.2.0", f.Version)
 	assert.Equal(t, int64(4), f.Size)
-	assert.Equal(t, "aabbcc", f.SHA256)
+	assert.Equal(t, "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd", f.SHA256)
 	assert.True(t, f.IsPrimary)
 
 	u, err := m.GetDownloadURL(ctx, mod, "main")

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -3,6 +3,7 @@ package custom
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -176,6 +177,34 @@ func TestManifestFetchRemoteErrorNamesURL(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), srv.URL)
 	assert.Contains(t, err.Error(), "my-repo")
+}
+
+// TestManifestFetchRemoteErrorDoesNotLeakQueryAPIKey pins final-review
+// finding 2: a query-auth manifest source hitting an unreachable server must
+// not leak the API key baked into the authenticated request URL. httpClient.Do
+// returns a *url.Error whose Error() string embeds the full request URL
+// (including the query-string key); fetchRemote must unwrap that before
+// wrapping, not report the raw error verbatim.
+func TestManifestFetchRemoteErrorDoesNotLeakQueryAPIKey(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close()) // now unreachable: connections refused
+
+	unauthURL := "http://" + addr + "/mods.yaml"
+	def := manifestDef(unauthURL)
+	def.AllowHTTP = true
+	def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+	m.SetAPIKey("LEAKME123")
+
+	_, err = m.fetch(context.Background())
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "LEAKME123", "error must not leak the query-auth API key")
+	assert.NotContains(t, err.Error(), "api_key=", "error must not leak the query parameter at all")
+	assert.Contains(t, err.Error(), "my-repo", "error must still name the source")
+	assert.Contains(t, err.Error(), unauthURL, "error must still name the (unauthenticated) manifest URL")
 }
 
 func TestManifestIsAuthenticated(t *testing.T) {

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -1,0 +1,186 @@
+package custom
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testManifest = `
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    author: someone
+    summary: Makes things cooler
+    game_ids: [skyrim]
+    dependencies: [other-mod]
+    files:
+      - id: main
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        size: 4
+        url: https://files.test/cool-mod-1.2.0.zip
+        sha256: aabbcc
+        primary: true
+  - id: other-mod
+    name: Other Mod
+    version: 0.9.0
+    summary: A dependency
+    files:
+      - id: main
+        filename: other-mod.zip
+        url: https://files.test/other-mod.zip
+`
+
+func manifestDef(url string) SourceDefinition {
+	return SourceDefinition{
+		ID:       "my-repo",
+		Name:     "My Repo",
+		Type:     TypeManifest,
+		Manifest: &ManifestConfig{URL: url},
+	}
+}
+
+// newLocalManifest writes testManifest to a temp file and builds a source over it.
+func newLocalManifest(t *testing.T) *Manifest {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "mods.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(testManifest), 0644))
+	m, err := NewManifest(manifestDef(path))
+	require.NoError(t, err)
+	return m
+}
+
+func TestNewManifestIsPure(t *testing.T) {
+	// Construction must succeed even when the manifest is unreachable —
+	// fetch errors are operation-time, not registration-time.
+	m, err := NewManifest(manifestDef("https://unreachable.invalid/mods.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "my-repo", m.ID())
+	assert.Equal(t, "My Repo", m.Name())
+}
+
+func TestManifestFetchLocal(t *testing.T) {
+	m := newLocalManifest(t)
+	doc, err := m.fetch(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, doc.Mods, 2)
+}
+
+func TestManifestFetchLocalMissingFileNamesPath(t *testing.T) {
+	def := manifestDef(filepath.Join(t.TempDir(), "gone.yaml"))
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+	_, err = m.fetch(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gone.yaml")
+	assert.Contains(t, err.Error(), "my-repo")
+}
+
+func TestManifestFetchRemoteTTL(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = w.Write([]byte(testManifest))
+	}))
+	defer srv.Close()
+
+	def := manifestDef(srv.URL + "/mods.yaml")
+	def.AllowHTTP = true // httptest is plain http
+	def.Manifest.Refresh = "15m"
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+
+	current := time.Unix(1_800_000_000, 0)
+	m.now = func() time.Time { return current }
+
+	ctx := context.Background()
+	_, err = m.fetch(ctx)
+	require.NoError(t, err)
+	_, err = m.fetch(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, hits, "second fetch within TTL must hit the cache")
+
+	current = current.Add(16 * time.Minute)
+	_, err = m.fetch(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, hits, "fetch after TTL expiry must re-download")
+}
+
+func TestManifestFetchAttachesAuth(t *testing.T) {
+	t.Run("header", func(t *testing.T) {
+		var gotHeader string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotHeader = r.Header.Get("X-API-Key")
+			_, _ = w.Write([]byte(testManifest))
+		}))
+		defer srv.Close()
+
+		def := manifestDef(srv.URL + "/mods.yaml")
+		def.AllowHTTP = true
+		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+
+		_, err = m.fetch(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "sekrit", gotHeader)
+	})
+
+	t.Run("query", func(t *testing.T) {
+		var gotQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query().Get("api_key")
+			_, _ = w.Write([]byte(testManifest))
+		}))
+		defer srv.Close()
+
+		def := manifestDef(srv.URL + "/mods.yaml")
+		def.AllowHTTP = true
+		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+
+		_, err = m.fetch(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "sekrit", gotQuery)
+	})
+}
+
+func TestManifestFetchRemoteErrorNamesURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	def := manifestDef(srv.URL + "/mods.yaml")
+	def.AllowHTTP = true
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+
+	_, err = m.fetch(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), srv.URL)
+	assert.Contains(t, err.Error(), "my-repo")
+}
+
+func TestManifestIsAuthenticated(t *testing.T) {
+	def := manifestDef("https://x.test/mods.yaml")
+	def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+	assert.False(t, m.IsAuthenticated())
+	m.SetAPIKey("k")
+	assert.True(t, m.IsAuthenticated())
+}

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -291,4 +292,37 @@ func TestManifestDownloadURLQueryAuth(t *testing.T) {
 	u, err := m.GetDownloadURL(context.Background(), mod, "main")
 	require.NoError(t, err)
 	assert.Equal(t, "https://files.test/cool-mod-1.2.0.zip?api_key=sekrit", u)
+}
+
+func TestManifestGetDependencies(t *testing.T) {
+	m := newLocalManifest(t)
+
+	mod, err := m.GetMod(context.Background(), "skyrim", "cool-mod")
+	require.NoError(t, err)
+	deps, err := m.GetDependencies(context.Background(), mod)
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, domain.ModReference{SourceID: "my-repo", ModID: "other-mod"}, deps[0])
+
+	other, err := m.GetMod(context.Background(), "skyrim", "other-mod")
+	require.NoError(t, err)
+	deps, err = m.GetDependencies(context.Background(), other)
+	require.NoError(t, err)
+	assert.Empty(t, deps)
+}
+
+func TestManifestCheckUpdates(t *testing.T) {
+	m := newLocalManifest(t) // cool-mod is at 1.2.0
+
+	installed := []domain.InstalledMod{
+		{Mod: domain.Mod{ID: "cool-mod", SourceID: "my-repo", Version: "1.0.0"}},
+		{Mod: domain.Mod{ID: "other-mod", SourceID: "my-repo", Version: "0.9.0"}},
+		{Mod: domain.Mod{ID: "removed", SourceID: "my-repo", Version: "1.0"}},
+	}
+
+	updates, err := m.CheckUpdates(context.Background(), installed)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "cool-mod", updates[0].InstalledMod.ID)
+	assert.Equal(t, "1.2.0", updates[0].NewVersion)
 }

--- a/internal/source/custom/manifestdoc.go
+++ b/internal/source/custom/manifestdoc.go
@@ -1,0 +1,83 @@
+package custom
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// manifestDoc is the lmm-defined manifest format (design §3), version 1.
+// YAML 1.2 is a superset of JSON, so yaml.v3 parses both encodings.
+type manifestDoc struct {
+	Version int           `yaml:"version"`
+	Mods    []manifestMod `yaml:"mods"`
+}
+
+type manifestMod struct {
+	ID           string         `yaml:"id"`
+	Name         string         `yaml:"name"`
+	Version      string         `yaml:"version"`
+	Author       string         `yaml:"author"`
+	Summary      string         `yaml:"summary"`
+	GameIDs      []string       `yaml:"game_ids"` // matched against the game's mapped value; empty = all games
+	URL          string         `yaml:"url"`
+	UpdatedAt    string         `yaml:"updated_at"` // RFC 3339; unparseable -> zero value (design §4 rule)
+	Dependencies []string       `yaml:"dependencies"`
+	Files        []manifestFile `yaml:"files"`
+}
+
+type manifestFile struct {
+	ID       string `yaml:"id"`
+	Name     string `yaml:"name"`
+	Filename string `yaml:"filename"`
+	Version  string `yaml:"version"`
+	Size     int64  `yaml:"size"`
+	URL      string `yaml:"url"`
+	SHA256   string `yaml:"sha256"` // optional; verified on download when present
+	Primary  bool   `yaml:"primary"`
+}
+
+// parseManifest decodes and validates a manifest document. allowHTTP mirrors
+// the definition's allow_http flag: file URLs must be https unless it is set.
+// Local file paths never appear here — manifest files reference downloads by
+// URL only.
+func parseManifest(data []byte, allowHTTP bool) (*manifestDoc, error) {
+	var doc manifestDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing manifest: %w", err)
+	}
+	if doc.Version != 1 {
+		return nil, fmt.Errorf("unsupported manifest version %d (expected 1)", doc.Version)
+	}
+
+	seen := make(map[string]bool, len(doc.Mods))
+	for i, m := range doc.Mods {
+		if m.ID == "" {
+			return nil, fmt.Errorf("mods[%d]: id is required", i)
+		}
+		if seen[m.ID] {
+			return nil, fmt.Errorf("duplicate mod id %q", m.ID)
+		}
+		seen[m.ID] = true
+		if m.Name == "" {
+			return nil, fmt.Errorf("mod %q: name is required", m.ID)
+		}
+		for j, f := range m.Files {
+			if f.ID == "" {
+				return nil, fmt.Errorf("mod %q: files[%d]: id is required", m.ID, j)
+			}
+			if f.Filename == "" {
+				return nil, fmt.Errorf("mod %q: file %q: filename is required", m.ID, f.ID)
+			}
+			if f.URL == "" {
+				return nil, fmt.Errorf("mod %q: file %q: url is required", m.ID, f.ID)
+			}
+			if strings.HasPrefix(f.URL, "http://") && !allowHTTP {
+				return nil, fmt.Errorf("mod %q: file %q: plain http is disabled; use https or set allow_http: true", m.ID, f.ID)
+			}
+		}
+	}
+
+	return &doc, nil
+}

--- a/internal/source/custom/manifestdoc.go
+++ b/internal/source/custom/manifestdoc.go
@@ -2,10 +2,14 @@ package custom
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// sha256Pattern matches a lowercase- or uppercase-hex SHA-256 digest.
+var sha256Pattern = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
 
 // manifestDoc is the lmm-defined manifest format (design §3), version 1.
 // YAML 1.2 is a superset of JSON, so yaml.v3 parses both encodings.
@@ -63,18 +67,29 @@ func parseManifest(data []byte, allowHTTP bool) (*manifestDoc, error) {
 		if m.Name == "" {
 			return nil, fmt.Errorf("mod %q: name is required", m.ID)
 		}
+		seenFile := make(map[string]bool, len(m.Files))
 		for j, f := range m.Files {
 			if f.ID == "" {
 				return nil, fmt.Errorf("mod %q: files[%d]: id is required", m.ID, j)
 			}
+			if seenFile[f.ID] {
+				return nil, fmt.Errorf("mod %q: duplicate file id %q", m.ID, f.ID)
+			}
+			seenFile[f.ID] = true
 			if f.Filename == "" {
 				return nil, fmt.Errorf("mod %q: file %q: filename is required", m.ID, f.ID)
 			}
 			if f.URL == "" {
 				return nil, fmt.Errorf("mod %q: file %q: url is required", m.ID, f.ID)
 			}
+			if !strings.HasPrefix(f.URL, "https://") && !strings.HasPrefix(f.URL, "http://") {
+				return nil, fmt.Errorf("mod %q: file %q: url must be http(s)", m.ID, f.ID)
+			}
 			if strings.HasPrefix(f.URL, "http://") && !allowHTTP {
 				return nil, fmt.Errorf("mod %q: file %q: plain http is disabled; use https or set allow_http: true", m.ID, f.ID)
+			}
+			if f.SHA256 != "" && !sha256Pattern.MatchString(f.SHA256) {
+				return nil, fmt.Errorf("mod %q: file %q: sha256 must be 64 hex characters", m.ID, f.ID)
 			}
 		}
 	}

--- a/internal/source/custom/manifestdoc_test.go
+++ b/internal/source/custom/manifestdoc_test.go
@@ -1,0 +1,93 @@
+package custom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validManifestYAML = `
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    author: someone
+    summary: Makes things cooler
+    game_ids: [skyrimspecialedition]
+    url: https://example.com/mods/cool-mod
+    updated_at: 2026-07-01T00:00:00Z
+    dependencies: [other-mod]
+    files:
+      - id: main
+        name: Main File
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        size: 123456
+        url: https://example.com/files/cool-mod-1.2.0.zip
+        sha256: aabbcc
+        primary: true
+  - id: other-mod
+    name: Other Mod
+    version: 0.9.0
+    files:
+      - id: main
+        filename: other-mod.zip
+        url: https://example.com/files/other-mod.zip
+`
+
+func TestParseManifestYAML(t *testing.T) {
+	doc, err := parseManifest([]byte(validManifestYAML), false)
+	require.NoError(t, err)
+	require.Len(t, doc.Mods, 2)
+	m := doc.Mods[0]
+	assert.Equal(t, "cool-mod", m.ID)
+	assert.Equal(t, "Cool Mod", m.Name)
+	assert.Equal(t, []string{"skyrimspecialedition"}, m.GameIDs)
+	assert.Equal(t, []string{"other-mod"}, m.Dependencies)
+	require.Len(t, m.Files, 1)
+	assert.Equal(t, "main", m.Files[0].ID)
+	assert.Equal(t, "cool-mod-1.2.0.zip", m.Files[0].Filename)
+	assert.Equal(t, int64(123456), m.Files[0].Size)
+	assert.Equal(t, "aabbcc", m.Files[0].SHA256)
+	assert.True(t, m.Files[0].Primary)
+}
+
+func TestParseManifestJSON(t *testing.T) {
+	doc, err := parseManifest([]byte(`{"version":1,"mods":[{"id":"j","name":"J","files":[{"id":"main","filename":"j.zip","url":"https://x.test/j.zip"}]}]}`), false)
+	require.NoError(t, err)
+	require.Len(t, doc.Mods, 1)
+	assert.Equal(t, "j", doc.Mods[0].ID)
+}
+
+func TestParseManifestErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     string
+		wantErr string
+	}{
+		{"bad syntax", "version: [unclosed", "parsing manifest"},
+		{"wrong version", "version: 2\nmods: []", "unsupported manifest version 2"},
+		{"missing version", "mods: []", "unsupported manifest version 0"},
+		{"mod missing id", "version: 1\nmods:\n  - name: X\n    files: [{id: main, filename: x.zip, url: https://x.test/x.zip}]", "mods[0]: id is required"},
+		{"mod missing name", "version: 1\nmods:\n  - id: x\n    files: [{id: main, filename: x.zip, url: https://x.test/x.zip}]", `mod "x": name is required`},
+		{"duplicate mod ids", "version: 1\nmods:\n  - {id: x, name: X}\n  - {id: x, name: X2}", `duplicate mod id "x"`},
+		{"file missing id", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{filename: x.zip, url: https://x.test/x.zip}]", `mod "x": files[0]: id is required`},
+		{"file missing filename", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, url: https://x.test/x.zip}]", `file "main": filename is required`},
+		{"file missing url", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip}]", `file "main": url is required`},
+		{"http file url rejected", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip, url: http://x.test/x.zip}]", "plain http"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseManifest([]byte(tt.doc), false)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestParseManifestAllowHTTP(t *testing.T) {
+	doc := "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip, url: http://x.test/x.zip}]"
+	_, err := parseManifest([]byte(doc), true)
+	assert.NoError(t, err)
+}

--- a/internal/source/custom/manifestdoc_test.go
+++ b/internal/source/custom/manifestdoc_test.go
@@ -26,7 +26,7 @@ mods:
         version: 1.2.0
         size: 123456
         url: https://example.com/files/cool-mod-1.2.0.zip
-        sha256: aabbcc
+        sha256: aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd
         primary: true
   - id: other-mod
     name: Other Mod
@@ -50,7 +50,7 @@ func TestParseManifestYAML(t *testing.T) {
 	assert.Equal(t, "main", m.Files[0].ID)
 	assert.Equal(t, "cool-mod-1.2.0.zip", m.Files[0].Filename)
 	assert.Equal(t, int64(123456), m.Files[0].Size)
-	assert.Equal(t, "aabbcc", m.Files[0].SHA256)
+	assert.Equal(t, "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd", m.Files[0].SHA256)
 	assert.True(t, m.Files[0].Primary)
 }
 
@@ -77,6 +77,9 @@ func TestParseManifestErrors(t *testing.T) {
 		{"file missing filename", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, url: https://x.test/x.zip}]", `file "main": filename is required`},
 		{"file missing url", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip}]", `file "main": url is required`},
 		{"http file url rejected", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip, url: http://x.test/x.zip}]", "plain http"},
+		{"duplicate file id", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip, url: https://x.test/x.zip}, {id: main, filename: x2.zip, url: https://x.test/x2.zip}]", `mod "x": duplicate file id "main"`},
+		{"ftp file url rejected", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip, url: ftp://x.test/x.zip}]", `mod "x": file "main": url must be http(s)`},
+		{"bad sha256 format", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip, url: https://x.test/x.zip, sha256: nothex}]", `mod "x": file "main": sha256 must be 64 hex characters`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -90,4 +93,11 @@ func TestParseManifestAllowHTTP(t *testing.T) {
 	doc := "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip, url: http://x.test/x.zip}]"
 	_, err := parseManifest([]byte(doc), true)
 	assert.NoError(t, err)
+}
+
+func TestParseManifestUppercaseSHA256Allowed(t *testing.T) {
+	doc := "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip, url: https://x.test/x.zip, sha256: AABBCCDDAABBCCDDAABBCCDDAABBCCDDAABBCCDDAABBCCDDAABBCCDDAABBCCDD}]"
+	parsed, err := parseManifest([]byte(doc), false)
+	require.NoError(t, err)
+	assert.Equal(t, "AABBCCDDAABBCCDDAABBCCDDAABBCCDDAABBCCDDAABBCCDDAABBCCDDAABBCCDD", parsed.Mods[0].Files[0].SHA256)
 }

--- a/internal/source/custom/search.go
+++ b/internal/source/custom/search.go
@@ -1,0 +1,65 @@
+package custom
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+)
+
+// searchMods implements the client-side search semantics shared by directory
+// and manifest sources (design §5): case-insensitive substring match on
+// name/ID/summary, name matches ranked before summary-only matches, then
+// alphabetical; local pagination with default page size 20. GameID is stamped
+// onto every returned mod so downstream installs are attributed correctly.
+func searchMods(mods []domain.Mod, query source.SearchQuery) source.SearchResult {
+	q := strings.ToLower(query.Query)
+	type ranked struct {
+		mod       domain.Mod
+		nameMatch bool
+	}
+	var matches []ranked
+	for _, m := range mods {
+		nameMatch := q == "" || strings.Contains(strings.ToLower(m.Name), q) || strings.Contains(strings.ToLower(m.ID), q)
+		summaryMatch := strings.Contains(strings.ToLower(m.Summary), q)
+		if !nameMatch && !summaryMatch {
+			continue
+		}
+		matches = append(matches, ranked{mod: m, nameMatch: nameMatch})
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].nameMatch != matches[j].nameMatch {
+			return matches[i].nameMatch
+		}
+		return matches[i].mod.Name < matches[j].mod.Name
+	})
+
+	pageSize := query.PageSize
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	start := query.Page * pageSize
+	if start < 0 {
+		start = 0
+	}
+	end := min(start+pageSize, len(matches))
+	if start > len(matches) {
+		start = len(matches)
+	}
+
+	out := make([]domain.Mod, 0, end-start)
+	for _, m := range matches[start:end] {
+		mod := m.mod
+		mod.GameID = query.GameID
+		out = append(out, mod)
+	}
+
+	return source.SearchResult{
+		Mods:       out,
+		TotalCount: len(matches),
+		Page:       query.Page,
+		PageSize:   pageSize,
+	}
+}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -84,3 +84,11 @@ func CapabilitiesOf(src ModSource) Capabilities {
 	}
 	return Capabilities{Search: true, Dependencies: true, Updates: true, Auth: true}
 }
+
+// DownloadHeaderProvider is implemented by sources whose file downloads need
+// extra HTTP headers (e.g. header-mode API-key auth on a manifest source).
+// Service.DownloadModToCache consults it before downloading. A nil map means
+// no extra headers.
+type DownloadHeaderProvider interface {
+	DownloadHeaders() map[string]string
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of the custom sources epic (#45): the `manifest` source type — publish a JSON/YAML mod list (https URL or local file) and use it as a full mod source with search, install, within-source dependencies, and update checks.

Closes #48

### What's new
- **Manifest document format (version 1)**: mods with metadata, `game_ids` scoping, dependencies, and files with download URLs and optional `sha256`
- **TTL-cached fetching**: remote manifests cached in memory for `refresh` (default 15m, 10 MiB read cap); local paths read live each operation; fetch/parse errors name the source and manifest URL and fail only the operation — a broken manifest never blocks startup or other sources
- **sha256 verification**: `DownloadableFile.SHA256` verified in `DownloadModToCache` before anything is committed to cache (covers both extract and copy deploy modes); mismatch aborts the install
- **API-key auth for custom sources**: `auth.api_key` (`in: header|query`) applies to both the manifest fetch and file downloads (`source.DownloadHeaderProvider` + `Downloader.DownloadWithHeaders`); keys resolve from `LMM_<ID>_API_KEY` env var, then the token store; `lmm auth login/logout` now accept auth-capable custom sources
- **Shared client-side search** extracted from the directory source (`searchMods`) and reused by manifest sources

### Review-driven fixes included
- **Critical (caught by live final review):** installs made under a non-empty `sources:` mapping (e.g. `my-repo: skyrim`) saved the source-mapped value as `game_id`, orphaning them from `list`/`update`/`uninstall`. All five save sites (install, batch install, and three profile install-missing-mods loops) now normalize the persisted GameID to the lmm game ID, with regression tests that drive the real install/profile-apply paths and fail on the unfixed code
- **Security:** query-mode API keys no longer leak into error output (wrapped `url.Error` request URLs are unwrapped/redacted in both the manifest fetcher and the downloader, preserving retry classification)
- Honest auth messaging for custom sources and README accuracy fixes

### Docs & release
- README: Manifest Sources + Authentication sections (document format tables, TTL/auth/sha256 semantics — every claim verified against the code); CHANGELOG 1.7.0; version bumped to 1.7.0

## Test plan
- [x] TDD throughout; full suite green (17 packages, 514 subtests), gofmt/vet clean, no new dependencies
- [x] E2E tests: static httptest file server as a full source (search → deps → sha256 files → download+verify → cache → update checks) and corrupt-download abort — both #48 acceptance criteria
- [x] Three independent live verification passes (scratch binary + temp config): full mapped-flow install→list→update→uninstall, failure isolation across broken sources, auth header delivery, key-leak checks, profile-switch repro
- [ ] User smoke test if desired: a local `type: manifest` definition pointing at a mods.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)
