### PR TITLE
feat: declarative REST api source type (Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API source type: describe a GET+JSON REST API declaratively (endpoint templates + dot-path mappings) and use it as a mod source — search, install (including install-by-ID-only definitions), and update checks
 - `lmm source validate --probe` — live smoke test for a definition (directory scan, manifest fetch, or API call; `--id` probes get_mod for search-less API definitions)
 
+### Fixed
+
+- API source search and file-listing endpoints no longer error on a JSON `null` list (e.g. `{"results": null}`, the standard zero-hits shape for Go-backed APIs) — it's now treated as an empty result set
+
 ## [1.8.0] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-15
+
+### Added
+
+- API source type: describe a GET+JSON REST API declaratively (endpoint templates + dot-path mappings) and use it as a mod source — search, install (including install-by-ID-only definitions), and update checks
+- `lmm source validate --probe` — live smoke test for a definition (directory scan, manifest fetch, or API call; `--id` probes get_mod for search-less API definitions)
+
 ## [1.8.0] - 2026-07-15
 
 ### Added
@@ -711,7 +718,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.5.0...v1.6.0

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ This allows you to store different games' mods on different drives (e.g., large 
 
 ## Custom Sources
 
-In addition to built-in mod sources (NexusMods, CurseForge), lmm lets you declare custom sources in YAML files instead of writing code. Two types are fully implemented: `directory` (a local folder of mods) and `manifest` (a JSON/YAML mod list you publish, over `https://` or as a local file) — both work from `search`/`install`/`update` like any built-in source, and `manifest` sources also support optional API-key authentication. `api` definitions parse and validate today, but the declarative-REST source type itself ships in a later release.
+In addition to built-in mod sources (NexusMods, CurseForge), lmm lets you declare custom sources in YAML files instead of writing code. Three types are fully implemented: `directory` (a local folder of mods), `manifest` (a JSON/YAML mod list you publish, over `https://` or as a local file), and `api` (a GET+JSON REST API described declaratively) — all three work from `search`/`install`/`update` like any built-in source (within each type's capabilities), and `manifest`/`api` sources also support optional API-key authentication.
 
 Custom source definitions are loaded from `~/.config/lmm/sources/*.yaml` (or `*.yml`). Each file must define exactly one source. Broken definition files are skipped with a warning — they never prevent lmm from starting.
 
@@ -251,7 +251,7 @@ directory:
 | ----------- | ------- | -------- | ----------------------------------------------------------------------------------- |
 | `id`        | string  | yes      | Unique source identifier; must contain only lowercase letters, numbers, and hyphens |
 | `name`      | string  | yes      | Display name shown in source lists and commands                                     |
-| `type`      | string  | yes      | Source type: `directory`, `manifest`, or `api`. All three parse and validate today; `directory` and `manifest` are fully supported (search/install/updates), `api` is planned for a later release. |
+| `type`      | string  | yes      | Source type: `directory`, `manifest`, or `api`. All three are fully supported, each within its own capabilities (see the sections below; `api` in particular can be install-by-ID-only if its definition omits a `search` endpoint). |
 | `allow_http` | boolean | no       | If `true`, allow unencrypted http:// URLs (default `false`, HTTPS only)            |
 
 ### Directory Sources
@@ -379,9 +379,113 @@ games:
       my-repo: skyrimspecialedition
 ```
 
+### API Sources
+
+An `api` source describes a GET+JSON REST API declaratively — endpoint URL templates plus JSON dot-path mappings — and lmm calls it directly: search, install, and update checks all work without writing a client. Every endpoint is optional; a definition with only enough endpoints to fetch and download a mod by a known ID (no `search`) is a valid "install-by-ID-only" source.
+
+```yaml
+id: esoui
+name: ESOUI
+type: api
+api:
+  base_url: https://api.example.com
+  page_start: 1                  # optional; first page number the API expects (default 1)
+  auth:                          # optional, same block as manifest sources
+    api_key:
+      in: header                 # "header" or "query"
+      name: X-API-Key
+  endpoints:                     # each endpoint is optional; an undefined one is a capability gap (see below)
+    search:
+      path: /mods?game={game_id}&q={query}&page={page}&limit={page_size}
+      list: results               # required: dot-path to the results array
+      total: pagination.total     # optional: dot-path to a total-count field
+    get_mod:
+      path: /mods/{mod_id}
+    mod_files:
+      path: /mods/{mod_id}/files
+      list: files                 # required: dot-path to the files array
+    download_url:
+      path: /files/{file_id}/download
+      field: url                  # required: dot-path to the URL string in the response
+  mappings:
+    mod:                          # domain field -> JSON dot-path
+      id: id
+      name: name
+      version: latest_version
+      author: author.name
+      summary: description
+      downloads: download_count
+      updated_at: updated         # RFC 3339 expected; unparseable is left unset
+      url: web_url
+    file:                         # domain field -> JSON dot-path
+      id: id
+      name: title
+      filename: file_name
+      version: version
+      size: size_bytes
+```
+
+**Placeholders** — every `{placeholder}` in an endpoint's `path` is substituted with a URL-escaped value before the request is made; a placeholder with no value for that request is left in the URL as-is:
+
+| Placeholder   | Value                                                                        | Used by                                          |
+| ------------- | ----------------------------------------------------------------------------- | ------------------------------------------------- |
+| `{game_id}`   | The current game's ID for this source (from the search query, the mod being fetched/installed, or an installed mod during update checks) | `search`, `get_mod`, `mod_files`, `download_url` |
+| `{query}`     | The search text                                                               | `search`                                          |
+| `{page}`      | The internal 0-based page number, plus `page_start` (default `1`)             | `search`                                          |
+| `{page_size}` | The requested page size (defaults to 20 when unspecified or ≤ 0)              | `search`                                          |
+| `{offset}`    | The internal 0-based page × `page_size` — independent of `page_start`, for offset-paginated APIs | `search`                                          |
+| `{mod_id}`    | The mod ID                                                                    | `get_mod`, `mod_files`, `download_url`            |
+| `{file_id}`   | The file ID                                                                   | `download_url`                                    |
+
+**`mappings.mod` keys** (`id` and `name` are required; every other key is optional and left at its zero value when unmapped or the path doesn't resolve):
+
+| Key           | Required | Domain field                                                |
+| ------------- | -------- | ------------------------------------------------------------- |
+| `id`          | **yes**  | Mod ID                                                         |
+| `name`        | **yes**  | Display name                                                    |
+| `version`     | no       | Compared against installed versions for update checks            |
+| `author`      | no       | —                                                                  |
+| `summary`     | no       | Shown in search results                                             |
+| `description` | no       | Falls back to `summary` when unmapped or empty                       |
+| `downloads`   | no       | Download count                                                        |
+| `updated_at`  | no       | RFC 3339 timestamp; unparseable is silently left unset                 |
+| `url`         | no       | Web page for the mod                                                    |
+| `picture_url` | no       | Main image URL                                                           |
+
+**`mappings.file` keys** (`id` is required only when `mod_files` is defined):
+
+| Key        | Required                     | Domain field              |
+| ---------- | ------------------------------ | --------------------------- |
+| `id`       | **yes** (when `mod_files` set)  | File ID, used to request a download |
+| `name`     | no                               | Display name                          |
+| `filename` | no                               | Name given to the downloaded/cached file |
+| `version`  | no                               | —                                          |
+| `size`     | no                               | Size in bytes                               |
+
+Unknown keys anywhere in `mappings.mod` or `mappings.file` fail validation at load time (typo detection) instead of silently mapping to nothing.
+
+**Capability gaps** — an endpoint you don't define makes the corresponding operation report "not supported" instead of failing at load time:
+
+- no `search` → searching is unsupported (a valid install-by-ID-only source; probe one with `lmm source validate --probe --id <mod-id>`, see below)
+- no `get_mod` → fetching a single mod is unsupported, and so are update checks (`api` sources check for updates by calling `get_mod` on each installed mod and comparing versions)
+- no `mod_files` → listing a mod's files is unsupported
+- no `download_url` → resolving a download URL is unsupported
+- dependency resolution (`GetDependencies`) is **always** unsupported for `api` sources — there is no dependency endpoint in v1
+
+`lmm source list`'s `CAPABILITIES` column reflects exactly this: a definition with only `get_mod` shows `updates`; adding `search` adds `search` to that list; `auth` appears only when the definition declares an `auth` block.
+
+**Guardrails:**
+
+- Requests are `GET` only, and only JSON responses are understood — no POST, GraphQL, or scraping.
+- `api.base_url` must be `https://` unless the definition sets `allow_http: true` (same rule as `manifest` sources).
+- Every request is bounded by a 30-second timeout.
+- Responses are capped at 10 MiB; a larger response fails the operation instead of being read into memory.
+
+**Credentials** — `api` sources use the same `auth.api_key` block as `manifest` sources (see [Authentication](#authentication) below): the resolved key is attached to every API request per `in: header` / `in: query`. For downloads, both header- and query-mode keys are only sent when the URL returned by `download_url` shares scheme and host with `api.base_url` — an endpoint that hands back a third-party CDN URL never receives the source's key, in either form. If a download is redirected to a different scheme or host, a header-mode key is stripped before the redirect is followed (the same v1.8.0 machinery `manifest` sources use).
+
 ### Authentication
 
-A custom source can require an API key, attached to every request as either a header or a query parameter. Today this is available to `manifest` sources (`directory` sources need no auth; `api` sources will reuse the same block when they ship):
+A custom source can require an API key, attached to every request as either a header or a query parameter. Today this is available to `manifest` and `api` sources (`directory` sources need no auth):
 
 ```yaml
 manifest:
@@ -395,10 +499,11 @@ manifest:
 - **Key resolution**, checked in order:
   1. The `LMM_<ID>_API_KEY` environment variable, with the source's `id` uppercased and `-` replaced by `_` (source `my-repo` → `LMM_MY_REPO_API_KEY`).
   2. A key saved with `lmm auth login <id>` — this works for any registered source whose definition declares `auth`, not just NexusMods/CurseForge, and stores the key in the same local token store.
-- The resolved key is always attached to the manifest fetch itself (the request for the mod list document).
+- The resolved key is always attached to the manifest fetch itself (the request for the mod list document); for `api` sources, it's attached to every request built from an `endpoints.*.path` template (search, get_mod, mod_files, download_url).
 - File downloads follow the same same-origin rule regardless of whether the key is `in: header` or `in: query`:
   - **Remote manifests** (`https://` URL): the key (as a header, or appended to the URL) is only sent to file downloads whose scheme and host match the manifest URL's — a manifest pointing files at a third-party CDN never receives the source's key, in either form.
   - **Local-file manifests**: the key is attached to every file download regardless of host, since a local manifest is user-authored and already trusted.
+  - **`api` sources**: the key is only sent to a `download_url` response whose scheme and host match `api.base_url`'s — see [API Sources](#api-sources) above.
 - If a file download is redirected to a different scheme or host, an `in: header` key is stripped before the redirect is followed — Go's HTTP client otherwise forwards custom headers across redirects even when it would strip `Authorization`/`Cookie`.
 - Keys are never printed or logged; `lmm source list` only reports whether one is configured (`AUTH` column: `yes` / `no` / `n/a`), and `lmm auth status` masks stored keys to their first/last 3 characters (keys of 8 characters or fewer are fully masked). `lmm auth status` also lists any registered custom source whose definition declares `auth`, alongside the built-in nexusmods/curseforge rows, plus any stored token whose source is no longer registered (with a hint to remove it). `lmm auth logout <id>` removes a stored token even if the source's definition file has since been removed.
 
@@ -418,6 +523,7 @@ nexusmods     Nexus Mods              built-in   yes   search,deps,updates,auth
 curseforge    CurseForge              built-in   yes   search,deps,updates,auth
 donovan-mods  Donovan's 7D2D Modlets  directory  n/a   search,updates
 my-repo       My Mod Repo             manifest   no    search,deps,updates,auth
+esoui         ESOUI                   api        no    search,updates,auth
 ```
 
 Validate a source definition file before use:
@@ -434,6 +540,26 @@ On success:
 On error (exits with code 1):
 ```
 Error: invalid definition: id "my-bad-source!" must match ^[a-z0-9-]+$
+```
+
+Add `--probe` to also perform a live smoke test — a directory scan, a manifest fetch+parse, or an API call, depending on the definition's `type`:
+
+```bash
+lmm source validate --probe ~/.config/lmm/sources/my-source.yaml
+```
+
+For an `api` definition with no `search` endpoint (install-by-ID-only), pass `--id` with a known mod ID so `--probe` has something to call `get_mod` with. Captured against a local test definition (a `get_mod`-only `api` source pointed at a throwaway local server):
+
+```
+$ lmm source validate --probe --id 42 demo-api.yaml
+demo-api.yaml: valid (api source "demo-api")
+probe: ok — get_mod 42 returned "Cool Mod"
+```
+
+Without `--id` on a search-less `api` definition, `--probe` fails with a clear message instead of silently doing nothing:
+
+```
+Error: probe: this definition has no search endpoint; provide a known mod id with --id to probe get_mod
 ```
 
 ### Adding a Custom Source
@@ -474,7 +600,7 @@ Error: invalid definition: id "my-bad-source!" must match ^[a-z0-9-]+$
    lmm install --source my-local-mods --id BiggerBackpack -g skyrim-se
    ```
 
-A `directory` source now shows up with real capabilities in `lmm source list` (`search,updates`, `auth=n/a`), and it will show as an `error` row if the configured path is missing or not a directory. A `manifest` source shows `search,deps,updates` (plus `auth` if the definition declares one, with the `AUTH` column reporting `yes`/`no` once a key is or isn't configured). Either type will show as an `error` row if construction fails (e.g. a directory source's path doesn't exist). A definition whose `id` collides with an already-registered source (a built-in, or another definition) also produces an `error` row (`id already in use`); the source that was already registered keeps its original row and type unchanged.
+A `directory` source now shows up with real capabilities in `lmm source list` (`search,updates`, `auth=n/a`), and it will show as an `error` row if the configured path is missing or not a directory. A `manifest` source shows `search,deps,updates` (plus `auth` if the definition declares one, with the `AUTH` column reporting `yes`/`no` once a key is or isn't configured). An `api` source shows only the capabilities its defined endpoints provide — `updates` alone for a `get_mod`-only definition, `search,updates` once a `search` endpoint is added, plus `auth` if the definition declares one — and never `deps` (dependency resolution isn't supported for `api` sources). Any type will show as an `error` row if construction fails (e.g. a directory source's path doesn't exist). A definition whose `id` collides with an already-registered source (a built-in, or another definition) also produces an `error` row (`id already in use`); the source that was already registered keeps its original row and type unchanged.
 
 ## CLI Reference
 
@@ -541,6 +667,8 @@ A `directory` source now shows up with real capabilities in `lmm source list` (`
 | `lmm conflicts`                        | Show file conflicts in current profile               |
 | `lmm source list`                      | List built-in and user-defined mod sources           |
 | `lmm source validate <file>`           | Validate a user-defined source definition           |
+| `lmm source validate --probe <file>`   | Also live-smoke-test the definition (scan/fetch/API call) |
+| `lmm source validate --probe --id <mod-id> <file>` | Probe an `api` definition that has no `search` endpoint |
 
 ### Update check behavior
 

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -23,7 +23,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.8.0"
+	version = "1.9.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/source.go
+++ b/cmd/lmm/source.go
@@ -106,10 +106,15 @@ var sourceListCmd = &cobra.Command{
 	},
 }
 
+var (
+	sourceProbe   bool
+	sourceProbeID string
+)
+
 var sourceValidateCmd = &cobra.Command{
 	Use:   "validate <file>",
 	Short: "Validate a source definition file",
-	Long:  "Parse and validate a user-defined source definition YAML file, reporting any problems.",
+	Long:  "Parse and validate a user-defined source definition YAML file, reporting any problems. With --probe, also perform a live smoke test (directory scan, manifest fetch+parse, or an API call).",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		def, err := config.LoadSourceDefinitionFile(args[0])
@@ -117,16 +122,63 @@ var sourceValidateCmd = &cobra.Command{
 			return err
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "%s: valid (%s source %q)\n", args[0], def.Type, def.ID)
-		return nil
+		if !sourceProbe {
+			return nil
+		}
+		return withService(cmd, func(ctx context.Context, svc *core.Service) error {
+			return probeSource(ctx, cmd, svc, def)
+		})
 	},
+}
+
+// probeSource constructs the definition's source and performs one live
+// operation against it, so users can smoke-test a definition before relying
+// on it (design §8).
+func probeSource(ctx context.Context, cmd *cobra.Command, svc *core.Service, def custom.SourceDefinition) error {
+	src, err := custom.New(def)
+	if err != nil {
+		return fmt.Errorf("probe: constructing source: %w", err)
+	}
+	if a, ok := src.(interface{ SetAPIKey(string) }); ok {
+		if key := getSourceAPIKey(svc, def.ID, envKeyForSourceID(def.ID)); key != "" {
+			a.SetAPIKey(key)
+		}
+	}
+
+	switch def.Type {
+	case custom.TypeDirectory, custom.TypeManifest:
+		res, err := src.Search(ctx, source.SearchQuery{PageSize: 1})
+		if err != nil {
+			return fmt.Errorf("probe: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "probe: ok — %d mod(s) visible\n", res.TotalCount)
+	case custom.TypeAPI:
+		if def.API.Endpoints.Search != nil {
+			res, err := src.Search(ctx, source.SearchQuery{PageSize: 1})
+			if err != nil {
+				return fmt.Errorf("probe: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "probe: ok — search responded (%d total reported)\n", res.TotalCount)
+			return nil
+		}
+		if sourceProbeID == "" {
+			return fmt.Errorf("probe: this definition has no search endpoint; provide a known mod id with --id to probe get_mod")
+		}
+		mod, err := src.GetMod(ctx, "", sourceProbeID)
+		if err != nil {
+			return fmt.Errorf("probe: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "probe: ok — get_mod %s returned %q\n", sourceProbeID, mod.Name)
+	}
+	return nil
 }
 
 // isCustomSource reports whether src was constructed from a user-defined
 // source definition (as opposed to a built-in like NexusMods/CurseForge).
-// Extend this switch as new custom source types (manifest, api) ship.
+// Extend this switch if a new custom source type ships.
 func isCustomSource(src source.ModSource) bool {
 	switch src.(type) {
-	case *custom.Directory, *custom.Manifest:
+	case *custom.Directory, *custom.Manifest, *custom.API:
 		return true
 	default:
 		return false
@@ -167,6 +219,9 @@ func capabilitySummary(c source.Capabilities) string {
 }
 
 func init() {
+	sourceValidateCmd.Flags().BoolVar(&sourceProbe, "probe", false, "perform a live smoke test after validation")
+	sourceValidateCmd.Flags().StringVar(&sourceProbeID, "id", "", "mod id to probe with (api definitions without a search endpoint)")
+
 	sourceCmd.AddCommand(sourceListCmd)
 	sourceCmd.AddCommand(sourceValidateCmd)
 	rootCmd.AddCommand(sourceCmd)

--- a/cmd/lmm/source_test.go
+++ b/cmd/lmm/source_test.go
@@ -24,18 +24,34 @@ func TestSourceCmd_Structure(t *testing.T) {
 	assert.Contains(t, names, "validate")
 }
 
-func TestSourceValidateCmd(t *testing.T) {
-	run := func(args ...string) (string, error) {
-		cmd := &cobra.Command{Use: "test"}
-		cmd.AddCommand(sourceCmd)
-		buf := new(bytes.Buffer)
-		cmd.SetOut(buf)
-		cmd.SetErr(buf)
-		cmd.SetArgs(args)
-		err := cmd.Execute()
-		return buf.String(), err
-	}
+// runSourceCmd executes the source command tree with args against a fresh
+// cobra root, capturing combined stdout/stderr. Shared by TestSourceValidateCmd
+// and TestSourceValidateProbe so both drive the real command wiring rather
+// than duplicating the harness.
+func runSourceCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.AddCommand(sourceCmd)
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
 
+// resetSourceProbeFlags restores the package-level --probe/--id flag vars to
+// their zero values. cobra flag vars persist across Execute() calls within a
+// test binary since Parse only touches flags actually present in argv, so
+// tests that don't pass --probe would otherwise see a value left behind by an
+// earlier subtest.
+func resetSourceProbeFlags(t *testing.T) {
+	t.Helper()
+	sourceProbe = false
+	sourceProbeID = ""
+}
+
+func TestSourceValidateCmd(t *testing.T) {
 	t.Run("valid file passes", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "good.yaml")
 		require.NoError(t, os.WriteFile(path, []byte(`
@@ -46,7 +62,7 @@ directory:
   path: ~/mods
 `), 0644))
 
-		out, err := run("source", "validate", path)
+		out, err := runSourceCmd(t, "source", "validate", path)
 		assert.NoError(t, err)
 		assert.Contains(t, out, "valid")
 	})
@@ -61,14 +77,93 @@ directory:
   path: ~/x
 `), 0644))
 
-		_, err := run("source", "validate", path)
+		_, err := runSourceCmd(t, "source", "validate", path)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "must match")
 	})
 
 	t.Run("missing argument errors", func(t *testing.T) {
-		_, err := run("source", "validate")
+		_, err := runSourceCmd(t, "source", "validate")
 		assert.Error(t, err)
+	})
+}
+
+func TestSourceValidateProbe(t *testing.T) {
+	t.Run("probe directory source reports mod count", func(t *testing.T) {
+		resetSourceProbeFlags(t)
+		t.Cleanup(func() { resetSourceProbeFlags(t) })
+
+		configDir = t.TempDir()
+		dataDir = t.TempDir()
+
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "SomeMod"), 0755))
+		path := filepath.Join(t.TempDir(), "dir.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+id: probe-dir
+name: Probe Dir
+type: directory
+directory:
+  path: `+root+`
+`), 0644))
+
+		out, err := runSourceCmd(t, "source", "validate", path, "--probe")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "probe: ok")
+		assert.Contains(t, out, "1 mod(s)")
+	})
+
+	t.Run("probe api without search requires --id", func(t *testing.T) {
+		resetSourceProbeFlags(t)
+		t.Cleanup(func() { resetSourceProbeFlags(t) })
+
+		// probeSource resolves the API key via the service (a local DB read,
+		// no network) before reaching the --id check, so withService still
+		// needs a real, isolated config/data dir here rather than the
+		// caller's actual home directory.
+		configDir = t.TempDir()
+		dataDir = t.TempDir()
+
+		path := filepath.Join(t.TempDir(), "api.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+id: probe-api
+name: Probe API
+type: api
+api:
+  base_url: https://api.x.test
+  endpoints:
+    get_mod:
+      path: /mods/{mod_id}
+  mappings:
+    mod:
+      id: id
+      name: name
+`), 0644))
+
+		_, err := runSourceCmd(t, "source", "validate", path, "--probe")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--id")
+	})
+
+	t.Run("probe failure exits non-zero", func(t *testing.T) {
+		resetSourceProbeFlags(t)
+		t.Cleanup(func() { resetSourceProbeFlags(t) })
+
+		configDir = t.TempDir()
+		dataDir = t.TempDir()
+
+		path := filepath.Join(t.TempDir(), "bad.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+id: probe-bad
+name: Probe Bad
+type: manifest
+manifest:
+  url: `+filepath.Join(t.TempDir(), "missing.yaml")+`
+`), 0644))
+
+		_, err := runSourceCmd(t, "source", "validate", path, "--probe")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "probe-bad")
 	})
 }
 

--- a/internal/core/service_api_source_test.go
+++ b/internal/core/service_api_source_test.go
@@ -1,0 +1,154 @@
+package core_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFakeRESTServer serves a minimal authenticated mod API plus the payload.
+func newFakeRESTServer(t *testing.T, requireKey bool) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	auth := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if requireKey && r.Header.Get("X-API-Key") != "e2e-key" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			h(w, r)
+		}
+	}
+
+	mux.HandleFunc("/mods", auth(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"results": [{"id": 77, "name": "Cool Mod", "latest_version": "1.2.0"}], "total": 1}`)
+	}))
+	mux.HandleFunc("/mods/77", auth(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"id": 77, "name": "Cool Mod", "latest_version": "1.2.0"}`)
+	}))
+	mux.HandleFunc("/mods/77/files", auth(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"files": [{"id": 900, "file_name": "cool-1.2.0.zip", "version": "1.2.0", "size_bytes": 11}]}`)
+	}))
+	mux.HandleFunc("/files/900/download", auth(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"url": %q}`, srv.URL+"/dl/cool-1.2.0.zip")
+	}))
+	mux.HandleFunc("/dl/cool-1.2.0.zip", auth(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("mod payload"))
+	}))
+
+	return srv
+}
+
+func apiSourceDef(baseURL string, withSearch bool) custom.SourceDefinition {
+	endpoints := custom.APIEndpoints{
+		GetMod:      &custom.EndpointConfig{Path: "/mods/{mod_id}"},
+		ModFiles:    &custom.EndpointConfig{Path: "/mods/{mod_id}/files", List: "files"},
+		DownloadURL: &custom.EndpointConfig{Path: "/files/{file_id}/download", Field: "url"},
+	}
+	if withSearch {
+		endpoints.Search = &custom.EndpointConfig{Path: "/mods?q={query}&page={page}", List: "results", Total: "total"}
+	}
+	return custom.SourceDefinition{
+		ID: "e2e-api", Name: "E2E API", Type: custom.TypeAPI, AllowHTTP: true,
+		API: &custom.APIConfig{
+			BaseURL:   baseURL,
+			Auth:      &custom.AuthConfig{APIKey: &custom.APIKeyConfig{In: "header", Name: "X-API-Key"}},
+			Endpoints: endpoints,
+			Mappings: custom.APIMappings{
+				Mod:  map[string]string{"id": "id", "name": "name", "version": "latest_version"},
+				File: map[string]string{"id": "id", "filename": "file_name", "version": "version", "size": "size_bytes"},
+			},
+		},
+	}
+}
+
+func TestAPISourceEndToEnd(t *testing.T) {
+	srv := newFakeRESTServer(t, true)
+
+	src, err := custom.New(apiSourceDef(srv.URL, true))
+	require.NoError(t, err)
+	src.(interface{ SetAPIKey(string) }).SetAPIKey("e2e-key")
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(src)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), DeployMode: domain.DeployCopy}
+	require.NoError(t, svc.AddGame(game))
+	ctx := context.Background()
+
+	res, err := src.Search(ctx, source.SearchQuery{Query: "cool", GameID: "testgame", PageSize: 20})
+	require.NoError(t, err)
+	require.Len(t, res.Mods, 1)
+	mod := res.Mods[0]
+	assert.Equal(t, "e2e-api", mod.SourceID)
+	assert.Equal(t, "testgame", mod.GameID)
+
+	files, err := src.GetModFiles(ctx, &mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	result, err := svc.DownloadMod(ctx, "e2e-api", game, &mod, &files[0], nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesExtracted)
+	gameCache := svc.GetGameCache(game)
+	assert.True(t, gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version))
+
+	installed := []domain.InstalledMod{{Mod: domain.Mod{ID: "77", SourceID: "e2e-api", Version: "1.0.0", GameID: "testgame"}}}
+	updates, err := src.CheckUpdates(ctx, installed)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "1.2.0", updates[0].NewVersion)
+}
+
+// TestAPISourceInstallByIDOnly pins #49 acceptance criterion 1: a definition
+// with no search endpoint works for install-by-ID, and search reports
+// unsupported cleanly.
+func TestAPISourceInstallByIDOnly(t *testing.T) {
+	srv := newFakeRESTServer(t, false)
+
+	src, err := custom.New(apiSourceDef(srv.URL, false))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = src.Search(ctx, source.SearchQuery{Query: "cool"})
+	assert.True(t, errors.Is(err, source.ErrNotSupported), "search must be a clean capability gap")
+	assert.False(t, source.CapabilitiesOf(src).Search)
+
+	mod, err := src.GetMod(ctx, "testgame", "77")
+	require.NoError(t, err)
+	files, err := src.GetModFiles(ctx, mod)
+	require.NoError(t, err)
+	u, err := src.GetDownloadURL(ctx, mod, files[0].ID)
+	require.NoError(t, err)
+	assert.Contains(t, u, "/dl/cool-1.2.0.zip")
+}
+
+// TestAPISourceKeyNeverInErrors pins #49 acceptance criterion 2's "never
+// logged" half for the error path.
+func TestAPISourceKeyNeverInErrors(t *testing.T) {
+	def := apiSourceDef("http://127.0.0.1:1", true)
+	def.API.Auth = &custom.AuthConfig{APIKey: &custom.APIKeyConfig{In: "query", Name: "api_key"}}
+	src, err := custom.New(def)
+	require.NoError(t, err)
+	src.(interface{ SetAPIKey(string) }).SetAPIKey("SUPERSECRET")
+
+	_, err = src.Search(context.Background(), source.SearchQuery{Query: "x"})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "SUPERSECRET")
+}

--- a/internal/source/custom/api.go
+++ b/internal/source/custom/api.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -190,9 +191,59 @@ var (
 	_ source.DownloadHeaderProvider = (*API)(nil)
 )
 
-// Search is implemented in the search task (replaces this stub).
+// Search implements source.ModSource by executing the search endpoint
+// template and mapping the results (design §4). An undefined search endpoint
+// is an unsupported capability.
 func (a *API) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
-	return source.SearchResult{}, fmt.Errorf("source %q: searching: %w", a.id, source.ErrNotSupported)
+	ep := a.endpoints.Search
+	if ep == nil {
+		return source.SearchResult{}, fmt.Errorf("source %q: searching: %w", a.id, source.ErrNotSupported)
+	}
+
+	pageSize := query.PageSize
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	vals := map[string]string{
+		"game_id":   query.GameID,
+		"query":     query.Query,
+		"page":      strconv.Itoa(query.Page + a.pageStart),
+		"page_size": strconv.Itoa(pageSize),
+		"offset":    strconv.Itoa(query.Page * pageSize),
+	}
+
+	doc, err := a.getJSON(ctx, a.baseURL+buildEndpointURL(ep.Path, vals))
+	if err != nil {
+		return source.SearchResult{}, fmt.Errorf("searching: %w", err)
+	}
+
+	listVal, ok := lookupPath(doc, ep.List)
+	if !ok {
+		return source.SearchResult{}, fmt.Errorf("source %q: searching: response has no %q array", a.id, ep.List)
+	}
+	items, ok := listVal.([]any)
+	if !ok {
+		return source.SearchResult{}, fmt.Errorf("source %q: searching: %q is not an array", a.id, ep.List)
+	}
+
+	mods := make([]domain.Mod, 0, len(items))
+	for i, item := range items {
+		mod, err := mapMod(item, a.mappings.Mod, a.id)
+		if err != nil {
+			return source.SearchResult{}, fmt.Errorf("source %q: searching: %s[%d]: %w", a.id, ep.List, i, err)
+		}
+		mod.GameID = query.GameID
+		mods = append(mods, mod)
+	}
+
+	total := 0
+	if ep.Total != "" {
+		if v, found := lookupPath(doc, ep.Total); found {
+			total = int(coerceInt64(v))
+		}
+	}
+
+	return source.SearchResult{Mods: mods, TotalCount: total, Page: query.Page, PageSize: pageSize}, nil
 }
 
 // GetMod is implemented in the read-ops task (replaces this stub).

--- a/internal/source/custom/api.go
+++ b/internal/source/custom/api.go
@@ -338,7 +338,34 @@ func (a *API) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string
 	return dlURL, nil
 }
 
-// CheckUpdates is implemented in the update-check task (replaces this stub).
+// CheckUpdates implements source.ModSource generically via get_mod + version
+// comparison (design §4). Per-mod fetch failures are collected and returned
+// alongside partial results so a single flaky mod page doesn't hide the rest
+// — and doesn't get silently skipped either.
 func (a *API) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
-	return nil, fmt.Errorf("source %q: update checks: %w", a.id, source.ErrNotSupported)
+	if a.endpoints.GetMod == nil {
+		return nil, fmt.Errorf("source %q: update checks: %w", a.id, source.ErrNotSupported)
+	}
+
+	var updates []domain.Update
+	var errs []error
+	for _, inst := range installed {
+		select {
+		case <-ctx.Done():
+			return updates, ctx.Err()
+		default:
+		}
+		current, err := a.GetMod(ctx, inst.GameID, inst.ID)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if domain.IsNewerVersion(inst.Version, current.Version) {
+			updates = append(updates, domain.Update{
+				InstalledMod: inst,
+				NewVersion:   current.Version,
+			})
+		}
+	}
+	return updates, errors.Join(errs...)
 }

--- a/internal/source/custom/api.go
+++ b/internal/source/custom/api.go
@@ -1,0 +1,216 @@
+package custom
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+)
+
+// apiRequestTimeout bounds every request to a declarative REST source.
+const apiRequestTimeout = 30 * time.Second
+
+// maxAPIResponseSize bounds how much of an API response we read into memory
+// (same defense class as maxManifestSize).
+const maxAPIResponseSize = 10 << 20 // 10 MiB
+
+// API is a ModSource backed by a declaratively-described GET+JSON REST API
+// (design §4). Endpoints that the definition omits surface as ErrNotSupported
+// capability gaps rather than errors at load time.
+type API struct {
+	id        string
+	name      string
+	baseURL   string
+	pageStart int
+	auth      *AuthConfig
+	endpoints APIEndpoints
+	mappings  APIMappings
+
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewAPI constructs an api source from a validated definition. It performs
+// no I/O — a valid definition always registers; request problems surface as
+// operation errors.
+func NewAPI(def SourceDefinition) (*API, error) {
+	cfg := def.API
+	pageStart := 1
+	if cfg.PageStart != nil {
+		pageStart = *cfg.PageStart
+	}
+	return &API{
+		id:         def.ID,
+		name:       def.Name,
+		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+		pageStart:  pageStart,
+		auth:       cfg.Auth,
+		endpoints:  cfg.Endpoints,
+		mappings:   cfg.Mappings,
+		httpClient: &http.Client{Timeout: apiRequestTimeout},
+	}, nil
+}
+
+// ID implements source.ModSource.
+func (a *API) ID() string { return a.id }
+
+// Name implements source.ModSource.
+func (a *API) Name() string { return a.name }
+
+// AuthURL implements source.ModSource; api sources use API keys, not OAuth.
+func (a *API) AuthURL() string { return "" }
+
+// ExchangeToken implements source.ModSource.
+func (a *API) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
+	return nil, fmt.Errorf("source %q: authentication: %w", a.id, source.ErrNotSupported)
+}
+
+// GetDependencies implements source.ModSource; always unsupported in v1
+// (design §4).
+func (a *API) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	return nil, fmt.Errorf("source %q: dependencies: %w", a.id, source.ErrNotSupported)
+}
+
+// SetAPIKey provides the API key resolved at startup (env var or token store).
+func (a *API) SetAPIKey(key string) { a.apiKey = key }
+
+// IsAuthenticated reports whether an API key is configured.
+func (a *API) IsAuthenticated() bool { return a.apiKey != "" }
+
+// Capabilities implements source.CapabilityReporter: an undefined endpoint is
+// an unsupported capability (design §4/§7).
+func (a *API) Capabilities() source.Capabilities {
+	return source.Capabilities{
+		Search:       a.endpoints.Search != nil,
+		Dependencies: false,
+		Updates:      a.endpoints.GetMod != nil,
+		Auth:         a.auth != nil,
+	}
+}
+
+// DownloadHeaders implements source.DownloadHeaderProvider: header-mode keys
+// go only to downloads on the API's own origin (design §9).
+func (a *API) DownloadHeaders(fileURL string) map[string]string {
+	if a.auth == nil || a.auth.APIKey.In != "header" || a.apiKey == "" {
+		return nil
+	}
+	if !sameOriginURLs(fileURL, a.baseURL) {
+		return nil
+	}
+	return map[string]string{a.auth.APIKey.Name: a.apiKey}
+}
+
+// buildEndpointURL substitutes {placeholder} tokens in an endpoint path
+// template with URL-escaped values. Placeholders without a value are left
+// intact (they will typically 404 loudly rather than silently matching).
+func buildEndpointURL(pathTemplate string, vals map[string]string) string {
+	out := pathTemplate
+	for name, value := range vals {
+		out = strings.ReplaceAll(out, "{"+name+"}", url.QueryEscape(value))
+	}
+	return out
+}
+
+// getJSON performs an authenticated GET against rawURL and decodes the JSON
+// response. 401 maps to domain.ErrAuthRequired; other non-200s surface the
+// status. Errors never contain the request URL's query string (keys ride
+// there in query mode) — the inner *url.Error is unwrapped, mirroring the
+// manifest fetcher's redaction.
+func (a *API) getJSON(ctx context.Context, rawURL string) (any, error) {
+	reqURL := rawURL
+	if a.auth != nil && a.auth.APIKey.In == "query" && a.apiKey != "" {
+		u, err := addQueryParam(reqURL, a.auth.APIKey.Name, a.apiKey)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: %w", a.id, err)
+		}
+		reqURL = u
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: building request: %w", a.id, err)
+	}
+	if a.auth != nil && a.auth.APIKey.In == "header" && a.apiKey != "" {
+		req.Header.Set(a.auth.APIKey.Name, a.apiKey)
+	}
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		var uerr *url.Error
+		if errors.As(err, &uerr) {
+			err = uerr.Err // strip the URL (and any query-mode key) from the message
+		}
+		return nil, fmt.Errorf("source %q: requesting %s: %w", a.id, redactedURL(rawURL), err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("source %q: %w", a.id, domain.ErrAuthRequired)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("source %q: requesting %s: HTTP %d", a.id, redactedURL(rawURL), resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("source %q: reading response: %w", a.id, err)
+	}
+	if len(data) > maxAPIResponseSize {
+		return nil, fmt.Errorf("source %q: response from %s exceeds %d bytes", a.id, redactedURL(rawURL), maxAPIResponseSize)
+	}
+
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("source %q: parsing response from %s: %w", a.id, redactedURL(rawURL), err)
+	}
+	return doc, nil
+}
+
+// redactedURL strips the query string from a URL for error messages.
+func redactedURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "(unparseable URL)"
+	}
+	u.RawQuery = ""
+	return u.String()
+}
+
+var (
+	_ source.ModSource              = (*API)(nil)
+	_ source.CapabilityReporter     = (*API)(nil)
+	_ source.DownloadHeaderProvider = (*API)(nil)
+)
+
+// Search is implemented in the search task (replaces this stub).
+func (a *API) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	return source.SearchResult{}, fmt.Errorf("source %q: searching: %w", a.id, source.ErrNotSupported)
+}
+
+// GetMod is implemented in the read-ops task (replaces this stub).
+func (a *API) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	return nil, fmt.Errorf("source %q: fetching mod: %w", a.id, source.ErrNotSupported)
+}
+
+// GetModFiles is implemented in the read-ops task (replaces this stub).
+func (a *API) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, fmt.Errorf("source %q: listing files: %w", a.id, source.ErrNotSupported)
+}
+
+// GetDownloadURL is implemented in the read-ops task (replaces this stub).
+func (a *API) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	return "", fmt.Errorf("source %q: download URL: %w", a.id, source.ErrNotSupported)
+}
+
+// CheckUpdates is implemented in the update-check task (replaces this stub).
+func (a *API) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, fmt.Errorf("source %q: update checks: %w", a.id, source.ErrNotSupported)
+}

--- a/internal/source/custom/api.go
+++ b/internal/source/custom/api.go
@@ -221,6 +221,12 @@ func (a *API) Search(ctx context.Context, query source.SearchQuery) (source.Sear
 	if !ok {
 		return source.SearchResult{}, fmt.Errorf("source %q: searching: response has no %q array", a.id, ep.List)
 	}
+	if listVal == nil {
+		// A Go-backed API's json.Marshal of a nil slice emits `null`, the
+		// standard zero-hits shape for such APIs — treat it as empty, not
+		// an error.
+		listVal = []any{}
+	}
 	items, ok := listVal.([]any)
 	if !ok {
 		return source.SearchResult{}, fmt.Errorf("source %q: searching: %q is not an array", a.id, ep.List)
@@ -285,6 +291,12 @@ func (a *API) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.Downlo
 	listVal, ok := lookupPath(doc, ep.List)
 	if !ok {
 		return nil, fmt.Errorf("source %q: mod %s: response has no %q array", a.id, mod.ID, ep.List)
+	}
+	if listVal == nil {
+		// A Go-backed API's json.Marshal of a nil slice emits `null`, the
+		// standard zero-hits shape for such APIs — treat it as empty, not
+		// an error.
+		listVal = []any{}
 	}
 	items, ok := listVal.([]any)
 	if !ok {

--- a/internal/source/custom/api.go
+++ b/internal/source/custom/api.go
@@ -246,19 +246,96 @@ func (a *API) Search(ctx context.Context, query source.SearchQuery) (source.Sear
 	return source.SearchResult{Mods: mods, TotalCount: total, Page: query.Page, PageSize: pageSize}, nil
 }
 
-// GetMod is implemented in the read-ops task (replaces this stub).
+// GetMod implements source.ModSource via the get_mod endpoint. gameID feeds
+// the {game_id} placeholder and is echoed onto the returned mod for
+// downstream attribution (the persisted row is normalized by the installer).
 func (a *API) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
-	return nil, fmt.Errorf("source %q: fetching mod: %w", a.id, source.ErrNotSupported)
+	ep := a.endpoints.GetMod
+	if ep == nil {
+		return nil, fmt.Errorf("source %q: fetching mod: %w", a.id, source.ErrNotSupported)
+	}
+
+	vals := map[string]string{"mod_id": modID, "game_id": gameID}
+	doc, err := a.getJSON(ctx, a.baseURL+buildEndpointURL(ep.Path, vals))
+	if err != nil {
+		return nil, fmt.Errorf("fetching mod %s: %w", modID, err)
+	}
+
+	mod, err := mapMod(doc, a.mappings.Mod, a.id)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: mod %s: %w", a.id, modID, err)
+	}
+	mod.GameID = gameID
+	return &mod, nil
 }
 
-// GetModFiles is implemented in the read-ops task (replaces this stub).
+// GetModFiles implements source.ModSource via the mod_files endpoint.
 func (a *API) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
-	return nil, fmt.Errorf("source %q: listing files: %w", a.id, source.ErrNotSupported)
+	ep := a.endpoints.ModFiles
+	if ep == nil {
+		return nil, fmt.Errorf("source %q: listing files: %w", a.id, source.ErrNotSupported)
+	}
+
+	vals := map[string]string{"mod_id": mod.ID, "game_id": mod.GameID}
+	doc, err := a.getJSON(ctx, a.baseURL+buildEndpointURL(ep.Path, vals))
+	if err != nil {
+		return nil, fmt.Errorf("listing files for %s: %w", mod.ID, err)
+	}
+
+	listVal, ok := lookupPath(doc, ep.List)
+	if !ok {
+		return nil, fmt.Errorf("source %q: mod %s: response has no %q array", a.id, mod.ID, ep.List)
+	}
+	items, ok := listVal.([]any)
+	if !ok {
+		return nil, fmt.Errorf("source %q: mod %s: %q is not an array", a.id, mod.ID, ep.List)
+	}
+
+	files := make([]domain.DownloadableFile, 0, len(items))
+	for i, item := range items {
+		f, err := mapFile(item, a.mappings.File)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: mod %s: %s[%d]: %w", a.id, mod.ID, ep.List, i, err)
+		}
+		files = append(files, f)
+	}
+	if len(files) == 1 {
+		files[0].IsPrimary = true // a single file is trivially the primary one
+	}
+	return files, nil
 }
 
-// GetDownloadURL is implemented in the read-ops task (replaces this stub).
+// GetDownloadURL implements source.ModSource via the download_url endpoint.
+// Query-mode keys are appended only for same-origin download URLs (design §9).
 func (a *API) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
-	return "", fmt.Errorf("source %q: download URL: %w", a.id, source.ErrNotSupported)
+	ep := a.endpoints.DownloadURL
+	if ep == nil {
+		return "", fmt.Errorf("source %q: download URL: %w", a.id, source.ErrNotSupported)
+	}
+
+	vals := map[string]string{"file_id": fileID, "mod_id": mod.ID, "game_id": mod.GameID}
+	doc, err := a.getJSON(ctx, a.baseURL+buildEndpointURL(ep.Path, vals))
+	if err != nil {
+		return "", fmt.Errorf("download URL for file %s: %w", fileID, err)
+	}
+
+	v, ok := lookupPath(doc, ep.Field)
+	if !ok {
+		return "", fmt.Errorf("source %q: file %s: response has no %q field", a.id, fileID, ep.Field)
+	}
+	dlURL := coerceString(v)
+	if dlURL == "" {
+		return "", fmt.Errorf("source %q: file %s: %q is not a URL string", a.id, fileID, ep.Field)
+	}
+
+	if a.auth != nil && a.auth.APIKey.In == "query" && a.apiKey != "" && sameOriginURLs(dlURL, a.baseURL) {
+		withKey, err := addQueryParam(dlURL, a.auth.APIKey.Name, a.apiKey)
+		if err != nil {
+			return "", fmt.Errorf("source %q: file %s: %w", a.id, fileID, err)
+		}
+		dlURL = withKey
+	}
+	return dlURL, nil
 }
 
 // CheckUpdates is implemented in the update-check task (replaces this stub).

--- a/internal/source/custom/api.go
+++ b/internal/source/custom/api.go
@@ -110,8 +110,10 @@ func (a *API) DownloadHeaders(fileURL string) map[string]string {
 }
 
 // buildEndpointURL substitutes {placeholder} tokens in an endpoint path
-// template with URL-escaped values. Placeholders without a value are left
-// intact (they will typically 404 loudly rather than silently matching).
+// template with URL-escaped values. Empty values substitute as empty strings
+// (an unset game id yields "game="), which is the correct query-parameter
+// semantics; only placeholders whose key is absent from vals entirely are
+// left intact (they will typically 404 loudly rather than silently matching).
 func buildEndpointURL(pathTemplate string, vals map[string]string) string {
 	out := pathTemplate
 	for name, value := range vals {

--- a/internal/source/custom/api_test.go
+++ b/internal/source/custom/api_test.go
@@ -225,6 +225,37 @@ func TestAPISearchTotalAbsentIsZero(t *testing.T) {
 	assert.Empty(t, res.Mods)
 }
 
+// TestAPISearchNullListIsEmpty guards against Go's json.Marshal encoding a
+// nil slice as `null`: {"results": null} is the standard zero-hits shape
+// for Go-backed REST APIs and must map to empty results, not an error.
+func TestAPISearchNullListIsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results": null}`))
+	}))
+	defer srv.Close()
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+	res, err := a.Search(context.Background(), source.SearchQuery{Query: "x"})
+	require.NoError(t, err)
+	assert.Empty(t, res.Mods)
+	assert.Zero(t, res.TotalCount)
+}
+
+// TestAPISearchNonArrayListFails proves the null-handling fix doesn't
+// over-relax: a present-but-non-array, non-null list value must still error.
+func TestAPISearchNonArrayListFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results": "nope"}`))
+	}))
+	defer srv.Close()
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+	_, err = a.Search(context.Background(), source.SearchQuery{Query: "x"})
+	assert.ErrorContains(t, err, "not an array")
+}
+
 // newTestAPIServer wires a minimal fake REST API for the read ops.
 func newTestAPIServer(t *testing.T) (*httptest.Server, *API) {
 	t.Helper()
@@ -268,6 +299,22 @@ func TestAPIGetModFiles(t *testing.T) {
 	assert.Equal(t, "900", files[0].ID)
 	assert.Equal(t, "cool-1.2.0.zip", files[0].FileName)
 	assert.Equal(t, int64(4), files[0].Size)
+}
+
+// TestAPIGetModFilesNullListIsEmpty mirrors TestAPISearchNullListIsEmpty for
+// the mod_files endpoint: {"files": null} is Go's standard zero-hits shape
+// and must map to an empty files slice, not an error.
+func TestAPIGetModFilesNullListIsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"files": null}`))
+	}))
+	defer srv.Close()
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+	files, err := a.GetModFiles(context.Background(), &domain.Mod{ID: "77", GameID: "skyrim"})
+	require.NoError(t, err)
+	assert.Empty(t, files)
 }
 
 func TestAPIGetDownloadURL(t *testing.T) {

--- a/internal/source/custom/api_test.go
+++ b/internal/source/custom/api_test.go
@@ -1,0 +1,148 @@
+package custom
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func apiDef(baseURL string) SourceDefinition {
+	def := validAPIDef()
+	def.API.BaseURL = baseURL
+	def.AllowHTTP = true // httptest serves plain http
+	return def
+}
+
+func TestNewAPIIsPure(t *testing.T) {
+	a, err := NewAPI(apiDef("https://unreachable.invalid"))
+	require.NoError(t, err)
+	assert.Equal(t, "my-api", a.ID())
+	assert.Equal(t, "My API", a.Name())
+	assert.Equal(t, apiRequestTimeout, a.httpClient.Timeout)
+	assert.Equal(t, 1, a.pageStart) // default when page_start omitted
+}
+
+func TestNewAPIExplicitPageStartZero(t *testing.T) {
+	def := apiDef("https://x.test")
+	zero := 0
+	def.API.PageStart = &zero
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+	assert.Equal(t, 0, a.pageStart)
+}
+
+func TestAPIIdentityAndCapabilities(t *testing.T) {
+	a, err := NewAPI(apiDef("https://x.test"))
+	require.NoError(t, err)
+	assert.Equal(t, source.Capabilities{Search: true, Dependencies: false, Updates: true, Auth: false}, a.Capabilities())
+	assert.Empty(t, a.AuthURL())
+
+	_, err = a.ExchangeToken(context.Background(), "code")
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+	_, err = a.GetDependencies(context.Background(), &domain.Mod{ID: "x"})
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+
+	def := apiDef("https://x.test")
+	def.API.Endpoints.Search = nil
+	def.API.Endpoints.GetMod = nil
+	limited, err := NewAPI(def)
+	require.NoError(t, err)
+	assert.Equal(t, source.Capabilities{Search: false, Dependencies: false, Updates: false, Auth: false}, limited.Capabilities())
+}
+
+func TestBuildEndpointURL(t *testing.T) {
+	got := buildEndpointURL("/mods?q={query}&page={page}&x={unknown}", map[string]string{
+		"query": "cool mod & more", "page": "2",
+	})
+	assert.Equal(t, "/mods?q=cool+mod+%26+more&page=2&x={unknown}", got)
+}
+
+func TestGetJSONAuthAndErrors(t *testing.T) {
+	t.Run("header auth attached and 401 maps to ErrAuthRequired", func(t *testing.T) {
+		var gotKey string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotKey = r.Header.Get("X-API-Key")
+			if gotKey == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte(`{"ok": true}`))
+		}))
+		defer srv.Close()
+
+		def := apiDef(srv.URL)
+		def.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+		a, err := NewAPI(def)
+		require.NoError(t, err)
+
+		_, err = a.getJSON(context.Background(), srv.URL+"/mods/1")
+		assert.True(t, errors.Is(err, domain.ErrAuthRequired))
+
+		a.SetAPIKey("sekrit")
+		doc, err := a.getJSON(context.Background(), srv.URL+"/mods/1")
+		require.NoError(t, err)
+		assert.Equal(t, "sekrit", gotKey)
+		assert.Equal(t, map[string]any{"ok": true}, doc)
+	})
+
+	t.Run("query auth attached", func(t *testing.T) {
+		var gotQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query().Get("api_key")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer srv.Close()
+
+		def := apiDef(srv.URL)
+		def.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+		a, err := NewAPI(def)
+		require.NoError(t, err)
+		a.SetAPIKey("sekrit")
+
+		_, err = a.getJSON(context.Background(), srv.URL+"/mods/1")
+		require.NoError(t, err)
+		assert.Equal(t, "sekrit", gotQuery)
+	})
+
+	t.Run("network error does not leak query key", func(t *testing.T) {
+		def := apiDef("http://127.0.0.1:1")
+		def.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+		a, err := NewAPI(def)
+		require.NoError(t, err)
+		a.SetAPIKey("LEAKME")
+
+		_, err = a.getJSON(context.Background(), "http://127.0.0.1:1/mods/1")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "LEAKME")
+		assert.Contains(t, err.Error(), "my-api")
+	})
+
+	t.Run("non-200 surfaces status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		a, err := NewAPI(apiDef(srv.URL))
+		require.NoError(t, err)
+		_, err = a.getJSON(context.Background(), srv.URL+"/x")
+		assert.ErrorContains(t, err, "HTTP 500")
+	})
+}
+
+func TestAPIDownloadHeaders(t *testing.T) {
+	def := apiDef("https://api.x.test")
+	def.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+	a.SetAPIKey("sekrit")
+
+	assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, a.DownloadHeaders("https://api.x.test/dl/1.zip"))
+	assert.Nil(t, a.DownloadHeaders("https://cdn.elsewhere.test/dl/1.zip"), "cross-origin downloads must not receive the key")
+}

--- a/internal/source/custom/api_test.go
+++ b/internal/source/custom/api_test.go
@@ -317,3 +317,44 @@ func TestAPIReadOpsMissingEndpoints(t *testing.T) {
 	_, err = a.GetDownloadURL(context.Background(), &domain.Mod{ID: "1"}, "f")
 	assert.True(t, errors.Is(err, source.ErrNotSupported))
 }
+
+func TestAPICheckUpdates(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/mods/77", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id": 77, "name": "Cool Mod", "latest_version": "1.2.0"}`))
+	})
+	mux.HandleFunc("/mods/88", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id": 88, "name": "Fresh Mod", "latest_version": "0.9.0"}`))
+	})
+	mux.HandleFunc("/mods/99", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "gone", http.StatusInternalServerError)
+	})
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+
+	installed := []domain.InstalledMod{
+		{Mod: domain.Mod{ID: "77", SourceID: "my-api", Version: "1.0.0", GameID: "skyrim"}},
+		{Mod: domain.Mod{ID: "88", SourceID: "my-api", Version: "0.9.0", GameID: "skyrim"}},
+		{Mod: domain.Mod{ID: "99", SourceID: "my-api", Version: "1.0", GameID: "skyrim"}},
+	}
+
+	updates, err := a.CheckUpdates(context.Background(), installed)
+	require.Error(t, err, "the failing mod must surface, not vanish")
+	assert.Contains(t, err.Error(), "99")
+	require.Len(t, updates, 1, "partial results returned alongside the error")
+	assert.Equal(t, "77", updates[0].InstalledMod.ID)
+	assert.Equal(t, "1.2.0", updates[0].NewVersion)
+}
+
+func TestAPICheckUpdatesNoEndpoint(t *testing.T) {
+	def := apiDef("https://x.test")
+	def.API.Endpoints = APIEndpoints{Search: &EndpointConfig{Path: "/mods", List: "results"}}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+
+	_, err = a.CheckUpdates(context.Background(), []domain.InstalledMod{{Mod: domain.Mod{ID: "1"}}})
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+}

--- a/internal/source/custom/api_test.go
+++ b/internal/source/custom/api_test.go
@@ -58,10 +58,12 @@ func TestAPIIdentityAndCapabilities(t *testing.T) {
 }
 
 func TestBuildEndpointURL(t *testing.T) {
-	got := buildEndpointURL("/mods?q={query}&page={page}&x={unknown}", map[string]string{
-		"query": "cool mod & more", "page": "2",
+	// Empty values are substituted (e.g. game= for empty game_id), but absent keys
+	// are left as {placeholder} literals.
+	got := buildEndpointURL("/mods?q={query}&page={page}&game={game_id}&x={unknown}", map[string]string{
+		"query": "cool mod & more", "page": "2", "game_id": "",
 	})
-	assert.Equal(t, "/mods?q=cool+mod+%26+more&page=2&x={unknown}", got)
+	assert.Equal(t, "/mods?q=cool+mod+%26+more&page=2&game=&x={unknown}", got)
 }
 
 func TestGetJSONAuthAndErrors(t *testing.T) {

--- a/internal/source/custom/api_test.go
+++ b/internal/source/custom/api_test.go
@@ -146,3 +146,81 @@ func TestAPIDownloadHeaders(t *testing.T) {
 	assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, a.DownloadHeaders("https://api.x.test/dl/1.zip"))
 	assert.Nil(t, a.DownloadHeaders("https://cdn.elsewhere.test/dl/1.zip"), "cross-origin downloads must not receive the key")
 }
+
+const apiSearchResponse = `{
+	"results": [
+		{"id": 1, "name": "Alpha Mod", "latest_version": "1.0.0"},
+		{"id": 2, "name": "Beta Mod", "latest_version": "2.0.0"}
+	],
+	"pagination": {"total": 41}
+}`
+
+func TestAPISearch(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.String()
+		_, _ = w.Write([]byte(apiSearchResponse))
+	}))
+	defer srv.Close()
+
+	def := apiDef(srv.URL)
+	def.API.Endpoints.Search = &EndpointConfig{
+		Path:  "/mods?game={game_id}&q={query}&page={page}&limit={page_size}&skip={offset}",
+		List:  "results",
+		Total: "pagination.total",
+	}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+
+	res, err := a.Search(context.Background(), source.SearchQuery{
+		GameID: "skyrim", Query: "cool mod", Page: 2, PageSize: 10,
+	})
+	require.NoError(t, err)
+
+	// {page} = 0-based page + page_start(1) = 3; {offset} = 2*10 = 20.
+	assert.Equal(t, "/mods?game=skyrim&q=cool+mod&page=3&limit=10&skip=20", gotPath)
+	require.Len(t, res.Mods, 2)
+	assert.Equal(t, "1", res.Mods[0].ID)
+	assert.Equal(t, "Alpha Mod", res.Mods[0].Name)
+	assert.Equal(t, "my-api", res.Mods[0].SourceID)
+	assert.Equal(t, "skyrim", res.Mods[0].GameID)
+	assert.Equal(t, 41, res.TotalCount)
+	assert.Equal(t, 2, res.Page)
+	assert.Equal(t, 10, res.PageSize)
+}
+
+func TestAPISearchNoEndpoint(t *testing.T) {
+	def := apiDef("https://x.test")
+	def.API.Endpoints.Search = nil
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+
+	_, err = a.Search(context.Background(), source.SearchQuery{Query: "x"})
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+}
+
+func TestAPISearchMissingListPathFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"unexpected": {}}`))
+	}))
+	defer srv.Close()
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+	_, err = a.Search(context.Background(), source.SearchQuery{Query: "x"})
+	assert.ErrorContains(t, err, "results")
+}
+
+func TestAPISearchTotalAbsentIsZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer srv.Close()
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+	res, err := a.Search(context.Background(), source.SearchQuery{Query: "x"})
+	require.NoError(t, err)
+	assert.Zero(t, res.TotalCount)
+	assert.Empty(t, res.Mods)
+}

--- a/internal/source/custom/api_test.go
+++ b/internal/source/custom/api_test.go
@@ -224,3 +224,96 @@ func TestAPISearchTotalAbsentIsZero(t *testing.T) {
 	assert.Zero(t, res.TotalCount)
 	assert.Empty(t, res.Mods)
 }
+
+// newTestAPIServer wires a minimal fake REST API for the read ops.
+func newTestAPIServer(t *testing.T) (*httptest.Server, *API) {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/mods/77", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id": 77, "name": "Cool Mod", "latest_version": "1.2.0"}`))
+	})
+	mux.HandleFunc("/mods/77/files", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"files": [{"id": 900, "file_name": "cool-1.2.0.zip", "version": "1.2.0", "size_bytes": 4}]}`))
+	})
+	mux.HandleFunc("/files/900/download", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"url": "` + srv.URL + `/dl/cool-1.2.0.zip"}`))
+	})
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+	return srv, a
+}
+
+func TestAPIGetMod(t *testing.T) {
+	_, a := newTestAPIServer(t)
+
+	mod, err := a.GetMod(context.Background(), "skyrim", "77")
+	require.NoError(t, err)
+	assert.Equal(t, "77", mod.ID)
+	assert.Equal(t, "Cool Mod", mod.Name)
+	assert.Equal(t, "1.2.0", mod.Version)
+	assert.Equal(t, "skyrim", mod.GameID)
+	assert.Equal(t, "my-api", mod.SourceID)
+}
+
+func TestAPIGetModFiles(t *testing.T) {
+	_, a := newTestAPIServer(t)
+
+	files, err := a.GetModFiles(context.Background(), &domain.Mod{ID: "77", GameID: "skyrim"})
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "900", files[0].ID)
+	assert.Equal(t, "cool-1.2.0.zip", files[0].FileName)
+	assert.Equal(t, int64(4), files[0].Size)
+}
+
+func TestAPIGetDownloadURL(t *testing.T) {
+	srv, a := newTestAPIServer(t)
+
+	u, err := a.GetDownloadURL(context.Background(), &domain.Mod{ID: "77", GameID: "skyrim"}, "900")
+	require.NoError(t, err)
+	assert.Equal(t, srv.URL+"/dl/cool-1.2.0.zip", u)
+}
+
+func TestAPIGetDownloadURLQueryAuthSameOriginOnly(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	sameOrigin := srv.URL + "/dl/a.zip"
+	mux.HandleFunc("/files/1/download", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"url": "` + sameOrigin + `"}`))
+	})
+	mux.HandleFunc("/files/2/download", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"url": "https://cdn.elsewhere.test/b.zip"}`))
+	})
+
+	def := apiDef(srv.URL)
+	def.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+	a.SetAPIKey("sekrit")
+
+	u, err := a.GetDownloadURL(context.Background(), &domain.Mod{ID: "x"}, "1")
+	require.NoError(t, err)
+	assert.Contains(t, u, "api_key=sekrit", "same-origin download URL gets the query key")
+
+	u, err = a.GetDownloadURL(context.Background(), &domain.Mod{ID: "x"}, "2")
+	require.NoError(t, err)
+	assert.NotContains(t, u, "sekrit", "cross-origin download URL must not carry the key")
+}
+
+func TestAPIReadOpsMissingEndpoints(t *testing.T) {
+	def := apiDef("https://x.test")
+	def.API.Endpoints = APIEndpoints{GetMod: &EndpointConfig{Path: "/mods/{mod_id}"}}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+
+	_, err = a.GetModFiles(context.Background(), &domain.Mod{ID: "1"})
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+	_, err = a.GetDownloadURL(context.Background(), &domain.Mod{ID: "1"}, "f")
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+}

--- a/internal/source/custom/custom.go
+++ b/internal/source/custom/custom.go
@@ -6,15 +6,18 @@ import (
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
 )
 
-// New constructs a ModSource from a validated definition. It returns an error
-// for definition types whose implementation has not shipped yet, so startup
-// can warn-and-skip instead of failing.
+// New constructs a ModSource from a validated definition. The default case
+// is defensive: SourceDefinition.Validate already rejects unknown type
+// strings, so it should be unreachable in practice, but New still returns a
+// clear error instead of panicking if it is ever reached.
 func New(def SourceDefinition) (source.ModSource, error) {
 	switch def.Type {
 	case TypeDirectory:
 		return NewDirectory(def)
 	case TypeManifest:
 		return NewManifest(def)
+	case TypeAPI:
+		return NewAPI(def)
 	default:
 		return nil, fmt.Errorf("source type %q is not yet supported", def.Type)
 	}

--- a/internal/source/custom/custom_test.go
+++ b/internal/source/custom/custom_test.go
@@ -31,8 +31,15 @@ func TestNew(t *testing.T) {
 		assert.Equal(t, "my-repo", src.ID())
 	})
 
-	t.Run("unimplemented types return a clear error", func(t *testing.T) {
-		def := SourceDefinition{ID: "x", Name: "X", Type: TypeAPI}
+	t.Run("api type constructs a source", func(t *testing.T) {
+		def := validAPIDef()
+		src, err := New(def)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-api", src.ID())
+	})
+
+	t.Run("unknown type is rejected", func(t *testing.T) {
+		def := SourceDefinition{ID: "x", Name: "X", Type: "ftp"}
 		_, err := New(def)
 		assert.ErrorContains(t, err, "not yet supported")
 	})

--- a/internal/source/custom/definition.go
+++ b/internal/source/custom/definition.go
@@ -145,7 +145,7 @@ func (c *APIConfig) validateEndpointsAndMappings() error {
 		return errors.New(`mappings.mod: "name" is required`)
 	}
 	if c.Endpoints.ModFiles != nil && c.Mappings.File["id"] == "" {
-		return errors.New(`mappings.file: "id" is required`)
+		return errors.New(`mappings.file: "id" is required when mod_files is defined`)
 	}
 	for k := range c.Mappings.Mod {
 		if !knownModMappingKeys[k] {

--- a/internal/source/custom/definition.go
+++ b/internal/source/custom/definition.go
@@ -58,10 +58,107 @@ type APIKeyConfig struct {
 
 // APIConfig configures a declarative REST source (expanded in Phase 4).
 type APIConfig struct {
-	BaseURL string `yaml:"base_url"`
+	BaseURL   string       `yaml:"base_url"`
+	PageStart *int         `yaml:"page_start"` // nil = default 1; explicit 0 respected
+	Auth      *AuthConfig  `yaml:"auth"`
+	Endpoints APIEndpoints `yaml:"endpoints"`
+	Mappings  APIMappings  `yaml:"mappings"`
+}
+
+// APIEndpoints defines optional endpoint configurations for an API source.
+type APIEndpoints struct {
+	Search      *EndpointConfig `yaml:"search"`
+	GetMod      *EndpointConfig `yaml:"get_mod"`
+	ModFiles    *EndpointConfig `yaml:"mod_files"`
+	DownloadURL *EndpointConfig `yaml:"download_url"`
+}
+
+// EndpointConfig configures a single API endpoint.
+type EndpointConfig struct {
+	Path  string `yaml:"path"`  // required; may contain {placeholders}
+	List  string `yaml:"list"`  // dot-path to results array (required for search & mod_files)
+	Total string `yaml:"total"` // optional dot-path to total count (search only)
+	Field string `yaml:"field"` // dot-path to a scalar (required for download_url)
+}
+
+// APIMappings maps domain field keys to JSON dot-paths.
+type APIMappings struct {
+	Mod  map[string]string `yaml:"mod"` // domain field key -> JSON dot-path
+	File map[string]string `yaml:"file"`
 }
 
 var idPattern = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// knownModMappingKeys / knownFileMappingKeys are the domain fields a mapping
+// may target. Unknown keys are validation errors so typos surface at load
+// time instead of silently producing empty fields.
+var knownModMappingKeys = map[string]bool{
+	"id": true, "name": true, "version": true, "author": true, "summary": true,
+	"description": true, "downloads": true, "updated_at": true, "url": true, "picture_url": true,
+}
+
+var knownFileMappingKeys = map[string]bool{
+	"id": true, "name": true, "filename": true, "version": true, "size": true,
+}
+
+// validateEndpointsAndMappings checks the api block's endpoint/mapping rules
+// (design §4): at least one endpoint, per-endpoint required fields, required
+// mapping keys, and no unknown mapping keys.
+func (c *APIConfig) validateEndpointsAndMappings() error {
+	eps := []struct {
+		name string
+		ep   *EndpointConfig
+	}{
+		{"search", c.Endpoints.Search},
+		{"get_mod", c.Endpoints.GetMod},
+		{"mod_files", c.Endpoints.ModFiles},
+		{"download_url", c.Endpoints.DownloadURL},
+	}
+
+	defined := false
+	for _, e := range eps {
+		if e.ep == nil {
+			continue
+		}
+		defined = true
+		if e.ep.Path == "" {
+			return fmt.Errorf("endpoints.%s: path is required", e.name)
+		}
+	}
+	if !defined {
+		return errors.New("endpoints: at least one endpoint must be defined")
+	}
+	if c.Endpoints.Search != nil && c.Endpoints.Search.List == "" {
+		return errors.New("endpoints.search: list is required")
+	}
+	if c.Endpoints.ModFiles != nil && c.Endpoints.ModFiles.List == "" {
+		return errors.New("endpoints.mod_files: list is required")
+	}
+	if c.Endpoints.DownloadURL != nil && c.Endpoints.DownloadURL.Field == "" {
+		return errors.New("endpoints.download_url: field is required")
+	}
+
+	if c.Mappings.Mod["id"] == "" {
+		return errors.New(`mappings.mod: "id" is required`)
+	}
+	if c.Mappings.Mod["name"] == "" {
+		return errors.New(`mappings.mod: "name" is required`)
+	}
+	if c.Endpoints.ModFiles != nil && c.Mappings.File["id"] == "" {
+		return errors.New(`mappings.file: "id" is required`)
+	}
+	for k := range c.Mappings.Mod {
+		if !knownModMappingKeys[k] {
+			return fmt.Errorf("mappings.mod: unknown key %q", k)
+		}
+	}
+	for k := range c.Mappings.File {
+		if !knownFileMappingKeys[k] {
+			return fmt.Errorf("mappings.file: unknown key %q", k)
+		}
+	}
+	return nil
+}
 
 // validateAuth checks an optional auth block. Shared by manifest (Phase 3)
 // and api (Phase 4) validation.
@@ -153,6 +250,12 @@ func (d *SourceDefinition) Validate() error {
 		}
 		if err := d.checkURL(d.API.BaseURL); err != nil {
 			return fmt.Errorf("api.base_url: %w", err)
+		}
+		if err := validateAuth(d.API.Auth); err != nil {
+			return fmt.Errorf("api: %w", err)
+		}
+		if err := d.API.validateEndpointsAndMappings(); err != nil {
+			return fmt.Errorf("api: %w", err)
 		}
 	default:
 		return fmt.Errorf("unknown type %q (expected %s, %s, or %s)", d.Type, TypeDirectory, TypeManifest, TypeAPI)

--- a/internal/source/custom/definition_test.go
+++ b/internal/source/custom/definition_test.go
@@ -30,7 +30,7 @@ func validAPIDef() SourceDefinition {
 			},
 			Mappings: APIMappings{
 				Mod:  map[string]string{"id": "id", "name": "name", "version": "latest_version"},
-				File: map[string]string{"id": "id", "filename": "file_name"},
+				File: map[string]string{"id": "id", "filename": "file_name", "size": "size_bytes"},
 			},
 		},
 	}

--- a/internal/source/custom/definition_test.go
+++ b/internal/source/custom/definition_test.go
@@ -15,6 +15,27 @@ func validDirectoryDef() SourceDefinition {
 	}
 }
 
+func validAPIDef() SourceDefinition {
+	return SourceDefinition{
+		ID:   "my-api",
+		Name: "My API",
+		Type: TypeAPI,
+		API: &APIConfig{
+			BaseURL: "https://api.x.test",
+			Endpoints: APIEndpoints{
+				Search:      &EndpointConfig{Path: "/mods?q={query}&page={page}", List: "results", Total: "total"},
+				GetMod:      &EndpointConfig{Path: "/mods/{mod_id}"},
+				ModFiles:    &EndpointConfig{Path: "/mods/{mod_id}/files", List: "files"},
+				DownloadURL: &EndpointConfig{Path: "/files/{file_id}/download", Field: "url"},
+			},
+			Mappings: APIMappings{
+				Mod:  map[string]string{"id": "id", "name": "name", "version": "latest_version"},
+				File: map[string]string{"id": "id", "filename": "file_name"},
+			},
+		},
+	}
+}
+
 func TestSourceDefinitionValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -63,16 +84,65 @@ func TestSourceDefinitionValidate(t *testing.T) {
 			d.Directory = nil
 			d.Manifest = &ManifestConfig{URL: "https://x.test/m.yaml", Refresh: "soon"}
 		}, "refresh"},
-		{"valid api", func(d *SourceDefinition) {
-			d.Type = TypeAPI
-			d.Directory = nil
-			d.API = &APIConfig{BaseURL: "https://api.x.test"}
+		{"valid full api", func(d *SourceDefinition) {
+			*d = validAPIDef()
 		}, ""},
 		{"http api rejected", func(d *SourceDefinition) {
-			d.Type = TypeAPI
-			d.Directory = nil
-			d.API = &APIConfig{BaseURL: "http://api.x.test"}
+			*d = validAPIDef()
+			d.API.BaseURL = "http://api.x.test"
 		}, "https"},
+		{"api no endpoints", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints = APIEndpoints{}
+		}, "at least one endpoint"},
+		{"api endpoint missing path", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints.GetMod = &EndpointConfig{}
+		}, "get_mod: path is required"},
+		{"api search missing list", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints.Search.List = ""
+		}, "search: list is required"},
+		{"api mod_files missing list", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints.ModFiles.List = ""
+		}, "mod_files: list is required"},
+		{"api download_url missing field", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints.DownloadURL.Field = ""
+		}, "download_url: field is required"},
+		{"api mappings missing mod id", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			delete(d.API.Mappings.Mod, "id")
+		}, `mappings.mod: "id" is required`},
+		{"api mappings missing mod name", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			delete(d.API.Mappings.Mod, "name")
+		}, `mappings.mod: "name" is required`},
+		{"api mod_files without file id mapping", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			delete(d.API.Mappings.File, "id")
+		}, `mappings.file: "id" is required`},
+		{"api unknown mod mapping key", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Mappings.Mod["fancyness"] = "x"
+		}, `mappings.mod: unknown key "fancyness"`},
+		{"api unknown file mapping key", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Mappings.File["sha512"] = "x"
+		}, `mappings.file: unknown key "sha512"`},
+		{"api with auth", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+		}, ""},
+		{"api bad auth", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "body", Name: "k"}}
+		}, `auth.api_key.in must be "header" or "query"`},
+		{"api install-by-id only is valid", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints.Search = nil
+		}, ""},
 		{"valid manifest auth header", func(d *SourceDefinition) {
 			d.Type = TypeManifest
 			d.Directory = nil

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -371,38 +371,10 @@ func (m *Manifest) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID s
 }
 
 // sameOrigin reports whether fileURL shares scheme and host with the
-// manifest's own URL. Ports are normalized before comparing: an explicit
-// default port (:443 on https, :80 on http) matches a URL with no port at
-// all, so "https://repo.test" and "https://repo.test:443" are the same
-// origin; any other explicit port must still match exactly. Only meaningful
-// for remote manifests (m.isRemote); callers guard local-path manifests
-// separately, since a local path has no URL origin to compare and is
-// trusted regardless of the file's host.
+// manifest's own URL. Only meaningful for remote manifests (m.isRemote);
+// callers guard local-path manifests separately.
 func (m *Manifest) sameOrigin(fileURL string) bool {
-	fu, err := url.Parse(fileURL)
-	if err != nil {
-		return false
-	}
-	mu, err := url.Parse(m.url)
-	if err != nil {
-		return false
-	}
-	return fu.Scheme == mu.Scheme && normalizedHost(fu) == normalizedHost(mu)
-}
-
-// normalizedHost returns u's hostname, with an explicit port stripped when
-// it is the scheme's default (443 for https, 80 for http). This lets
-// sameOrigin treat a bare host and that same host with its default port
-// spelled out as identical origins.
-func normalizedHost(u *url.URL) string {
-	port := u.Port()
-	if port == "" {
-		return u.Hostname()
-	}
-	if (u.Scheme == "https" && port == "443") || (u.Scheme == "http" && port == "80") {
-		return u.Hostname()
-	}
-	return u.Hostname() + ":" + port
+	return sameOriginURLs(fileURL, m.url)
 }
 
 // findMod fetches the manifest and returns the entry with the given ID.

--- a/internal/source/custom/mapping.go
+++ b/internal/source/custom/mapping.go
@@ -1,0 +1,131 @@
+package custom
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// lookupPath traverses a decoded JSON document (map[string]any tree) by a
+// dot-separated path. Returns (value, true) when every segment resolves;
+// (nil, false) when any segment is missing or a non-object is traversed
+// into. Array indexing is not supported in v1 (design §4).
+func lookupPath(doc any, path string) (any, bool) {
+	cur := doc
+	for _, seg := range strings.Split(path, ".") {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = m[seg]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// coerceString renders a JSON scalar as a string. JSON numbers decode as
+// float64, so integer ids must format without a trailing ".0".
+func coerceString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	default:
+		return ""
+	}
+}
+
+// coerceInt64 renders a JSON scalar as an int64, best effort (0 on failure).
+func coerceInt64(v any) int64 {
+	switch t := v.(type) {
+	case float64:
+		return int64(t)
+	case string:
+		n, err := strconv.ParseInt(t, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return n
+	default:
+		return 0
+	}
+}
+
+// pathString resolves a mapping path to a string; "" when the mapping key or
+// the path is absent.
+func pathString(doc any, mapping map[string]string, key string) string {
+	path, ok := mapping[key]
+	if !ok {
+		return ""
+	}
+	v, ok := lookupPath(doc, path)
+	if !ok {
+		return ""
+	}
+	return coerceString(v)
+}
+
+// mapMod builds a domain.Mod from a decoded JSON object using the definition's
+// mod mappings. id and name are required (design §4); everything else is a
+// zero value when missing or unmapped.
+func mapMod(doc any, mapping map[string]string, sourceID string) (domain.Mod, error) {
+	mod := domain.Mod{SourceID: sourceID}
+
+	mod.ID = pathString(doc, mapping, "id")
+	if mod.ID == "" {
+		return domain.Mod{}, fmt.Errorf(`response is missing required field "id" (mapped from %q)`, mapping["id"])
+	}
+	mod.Name = pathString(doc, mapping, "name")
+	if mod.Name == "" {
+		return domain.Mod{}, fmt.Errorf(`response is missing required field "name" (mapped from %q)`, mapping["name"])
+	}
+
+	mod.Version = pathString(doc, mapping, "version")
+	mod.Author = pathString(doc, mapping, "author")
+	mod.Summary = pathString(doc, mapping, "summary")
+	mod.Description = pathString(doc, mapping, "description")
+	if mod.Description == "" {
+		mod.Description = mod.Summary
+	}
+	mod.SourceURL = pathString(doc, mapping, "url")
+	mod.PictureURL = pathString(doc, mapping, "picture_url")
+
+	if path, ok := mapping["downloads"]; ok {
+		if v, found := lookupPath(doc, path); found {
+			mod.Downloads = coerceInt64(v)
+		}
+	}
+	if ts := pathString(doc, mapping, "updated_at"); ts != "" {
+		if parsed, err := time.Parse(time.RFC3339, ts); err == nil {
+			mod.UpdatedAt = parsed // unparseable -> zero value, by design
+		}
+	}
+
+	return mod, nil
+}
+
+// mapFile builds a domain.DownloadableFile from a decoded JSON object using
+// the definition's file mappings. id is required (design §4).
+func mapFile(doc any, mapping map[string]string) (domain.DownloadableFile, error) {
+	f := domain.DownloadableFile{}
+
+	f.ID = pathString(doc, mapping, "id")
+	if f.ID == "" {
+		return domain.DownloadableFile{}, fmt.Errorf(`response is missing required field "id" (mapped from %q)`, mapping["id"])
+	}
+	f.Name = pathString(doc, mapping, "name")
+	f.FileName = pathString(doc, mapping, "filename")
+	f.Version = pathString(doc, mapping, "version")
+	if path, ok := mapping["size"]; ok {
+		if v, found := lookupPath(doc, path); found {
+			f.Size = coerceInt64(v)
+		}
+	}
+	return f, nil
+}

--- a/internal/source/custom/mapping_test.go
+++ b/internal/source/custom/mapping_test.go
@@ -1,0 +1,112 @@
+package custom
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// jsonDoc decodes a JSON literal the way the API source does (numbers become
+// float64), so tests exercise the real coercion paths.
+func jsonDoc(t *testing.T, s string) any {
+	t.Helper()
+	var doc any
+	require.NoError(t, json.Unmarshal([]byte(s), &doc))
+	return doc
+}
+
+func TestLookupPath(t *testing.T) {
+	doc := jsonDoc(t, `{"a": {"b": {"c": 42}}, "top": "x", "arr": [1,2]}`)
+
+	v, ok := lookupPath(doc, "a.b.c")
+	require.True(t, ok)
+	assert.Equal(t, float64(42), v)
+
+	v, ok = lookupPath(doc, "top")
+	require.True(t, ok)
+	assert.Equal(t, "x", v)
+
+	_, ok = lookupPath(doc, "a.missing")
+	assert.False(t, ok)
+
+	_, ok = lookupPath(doc, "top.deeper") // traversing into a non-map
+	assert.False(t, ok)
+
+	_, ok = lookupPath(doc, "arr.0") // array indexing unsupported in v1
+	assert.False(t, ok)
+}
+
+func TestCoercions(t *testing.T) {
+	assert.Equal(t, "hello", coerceString("hello"))
+	assert.Equal(t, "123", coerceString(float64(123))) // integer id, no ".0"
+	assert.Equal(t, "1.5", coerceString(float64(1.5)))
+	assert.Equal(t, "", coerceString(nil))
+	assert.Equal(t, "", coerceString(true))
+
+	assert.Equal(t, int64(42), coerceInt64(float64(42)))
+	assert.Equal(t, int64(42), coerceInt64("42"))
+	assert.Equal(t, int64(0), coerceInt64("not a number"))
+	assert.Equal(t, int64(0), coerceInt64(nil))
+}
+
+func TestMapMod(t *testing.T) {
+	doc := jsonDoc(t, `{
+		"id": 77, "name": "Cool Mod", "latest_version": "1.2.0",
+		"author": {"name": "someone"}, "description": "Makes things cooler",
+		"download_count": 12345, "updated": "2026-07-01T00:00:00Z",
+		"web_url": "https://x.test/mods/77"
+	}`)
+	mapping := map[string]string{
+		"id": "id", "name": "name", "version": "latest_version",
+		"author": "author.name", "summary": "description",
+		"downloads": "download_count", "updated_at": "updated", "url": "web_url",
+	}
+
+	mod, err := mapMod(doc, mapping, "my-api")
+	require.NoError(t, err)
+	assert.Equal(t, "77", mod.ID) // numeric id coerced without ".0"
+	assert.Equal(t, "my-api", mod.SourceID)
+	assert.Equal(t, "Cool Mod", mod.Name)
+	assert.Equal(t, "1.2.0", mod.Version)
+	assert.Equal(t, "someone", mod.Author)
+	assert.Equal(t, "Makes things cooler", mod.Summary)
+	assert.Equal(t, int64(12345), mod.Downloads)
+	assert.Equal(t, 2026, mod.UpdatedAt.Year())
+	assert.Equal(t, "https://x.test/mods/77", mod.SourceURL)
+}
+
+func TestMapModRequiredFields(t *testing.T) {
+	mapping := map[string]string{"id": "id", "name": "name"}
+
+	_, err := mapMod(jsonDoc(t, `{"name": "NoID"}`), mapping, "s")
+	assert.ErrorContains(t, err, `required field "id"`)
+
+	_, err = mapMod(jsonDoc(t, `{"id": 1}`), mapping, "s")
+	assert.ErrorContains(t, err, `required field "name"`)
+}
+
+func TestMapModOptionalMissingYieldsZero(t *testing.T) {
+	mapping := map[string]string{"id": "id", "name": "name", "version": "nope.nothere", "updated_at": "bad_time"}
+	mod, err := mapMod(jsonDoc(t, `{"id": "x", "name": "X", "bad_time": "yesterday-ish"}`), mapping, "s")
+	require.NoError(t, err)
+	assert.Empty(t, mod.Version)
+	assert.True(t, mod.UpdatedAt.IsZero())
+}
+
+func TestMapFile(t *testing.T) {
+	doc := jsonDoc(t, `{"id": 900, "title": "Main File", "file_name": "cool-1.2.0.zip", "version": "1.2.0", "size_bytes": 123456}`)
+	mapping := map[string]string{"id": "id", "name": "title", "filename": "file_name", "version": "version", "size": "size_bytes"}
+
+	f, err := mapFile(doc, mapping)
+	require.NoError(t, err)
+	assert.Equal(t, "900", f.ID)
+	assert.Equal(t, "Main File", f.Name)
+	assert.Equal(t, "cool-1.2.0.zip", f.FileName)
+	assert.Equal(t, "1.2.0", f.Version)
+	assert.Equal(t, int64(123456), f.Size)
+
+	_, err = mapFile(jsonDoc(t, `{"title": "no id"}`), mapping)
+	assert.ErrorContains(t, err, `required field "id"`)
+}

--- a/internal/source/custom/origin.go
+++ b/internal/source/custom/origin.go
@@ -1,0 +1,35 @@
+package custom
+
+import "net/url"
+
+// sameOriginURLs reports whether two URLs share scheme and host. Ports are
+// normalized before comparing: an explicit default port (:443 on https, :80
+// on http) matches a URL with no port at all; any other explicit port must
+// match exactly. Either URL failing to parse is not same-origin (fail closed).
+// Used to scope custom-source API keys to their own origin (design §9).
+func sameOriginURLs(a, b string) bool {
+	au, err := url.Parse(a)
+	if err != nil {
+		return false
+	}
+	bu, err := url.Parse(b)
+	if err != nil {
+		return false
+	}
+	return au.Scheme == bu.Scheme && normalizedHost(au) == normalizedHost(bu)
+}
+
+// normalizedHost returns u's hostname, with an explicit port stripped when
+// it is the scheme's default (443 for https, 80 for http). This lets
+// sameOrigin treat a bare host and that same host with its default port
+// spelled out as identical origins.
+func normalizedHost(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		return u.Hostname()
+	}
+	if (u.Scheme == "https" && port == "443") || (u.Scheme == "http" && port == "80") {
+		return u.Hostname()
+	}
+	return u.Hostname() + ":" + port
+}


### PR DESCRIPTION
## Summary

Implements Phase 4 of the custom sources epic (#45): the `api` source type — describe a GET+JSON REST API declaratively (endpoint URL templates + JSON dot-path mappings) and use it as a mod source, including install-by-ID-only definitions. Also ships `lmm source validate --probe`.

Closes #49

### What's new
- **`type: api` definitions**: per-operation endpoints (`search`, `get_mod`, `mod_files`, `download_url`) with URL-escaped placeholders (`{game_id}`, `{query}`, `{page}` with `page_start`, `{page_size}`, `{offset}`, `{mod_id}`, `{file_id}`) and dot-path mappings onto `domain.Mod`/`DownloadableFile` — required keys validated at load time, unknown keys rejected (typo detection)
- **Capability gaps by construction**: an undefined endpoint means that operation reports unsupported (`ErrNotSupported`); a definition with only `get_mod` + `mod_files` + `download_url` is a valid install-by-ID source (acceptance criterion 1); dependencies always unsupported in v1
- **Auth reuses the hardened v1.8.0 machinery**: `AuthConfig` (header/query), `LMM_<ID>_API_KEY` env → token store, `auth login/status/logout` work unchanged; keys are scoped same-origin (scheme+host vs `base_url`) for both modes on downloads, header keys stripped on off-origin redirects, and never appear in error text (acceptance criterion 2)
- **Guardrails**: GET+JSON only, https unless `allow_http: true`, 30s request timeout, 10 MiB response cap, JSON `null` list responses treated as empty results (the standard Go-API zero-hits shape — caught by the final review's live testing)
- **`lmm source validate --probe [--id <mod-id>]`**: live smoke test for any custom source type (directory scan, manifest fetch+parse, or an API search/get_mod call)

### Review-driven fixes included
- `null` at a list dot-path no longer hard-errors empty search results (RED-first regression tests)
- Conditional validation message wording restored

## Test plan
- [x] TDD throughout; full suite green incl. `-race`; gofmt/vet clean; no new dependencies
- [x] E2E tests pin both #49 acceptance criteria (authenticated fake REST server full loop incl. header key riding the real download path; install-by-ID-only; key-never-in-errors)
- [x] Live final review: full CLI loop (search → install → list with a non-empty divergent `sources:` mapping → update → uninstall) against a two-origin fake API; cross-origin download verified to receive neither header nor query key; probe paths incl. dead-server redaction; auth login/status/logout loop
- [x] Deferred polish triaged into a follow-up (design-§7 clean capability-gap rendering belongs with #50's Phase 5 UX work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
