### PR TITLE
fix: manifest-source and auth hardening (issue #54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `lmm auth status` reports auth-capable custom sources (stored token or env var, masked)
+- `lmm auth status` lists stored tokens whose source is no longer registered (e.g. a removed custom-source definition file), with a `lmm auth logout` hint to remove them
 
 ### Fixed
 
@@ -21,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Header-mode API keys are only sent to file downloads on the manifest's own host
+- Header- and query-mode manifest API keys are only sent to file downloads on the manifest's own scheme+host (a manifest pointing files at a third-party CDN no longer leaks its key there, in either form)
+- Header-mode API keys are stripped before a file download follows a redirect off the original request's scheme+host (Go's HTTP client otherwise forwards custom headers across redirects)
+- `maskAPIKey` fully masks keys of 8 characters or fewer instead of 7, so short keys no longer expose most of their characters
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-07-15
+
+### Added
+
+- `lmm auth status` reports auth-capable custom sources (stored token or env var, masked)
+
+### Fixed
+
+- `lmm auth logout` works for sources whose definition file was removed
+- Update checks translate installed mods to each source's mapped game ID (fixes NexusMods update checks for games whose lmm ID differs from the Nexus domain)
+- Remote manifest fetches are bounded by a 30-second timeout and no longer block other operations on the same source
+
+### Security
+
+- Header-mode API keys are only sent to file downloads on the manifest's own host
+
+### Changed
+
+- Download checksums (MD5 + SHA-256) are computed in a single streaming pass
+
 ## [1.7.0] - 2026-07-14
 
 ### Added
@@ -688,7 +708,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.4.0...v1.5.0

--- a/README.md
+++ b/README.md
@@ -395,11 +395,12 @@ manifest:
 - **Key resolution**, checked in order:
   1. The `LMM_<ID>_API_KEY` environment variable, with the source's `id` uppercased and `-` replaced by `_` (source `my-repo` → `LMM_MY_REPO_API_KEY`).
   2. A key saved with `lmm auth login <id>` — this works for any registered source whose definition declares `auth`, not just NexusMods/CurseForge, and stores the key in the same local token store.
-- The resolved key is always attached to the manifest fetch, and to every file download's URL when `in: query`, using the same `in`/`name` the definition declares.
-- For `in: header` keys, whether a file download also gets the key depends on the manifest's origin:
-  - **Remote manifests** (`https://` URL): the key is only sent to file downloads whose host (host and port, ignoring scheme) matches the manifest URL's host — a manifest pointing files at a third-party CDN never receives the source's key.
+- The resolved key is always attached to the manifest fetch itself (the request for the mod list document).
+- File downloads follow the same same-origin rule regardless of whether the key is `in: header` or `in: query`:
+  - **Remote manifests** (`https://` URL): the key (as a header, or appended to the URL) is only sent to file downloads whose scheme and host match the manifest URL's — a manifest pointing files at a third-party CDN never receives the source's key, in either form.
   - **Local-file manifests**: the key is attached to every file download regardless of host, since a local manifest is user-authored and already trusted.
-- Keys are never printed or logged; `lmm source list` only reports whether one is configured (`AUTH` column: `yes` / `no` / `n/a`), and `lmm auth status` masks stored keys to their first/last 3 characters. `lmm auth status` also lists any registered custom source whose definition declares `auth`, alongside the built-in nexusmods/curseforge rows. `lmm auth logout <id>` removes a stored token even if the source's definition file has since been removed.
+- If a file download is redirected to a different scheme or host, an `in: header` key is stripped before the redirect is followed — Go's HTTP client otherwise forwards custom headers across redirects even when it would strip `Authorization`/`Cookie`.
+- Keys are never printed or logged; `lmm source list` only reports whether one is configured (`AUTH` column: `yes` / `no` / `n/a`), and `lmm auth status` masks stored keys to their first/last 3 characters (keys of 8 characters or fewer are fully masked). `lmm auth status` also lists any registered custom source whose definition declares `auth`, alongside the built-in nexusmods/curseforge rows, plus any stored token whose source is no longer registered (with a hint to remove it). `lmm auth logout <id>` removes a stored token even if the source's definition file has since been removed.
 
 ### Source Management Commands
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ manifest:
 - **Remote URLs** (`https://...`) are fetched on demand and cached in memory for `refresh` — a Go duration string like `30s`, `15m`, or `2h` (default `15m` when omitted). **Local file paths** are read fresh on every operation instead of being cached, so edits show up immediately.
 - Fetch/parse problems (unreachable URL, malformed document, unsupported `version`) surface as an operation error naming the source and the manifest URL, at the point something actually uses the source. This is different from a broken *definition* file, which is caught at load time and skipped with a warning before lmm ever starts (see above).
 - `https://` is required for the manifest `url`, and for every file `url` inside the document, unless the definition sets `allow_http: true`; local paths are exempt.
+- Remote manifest fetches are bounded by a 30-second timeout, so a hung server can't block other operations indefinitely.
 
 The manifest document itself:
 
@@ -394,8 +395,11 @@ manifest:
 - **Key resolution**, checked in order:
   1. The `LMM_<ID>_API_KEY` environment variable, with the source's `id` uppercased and `-` replaced by `_` (source `my-repo` → `LMM_MY_REPO_API_KEY`).
   2. A key saved with `lmm auth login <id>` — this works for any registered source whose definition declares `auth`, not just NexusMods/CurseForge, and stores the key in the same local token store.
-- The resolved key is attached to **both** the manifest fetch and every file download from that source, using the same `in`/`name` the definition declares.
-- Keys are never printed or logged; `lmm source list` only reports whether one is configured (`AUTH` column: `yes` / `no` / `n/a`), and `lmm auth status` masks stored keys to their first/last 3 characters. (`lmm auth status` currently only reports on built-in sources — nexusmods and curseforge.)
+- The resolved key is always attached to the manifest fetch, and to every file download's URL when `in: query`, using the same `in`/`name` the definition declares.
+- For `in: header` keys, whether a file download also gets the key depends on the manifest's origin:
+  - **Remote manifests** (`https://` URL): the key is only sent to file downloads whose host (host and port, ignoring scheme) matches the manifest URL's host — a manifest pointing files at a third-party CDN never receives the source's key.
+  - **Local-file manifests**: the key is attached to every file download regardless of host, since a local manifest is user-authored and already trusted.
+- Keys are never printed or logged; `lmm source list` only reports whether one is configured (`AUTH` column: `yes` / `no` / `n/a`), and `lmm auth status` masks stored keys to their first/last 3 characters. `lmm auth status` also lists any registered custom source whose definition declares `auth`, alongside the built-in nexusmods/curseforge rows. `lmm auth logout <id>` removes a stored token even if the source's definition file has since been removed.
 
 ### Source Management Commands
 

--- a/cmd/lmm/auth.go
+++ b/cmd/lmm/auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -275,8 +276,19 @@ func doAuthStatus(service *core.Service) error {
 	}
 
 	// Custom sources that declare auth get the same treatment as built-ins.
-	for _, src := range service.ListSources() {
+	// Sorted by ID: registry/ListSources order is map iteration, which Go
+	// randomizes, and this output must be deterministic.
+	customSources := service.ListSources()
+	sort.Slice(customSources, func(i, j int) bool { return customSources[i].ID() < customSources[j].ID() })
+
+	registered := make(map[string]bool, len(supportedSources)+len(customSources))
+	for _, id := range supportedSources {
+		registered[id] = true
+	}
+
+	for _, src := range customSources {
 		id := src.ID()
+		registered[id] = true
 		if isSupportedSource(id) {
 			continue // already reported above
 		}
@@ -298,6 +310,22 @@ func doAuthStatus(service *core.Service) error {
 			continue
 		}
 		fmt.Printf("%s: not authenticated (run: lmm auth login %s)\n", id, id)
+	}
+
+	// Stored tokens whose source matches nothing registered (built-in or
+	// custom) are otherwise invisible — e.g. a custom source's definition
+	// file was deleted after `lmm auth login`. Surface them so the user
+	// knows the credential still exists and how to remove it.
+	tokens, err := service.ListSourceTokens()
+	if err != nil {
+		return fmt.Errorf("listing stored tokens: %w", err)
+	}
+	for _, tok := range tokens {
+		if registered[tok.SourceID] {
+			continue
+		}
+		fmt.Printf("%s: stored token with no matching source (key: %s) — remove with: lmm auth logout %s\n",
+			tok.SourceID, maskAPIKey(tok.APIKey), tok.SourceID)
 	}
 
 	return nil
@@ -408,9 +436,12 @@ func readAPIKey() (string, error) {
 	return strings.TrimSpace(key), nil
 }
 
-// maskAPIKey returns a masked version of the API key (shows first 3 and last 3 chars)
+// maskAPIKey returns a masked version of the API key (shows first 3 and last
+// 3 chars). Keys of 8 characters or fewer are fully masked instead: showing
+// 6 of 7-8 characters exposes most of the key, defeating the point of
+// masking.
 func maskAPIKey(key string) string {
-	if len(key) <= 6 {
+	if len(key) <= 8 {
 		return "***"
 	}
 	return key[:3] + "..." + key[len(key)-3:]

--- a/cmd/lmm/auth.go
+++ b/cmd/lmm/auth.go
@@ -252,6 +252,32 @@ func doAuthStatus(service *core.Service) error {
 		fmt.Printf("%s: not authenticated\n", getSourceDisplayName(sourceID))
 	}
 
+	// Custom sources that declare auth get the same treatment as built-ins.
+	for _, src := range service.ListSources() {
+		id := src.ID()
+		if isSupportedSource(id) {
+			continue // already reported above
+		}
+		if !source.CapabilitiesOf(src).Auth {
+			continue // directory sources, auth-less manifests: nothing to report
+		}
+
+		token, err := service.GetSourceToken(id)
+		if err != nil {
+			return fmt.Errorf("checking %s: %w", id, err)
+		}
+		if token != nil {
+			fmt.Printf("%s: authenticated (key: %s)\n", id, maskAPIKey(token.APIKey))
+			continue
+		}
+		envKey := envKeyForSourceID(id)
+		if apiKey := os.Getenv(envKey); apiKey != "" {
+			fmt.Printf("%s: authenticated via %s (key: %s)\n", id, envKey, maskAPIKey(apiKey))
+			continue
+		}
+		fmt.Printf("%s: not authenticated (run: lmm auth login %s)\n", id, id)
+	}
+
 	return nil
 }
 

--- a/cmd/lmm/auth.go
+++ b/cmd/lmm/auth.go
@@ -191,6 +191,28 @@ func selectAuthSource(service *core.Service, args []string) (string, error) {
 	return sourceID, nil
 }
 
+// resolveLogoutSource picks the source to log out. Unlike login, logout must
+// also work for sources that are no longer registered (definition file
+// deleted after a key was stored) — otherwise the stored token becomes
+// unremovable via the CLI.
+func resolveLogoutSource(service *core.Service, args []string) (string, error) {
+	if len(args) == 0 {
+		return selectAuthSource(service, args) // interactive prompt path unchanged
+	}
+	sourceID := args[0]
+	if isAuthCapableSource(service, sourceID) {
+		return sourceID, nil
+	}
+	token, err := service.GetSourceToken(sourceID)
+	if err != nil {
+		return "", fmt.Errorf("checking stored credentials for %s: %w", sourceID, err)
+	}
+	if token != nil {
+		return sourceID, nil
+	}
+	return "", fmt.Errorf("no stored credentials for %q and it is not a registered auth-capable source", sourceID)
+}
+
 // isAuthCapableSource reports whether sourceID can hold an API key: either a
 // built-in from supportedSources, or a registered custom source whose
 // definition declares auth.
@@ -207,7 +229,7 @@ func isAuthCapableSource(service *core.Service, sourceID string) bool {
 
 func runAuthLogout(cmd *cobra.Command, args []string) error {
 	return withService(cmd, func(ctx context.Context, service *core.Service) error {
-		sourceID, err := selectAuthSource(service, args)
+		sourceID, err := resolveLogoutSource(service, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/lmm/auth_status_test.go
+++ b/cmd/lmm/auth_status_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
@@ -70,4 +71,59 @@ func TestDoAuthStatusIncludesCustomSources(t *testing.T) {
 	assert.NotContains(t, out, "supersecretkey")
 	assert.Contains(t, out, "keyless-repo: not authenticated")
 	assert.NotContains(t, out, "local-mods")
+}
+
+// TestDoAuthStatusListsCustomSourcesInSortedOrder pins finding 3b: the
+// custom-sources stanza must not depend on registry map iteration order,
+// which Go randomizes.
+func TestDoAuthStatusListsCustomSourcesInSortedOrder(t *testing.T) {
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	for _, id := range []string{"zeta-repo", "alpha-repo", "mid-repo"} {
+		src, err := custom.NewManifest(custom.SourceDefinition{
+			ID: id, Name: id, Type: custom.TypeManifest,
+			Manifest: &custom.ManifestConfig{
+				URL:  "https://" + id + ".test/mods.yaml",
+				Auth: &custom.AuthConfig{APIKey: &custom.APIKeyConfig{In: "header", Name: "X-API-Key"}},
+			},
+		})
+		require.NoError(t, err)
+		svc.RegisterSource(src)
+	}
+
+	out := captureStdout(t, func() error { return doAuthStatus(svc) })
+
+	alpha, mid, zeta := strings.Index(out, "alpha-repo:"), strings.Index(out, "mid-repo:"), strings.Index(out, "zeta-repo:")
+	require.True(t, alpha >= 0 && mid >= 0 && zeta >= 0, "all three sources must be reported")
+	assert.Less(t, alpha, mid, "custom sources must be reported in ID order")
+	assert.Less(t, mid, zeta, "custom sources must be reported in ID order")
+}
+
+// TestDoAuthStatusListsOrphanedTokens pins finding 3a: a token stored for a
+// source that is no longer registered (built-in or custom) is otherwise
+// invisible — it must get a final stanza pointing at how to remove it.
+// Registered sources with stored tokens must NOT be reported as orphaned.
+func TestDoAuthStatusListsOrphanedTokens(t *testing.T) {
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	// A token for a source ID that matches nothing registered (built-in or
+	// custom) — e.g. its definition file was deleted after login.
+	require.NoError(t, svc.SaveSourceToken("ghost-repo", "leftover-secret-key"))
+	// A token for a still-registered built-in must not be reported as orphaned.
+	require.NoError(t, svc.SaveSourceToken("nexusmods", "built-in-key-1234567"))
+
+	out := captureStdout(t, func() error { return doAuthStatus(svc) })
+
+	assert.Contains(t, out, "ghost-repo: stored token with no matching source (key:")
+	assert.Contains(t, out, "remove with: lmm auth logout ghost-repo")
+	assert.NotContains(t, out, "leftover-secret-key")
+	assert.NotContains(t, out, "nexusmods: stored token with no matching source")
 }

--- a/cmd/lmm/auth_status_test.go
+++ b/cmd/lmm/auth_status_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	require.NoError(t, fn())
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestDoAuthStatusIncludesCustomSources(t *testing.T) {
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	// Auth-capable manifest source, key provided via env.
+	withAuth, err := custom.NewManifest(custom.SourceDefinition{
+		ID: "my-repo", Name: "My Repo", Type: custom.TypeManifest,
+		Manifest: &custom.ManifestConfig{
+			URL:  "https://repo.test/mods.yaml",
+			Auth: &custom.AuthConfig{APIKey: &custom.APIKeyConfig{In: "header", Name: "X-API-Key"}},
+		},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(withAuth)
+
+	// Auth-capable manifest source with no key anywhere.
+	noKey, err := custom.NewManifest(custom.SourceDefinition{
+		ID: "keyless-repo", Name: "Keyless", Type: custom.TypeManifest,
+		Manifest: &custom.ManifestConfig{
+			URL:  "https://other.test/mods.yaml",
+			Auth: &custom.AuthConfig{APIKey: &custom.APIKeyConfig{In: "header", Name: "X-API-Key"}},
+		},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(noKey)
+
+	// Directory source: no auth capability, must not be listed.
+	dir, err := custom.NewDirectory(custom.SourceDefinition{
+		ID: "local-mods", Name: "Local", Type: custom.TypeDirectory,
+		Directory: &custom.DirectoryConfig{Path: t.TempDir()},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(dir)
+
+	t.Setenv("LMM_MY_REPO_API_KEY", "supersecretkey")
+
+	out := captureStdout(t, func() error { return doAuthStatus(svc) })
+
+	assert.Contains(t, out, "my-repo: authenticated via LMM_MY_REPO_API_KEY")
+	assert.NotContains(t, out, "supersecretkey")
+	assert.Contains(t, out, "keyless-repo: not authenticated")
+	assert.NotContains(t, out, "local-mods")
+}

--- a/cmd/lmm/auth_status_test.go
+++ b/cmd/lmm/auth_status_test.go
@@ -19,10 +19,14 @@ func captureStdout(t *testing.T, fn func() error) string {
 	require.NoError(t, err)
 	os.Stdout = w
 	defer func() { os.Stdout = old }()
-	require.NoError(t, fn())
-	require.NoError(t, w.Close())
-	out, err := io.ReadAll(r)
-	require.NoError(t, err)
+	defer r.Close()
+
+	fnErr := fn()
+	require.NoError(t, w.Close(), "closing write end of the pipe")
+	out, readErr := io.ReadAll(r)
+
+	require.NoError(t, fnErr)
+	require.NoError(t, readErr)
 	return string(out)
 }
 

--- a/cmd/lmm/auth_test.go
+++ b/cmd/lmm/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,14 +66,14 @@ func TestGetEnvKeyForSource(t *testing.T) {
 			expected: "NEXUSMODS_API_KEY",
 		},
 		{
-			name:     "unknown source falls back to the derived LMM_*_API_KEY name",
-			sourceID: "unknown",
-			expected: "LMM_UNKNOWN_API_KEY",
+			name:     "curseforge",
+			sourceID: "curseforge",
+			expected: "CURSEFORGE_API_KEY",
 		},
 		{
-			name:     "empty source",
-			sourceID: "",
-			expected: "LMM__API_KEY",
+			name:     "custom source falls back to the derived LMM_*_API_KEY name",
+			sourceID: "unknown-source",
+			expected: "LMM_UNKNOWN_SOURCE_API_KEY",
 		},
 	}
 
@@ -178,7 +179,7 @@ func TestAuthLogoutCmd_UnsupportedSource(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported source")
+	assert.Contains(t, err.Error(), "no stored credentials")
 }
 
 // TestAuthLogoutCmd_NotAuthenticated tests logout when not authenticated
@@ -404,4 +405,29 @@ func TestPrintAuthLoginSuccess(t *testing.T) {
 		assert.Equal(t, "API key stored for my-repo.\n", buf.String())
 		assert.NotContains(t, buf.String(), "Successfully authenticated", "must not fabricate a validation result that never happened")
 	})
+}
+
+func TestResolveLogoutSource(t *testing.T) {
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	// A token stored for a source whose definition file has been deleted:
+	// not registered, but logout must still be able to remove it.
+	require.NoError(t, svc.SaveSourceToken("ghost-repo", "leftover-key"))
+
+	id, err := resolveLogoutSource(svc, []string{"ghost-repo"})
+	require.NoError(t, err)
+	assert.Equal(t, "ghost-repo", id)
+
+	// Unknown ID with no token and no registration still errors.
+	_, err = resolveLogoutSource(svc, []string{"never-existed"})
+	assert.Error(t, err)
+
+	// Built-ins keep working.
+	id, err = resolveLogoutSource(svc, []string{"nexusmods"})
+	require.NoError(t, err)
+	assert.Equal(t, "nexusmods", id)
 }

--- a/cmd/lmm/auth_test.go
+++ b/cmd/lmm/auth_test.go
@@ -24,9 +24,19 @@ func TestMaskAPIKey(t *testing.T) {
 			expected: "abc...nop",
 		},
 		{
-			name:     "exactly 7 chars",
+			name:     "exactly 9 chars reveals both ends",
+			input:    "123456789",
+			expected: "123...789",
+		},
+		{
+			name:     "exactly 8 chars fully masked",
+			input:    "12345678",
+			expected: "***",
+		},
+		{
+			name:     "exactly 7 chars fully masked",
 			input:    "1234567",
-			expected: "123...567",
+			expected: "***",
 		},
 		{
 			name:     "6 chars or less returns ***",
@@ -163,8 +173,10 @@ func TestAuthLoginCmd_UnsupportedSourceMentionsCustomSources(t *testing.T) {
 	assert.Contains(t, err.Error(), "registered custom source with auth declared")
 }
 
-// TestAuthLogoutCmd_UnsupportedSource tests logout with unsupported source
-func TestAuthLogoutCmd_UnsupportedSource(t *testing.T) {
+// TestAuthLogoutCmd_NoStoredCredentials tests logout for a source ID that
+// has no stored token and isn't a registered auth-capable source (built-in
+// or custom) — resolveLogoutSource must reject it.
+func TestAuthLogoutCmd_NoStoredCredentials(t *testing.T) {
 	// Use temp directories
 	configDir = t.TempDir()
 	dataDir = t.TempDir()

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -23,7 +23,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.7.0"
+	version = "1.8.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/update.go
+++ b/cmd/lmm/update.go
@@ -137,7 +137,7 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 
 	// Check for updates (partial results returned even when some mods fail to fetch)
 	updater := service.NewUpdater()
-	updates, err := updater.CheckUpdates(ctx, installed)
+	updates, err := updater.CheckUpdates(ctx, game, installed)
 	if err != nil {
 		if errors.Is(err, domain.ErrAuthRequired) {
 			return authPromptError(updateSource)
@@ -282,7 +282,7 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 func applySingleUpdate(ctx context.Context, service *core.Service, game *domain.Game, mod *domain.InstalledMod, profileName string) error {
 	// Check for update for this specific mod
 	updater := service.NewUpdater()
-	updates, err := updater.CheckUpdates(ctx, []domain.InstalledMod{*mod})
+	updates, err := updater.CheckUpdates(ctx, game, []domain.InstalledMod{*mod})
 	if err != nil {
 		if errors.Is(err, domain.ErrAuthRequired) {
 			return authPromptError(updateSource)

--- a/internal/core/downloader.go
+++ b/internal/core/downloader.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -35,7 +36,8 @@ type ProgressFunc func(DownloadProgress)
 type DownloadResult struct {
 	Path     string // Final file path
 	Size     int64  // Bytes downloaded
-	Checksum string // MD5 hash of downloaded file
+	Checksum string // MD5 hash of downloaded file (recorded in the DB)
+	SHA256   string // SHA-256 of downloaded file (compared against source-declared checksums)
 }
 
 // Downloader handles HTTP file downloads with progress tracking
@@ -196,13 +198,14 @@ func (d *Downloader) downloadOnce(ctx context.Context, url, destPath string, hea
 	}()
 
 	totalBytes := resp.ContentLength
-	hasher := md5.New()
+	md5Hasher := md5.New()
+	shaHasher := sha256.New()
 	reader := &progressReader{
 		reader:     resp.Body,
 		totalBytes: totalBytes,
 		progressFn: progressFn,
 	}
-	teeReader := io.TeeReader(reader, hasher)
+	teeReader := io.TeeReader(reader, io.MultiWriter(md5Hasher, shaHasher))
 
 	written, err := io.Copy(file, teeReader)
 	if err != nil {
@@ -221,7 +224,8 @@ func (d *Downloader) downloadOnce(ctx context.Context, url, destPath string, hea
 	return &DownloadResult{
 		Path:     destPath,
 		Size:     written,
-		Checksum: hex.EncodeToString(hasher.Sum(nil)),
+		Checksum: hex.EncodeToString(md5Hasher.Sum(nil)),
+		SHA256:   hex.EncodeToString(shaHasher.Sum(nil)),
 	}, nil
 }
 

--- a/internal/core/downloader.go
+++ b/internal/core/downloader.go
@@ -139,6 +139,37 @@ func (e *httpStatusError) Error() string {
 	return e.msg
 }
 
+// redirectSafeClient returns the HTTP client to use for one download
+// attempt. Go's http.Client automatically strips only the Authorization and
+// Cookie headers on a cross-host redirect; any other header we set —
+// notably an API-key header for authenticated custom-source downloads — is
+// otherwise forwarded verbatim to whatever host the redirect points at. When
+// headers are supplied, this returns a shallow copy of the base client with
+// a CheckRedirect that deletes those header names once the redirect leaves
+// the original request's scheme+host (Go re-applies the original request's
+// headers to each redirect, so deleting them here — the documented hook for
+// this — is sufficient) and otherwise preserves the default 10-redirect
+// cap. Calls with no headers (plain Download) use the base client
+// untouched.
+func (d *Downloader) redirectSafeClient(headers map[string]string) *http.Client {
+	if len(headers) == 0 {
+		return d.httpClient
+	}
+	client := *d.httpClient // shallow copy: shares Transport/Timeout/Jar
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		if req.URL.Scheme != via[0].URL.Scheme || req.URL.Host != via[0].URL.Host {
+			for name := range headers {
+				req.Header.Del(name)
+			}
+		}
+		return nil
+	}
+	return &client
+}
+
 // downloadOnce performs a single download attempt (no retries).
 func (d *Downloader) downloadOnce(ctx context.Context, url, destPath string, headers map[string]string, progressFn ProgressFunc) (result *DownloadResult, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -149,7 +180,7 @@ func (d *Downloader) downloadOnce(ctx context.Context, url, destPath string, hea
 		req.Header.Set(name, value)
 	}
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.redirectSafeClient(headers).Do(req)
 	if err != nil {
 		// *url.Error's Error() embeds the request URL verbatim, which for
 		// query-mode auth (custom sources' GetDownloadURL) contains the API

--- a/internal/core/downloader.go
+++ b/internal/core/downloader.go
@@ -148,22 +148,29 @@ func (e *httpStatusError) Error() string {
 // a CheckRedirect that deletes those header names once the redirect leaves
 // the original request's scheme+host (Go re-applies the original request's
 // headers to each redirect, so deleting them here — the documented hook for
-// this — is sufficient) and otherwise preserves the default 10-redirect
-// cap. Calls with no headers (plain Download) use the base client
-// untouched.
+// this — is sufficient) and enforces the default 10-redirect cap. If the
+// base client already had its own CheckRedirect, it is chained: our
+// header-stripping and redirect-cap logic runs first, then the base policy
+// runs and its error (if any) is returned — a base client's own redirect
+// policy must never be silently discarded. Calls with no headers (plain
+// Download) use the base client untouched.
 func (d *Downloader) redirectSafeClient(headers map[string]string) *http.Client {
 	if len(headers) == 0 {
 		return d.httpClient
 	}
 	client := *d.httpClient // shallow copy: shares Transport/Timeout/Jar
+	baseCheckRedirect := d.httpClient.CheckRedirect
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
 		if req.URL.Scheme != via[0].URL.Scheme || req.URL.Host != via[0].URL.Host {
 			for name := range headers {
 				req.Header.Del(name)
 			}
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		if baseCheckRedirect != nil {
+			return baseCheckRedirect(req, via)
 		}
 		return nil
 	}

--- a/internal/core/downloader_test.go
+++ b/internal/core/downloader_test.go
@@ -410,6 +410,56 @@ func TestDownloadWithHeadersSetsHeaders(t *testing.T) {
 	assert.Equal(t, "sekrit", got)
 }
 
+// TestDownloadWithHeaders_StripsHeaderOnCrossHostRedirect pins final-review
+// finding 1: Go's http.Client automatically strips only Authorization/Cookie
+// on a cross-host redirect — a custom header like X-API-Key is otherwise
+// forwarded verbatim to whatever host the redirect points at. A same-origin
+// URL that 302s to a different host must not ship the key there.
+func TestDownloadWithHeaders_StripsHeaderOnCrossHostRedirect(t *testing.T) {
+	var gotOnB string
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotOnB = r.Header.Get("X-API-Key")
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer serverB.Close()
+
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, serverB.URL+"/final.zip", http.StatusFound)
+	}))
+	defer serverA.Close()
+
+	d := core.NewDownloader(nil)
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	result, err := d.DownloadWithHeaders(context.Background(), serverA.URL+"/redir.zip", dest, map[string]string{"X-API-Key": "sekrit"}, nil)
+	require.NoError(t, err, "the download itself must still succeed")
+	assert.Equal(t, int64(len("payload")), result.Size)
+	assert.Empty(t, gotOnB, "the API key header must not be forwarded to the redirect target host")
+}
+
+// TestDownloadWithHeaders_KeepsHeaderOnSameHostRedirect proves the fix for
+// the cross-host case doesn't collaterally break the common case of a
+// same-host redirect (e.g. a source's file host 302ing to a versioned path
+// on itself), where the header must still be sent.
+func TestDownloadWithHeaders_KeepsHeaderOnSameHostRedirect(t *testing.T) {
+	var gotOnFinal string
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/redir.zip", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srv.URL+"/final.zip", http.StatusFound)
+	})
+	mux.HandleFunc("/final.zip", func(w http.ResponseWriter, r *http.Request) {
+		gotOnFinal = r.Header.Get("X-API-Key")
+		_, _ = w.Write([]byte("payload"))
+	})
+
+	d := core.NewDownloader(nil)
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	_, err := d.DownloadWithHeaders(context.Background(), srv.URL+"/redir.zip", dest, map[string]string{"X-API-Key": "sekrit"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "sekrit", gotOnFinal, "a same-host redirect must keep the header")
+}
+
 // TestDownloadWithHeaders_ErrorDoesNotLeakQueryParam pins final-review
 // finding 2's download-path leak: GetDownloadURL bakes an auth key into the
 // URL's query string for query-mode custom sources, and httpClient.Do's

--- a/internal/core/downloader_test.go
+++ b/internal/core/downloader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -458,6 +459,44 @@ func TestDownloadWithHeaders_KeepsHeaderOnSameHostRedirect(t *testing.T) {
 	_, err := d.DownloadWithHeaders(context.Background(), srv.URL+"/redir.zip", dest, map[string]string{"X-API-Key": "sekrit"}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "sekrit", gotOnFinal, "a same-host redirect must keep the header")
+}
+
+// errChainedRedirectSentinel is returned unconditionally by a fake base
+// CheckRedirect, so its appearance in DownloadWithHeaders' error proves
+// redirectSafeClient delegated to it rather than silently discarding it.
+var errChainedRedirectSentinel = errors.New("sentinel: base CheckRedirect blocked this redirect")
+
+// TestDownloadWithHeaders_ChainsBaseCheckRedirect pins PR #55 review comment
+// 1: redirectSafeClient must not clobber a CheckRedirect already set on the
+// injected base client — it should run its own header-stripping/redirect-cap
+// logic first, then delegate to the base policy (if any). A client with no
+// CheckRedirect of its own must keep working exactly as before.
+func TestDownloadWithHeaders_ChainsBaseCheckRedirect(t *testing.T) {
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer serverB.Close()
+
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, serverB.URL+"/final.zip", http.StatusFound)
+	}))
+	defer serverA.Close()
+
+	baseClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return errChainedRedirectSentinel
+		},
+	}
+	d := core.NewDownloader(baseClient)
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	_, err := d.DownloadWithHeaders(context.Background(), serverA.URL+"/redir.zip", dest, map[string]string{"X-API-Key": "sekrit"}, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errChainedRedirectSentinel, "the base client's own CheckRedirect must still run")
+
+	// A plain client with no CheckRedirect of its own must be unaffected.
+	plain := core.NewDownloader(nil)
+	_, err = plain.DownloadWithHeaders(context.Background(), serverA.URL+"/redir.zip", dest, map[string]string{"X-API-Key": "sekrit"}, nil)
+	require.NoError(t, err, "a plain client must still follow the redirect and succeed")
 }
 
 // TestDownloadWithHeaders_ErrorDoesNotLeakQueryParam pins final-review

--- a/internal/core/downloader_test.go
+++ b/internal/core/downloader_test.go
@@ -2,6 +2,8 @@ package core_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"net"
 	"net/http"
@@ -502,4 +504,21 @@ func (r *contentReader) Read(p []byte) (n int, err error) {
 	n = copy(p, r.content[r.pos:])
 	r.pos += n
 	return n, nil
+}
+
+func TestDownloadComputesSHA256(t *testing.T) {
+	content := []byte("payload for hashing")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer srv.Close()
+
+	d := core.NewDownloader(nil)
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	result, err := d.Download(context.Background(), srv.URL, dest, nil)
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(content)
+	assert.Equal(t, hex.EncodeToString(sum[:]), result.SHA256)
+	assert.NotEmpty(t, result.Checksum) // MD5 still present
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -507,6 +507,13 @@ func (s *Service) DeleteSourceToken(sourceID string) error {
 	return s.db.DeleteToken(sourceID)
 }
 
+// ListSourceTokens returns every stored API token, including ones whose
+// source is no longer registered (e.g. the custom-source definition file
+// was removed) — used by `lmm auth status` to surface orphaned credentials.
+func (s *Service) ListSourceTokens() ([]db.StoredToken, error) {
+	return s.db.ListTokens()
+}
+
 // IsSourceAuthenticated checks if a source has a stored API token
 func (s *Service) IsSourceAuthenticated(sourceID string) bool {
 	has, err := s.db.HasToken(sourceID)

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -2,10 +2,7 @@ package core
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -234,10 +231,9 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 		return nil, fmt.Errorf("downloading mod: %w", err)
 	}
 
-	if file.SHA256 != "" {
-		if err := verifyFileSHA256(archivePath, file.SHA256); err != nil {
-			return nil, fmt.Errorf("verifying download of %s: %w", file.FileName, err)
-		}
+	if file.SHA256 != "" && !strings.EqualFold(downloadResult.SHA256, file.SHA256) {
+		return nil, fmt.Errorf("verifying download of %s: sha256 mismatch: source declares %s, downloaded file is %s",
+			file.FileName, file.SHA256, downloadResult.SHA256)
 	}
 
 	// Extract to cache location
@@ -288,27 +284,6 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 		FilesExtracted: len(files),
 		Checksum:       downloadResult.Checksum,
 	}, nil
-}
-
-// verifyFileSHA256 streams path and compares its SHA-256 against expectedHex
-// (case-insensitive). Sources that publish expected checksums (manifest
-// sha256) set DownloadableFile.SHA256; built-in sources leave it empty and
-// skip this entirely.
-func verifyFileSHA256(path, expectedHex string) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("opening downloaded file: %w", err)
-	}
-	defer f.Close() //nolint:errcheck
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return fmt.Errorf("hashing downloaded file: %w", err)
-	}
-	got := hex.EncodeToString(h.Sum(nil))
-	if !strings.EqualFold(got, expectedHex) {
-		return fmt.Errorf("sha256 mismatch: source declares %s, downloaded file is %s", expectedHex, got)
-	}
-	return nil
 }
 
 // ingestLocalToCache copies a local mod (directory or archive) into the cache

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -227,7 +227,7 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 	archivePath := filepath.Join(tempDir, file.FileName)
 	var headers map[string]string
 	if hp, ok := src.(source.DownloadHeaderProvider); ok {
-		headers = hp.DownloadHeaders()
+		headers = hp.DownloadHeaders(url)
 	}
 	downloadResult, err := s.downloader.DownloadWithHeaders(ctx, url, archivePath, headers, progressFn)
 	if err != nil {

--- a/internal/core/updater.go
+++ b/internal/core/updater.go
@@ -21,8 +21,12 @@ func NewUpdater(registry *source.Registry) *Updater {
 	}
 }
 
-// CheckUpdates checks for available updates for installed mods
-func (u *Updater) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+// CheckUpdates checks for available updates for installed mods. game supplies
+// the source-ID mapping: installed rows persist the lmm game ID, but sources
+// like NexusMods address games by their own domain, so each source's batch is
+// translated via game.SourceIDs before the call (empty mapping = keep the lmm
+// id, matching the search-side semantics in Service.SearchMods/GetMod).
+func (u *Updater) CheckUpdates(ctx context.Context, game *domain.Game, installed []domain.InstalledMod) ([]domain.Update, error) {
 	// Filter out pinned mods and local mods (local mods have no remote source)
 	var checkable []domain.InstalledMod
 	for _, mod := range installed {
@@ -56,6 +60,17 @@ func (u *Updater) CheckUpdates(ctx context.Context, installed []domain.Installed
 		if err != nil {
 			checkErrs = append(checkErrs, fmt.Errorf("source %s: %w", sourceID, err))
 			continue
+		}
+
+		if game != nil {
+			if mappedID, ok := game.SourceIDs[sourceID]; ok && mappedID != "" {
+				translated := make([]domain.InstalledMod, len(mods))
+				copy(translated, mods)
+				for i := range translated {
+					translated[i].GameID = mappedID
+				}
+				mods = translated
+			}
 		}
 
 		updates, err := src.CheckUpdates(ctx, mods)

--- a/internal/core/updater_test.go
+++ b/internal/core/updater_test.go
@@ -89,7 +89,7 @@ func TestUpdater_CheckUpdates(t *testing.T) {
 		},
 	}
 
-	updates, err := updater.CheckUpdates(context.Background(), installed)
+	updates, err := updater.CheckUpdates(context.Background(), nil, installed)
 	require.NoError(t, err)
 	require.Len(t, updates, 1)
 	assert.Equal(t, "2.0.0", updates[0].NewVersion)
@@ -125,7 +125,7 @@ func TestUpdater_CheckUpdates_NoUpdates(t *testing.T) {
 		},
 	}
 
-	updates, err := updater.CheckUpdates(context.Background(), installed)
+	updates, err := updater.CheckUpdates(context.Background(), nil, installed)
 	require.NoError(t, err)
 	assert.Empty(t, updates)
 }
@@ -155,7 +155,7 @@ func TestUpdater_CheckUpdates_PinnedModsSkipped(t *testing.T) {
 		},
 	}
 
-	updates, err := updater.CheckUpdates(context.Background(), installed)
+	updates, err := updater.CheckUpdates(context.Background(), nil, installed)
 	require.NoError(t, err)
 	assert.Empty(t, updates, "pinned mods should not show updates")
 }
@@ -177,9 +177,52 @@ func TestUpdater_CheckUpdates_LocalModsSkipped(t *testing.T) {
 		},
 	}
 
-	updates, err := updater.CheckUpdates(context.Background(), installed)
+	updates, err := updater.CheckUpdates(context.Background(), nil, installed)
 	require.NoError(t, err)
 	assert.Empty(t, updates, "local mods should not be checked for updates")
+}
+
+// gameIDCapturingSource records the GameIDs it receives in CheckUpdates.
+type gameIDCapturingSource struct {
+	source.ModSource // embed an existing test mock for the other methods
+	id               string
+	received         []string
+}
+
+func (g *gameIDCapturingSource) ID() string { return g.id }
+func (g *gameIDCapturingSource) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	for _, inst := range installed {
+		g.received = append(g.received, inst.GameID)
+	}
+	return nil, nil
+}
+
+func TestCheckUpdatesTranslatesGameIDPerSourceMapping(t *testing.T) {
+	reg := source.NewRegistry()
+	mapped := &gameIDCapturingSource{id: "nexusmods"}
+	unmapped := &gameIDCapturingSource{id: "my-repo"}
+	reg.Register(mapped)
+	reg.Register(unmapped)
+	u := core.NewUpdater(reg)
+
+	game := &domain.Game{
+		ID: "skyrim-se",
+		SourceIDs: map[string]string{
+			"nexusmods": "skyrimspecialedition",
+			"my-repo":   "", // empty mapping: keep the lmm game id
+		},
+	}
+	installed := []domain.InstalledMod{
+		{Mod: domain.Mod{ID: "a", SourceID: "nexusmods", GameID: "skyrim-se", Version: "1.0"}},
+		{Mod: domain.Mod{ID: "b", SourceID: "my-repo", GameID: "skyrim-se", Version: "1.0"}},
+	}
+
+	_, err := u.CheckUpdates(context.Background(), game, installed)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"skyrimspecialedition"}, mapped.received)
+	assert.Equal(t, []string{"skyrim-se"}, unmapped.received)
+	// Caller's slice must be untouched.
+	assert.Equal(t, "skyrim-se", installed[0].GameID)
 }
 
 func TestCompareVersions(t *testing.T) {

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -343,7 +343,11 @@ func (m *Manifest) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.D
 }
 
 // GetDownloadURL implements source.ModSource. Query-mode auth is appended
-// here; header-mode auth rides via DownloadHeaders (see DownloadHeaderProvider).
+// here — for remote manifests, only when the file URL is same-origin with
+// the manifest (see sameOrigin); a manifest pointing files at a third-party
+// CDN must not ship the repo's key there via the URL either. Header-mode
+// auth rides via DownloadHeaders (see DownloadHeaderProvider) under the same
+// rule.
 func (m *Manifest) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
 	mm, err := m.findMod(ctx, mod.ID)
 	if err != nil {
@@ -354,7 +358,7 @@ func (m *Manifest) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID s
 			continue
 		}
 		u := f.URL
-		if m.auth != nil && m.auth.APIKey.In == "query" && m.apiKey != "" {
+		if m.auth != nil && m.auth.APIKey.In == "query" && m.apiKey != "" && (!m.isRemote || m.sameOrigin(u)) {
 			withKey, err := addQueryParam(u, m.auth.APIKey.Name, m.apiKey)
 			if err != nil {
 				return "", fmt.Errorf("source %q: file %q: %w", m.id, fileID, err)
@@ -364,6 +368,22 @@ func (m *Manifest) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID s
 		return u, nil
 	}
 	return "", fmt.Errorf("source %q: mod %q: file not found: %s", m.id, mod.ID, fileID)
+}
+
+// sameOrigin reports whether fileURL shares scheme and host with the
+// manifest's own URL. Only meaningful for remote manifests (m.isRemote);
+// callers guard local-path manifests separately, since a local path has no
+// URL origin to compare and is trusted regardless of the file's host.
+func (m *Manifest) sameOrigin(fileURL string) bool {
+	fu, err := url.Parse(fileURL)
+	if err != nil {
+		return false
+	}
+	mu, err := url.Parse(m.url)
+	if err != nil {
+		return false
+	}
+	return fu.Scheme == mu.Scheme && fu.Host == mu.Host
 }
 
 // findMod fetches the manifest and returns the entry with the given ID.
@@ -429,26 +449,17 @@ func (m *Manifest) CheckUpdates(ctx context.Context, installed []domain.Installe
 
 // DownloadHeaders implements source.DownloadHeaderProvider. Header-mode auth
 // applies the same key to file downloads as to manifest fetches (design §6),
-// but for remote manifests only when the file URL is same-origin with the
-// manifest — a manifest pointing files at a third-party CDN must not ship the
-// repo's key there. Local-path manifests are user-authored and trusted, so
-// their configured key attaches regardless of host.
+// but for remote manifests only when the file URL is same-origin (scheme and
+// host, via sameOrigin) with the manifest — a manifest pointing files at a
+// third-party CDN, or downgrading from https to http on the same host, must
+// not ship the repo's key there. Local-path manifests are user-authored and
+// trusted, so their configured key attaches regardless of host.
 func (m *Manifest) DownloadHeaders(fileURL string) map[string]string {
 	if m.auth == nil || m.auth.APIKey.In != "header" || m.apiKey == "" {
 		return nil
 	}
-	if m.isRemote {
-		fu, err := url.Parse(fileURL)
-		if err != nil {
-			return nil
-		}
-		mu, err := url.Parse(m.url)
-		if err != nil {
-			return nil
-		}
-		if fu.Host != mu.Host {
-			return nil
-		}
+	if m.isRemote && !m.sameOrigin(fileURL) {
+		return nil
 	}
 	return map[string]string{m.auth.APIKey.Name: m.apiKey}
 }

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -26,6 +26,11 @@ const defaultManifestRefresh = 15 * time.Minute
 // server from exhausting memory.
 const maxManifestSize = 10 << 20 // 10 MiB
 
+// manifestFetchTimeout bounds a remote manifest fetch. Without it a hung
+// server would block the fetching goroutine indefinitely (and, before the
+// lock rework, every other operation on this source).
+const manifestFetchTimeout = 30 * time.Second
+
 // Manifest is a ModSource backed by a published mod-list document (design §3).
 // Remote manifests are fetched on demand and cached in memory for the
 // configured TTL; local paths are read on every operation (cheap).
@@ -88,7 +93,7 @@ func NewManifest(def SourceDefinition) (*Manifest, error) {
 		refresh:    refresh,
 		allowHTTP:  def.AllowHTTP,
 		auth:       cfg.Auth,
-		httpClient: http.DefaultClient,
+		httpClient: &http.Client{Timeout: manifestFetchTimeout},
 		now:        time.Now,
 	}, nil
 }
@@ -107,13 +112,22 @@ func (m *Manifest) SetAPIKey(key string) { m.apiKey = key }
 func (m *Manifest) IsAuthenticated() bool { return m.apiKey != "" }
 
 // fetch returns the parsed manifest, honoring the TTL cache for remote URLs.
-// Errors name the source and manifest URL so users can act on them.
+// The returned document is a deep copy the caller owns exclusively — mutating
+// it can never corrupt the cache. m.mu guards only the cache check and store;
+// it is never held across the network call, so two goroutines racing past an
+// expired TTL may both fetch remotely. That duplication is acceptable (and
+// idempotent) — it trades a rare extra request for never blocking readers of
+// the cached copy behind a slow server. Errors name the source and manifest
+// URL so users can act on them.
 func (m *Manifest) fetch(ctx context.Context) (*manifestDoc, error) {
 	if !m.isRemote {
 		data, err := os.ReadFile(m.url)
 		if err != nil {
 			return nil, fmt.Errorf("source %q: reading manifest %s: %w", m.id, m.url, err)
 		}
+		// parseManifest returns a freshly allocated doc on every call (the
+		// file is re-read each time), so it is already caller-owned; no
+		// defensive copy is needed here.
 		doc, err := parseManifest(data, m.allowHTTP)
 		if err != nil {
 			return nil, fmt.Errorf("source %q: manifest %s: %w", m.id, m.url, err)
@@ -122,22 +136,30 @@ func (m *Manifest) fetch(ctx context.Context) (*manifestDoc, error) {
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if m.cached != nil && m.now().Sub(m.fetchedAt) < m.refresh {
-		return m.cached, nil
+		doc := m.cached
+		m.mu.Unlock()
+		return deepCopyManifest(doc), nil
 	}
+	m.mu.Unlock()
 
+	// Network I/O happens outside the lock. Two goroutines racing past the
+	// TTL check may both fetch — an acceptable, idempotent duplication that
+	// keeps a slow server from blocking readers of the cached copy.
 	doc, err := m.fetchRemote(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	m.mu.Lock()
 	m.cached = doc
 	m.fetchedAt = m.now()
-	return doc, nil
+	m.mu.Unlock()
+	return deepCopyManifest(doc), nil
 }
 
-// fetchRemote downloads and parses the manifest document. Callers hold m.mu.
+// fetchRemote downloads and parses the manifest document. Called without
+// m.mu held: this method performs the network I/O.
 func (m *Manifest) fetchRemote(ctx context.Context) (*manifestDoc, error) {
 	reqURL := m.url
 	if m.auth != nil && m.auth.APIKey.In == "query" && m.apiKey != "" {
@@ -187,6 +209,21 @@ func (m *Manifest) fetchRemote(ctx context.Context) (*manifestDoc, error) {
 		return nil, fmt.Errorf("source %q: manifest %s: %w", m.id, m.url, err)
 	}
 	return doc, nil
+}
+
+// deepCopyManifest returns a copy of doc that shares no mutable memory with
+// the cached original, so callers can never corrupt the cache between TTL
+// refreshes.
+func deepCopyManifest(doc *manifestDoc) *manifestDoc {
+	out := &manifestDoc{Version: doc.Version, Mods: make([]manifestMod, len(doc.Mods))}
+	for i, m := range doc.Mods {
+		cm := m // struct copy; now fix up slice fields
+		cm.GameIDs = append([]string(nil), m.GameIDs...)
+		cm.Dependencies = append([]string(nil), m.Dependencies...)
+		cm.Files = append([]manifestFile(nil), m.Files...)
+		out.Mods[i] = cm
+	}
+	return out
 }
 
 // addQueryParam returns rawURL with name=value appended to its query string,

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -427,11 +427,28 @@ func (m *Manifest) CheckUpdates(ctx context.Context, installed []domain.Installe
 	return updates, nil
 }
 
-// DownloadHeaders implements source.DownloadHeaderProvider: header-mode auth
-// applies the same key to file downloads as to manifest fetches (design §6).
-func (m *Manifest) DownloadHeaders() map[string]string {
+// DownloadHeaders implements source.DownloadHeaderProvider. Header-mode auth
+// applies the same key to file downloads as to manifest fetches (design §6),
+// but for remote manifests only when the file URL is same-origin with the
+// manifest — a manifest pointing files at a third-party CDN must not ship the
+// repo's key there. Local-path manifests are user-authored and trusted, so
+// their configured key attaches regardless of host.
+func (m *Manifest) DownloadHeaders(fileURL string) map[string]string {
 	if m.auth == nil || m.auth.APIKey.In != "header" || m.apiKey == "" {
 		return nil
+	}
+	if m.isRemote {
+		fu, err := url.Parse(fileURL)
+		if err != nil {
+			return nil
+		}
+		mu, err := url.Parse(m.url)
+		if err != nil {
+			return nil
+		}
+		if fu.Host != mu.Host {
+			return nil
+		}
 	}
 	return map[string]string{m.auth.APIKey.Name: m.apiKey}
 }

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -371,9 +371,13 @@ func (m *Manifest) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID s
 }
 
 // sameOrigin reports whether fileURL shares scheme and host with the
-// manifest's own URL. Only meaningful for remote manifests (m.isRemote);
-// callers guard local-path manifests separately, since a local path has no
-// URL origin to compare and is trusted regardless of the file's host.
+// manifest's own URL. Ports are normalized before comparing: an explicit
+// default port (:443 on https, :80 on http) matches a URL with no port at
+// all, so "https://repo.test" and "https://repo.test:443" are the same
+// origin; any other explicit port must still match exactly. Only meaningful
+// for remote manifests (m.isRemote); callers guard local-path manifests
+// separately, since a local path has no URL origin to compare and is
+// trusted regardless of the file's host.
 func (m *Manifest) sameOrigin(fileURL string) bool {
 	fu, err := url.Parse(fileURL)
 	if err != nil {
@@ -383,7 +387,22 @@ func (m *Manifest) sameOrigin(fileURL string) bool {
 	if err != nil {
 		return false
 	}
-	return fu.Scheme == mu.Scheme && fu.Host == mu.Host
+	return fu.Scheme == mu.Scheme && normalizedHost(fu) == normalizedHost(mu)
+}
+
+// normalizedHost returns u's hostname, with an explicit port stripped when
+// it is the scheme's default (443 for https, 80 for http). This lets
+// sameOrigin treat a bare host and that same host with its default port
+// spelled out as identical origins.
+func normalizedHost(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		return u.Hostname()
+	}
+	if (u.Scheme == "https" && port == "443") || (u.Scheme == "http" && port == "80") {
+		return u.Hostname()
+	}
+	return u.Hostname() + ":" + port
 }
 
 // findMod fetches the manifest and returns the entry with the given ID.

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -419,6 +419,94 @@ func TestManifestGetDownloadURLQueryAuthOrigin(t *testing.T) {
 	})
 }
 
+// TestManifestSameOriginNormalizesDefaultPorts pins PR #55 review comment 2:
+// an explicit default port (:443 on https, :80 on http) must compare equal
+// to a bare host with an implicit default port — the prior byte-for-byte
+// Host comparison treated them as cross-origin, a fail-closed false negative
+// (the key gets withheld, not leaked) that still breaks legitimate
+// same-origin file URLs. An explicit non-default port must still mismatch.
+// Both header-mode (DownloadHeaders) and query-mode (GetDownloadURL) auth
+// flow through the shared sameOrigin helper, so both are exercised here.
+func TestManifestSameOriginNormalizesDefaultPorts(t *testing.T) {
+	tests := []struct {
+		name        string
+		manifestURL string
+		fileURL     string
+		wantMatch   bool
+	}{
+		{
+			name:        "https explicit :443 matches implicit default",
+			manifestURL: "https://repo.test/mods.yaml",
+			fileURL:     "https://repo.test:443/a.zip",
+			wantMatch:   true,
+		},
+		{
+			name:        "http explicit :80 matches implicit default",
+			manifestURL: "http://repo.test/mods.yaml",
+			fileURL:     "http://repo.test:80/a.zip",
+			wantMatch:   true,
+		},
+		{
+			name:        "https explicit non-default port still mismatches",
+			manifestURL: "https://repo.test/mods.yaml",
+			fileURL:     "https://repo.test:8443/a.zip",
+			wantMatch:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("header mode", func(t *testing.T) {
+				def := manifestDef(tt.manifestURL)
+				def.AllowHTTP = true
+				def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+				m, err := NewManifest(def)
+				require.NoError(t, err)
+				m.SetAPIKey("sekrit")
+
+				headers := m.DownloadHeaders(tt.fileURL)
+				if tt.wantMatch {
+					assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, headers)
+				} else {
+					assert.Nil(t, headers)
+				}
+			})
+
+			t.Run("query mode", func(t *testing.T) {
+				def := manifestDef(tt.manifestURL)
+				def.AllowHTTP = true
+				def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+				m, err := NewManifest(def)
+				require.NoError(t, err)
+				m.SetAPIKey("sekrit")
+
+				// Pre-populate the TTL cache so fetch() never hits the network —
+				// only sameOrigin's port normalization is under test here.
+				m.mu.Lock()
+				m.cached = &manifestDoc{
+					Version: 1,
+					Mods: []manifestMod{{
+						ID: "mod-a", Name: "Mod A", Version: "1.0.0",
+						Files: []manifestFile{{ID: "main", Filename: "a.zip", URL: tt.fileURL}},
+					}},
+				}
+				m.fetchedAt = m.now()
+				m.mu.Unlock()
+
+				mod, err := m.GetMod(context.Background(), "", "mod-a")
+				require.NoError(t, err)
+				u, err := m.GetDownloadURL(context.Background(), mod, "main")
+				require.NoError(t, err)
+				if tt.wantMatch {
+					assert.Equal(t, tt.fileURL+"?api_key=sekrit", u)
+				} else {
+					assert.Equal(t, tt.fileURL, u)
+				}
+			})
+		})
+	}
+}
+
 func TestManifestGetDependencies(t *testing.T) {
 	m := newLocalManifest(t)
 

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -493,25 +493,48 @@ func TestNewManifestClientHasTimeout(t *testing.T) {
 }
 
 func TestManifestDownloadHeaders(t *testing.T) {
-	t.Run("header auth with key", func(t *testing.T) {
-		def := manifestDef("https://x.test/mods.yaml")
-		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+	headerAuth := &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+
+	t.Run("remote manifest: same-origin file URL gets the key", func(t *testing.T) {
+		def := manifestDef("https://repo.test/mods.yaml")
+		def.Manifest.Auth = headerAuth
 		m, err := NewManifest(def)
 		require.NoError(t, err)
 		m.SetAPIKey("sekrit")
-		assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, m.DownloadHeaders())
+		assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, m.DownloadHeaders("https://repo.test/files/a.zip"))
+	})
+
+	t.Run("remote manifest: cross-origin file URL gets nothing", func(t *testing.T) {
+		def := manifestDef("https://repo.test/mods.yaml")
+		def.Manifest.Auth = headerAuth
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Nil(t, m.DownloadHeaders("https://cdn.example.com/files/a.zip"),
+			"the repo's API key must not be shipped to third-party hosts")
+	})
+
+	t.Run("local manifest: any host gets the key (user-authored, trusted)", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "mods.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(testManifest), 0644))
+		def := manifestDef(path)
+		def.Manifest.Auth = headerAuth
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, m.DownloadHeaders("https://anywhere.test/a.zip"))
 	})
 
 	t.Run("query auth or no key yields nil", func(t *testing.T) {
-		def := manifestDef("https://x.test/mods.yaml")
+		def := manifestDef("https://repo.test/mods.yaml")
 		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
 		m, err := NewManifest(def)
 		require.NoError(t, err)
 		m.SetAPIKey("sekrit")
-		assert.Nil(t, m.DownloadHeaders())
+		assert.Nil(t, m.DownloadHeaders("https://repo.test/a.zip"))
 
-		noKey, err := NewManifest(manifestDef("https://x.test/mods.yaml"))
+		noKey, err := NewManifest(manifestDef("https://repo.test/mods.yaml"))
 		require.NoError(t, err)
-		assert.Nil(t, noKey.DownloadHeaders())
+		assert.Nil(t, noKey.DownloadHeaders("https://repo.test/a.zip"))
 	})
 }

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -480,8 +480,11 @@ func TestManifestFetchReturnsDefensiveCopy(t *testing.T) {
 // came from cache, not the network.
 func TestManifestFetchRemoteReturnsDefensiveCopy(t *testing.T) {
 	hits := 0
+	var hitsMu sync.Mutex
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitsMu.Lock()
 		hits++
+		hitsMu.Unlock()
 		_, _ = w.Write([]byte(testManifest))
 	}))
 	defer srv.Close()
@@ -498,7 +501,9 @@ func TestManifestFetchRemoteReturnsDefensiveCopy(t *testing.T) {
 	first, err := m.fetch(ctx)
 	require.NoError(t, err)
 	require.Len(t, first.Mods, 2)
+	hitsMu.Lock()
 	assert.Equal(t, 1, hits, "first fetch must hit the server")
+	hitsMu.Unlock()
 
 	// Mutate everything a caller could plausibly touch.
 	first.Mods[0].Name = "MUTATED"
@@ -513,7 +518,9 @@ func TestManifestFetchRemoteReturnsDefensiveCopy(t *testing.T) {
 	assert.Equal(t, "Cool Mod", second.Mods[0].Name)
 	assert.Equal(t, "skyrim", second.Mods[0].GameIDs[0])
 	assert.NotEqual(t, "MUTATED", second.Mods[0].Files[0].URL)
+	hitsMu.Lock()
 	assert.Equal(t, 1, hits, "second fetch within TTL must use cache, not hit server")
+	hitsMu.Unlock()
 }
 
 func TestManifestFetchConcurrent(t *testing.T) {

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -387,6 +387,50 @@ func TestManifestFetchReturnsDefensiveCopy(t *testing.T) {
 	assert.NotEqual(t, "MUTATED", second.Mods[0].Files[0].URL)
 }
 
+// TestManifestFetchRemoteReturnsDefensiveCopy pins that callers cannot corrupt
+// the remote cache (m.cached) via the returned pointer. Uses an httptest server,
+// fetches once (populates cache), mutates the returned doc thoroughly (mirroring
+// the local test's mutations), fetches again within TTL (cache hit), and asserts
+// the second result is pristine. Counts server hits to prove the second fetch
+// came from cache, not the network.
+func TestManifestFetchRemoteReturnsDefensiveCopy(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = w.Write([]byte(testManifest))
+	}))
+	defer srv.Close()
+
+	def := manifestDef(srv.URL + "/mods.yaml")
+	def.AllowHTTP = true
+	def.Manifest.Refresh = "15m" // explicit TTL; default is fine
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// First fetch: populates cache
+	first, err := m.fetch(ctx)
+	require.NoError(t, err)
+	require.Len(t, first.Mods, 2)
+	assert.Equal(t, 1, hits, "first fetch must hit the server")
+
+	// Mutate everything a caller could plausibly touch.
+	first.Mods[0].Name = "MUTATED"
+	first.Mods[0].GameIDs[0] = "MUTATED"
+	first.Mods[0].Files[0].URL = "MUTATED"
+	first.Mods = nil
+
+	// Second fetch: within TTL, must be from cache
+	second, err := m.fetch(ctx)
+	require.NoError(t, err)
+	require.Len(t, second.Mods, 2)
+	assert.Equal(t, "Cool Mod", second.Mods[0].Name)
+	assert.Equal(t, "skyrim", second.Mods[0].GameIDs[0])
+	assert.NotEqual(t, "MUTATED", second.Mods[0].Files[0].URL)
+	assert.Equal(t, 1, hits, "second fetch within TTL must use cache, not hit server")
+}
+
 func TestManifestFetchConcurrent(t *testing.T) {
 	// Race-detector safety net: concurrent fetches (cache hits and misses)
 	// must be data-race free. Run with -race in CI/the suite.

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -3,6 +3,7 @@ package custom
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -44,6 +45,21 @@ mods:
       - id: main
         filename: other-mod.zip
         url: https://files.test/other-mod.zip
+`
+
+// originManifestFmt is a single-mod manifest template used to control a
+// file's URL precisely, for same-origin/cross-origin comparisons against the
+// manifest's own URL.
+const originManifestFmt = `
+version: 1
+mods:
+  - id: mod-a
+    name: Mod A
+    version: 1.0.0
+    files:
+      - id: main
+        filename: a.zip
+        url: %s
 `
 
 func manifestDef(url string) SourceDefinition {
@@ -319,6 +335,9 @@ func TestManifestFilesAndDownloadURL(t *testing.T) {
 }
 
 func TestManifestDownloadURLQueryAuth(t *testing.T) {
+	// This manifest is local (a temp-file path, not a remote URL), so — per
+	// the same-origin rule — the query key attaches regardless of the file
+	// URL's host: local manifests are user-authored and trusted.
 	path := filepath.Join(t.TempDir(), "mods.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(testManifest), 0644))
 	def := manifestDef(path)
@@ -332,6 +351,72 @@ func TestManifestDownloadURLQueryAuth(t *testing.T) {
 	u, err := m.GetDownloadURL(context.Background(), mod, "main")
 	require.NoError(t, err)
 	assert.Equal(t, "https://files.test/cool-mod-1.2.0.zip?api_key=sekrit", u)
+}
+
+// TestManifestGetDownloadURLQueryAuthOrigin pins the same-origin rule for
+// query-mode auth (final-review finding 2a): a remote manifest must only
+// attach its key to file URLs on its own scheme+host, exactly mirroring the
+// header-mode rule. Local manifests keep attaching regardless of host.
+func TestManifestGetDownloadURLQueryAuthOrigin(t *testing.T) {
+	queryAuth := &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+
+	t.Run("remote manifest: same-origin file URL gets the key", func(t *testing.T) {
+		var srv *httptest.Server
+		srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprintf(w, originManifestFmt, srv.URL+"/files/a.zip")
+		}))
+		defer srv.Close()
+
+		def := manifestDef(srv.URL + "/mods.yaml")
+		def.AllowHTTP = true
+		def.Manifest.Auth = queryAuth
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+
+		mod, err := m.GetMod(context.Background(), "", "mod-a")
+		require.NoError(t, err)
+		u, err := m.GetDownloadURL(context.Background(), mod, "main")
+		require.NoError(t, err)
+		assert.Equal(t, srv.URL+"/files/a.zip?api_key=sekrit", u)
+	})
+
+	t.Run("remote manifest: cross-origin file URL gets nothing", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprintf(w, originManifestFmt, "https://cdn.example.com/files/a.zip")
+		}))
+		defer srv.Close()
+
+		def := manifestDef(srv.URL + "/mods.yaml")
+		def.AllowHTTP = true
+		def.Manifest.Auth = queryAuth
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+
+		mod, err := m.GetMod(context.Background(), "", "mod-a")
+		require.NoError(t, err)
+		u, err := m.GetDownloadURL(context.Background(), mod, "main")
+		require.NoError(t, err)
+		assert.Equal(t, "https://cdn.example.com/files/a.zip", u,
+			"the repo's API key must not be shipped to third-party hosts")
+	})
+
+	t.Run("local manifest: any host gets the key (user-authored, trusted)", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "mods.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(originManifestFmt, "https://anywhere.test/a.zip")), 0644))
+		def := manifestDef(path)
+		def.Manifest.Auth = queryAuth
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+
+		mod, err := m.GetMod(context.Background(), "", "mod-a")
+		require.NoError(t, err)
+		u, err := m.GetDownloadURL(context.Background(), mod, "main")
+		require.NoError(t, err)
+		assert.Equal(t, "https://anywhere.test/a.zip?api_key=sekrit", u)
+	})
 }
 
 func TestManifestGetDependencies(t *testing.T) {
@@ -523,6 +608,16 @@ func TestManifestDownloadHeaders(t *testing.T) {
 		require.NoError(t, err)
 		m.SetAPIKey("sekrit")
 		assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, m.DownloadHeaders("https://anywhere.test/a.zip"))
+	})
+
+	t.Run("remote manifest: same host but different scheme gets nothing", func(t *testing.T) {
+		def := manifestDef("https://repo.test/mods.yaml")
+		def.Manifest.Auth = headerAuth
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Nil(t, m.DownloadHeaders("http://repo.test/files/a.zip"),
+			"a scheme downgrade must not carry the key even though the host matches")
 	})
 
 	t.Run("query auth or no key yields nil", func(t *testing.T) {

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -364,6 +365,87 @@ func TestManifestCheckUpdates(t *testing.T) {
 	require.Len(t, updates, 1)
 	assert.Equal(t, "cool-mod", updates[0].InstalledMod.ID)
 	assert.Equal(t, "1.2.0", updates[0].NewVersion)
+}
+
+func TestManifestFetchReturnsDefensiveCopy(t *testing.T) {
+	m := newLocalManifest(t)
+	ctx := context.Background()
+
+	first, err := m.fetch(ctx)
+	require.NoError(t, err)
+	// Mutate everything a caller could plausibly touch.
+	first.Mods[0].Name = "MUTATED"
+	first.Mods[0].GameIDs[0] = "MUTATED"
+	first.Mods[0].Files[0].URL = "MUTATED"
+	first.Mods = nil
+
+	second, err := m.fetch(ctx)
+	require.NoError(t, err)
+	require.Len(t, second.Mods, 2)
+	assert.Equal(t, "Cool Mod", second.Mods[0].Name)
+	assert.Equal(t, "skyrim", second.Mods[0].GameIDs[0])
+	assert.NotEqual(t, "MUTATED", second.Mods[0].Files[0].URL)
+}
+
+func TestManifestFetchConcurrent(t *testing.T) {
+	// Race-detector safety net: concurrent fetches (cache hits and misses)
+	// must be data-race free. Run with -race in CI/the suite.
+	hits := 0
+	var srvMu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srvMu.Lock()
+		hits++
+		srvMu.Unlock()
+		_, _ = w.Write([]byte(testManifest))
+	}))
+	defer srv.Close()
+
+	def := manifestDef(srv.URL + "/mods.yaml")
+	def.AllowHTTP = true
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, ferr := m.fetch(context.Background())
+			assert.NoError(t, ferr)
+		}()
+	}
+	wg.Wait()
+	srvMu.Lock()
+	defer srvMu.Unlock()
+	assert.GreaterOrEqual(t, hits, 1)
+}
+
+func TestManifestFetchDoesNotBlockOnHungServer(t *testing.T) {
+	// A hung server must be bounded by the client timeout, not hang forever.
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // hang until test cleanup
+	}))
+	defer func() { close(release); srv.Close() }()
+
+	def := manifestDef(srv.URL + "/mods.yaml")
+	def.AllowHTTP = true
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+	m.httpClient = &http.Client{Timeout: 200 * time.Millisecond}
+
+	start := time.Now()
+	_, err = m.fetch(context.Background())
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second)
+	assert.NotContains(t, err.Error(), "api_key")
+}
+
+func TestNewManifestClientHasTimeout(t *testing.T) {
+	m, err := NewManifest(manifestDef("https://x.test/mods.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, m.httpClient)
+	assert.Equal(t, manifestFetchTimeout, m.httpClient.Timeout)
 }
 
 func TestManifestDownloadHeaders(t *testing.T) {

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -87,8 +87,9 @@ func CapabilitiesOf(src ModSource) Capabilities {
 
 // DownloadHeaderProvider is implemented by sources whose file downloads need
 // extra HTTP headers (e.g. header-mode API-key auth on a manifest source).
-// Service.DownloadModToCache consults it before downloading. A nil map means
+// Service.DownloadModToCache consults it with the resolved download URL so
+// the source can scope credentials (e.g. same-origin only). A nil map means
 // no extra headers.
 type DownloadHeaderProvider interface {
-	DownloadHeaders() map[string]string
+	DownloadHeaders(fileURL string) map[string]string
 }

--- a/internal/storage/db/tokens.go
+++ b/internal/storage/db/tokens.go
@@ -64,3 +64,32 @@ func (d *DB) HasToken(sourceID string) (bool, error) {
 	}
 	return count > 0, nil
 }
+
+// ListTokens returns every stored API token, ordered by source ID,
+// regardless of whether that source is still registered. `lmm auth status`
+// uses this to surface orphaned tokens (source removed or renamed) that
+// would otherwise be invisible.
+func (d *DB) ListTokens() ([]StoredToken, error) {
+	rows, err := d.Query(`
+        SELECT source_id, token_data, updated_at
+        FROM auth_tokens
+        ORDER BY source_id
+    `)
+	if err != nil {
+		return nil, fmt.Errorf("listing tokens: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var tokens []StoredToken
+	for rows.Next() {
+		var token StoredToken
+		if err := rows.Scan(&token.SourceID, &token.APIKey, &token.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scanning token: %w", err)
+		}
+		tokens = append(tokens, token)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing tokens: %w", err)
+	}
+	return tokens, nil
+}

--- a/internal/storage/db/tokens_test.go
+++ b/internal/storage/db/tokens_test.go
@@ -119,6 +119,30 @@ func TestHasToken(t *testing.T) {
 	assert.False(t, has)
 }
 
+func TestListTokens(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	// No tokens initially.
+	tokens, err := db.ListTokens()
+	require.NoError(t, err)
+	assert.Empty(t, tokens)
+
+	require.NoError(t, db.SaveToken("nexusmods", "key-a"))
+	require.NoError(t, db.SaveToken("ghost-repo", "key-b"))
+
+	tokens, err = db.ListTokens()
+	require.NoError(t, err)
+	require.Len(t, tokens, 2)
+	// Ordered by source_id so callers get deterministic output.
+	assert.Equal(t, "ghost-repo", tokens[0].SourceID)
+	assert.Equal(t, "key-b", tokens[0].APIKey)
+	assert.Equal(t, "nexusmods", tokens[1].SourceID)
+	assert.Equal(t, "key-a", tokens[1].APIKey)
+}
+
 func setupTestDB(t *testing.T) *DB {
 	t.Helper()
 	db, err := New(":memory:")


### PR DESCRIPTION
## Summary

Closes every checkbox in #54 — the deferred review findings from the manifest-sources release, including the Phase 5 concurrency prerequisite — plus the credential-scoping gaps the final review of this very branch uncovered live.

Closes #54

### Phase 5 prerequisite (unblocks #50 aggregate search)
- Manifest fetches use a dedicated HTTP client with a **30s timeout**, and the source's mutex is **no longer held across the network** — a hung server can no longer block other operations on the source (duplicate concurrent fetches are accepted and idempotent)
- `fetch` returns **deep copies** of the cached document, so no caller can corrupt the cache (regression test proven RED against a no-copy implementation)

### Correctness
- **Update checks translate installed mods to each source's mapped game ID** (`Updater.CheckUpdates` gains the game) — fixes NexusMods update checks for games whose lmm ID differs from the Nexus domain
- Download checksums (MD5 + SHA-256) computed in a **single streaming pass**; the second full file read is gone

### Security — download credential scoping (one coherent rule)
For remote manifests, API keys are sent only to file URLs on the manifest's own **scheme+host**, in **both** header and query modes; header keys are **stripped when a download redirects off-origin** (live-verified: a same-origin 302 to another host arrives keyless and the download still succeeds). Local-path manifests are user-authored and attach the key regardless of host. The redirect finding was discovered by live testing during this branch's own final review and fixed rather than deferred.

### CLI polish
- `lmm auth status` lists auth-capable **custom sources** (stored token → env var → not authenticated, masked) — sorted, deterministic — and surfaces **orphaned stored tokens** whose definition file was removed, with the logout hint
- `lmm auth logout <id>` works for unregistered sources that still have a stored token
- `maskAPIKey` fully masks keys ≤8 chars; env-key test pins cleaned up

## Test plan
- [x] TDD throughout; every security fix has a test proven to FAIL on the unfixed code
- [x] Full suite green under `go test ./... -race -count=1` (17 packages)
- [x] Two independent live verification passes (scratch binary + temp config + logging HTTP servers): install→update flow, cross-host redirect stripping with same-host preservation, orphaned-token status/logout sequence
- [x] Deferred (by review triage, needs design): flat timeout is wrong for large file downloads — the hung-server hardening covers manifest fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
