### PR TITLE
feat: aggregate search + TUI Sources screen (Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TUI search: a long per-source warning on a zero-results all-sources search no longer wraps inside the results panel and grows it past its height budget
 - `lmm search --limit -1` (or any negative value) no longer panics; a non-positive `--limit` now shows all results instead of crashing (or, for `0`, silently returning none)
+- `lmm search --limit N` now requests `N` results from each source instead of always requesting a source's internal default (20) and only truncating downward; a query with more than 20 true matches was previously stuck at the first 20 with no way to see more, regardless of `--limit`
 
 ## [1.9.0] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search results (CLI and TUI) show each mod's source; the TUI search defaults to "All sources"
 - TUI Sources screen (key `5`) mirroring `lmm source list`
 
+### Fixed
+
+- TUI search: a long per-source warning on a zero-results all-sources search no longer wraps inside the results panel and grows it past its height budget
+- `lmm search --limit -1` (or any negative value) no longer panics; a non-positive `--limit` now shows all results instead of crashing (or, for `0`, silently returning none)
+
 ## [1.9.0] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search results (CLI and TUI) show each mod's source; the TUI search defaults to "All sources"
 - TUI Sources screen (key `5`) mirroring `lmm source list`
 
+### Changed
+
+- TUI: every entry path into the Search screen (`3`, tab-cycling, the dashboard menu, and `/`) now focuses the search input immediately, so typing can start right away; `Esc` unfocuses it so screen-level keys (`s` source cycling, navigation, `n`/`p` paging) work again
+
 ### Fixed
 
 - TUI search: a long per-source warning on a zero-results all-sources search no longer wraps inside the results panel and grows it past its height budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-18
+
+### Added
+
+- Aggregate search: `lmm search` without `--source` now queries every source configured for the game concurrently, with per-source failures reported as warnings
+- Search results (CLI and TUI) show each mod's source; the TUI search defaults to "All sources"
+- TUI Sources screen (key `5`) mirroring `lmm source list`
+
 ## [1.9.0] - 2026-07-15
 
 ### Added
@@ -722,7 +730,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.6.0...v1.7.0

--- a/README.md
+++ b/README.md
@@ -153,12 +153,11 @@ lmm tui --theme amber       # themes: wizardry (default), amber, dos, green
 lmm tui --prototype         # demo mode with static fake data
 ```
 
-Keys: `tab`/`h`/`l` cycle screens, `1`–`5` jump (`3` alone jumps to Search
-without focusing input; `5` opens Sources), `↑↓`/`j`/`k` move, `enter`
-open/select, `/` searches from anywhere (jumps to the Search screen and
-focuses the input; type query, `enter` to search, `esc` returns to
-navigation), `n`/`p` next/previous page, `s` cycle sources, `?` help, `q`
-quit.
+Keys: `tab`/`h`/`l` cycle screens, `1`–`5` jump, `3` jumps to Search (any
+entry path focuses the input immediately; `5` opens Sources), `↑↓`/`j`/`k`
+move, `enter` open/select, `/` focus search from anywhere, type query,
+`enter` to search, `esc` unfocus (clears focus; afterward `s` cycles sources,
+number keys switch screens), `n`/`p` next/previous page, `?` help, `q` quit.
 
 The Search screen defaults to **All sources**, mirroring the CLI: the typed
 query runs concurrently against every source configured for the game. Press

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ lmm game clear-default
 
 ### Basic Usage
 
-**Source auto-detection:** Commands automatically use the mod source configured for your game. If a game has multiple sources, you will be prompted to choose (or use `-y` to auto-select, or `--source` to specify explicitly).
+**Source auto-detection:** Commands automatically use the mod source configured for your game. If a game has multiple sources, you will be prompted to choose (or use `-y` to auto-select, or `--source` to specify explicitly) — **except `search`**, which queries every configured source concurrently by default instead of prompting (see [Search](#search) below).
 
 ```bash
-# Search for mods
+# Search for mods (all configured sources by default)
 lmm search "skyui" --game skyrim-se
 
 # Install a mod (interactive selection)
@@ -145,7 +145,7 @@ lmm mod set-update 12345 --game skyrim-se --pin
 
 ### Terminal UI
 
-Browse your configured game, installed mods, and profiles interactively, and search mod sources:
+Browse your configured game, installed mods, and profiles interactively, search mod sources, and inspect the source registry:
 
 ```bash
 lmm tui                     # real data, read-only
@@ -153,12 +153,28 @@ lmm tui --theme amber       # themes: wizardry (default), amber, dos, green
 lmm tui --prototype         # demo mode with static fake data
 ```
 
-Keys: `tab`/`h`/`l` cycle screens, `1`–`4` jump (`3` alone jumps to Search without
-focusing input), `↑↓`/`j`/`k` move, `enter` open/select,
-`/` searches from anywhere (jumps to the Search screen and focuses the input;
-type query, `enter` to search, `esc` returns to navigation),
-`n`/`p` next/previous page, `s` cycle sources, `?` help, `q` quit.
-Results mark already-installed mods; selecting a result shows a detail panel.
+Keys: `tab`/`h`/`l` cycle screens, `1`–`5` jump (`3` alone jumps to Search
+without focusing input; `5` opens Sources), `↑↓`/`j`/`k` move, `enter`
+open/select, `/` searches from anywhere (jumps to the Search screen and
+focuses the input; type query, `enter` to search, `esc` returns to
+navigation), `n`/`p` next/previous page, `s` cycle sources, `?` help, `q`
+quit.
+
+The Search screen defaults to **All sources**, mirroring the CLI: the typed
+query runs concurrently against every source configured for the game. Press
+`s` to cycle to a single source and back to "All sources". While "All
+sources" is selected, results carry a source column, and if any source
+failed, a one-line warning (e.g. `⚠ 1 source unavailable: my-repo: ...`)
+appears above the results — the sources that succeeded are still shown.
+Results mark already-installed mods; selecting a result shows a detail
+panel.
+
+The **Sources** screen (key `5`) lists every source registered with lmm —
+built-in and custom — with the same ID/TYPE/AUTH/CAPABILITIES columns as
+`lmm source list`. It only shows sources that actually registered: a custom
+source whose definition file failed to load (bad YAML, ID collision, etc.)
+has no row here — check `lmm source list` for those.
+
 Browsing and searching are read-only — install/update/deploy actions from the TUI arrive in a later release.
 
 ## Configuration
@@ -228,7 +244,7 @@ This allows you to store different games' mods on different drives (e.g., large 
 
 ## Custom Sources
 
-In addition to built-in mod sources (NexusMods, CurseForge), lmm lets you declare custom sources in YAML files instead of writing code. Three types are fully implemented: `directory` (a local folder of mods), `manifest` (a JSON/YAML mod list you publish, over `https://` or as a local file), and `api` (a GET+JSON REST API described declaratively) — all three work from `search`/`install`/`update` like any built-in source (within each type's capabilities), and `manifest`/`api` sources also support optional API-key authentication.
+In addition to built-in mod sources (NexusMods, CurseForge), lmm lets you declare custom sources in YAML files instead of writing code. Three types are fully implemented: `directory` (a local folder of mods), `manifest` (a JSON/YAML mod list you publish, over `https://` or as a local file), and `api` (a GET+JSON REST API described declaratively) — all three work from `search`/`install`/`update` like any built-in source (within each type's capabilities), and `manifest`/`api` sources also support optional API-key authentication. Because `lmm search` queries every source configured for a game concurrently by default (see [Search](#search)), a game mapping several of these alongside NexusMods/CurseForge surfaces results from all of them in one query.
 
 Custom source definitions are loaded from `~/.config/lmm/sources/*.yaml` (or `*.yml`). Each file must define exactly one source. Broken definition files are skipped with a warning — they never prevent lmm from starting.
 
@@ -620,7 +636,8 @@ A `directory` source now shows up with real capabilities in `lmm source list` (`
 
 | Command                                | Description                                          |
 | -------------------------------------- | ---------------------------------------------------- |
-| `lmm search <query>`                   | Search for mods                                      |
+| `lmm search <query>`                   | Search all configured sources concurrently           |
+| `lmm search <query> --source ID`       | Search a single source instead of all configured ones |
 | `lmm search <query> --category ID`     | Filter by NexusMods category                         |
 | `lmm search <query> --tag TAG`         | Filter by tag (repeat for multiple)                  |
 | `lmm install <query>`                  | Search and install a mod                             |
@@ -669,6 +686,49 @@ A `directory` source now shows up with real capabilities in `lmm source list` (`
 | `lmm source validate <file>`           | Validate a user-defined source definition           |
 | `lmm source validate --probe <file>`   | Also live-smoke-test the definition (scan/fetch/API call) |
 | `lmm source validate --probe --id <mod-id> <file>` | Probe an `api` definition that has no `search` endpoint |
+
+### Search
+
+`lmm search <query>` queries every source configured for the game concurrently by default — there's no prompt to pick one first, even when several sources are mapped. Results carry a `SOURCE` column so you can tell which source found each mod:
+
+```
+$ lmm search bigger --game skyrim-se
+ID                  NAME             AUTHOR   VERSION  SOURCE
+--                  ----             ------   -------  ------
+BiggerBackpack-2.1  Bigger Backpack  donovan  2.1      donovan-mods
+```
+
+If one source fails, its failure is reported as a warning on stderr and the other sources' results are still returned — a flaky manifest URL doesn't hide results from a source that responded:
+
+```
+warning: source my-repo: source "my-repo": reading manifest /opt/mods/my-repo.yaml: open /opt/mods/my-repo.yaml: no such file or directory
+```
+
+Only when **every** configured source fails does the command return an error, which names each source's failure:
+
+```
+Error: search failed: all 1 source(s) failed: source my-repo: source "my-repo": reading manifest /opt/mods/my-repo.yaml: open /opt/mods/my-repo.yaml: no such file or directory
+```
+
+Use `--source <id>` to search a single configured source instead of aggregating:
+
+```bash
+lmm search bigger --game skyrim-se --source donovan-mods
+```
+
+A source that doesn't support searching (e.g. an `api` source defined without a `search` endpoint — see [API Sources](#api-sources)) is silently skipped when aggregating, but targeting it directly with `--source` reports a clear notice instead of a generic error:
+
+```
+Error: source "demo-api" does not support searching; install by ID instead: lmm install --source demo-api --id <mod-id>
+```
+
+A game with no configured sources at all fails fast with a diagnostic instead of an empty result:
+
+```
+Error: no mod sources configured for Skyrim Special Edition; add sources with 'lmm game add' or edit games.yaml
+```
+
+`--json search` includes the same per-source failures as a `"warnings"` array alongside `"mods"`.
 
 ### Update check behavior
 

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -23,7 +23,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.9.0"
+	version = "1.10.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/search.go
+++ b/cmd/lmm/search.go
@@ -90,6 +90,17 @@ func capabilityGapNotice(sourceID string, err error) (string, bool) {
 	return fmt.Sprintf("source %q does not support searching; install by ID instead: lmm install --source %s --id <mod-id>", sourceID, sourceID), true
 }
 
+// limitResults truncates mods to at most limit entries for display. A
+// non-positive limit (e.g. --limit 0 or a negative value) leaves mods
+// untouched instead of truncating to nothing or panicking on a negative
+// slice bound (mods[:-1]).
+func limitResults(mods []domain.Mod, limit int) []domain.Mod {
+	if limit > 0 && len(mods) > limit {
+		mods = mods[:limit]
+	}
+	return mods
+}
+
 func doSearch(ctx context.Context, service *core.Service, game *domain.Game, args []string) error {
 	query := args[0]
 	if len(args) > 1 {
@@ -175,9 +186,7 @@ func doSearch(ctx context.Context, service *core.Service, game *domain.Game, arg
 	}
 
 	// Apply result limit for display (totalResults captured earlier per-branch for "Showing X of Y")
-	if len(mods) > searchLimit {
-		mods = mods[:searchLimit]
-	}
+	mods = limitResults(mods, searchLimit)
 
 	if jsonOutput {
 		out := searchJSONOutput{GameID: game.ID, Query: query, Mods: make([]searchModJSON, len(mods)), Warnings: warningStrs}

--- a/cmd/lmm/search.go
+++ b/cmd/lmm/search.go
@@ -70,6 +70,16 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	})
 }
 
+// noSourcesConfiguredErr returns an error if the game has no configured sources.
+// Used by the aggregate search path (when --source is not specified) to provide
+// the same diagnostic as resolveSource in the single-source path.
+func noSourcesConfiguredErr(game *domain.Game) error {
+	if len(game.SourceIDs) == 0 {
+		return fmt.Errorf("no mod sources configured for %s; add sources with 'lmm game add' or edit games.yaml", game.Name)
+	}
+	return nil
+}
+
 // capabilityGapNotice turns an ErrNotSupported search failure into a clean
 // one-line notice (design §7) instead of a wrapped-error dump. ok is false
 // for every other error.
@@ -94,6 +104,11 @@ func doSearch(ctx context.Context, service *core.Service, game *domain.Game, arg
 	var totalResults int
 
 	if searchSource == "" {
+		// Guard: game must have at least one configured source
+		if err := noSourcesConfiguredErr(game); err != nil {
+			return err
+		}
+
 		if verbose {
 			fmt.Printf("Searching for %q in %s (all sources)...\n", query, game.Name)
 		}
@@ -159,7 +174,7 @@ func doSearch(ctx context.Context, service *core.Service, game *domain.Game, arg
 		installedKeys[domain.ModKey(im.SourceID, im.ID)] = true
 	}
 
-	// Capture total count before limiting for "Showing X of Y"
+	// Apply result limit for display (totalResults captured earlier per-branch for "Showing X of Y")
 	if len(mods) > searchLimit {
 		mods = mods[:searchLimit]
 	}

--- a/cmd/lmm/search.go
+++ b/cmd/lmm/search.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
 
 	"github.com/spf13/cobra"
 )
@@ -23,9 +24,10 @@ var (
 )
 
 type searchJSONOutput struct {
-	GameID string          `json:"game_id"`
-	Query  string          `json:"query"`
-	Mods   []searchModJSON `json:"mods"`
+	GameID   string          `json:"game_id"`
+	Query    string          `json:"query"`
+	Mods     []searchModJSON `json:"mods"`
+	Warnings []string        `json:"warnings,omitempty"`
 }
 
 type searchModJSON struct {
@@ -33,6 +35,7 @@ type searchModJSON struct {
 	Name      string `json:"name"`
 	Author    string `json:"author"`
 	Version   string `json:"version"`
+	Source    string `json:"source"`
 	Installed bool   `json:"installed"`
 }
 
@@ -41,7 +44,8 @@ var searchCmd = &cobra.Command{
 	Short: "Search for mods",
 	Long: `Search for mods in the configured sources.
 
-If --source is not specified, uses the first configured source for the game.
+If --source is not specified, all configured sources for the game are
+searched concurrently and the results are merged.
 
 Examples:
   lmm search skyui --game skyrim-se
@@ -51,7 +55,7 @@ Examples:
 }
 
 func init() {
-	searchCmd.Flags().StringVarP(&searchSource, "source", "s", "", "mod source to search (default: first configured source alphabetically)")
+	searchCmd.Flags().StringVarP(&searchSource, "source", "s", "", "mod source to search (default: all configured sources)")
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "l", 10, "maximum number of results")
 	searchCmd.Flags().StringVarP(&searchProfile, "profile", "p", "", "profile to check for installed mods (default: active profile)")
 	searchCmd.Flags().StringVar(&searchCategory, "category", "", "filter by category (source-specific ID or name)")
@@ -66,6 +70,16 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	})
 }
 
+// capabilityGapNotice turns an ErrNotSupported search failure into a clean
+// one-line notice (design §7) instead of a wrapped-error dump. ok is false
+// for every other error.
+func capabilityGapNotice(sourceID string, err error) (string, bool) {
+	if !errors.Is(err, source.ErrNotSupported) {
+		return "", false
+	}
+	return fmt.Sprintf("source %q does not support searching; install by ID instead: lmm install --source %s --id <mod-id>", sourceID, sourceID), true
+}
+
 func doSearch(ctx context.Context, service *core.Service, game *domain.Game, args []string) error {
 	query := args[0]
 	if len(args) > 1 {
@@ -75,30 +89,59 @@ func doSearch(ctx context.Context, service *core.Service, game *domain.Game, arg
 		}
 	}
 
-	// Determine source: use flag if set, otherwise first configured source
-	sourceToUse, err := resolveSource(game, searchSource, false)
-	if err != nil {
-		return err
-	}
+	var mods []domain.Mod
+	var warnings []core.SourceWarning
+	var totalResults int
 
-	if verbose {
-		fmt.Printf("Searching for \"%s\" in %s (%s)...\n", query, game.Name, sourceToUse)
-	}
-
-	searchResult, err := service.SearchMods(ctx, sourceToUse, game.ID, query, searchCategory, searchTags, 0, 0)
-	if err != nil {
-		if errors.Is(err, domain.ErrAuthRequired) {
-			return authPromptError(sourceToUse)
+	if searchSource == "" {
+		if verbose {
+			fmt.Printf("Searching for %q in %s (all sources)...\n", query, game.Name)
 		}
-		return fmt.Errorf("search failed: %w", err)
+		agg, err := service.SearchAllSources(ctx, game.ID, query, searchCategory, searchTags, 0, 0)
+		if err != nil {
+			// No ErrAuthRequired special-case here: an all-sources failure's
+			// joined error already names each source and its reason (including
+			// auth), and a per-source auth hint lives in the warnings path.
+			return fmt.Errorf("search failed: %w", err)
+		}
+		mods, warnings = agg.Mods, agg.Warnings
+		totalResults = len(mods)
+		for _, w := range warnings {
+			fmt.Fprintf(os.Stderr, "warning: source %s: %v\n", w.SourceID, w.Err)
+		}
+	} else {
+		sourceToUse, err := resolveSource(game, searchSource, false)
+		if err != nil {
+			return err
+		}
+		if verbose {
+			fmt.Printf("Searching for %q in %s (%s)...\n", query, game.Name, sourceToUse)
+		}
+		searchResult, err := service.SearchMods(ctx, sourceToUse, game.ID, query, searchCategory, searchTags, 0, 0)
+		if err != nil {
+			if notice, ok := capabilityGapNotice(sourceToUse, err); ok {
+				return errors.New(notice)
+			}
+			if errors.Is(err, domain.ErrAuthRequired) {
+				return authPromptError(sourceToUse)
+			}
+			return fmt.Errorf("search failed: %w", err)
+		}
+		mods = searchResult.Mods
+		totalResults = len(mods)
 	}
 
-	mods := searchResult.Mods
+	warningStrs := make([]string, len(warnings))
+	for i, w := range warnings {
+		warningStrs[i] = fmt.Sprintf("source %s: %v", w.SourceID, w.Err)
+	}
+
 	if len(mods) == 0 {
 		if jsonOutput {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
-			if err := enc.Encode(searchJSONOutput{GameID: game.ID, Query: query, Mods: []searchModJSON{}}); err != nil {
+			out := searchJSONOutput{GameID: game.ID, Query: query, Mods: []searchModJSON{}, Warnings: warningStrs}
+			if err := enc.Encode(out); err != nil {
 				return fmt.Errorf("encoding json: %w", err)
 			}
 			return nil
@@ -107,31 +150,30 @@ func doSearch(ctx context.Context, service *core.Service, game *domain.Game, arg
 		return nil
 	}
 
-	// Get installed mods to mark already-installed ones
+	// Get installed mods to mark already-installed ones (source-aware: a mod
+	// ID is only unique within its source, so key on both).
 	profileName := profileOrDefault(searchProfile)
 	installedMods, _ := service.GetInstalledMods(game.ID, profileName)
-	installedIDs := make(map[string]bool)
+	installedKeys := make(map[string]bool)
 	for _, im := range installedMods {
-		if im.SourceID == sourceToUse {
-			installedIDs[im.ID] = true
-		}
+		installedKeys[domain.ModKey(im.SourceID, im.ID)] = true
 	}
 
 	// Capture total count before limiting for "Showing X of Y"
-	totalResults := len(mods)
 	if len(mods) > searchLimit {
 		mods = mods[:searchLimit]
 	}
 
 	if jsonOutput {
-		out := searchJSONOutput{GameID: game.ID, Query: query, Mods: make([]searchModJSON, len(mods))}
+		out := searchJSONOutput{GameID: game.ID, Query: query, Mods: make([]searchModJSON, len(mods)), Warnings: warningStrs}
 		for i, mod := range mods {
 			out.Mods[i] = searchModJSON{
 				ID:        mod.ID,
 				Name:      mod.Name,
 				Author:    mod.Author,
 				Version:   mod.Version,
-				Installed: installedIDs[mod.ID],
+				Source:    mod.SourceID,
+				Installed: installedKeys[domain.ModKey(mod.SourceID, mod.ID)],
 			}
 		}
 		enc := json.NewEncoder(os.Stdout)
@@ -144,23 +186,24 @@ func doSearch(ctx context.Context, service *core.Service, game *domain.Game, arg
 
 	// Print results
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(w, "ID\tNAME\tAUTHOR\tVERSION\t"); err != nil {
+	if _, err := fmt.Fprintln(w, "ID\tNAME\tAUTHOR\tVERSION\tSOURCE\t"); err != nil {
 		return fmt.Errorf("writing header: %w", err)
 	}
-	if _, err := fmt.Fprintln(w, "--\t----\t------\t-------\t"); err != nil {
+	if _, err := fmt.Fprintln(w, "--\t----\t------\t-------\t------\t"); err != nil {
 		return fmt.Errorf("writing separator: %w", err)
 	}
 
 	for _, mod := range mods {
 		installedMark := ""
-		if installedIDs[mod.ID] {
+		if installedKeys[domain.ModKey(mod.SourceID, mod.ID)] {
 			installedMark = "[installed]"
 		}
-		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			mod.ID,
 			truncate(mod.Name, 40),
 			truncate(mod.Author, 20),
 			mod.Version,
+			mod.SourceID,
 			installedMark,
 		); err != nil {
 			return fmt.Errorf("writing row: %w", err)

--- a/cmd/lmm/search.go
+++ b/cmd/lmm/search.go
@@ -101,6 +101,21 @@ func limitResults(mods []domain.Mod, limit int) []domain.Mod {
 	return mods
 }
 
+// searchPageSize turns --limit into the page size requested from sources. A
+// positive limit is requested verbatim so `--limit 30` can actually fetch 30
+// results instead of being capped at each source's own default page size
+// (20 — see internal/source/custom/search.go and internal/source/nexusmods)
+// and then merely truncating an already-short list; there is no --page flag,
+// so that default has otherwise been an invisible, unreachable ceiling. A
+// non-positive limit (0, or the historical --limit -1 case) falls back to 0
+// so sources keep applying their own default, matching prior behavior.
+func searchPageSize(limit int) int {
+	if limit > 0 {
+		return limit
+	}
+	return 0
+}
+
 func doSearch(ctx context.Context, service *core.Service, game *domain.Game, args []string) error {
 	query := args[0]
 	if len(args) > 1 {
@@ -123,7 +138,7 @@ func doSearch(ctx context.Context, service *core.Service, game *domain.Game, arg
 		if verbose {
 			fmt.Printf("Searching for %q in %s (all sources)...\n", query, game.Name)
 		}
-		agg, err := service.SearchAllSources(ctx, game.ID, query, searchCategory, searchTags, 0, 0)
+		agg, err := service.SearchAllSources(ctx, game.ID, query, searchCategory, searchTags, 0, searchPageSize(searchLimit))
 		if err != nil {
 			// No ErrAuthRequired special-case here: an all-sources failure's
 			// joined error already names each source and its reason (including
@@ -143,7 +158,7 @@ func doSearch(ctx context.Context, service *core.Service, game *domain.Game, arg
 		if verbose {
 			fmt.Printf("Searching for %q in %s (%s)...\n", query, game.Name, sourceToUse)
 		}
-		searchResult, err := service.SearchMods(ctx, sourceToUse, game.ID, query, searchCategory, searchTags, 0, 0)
+		searchResult, err := service.SearchMods(ctx, sourceToUse, game.ID, query, searchCategory, searchTags, 0, searchPageSize(searchLimit))
 		if err != nil {
 			if notice, ok := capabilityGapNotice(sourceToUse, err); ok {
 				return errors.New(notice)

--- a/cmd/lmm/search_test.go
+++ b/cmd/lmm/search_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -124,4 +127,26 @@ func TestSearchCmd_DefaultFlags(t *testing.T) {
 
 	limitFlag := searchCmd.Flags().Lookup("limit")
 	assert.Equal(t, "10", limitFlag.DefValue)
+}
+
+func TestSearchCmdStructure(t *testing.T) {
+	assert.Equal(t, "search <query>", searchCmd.Use)
+	flag := searchCmd.Flags().Lookup("source")
+	if assert.NotNil(t, flag) {
+		assert.Contains(t, flag.Usage, "all configured sources",
+			"help text must reflect the new aggregate default")
+	}
+}
+
+func TestCapabilityGapNotice(t *testing.T) {
+	err := fmt.Errorf("source %q: searching: %w", "id-only", source.ErrNotSupported)
+	notice, ok := capabilityGapNotice("id-only", err)
+	assert.True(t, ok)
+	assert.Contains(t, notice, "does not support searching")
+	assert.Contains(t, notice, "lmm install --source id-only")
+	assert.NotContains(t, notice, "operation not supported by this source",
+		"the raw wrapped error must not leak into the notice")
+
+	_, ok = capabilityGapNotice("x", errors.New("network down"))
+	assert.False(t, ok)
 }

--- a/cmd/lmm/search_test.go
+++ b/cmd/lmm/search_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -149,4 +150,49 @@ func TestCapabilityGapNotice(t *testing.T) {
 
 	_, ok = capabilityGapNotice("x", errors.New("network down"))
 	assert.False(t, ok)
+}
+
+// TestNoSourcesConfiguredErr tests the no-sources-configured guard
+func TestNoSourcesConfiguredErr(t *testing.T) {
+	tests := []struct {
+		name    string
+		game    *domain.Game
+		wantErr bool
+		wantMsg string
+	}{
+		{
+			name: "empty sources returns error",
+			game: &domain.Game{
+				ID:        "test-game",
+				Name:      "Test Game",
+				SourceIDs: map[string]string{},
+			},
+			wantErr: true,
+			wantMsg: "no mod sources configured",
+		},
+		{
+			name: "non-empty sources returns nil",
+			game: &domain.Game{
+				ID:   "test-game",
+				Name: "Test Game",
+				SourceIDs: map[string]string{
+					"nexusmods": "skyrimspecialedition",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := noSourcesConfiguredErr(tt.game)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantMsg)
+				assert.Contains(t, err.Error(), "add sources with 'lmm game add' or edit games.yaml")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/cmd/lmm/search_test.go
+++ b/cmd/lmm/search_test.go
@@ -139,6 +139,43 @@ func TestSearchCmdStructure(t *testing.T) {
 	}
 }
 
+// TestLimitResults_NegativeLimitDoesNotPanic reproduces a pre-existing panic:
+// `lmm search --limit -1` reaches `mods[:searchLimit]` with a negative
+// index, which is a slice-bounds panic in Go. A negative (or otherwise
+// non-positive) limit should mean "no truncation," not "truncate to a
+// nonsensical bound."
+func TestLimitResults_NegativeLimitDoesNotPanic(t *testing.T) {
+	mods := []domain.Mod{{ID: "a"}, {ID: "b"}, {ID: "c"}}
+
+	assert.NotPanics(t, func() {
+		result := limitResults(mods, -1)
+		assert.Equal(t, mods, result, "a negative limit must not truncate")
+	})
+}
+
+func TestLimitResults_ZeroLimitDoesNotPanic(t *testing.T) {
+	mods := []domain.Mod{{ID: "a"}, {ID: "b"}}
+
+	assert.NotPanics(t, func() {
+		result := limitResults(mods, 0)
+		assert.Equal(t, mods, result, "a zero limit must not truncate")
+	})
+}
+
+func TestLimitResults_PositiveLimitTruncates(t *testing.T) {
+	mods := []domain.Mod{{ID: "a"}, {ID: "b"}, {ID: "c"}}
+
+	result := limitResults(mods, 2)
+	assert.Equal(t, []domain.Mod{{ID: "a"}, {ID: "b"}}, result)
+}
+
+func TestLimitResults_LimitAboveLenIsNoop(t *testing.T) {
+	mods := []domain.Mod{{ID: "a"}}
+
+	result := limitResults(mods, 10)
+	assert.Equal(t, mods, result)
+}
+
 func TestCapabilityGapNotice(t *testing.T) {
 	err := fmt.Errorf("source %q: searching: %w", "id-only", source.ErrNotSupported)
 	notice, ok := capabilityGapNotice("id-only", err)

--- a/cmd/lmm/search_test.go
+++ b/cmd/lmm/search_test.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestTruncate tests the string truncation helper function
@@ -231,5 +234,129 @@ func TestNoSourcesConfiguredErr(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+// pageSizeSpySource is a minimal ModSource that records the Page/PageSize it
+// was queried with. It exists to prove (or disprove) that the CLI's --limit
+// flag actually reaches the source as a requested page size, rather than
+// being silently discarded after the source applies its own fixed default
+// (see internal/source/custom/search.go and internal/source/nexusmods,
+// which both default an unset PageSize to 20 — a page 0 with no --page flag
+// therefore hard-caps every search at 20 results no matter what --limit is).
+type pageSizeSpySource struct {
+	id          string
+	gotPage     int
+	gotPageSize int
+	calls       int
+}
+
+func (s *pageSizeSpySource) ID() string      { return s.id }
+func (s *pageSizeSpySource) Name() string    { return s.id }
+func (s *pageSizeSpySource) AuthURL() string { return "" }
+func (s *pageSizeSpySource) ExchangeToken(context.Context, string) (*source.Token, error) {
+	return nil, nil
+}
+func (s *pageSizeSpySource) Search(ctx context.Context, q source.SearchQuery) (source.SearchResult, error) {
+	s.calls++
+	s.gotPage = q.Page
+	s.gotPageSize = q.PageSize
+	return source.SearchResult{Mods: []domain.Mod{{ID: "m1", SourceID: s.id, Name: "Mod One"}}, TotalCount: 1}, nil
+}
+func (s *pageSizeSpySource) GetMod(context.Context, string, string) (*domain.Mod, error) {
+	return nil, nil
+}
+func (s *pageSizeSpySource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) {
+	return nil, nil
+}
+func (s *pageSizeSpySource) GetModFiles(context.Context, *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, nil
+}
+func (s *pageSizeSpySource) GetDownloadURL(context.Context, *domain.Mod, string) (string, error) {
+	return "", nil
+}
+func (s *pageSizeSpySource) CheckUpdates(context.Context, []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, nil
+}
+
+// newPageSizeSpyService wires a real core.Service and game around a single
+// pageSizeSpySource, so doSearch runs its real code path (not a mock of
+// doSearch itself).
+func newPageSizeSpyService(t *testing.T, spy *pageSizeSpySource) (*core.Service, *domain.Game) {
+	t.Helper()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(spy)
+
+	game := &domain.Game{
+		ID:        "testgame",
+		Name:      "Test Game",
+		ModPath:   t.TempDir(),
+		SourceIDs: map[string]string{spy.id: ""},
+	}
+	require.NoError(t, svc.AddGame(game))
+	return svc, game
+}
+
+// withSearchFlags saves and restores the package-level search flag globals
+// doSearch reads, so tests can drive them without leaking state.
+func withSearchFlags(t *testing.T, source string, limit int) {
+	t.Helper()
+	origSource, origLimit := searchSource, searchLimit
+	t.Cleanup(func() { searchSource, searchLimit = origSource, origLimit })
+	searchSource, searchLimit = source, limit
+}
+
+// TestDoSearch_AggregateDefault_RequestsSearchLimitAsPageSize reproduces the
+// user-reported regression on PR #57: `lmm search <query> --limit 30` (no
+// --source, so the aggregate default path) must fetch up to 30 results per
+// source. Before the fix, doSearch always called SearchAllSources with a
+// literal pageSize of 0, so every source's own default (20) silently
+// capped results regardless of --limit, and there is no --page flag to
+// reach anything beyond that.
+func TestDoSearch_AggregateDefault_RequestsSearchLimitAsPageSize(t *testing.T) {
+	spy := &pageSizeSpySource{id: "spy-agg"}
+	svc, game := newPageSizeSpyService(t, spy)
+	withSearchFlags(t, "", 30)
+
+	require.NoError(t, doSearch(context.Background(), svc, game, []string{"query"}))
+
+	require.Equal(t, 1, spy.calls)
+	assert.Equal(t, 30, spy.gotPageSize, "--limit 30 must be requested as the page size, not discarded")
+}
+
+// TestDoSearch_ExplicitSource_RequestsSearchLimitAsPageSize is the
+// apples-to-apples single-source counterpart: `--source <id> --limit 30`
+// must also request a page size of 30 from the source.
+func TestDoSearch_ExplicitSource_RequestsSearchLimitAsPageSize(t *testing.T) {
+	spy := &pageSizeSpySource{id: "spy-single"}
+	svc, game := newPageSizeSpyService(t, spy)
+	withSearchFlags(t, "spy-single", 30)
+
+	require.NoError(t, doSearch(context.Background(), svc, game, []string{"query"}))
+
+	require.Equal(t, 1, spy.calls)
+	assert.Equal(t, 30, spy.gotPageSize, "--limit 30 must be requested as the page size, not discarded")
+}
+
+// TestDoSearch_NonPositiveLimit_FallsBackToSourceDefaultPageSize pins the
+// edge case at the boundary of the fix: --limit 0 (explicitly unset) or a
+// negative --limit (the historical --limit -1 panic case, cmd/lmm/search.go
+// limitResults) must not be forwarded as a nonsensical or unbounded page
+// size request — it falls back to 0, letting each source apply its own
+// default, exactly like before this fix.
+func TestDoSearch_NonPositiveLimit_FallsBackToSourceDefaultPageSize(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		spy := &pageSizeSpySource{id: "spy-nonpositive"}
+		svc, game := newPageSizeSpyService(t, spy)
+		withSearchFlags(t, "spy-nonpositive", limit)
+
+		require.NoError(t, doSearch(context.Background(), svc, game, []string{"query"}))
+
+		require.Equal(t, 1, spy.calls)
+		assert.Equal(t, 0, spy.gotPageSize, "limit %d must not be forwarded as the requested page size", limit)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.19.0
 	golang.org/x/term v0.39.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.44.3

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -2,9 +2,11 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -14,6 +16,7 @@ import (
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/db"
+	"golang.org/x/sync/errgroup"
 )
 
 // ServiceConfig holds configuration for the core service
@@ -128,6 +131,126 @@ func (s *Service) SearchMods(ctx context.Context, sourceID, gameID, query string
 		Tags:     tags,
 		Page:     page,
 		PageSize: pageSize,
+	})
+}
+
+// SourceWarning reports a per-source failure during an aggregate operation.
+type SourceWarning struct {
+	SourceID string
+	Err      error
+}
+
+// AggregateSearchResult is the merged outcome of searching every source
+// configured for a game.
+type AggregateSearchResult struct {
+	Mods       []domain.Mod    // merged, ranked; each Mod carries its SourceID
+	TotalCount int             // sum of per-source totals (sources reporting 0/unknown contribute 0)
+	Warnings   []SourceWarning // per-source failures (design §5: warnings, not errors)
+}
+
+// SearchAllSources searches every source configured for a game concurrently
+// and merges the results (design §5). Per-source failures become Warnings —
+// one flaky API must not hide local modlets; only all-sources-failed is an
+// error. Sources without search capability are skipped silently. Pagination
+// is per-source: page N requests page N from each source and merges.
+func (s *Service) SearchAllSources(ctx context.Context, gameID, query, category string, tags []string, page, pageSize int) (AggregateSearchResult, error) {
+	game, ok := s.games[gameID]
+	if !ok {
+		return AggregateSearchResult{}, fmt.Errorf("game not found: %s", gameID)
+	}
+
+	sourceIDs := make([]string, 0, len(game.SourceIDs))
+	for id := range game.SourceIDs {
+		sourceIDs = append(sourceIDs, id)
+	}
+	sort.Strings(sourceIDs)
+
+	var result AggregateSearchResult
+	type slot struct {
+		res source.SearchResult
+		err error
+	}
+	slots := make([]slot, len(sourceIDs))
+	attempted := make([]bool, len(sourceIDs))
+
+	g, gctx := errgroup.WithContext(ctx)
+	for i, sourceID := range sourceIDs {
+		src, err := s.registry.Get(sourceID)
+		if err != nil {
+			slots[i].err = err
+			attempted[i] = true
+			continue
+		}
+		if !source.CapabilitiesOf(src).Search {
+			continue // silent skip (design §5)
+		}
+		attempted[i] = true
+		i, sourceID := i, sourceID
+		g.Go(func() error {
+			res, err := s.SearchMods(gctx, sourceID, gameID, query, category, tags, page, pageSize)
+			if err != nil {
+				if errors.Is(err, source.ErrNotSupported) {
+					attempted[i] = false // runtime capability gap: silent skip, not a warning
+					return nil
+				}
+				slots[i].err = err
+				return nil // never abort the group: siblings keep searching
+			}
+			slots[i].res = res
+			return nil
+		})
+	}
+	_ = g.Wait() // goroutines always return nil; errors live in slots
+
+	succeeded := 0
+	for i, sourceID := range sourceIDs {
+		if !attempted[i] {
+			continue
+		}
+		if slots[i].err != nil {
+			result.Warnings = append(result.Warnings, SourceWarning{SourceID: sourceID, Err: slots[i].err})
+			continue
+		}
+		succeeded++
+		result.Mods = append(result.Mods, slots[i].res.Mods...)
+		result.TotalCount += slots[i].res.TotalCount
+	}
+
+	rankAggregate(result.Mods, query)
+
+	attemptedCount := 0
+	for _, a := range attempted {
+		if a {
+			attemptedCount++
+		}
+	}
+	if attemptedCount > 0 && succeeded == 0 {
+		errs := make([]error, 0, len(result.Warnings))
+		for _, w := range result.Warnings {
+			errs = append(errs, fmt.Errorf("source %s: %w", w.SourceID, w.Err))
+		}
+		return result, fmt.Errorf("all %d source(s) failed: %w", attemptedCount, errors.Join(errs...))
+	}
+	return result, nil
+}
+
+// rankAggregate orders merged results: query-name matches first, then by
+// Downloads descending, then Name ascending — deterministic regardless of
+// which source responded first (design §5: no global re-ranking beyond this).
+func rankAggregate(mods []domain.Mod, query string) {
+	q := strings.ToLower(query)
+	nameMatch := func(m domain.Mod) bool {
+		return q != "" && (strings.Contains(strings.ToLower(m.Name), q) || strings.Contains(strings.ToLower(m.ID), q))
+	}
+	sort.SliceStable(mods, func(i, j int) bool {
+		mi, mj := nameMatch(mods[i]), nameMatch(mods[j])
+		if mi != mj {
+			return mi
+		}
+		if mods[i].Downloads != mods[j].Downloads {
+			return mods[i].Downloads > mods[j].Downloads
+		}
+		return mods[i].Name < mods[j].Name
 	})
 }
 

--- a/internal/core/service_aggregate_e2e_test.go
+++ b/internal/core/service_aggregate_e2e_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -134,4 +135,53 @@ func TestAggregateSearchEndToEndSingleSourceStillWorks(t *testing.T) {
 	assert.Equal(t, "manifest-repo", res.Mods[0].SourceID)
 	assert.Equal(t, "cool-remote", res.Mods[0].ID)
 	assert.Equal(t, game.ID, res.Mods[0].GameID)
+}
+
+// TestSearchAllSources_PageSizeAboveDefaultReturnsMoreThanDefaultCap is a
+// characterization test for the #57 CLI paging regression: it pins that
+// SearchAllSources (and, transitively, a real Directory source's Search)
+// already honors a requested pageSize above the source-internal default of
+// 20 (internal/source/custom/search.go's searchMods). It passes with or
+// without the cmd/lmm/search.go fix — the bug was entirely in the CLI layer
+// always requesting pageSize 0, never in this core/source plumbing.
+func TestSearchAllSources_PageSizeAboveDefaultReturnsMoreThanDefaultCap(t *testing.T) {
+	dirRoot := t.TempDir()
+	for i := 1; i <= 30; i++ {
+		require.NoError(t, os.MkdirAll(filepath.Join(dirRoot, fmt.Sprintf("TestMod%02d", i)), 0755))
+	}
+	dirSrc, err := custom.New(custom.SourceDefinition{
+		ID:        "big-dir",
+		Name:      "Big Directory",
+		Type:      custom.TypeDirectory,
+		Directory: &custom.DirectoryConfig{Path: dirRoot},
+	})
+	require.NoError(t, err)
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(dirSrc)
+
+	game := &domain.Game{
+		ID:         "testgame",
+		Name:       "Test Game",
+		ModPath:    t.TempDir(),
+		DeployMode: domain.DeployCopy,
+		SourceIDs:  map[string]string{"big-dir": ""},
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	// pageSize 0 (the CLI's pre-fix default): capped at the source's
+	// internal default of 20, even though 30 mods match.
+	capped, err := svc.SearchAllSources(context.Background(), game.ID, "testmod", "", nil, 0, 0)
+	require.NoError(t, err)
+	assert.Len(t, capped.Mods, 20, "pageSize 0 must fall back to the source default cap")
+
+	// pageSize 30 (what the CLI now sends for --limit 30): all 30 matches
+	// come back, proving the ceiling is a CLI-layer default, not a
+	// core/source limitation.
+	full, err := svc.SearchAllSources(context.Background(), game.ID, "testmod", "", nil, 0, 30)
+	require.NoError(t, err)
+	assert.Len(t, full.Mods, 30, "pageSize 30 must return all 30 matching mods")
 }

--- a/internal/core/service_aggregate_e2e_test.go
+++ b/internal/core/service_aggregate_e2e_test.go
@@ -1,0 +1,137 @@
+package core_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupAggregateSources wires three real sources for aggregate-search e2e
+// coverage (#50 acceptance criterion 1):
+//   - "local-mods": a directory source with one on-disk mod ("CoolLocalMod").
+//   - "manifest-repo": a manifest source backed by a local mods.yaml (mod
+//     "cool-remote"). Local-path manifests are read directly, so this needs
+//     no HTTP server.
+//   - "dead-repo": a manifest source pointed at an unroutable https URL.
+//     Construction is pure (custom.New performs no I/O); the fetch only
+//     fails once a search actually runs, so it degrades to a warning instead
+//     of failing at setup.
+//
+// The game maps all three sources with the empty-string value, mirroring the
+// README-documented convention that "this source applies to any game" — and
+// pinning the Phase 2/3 lesson that an empty mapping must not blank out the
+// mod's GameID.
+func setupAggregateSources(t *testing.T) (*core.Service, *domain.Game) {
+	t.Helper()
+
+	dirRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dirRoot, "CoolLocalMod"), 0755))
+	dirSrc, err := custom.New(custom.SourceDefinition{
+		ID:        "local-mods",
+		Name:      "Local Mods",
+		Type:      custom.TypeDirectory,
+		Directory: &custom.DirectoryConfig{Path: dirRoot},
+	})
+	require.NoError(t, err)
+
+	manifestPath := filepath.Join(t.TempDir(), "mods.yaml")
+	manifest := `
+version: 1
+mods:
+  - id: cool-remote
+    name: Cool Remote
+    version: 1.0.0
+    summary: A remotely published cool mod
+`
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0644))
+	manifestSrc, err := custom.New(custom.SourceDefinition{
+		ID:       "manifest-repo",
+		Name:     "Manifest Repo",
+		Type:     custom.TypeManifest,
+		Manifest: &custom.ManifestConfig{URL: manifestPath},
+	})
+	require.NoError(t, err)
+
+	deadSrc, err := custom.New(custom.SourceDefinition{
+		ID:        "dead-repo",
+		Name:      "Dead Repo",
+		Type:      custom.TypeManifest,
+		AllowHTTP: false,
+		Manifest:  &custom.ManifestConfig{URL: "https://127.0.0.1:1/mods.yaml"},
+	})
+	require.NoError(t, err)
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	svc.RegisterSource(dirSrc)
+	svc.RegisterSource(manifestSrc)
+	svc.RegisterSource(deadSrc)
+
+	game := &domain.Game{
+		ID:         "testgame",
+		Name:       "Test Game",
+		ModPath:    t.TempDir(),
+		DeployMode: domain.DeployCopy,
+		SourceIDs:  map[string]string{"local-mods": "", "manifest-repo": "", "dead-repo": ""},
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	return svc, game
+}
+
+// TestAggregateSearchEndToEnd pins #50 acceptance criterion 1 with real
+// source implementations: a directory source and a local-file manifest
+// source both surface labeled results in one aggregate search, while a
+// dead remote manifest source degrades to a single warning instead of
+// hiding the working sources' results.
+func TestAggregateSearchEndToEnd(t *testing.T) {
+	svc, game := setupAggregateSources(t)
+	ctx := context.Background()
+
+	res, err := svc.SearchAllSources(ctx, game.ID, "cool", "", nil, 0, 20)
+	require.NoError(t, err, "dead source must not fail the aggregate")
+
+	bySource := map[string][]string{}
+	for _, m := range res.Mods {
+		bySource[m.SourceID] = append(bySource[m.SourceID], m.ID)
+	}
+	assert.Contains(t, bySource, "local-mods")
+	assert.Contains(t, bySource, "manifest-repo")
+	assert.Contains(t, bySource["local-mods"], "CoolLocalMod")
+	assert.Contains(t, bySource["manifest-repo"], "cool-remote")
+
+	require.Len(t, res.Warnings, 1)
+	assert.Equal(t, "dead-repo", res.Warnings[0].SourceID)
+
+	// Every merged mod carries the lmm game id (the Phase 2/3 lesson).
+	for _, m := range res.Mods {
+		assert.Equal(t, game.ID, m.GameID)
+	}
+}
+
+// TestAggregateSearchEndToEndSingleSourceStillWorks guards against a
+// regression where wiring the aggregate path broke single-source search:
+// the same three-source setup, queried through SearchMods with one
+// explicit source, must still return that source's results untouched by
+// the other two.
+func TestAggregateSearchEndToEndSingleSourceStillWorks(t *testing.T) {
+	svc, game := setupAggregateSources(t)
+	ctx := context.Background()
+
+	res, err := svc.SearchMods(ctx, "manifest-repo", game.ID, "cool", "", nil, 0, 20)
+	require.NoError(t, err)
+	require.Len(t, res.Mods, 1)
+	assert.Equal(t, "manifest-repo", res.Mods[0].SourceID)
+	assert.Equal(t, "cool-remote", res.Mods[0].ID)
+	assert.Equal(t, game.ID, res.Mods[0].GameID)
+}

--- a/internal/core/service_aggregate_search_test.go
+++ b/internal/core/service_aggregate_search_test.go
@@ -1,0 +1,167 @@
+package core_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// searchStubSource is a minimal ModSource whose Search returns canned data.
+type searchStubSource struct {
+	id      string
+	caps    *source.Capabilities // nil = no CapabilityReporter (assumed fully capable)
+	result  source.SearchResult
+	err     error
+	gotGame string // records the GameID the source was queried with
+}
+
+func (s *searchStubSource) ID() string      { return s.id }
+func (s *searchStubSource) Name() string    { return s.id }
+func (s *searchStubSource) AuthURL() string { return "" }
+func (s *searchStubSource) ExchangeToken(context.Context, string) (*source.Token, error) {
+	return nil, nil
+}
+func (s *searchStubSource) Search(ctx context.Context, q source.SearchQuery) (source.SearchResult, error) {
+	s.gotGame = q.GameID
+	if s.err != nil {
+		return source.SearchResult{}, s.err
+	}
+	return s.result, nil
+}
+func (s *searchStubSource) GetMod(context.Context, string, string) (*domain.Mod, error) {
+	return nil, nil
+}
+func (s *searchStubSource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) {
+	return nil, nil
+}
+func (s *searchStubSource) GetModFiles(context.Context, *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, nil
+}
+func (s *searchStubSource) GetDownloadURL(context.Context, *domain.Mod, string) (string, error) {
+	return "", nil
+}
+func (s *searchStubSource) CheckUpdates(context.Context, []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, nil
+}
+
+// capsStubSource adds a CapabilityReporter to searchStubSource.
+type capsStubSource struct{ *searchStubSource }
+
+func (c *capsStubSource) Capabilities() source.Capabilities { return *c.caps }
+
+func newAggregateTestService(t *testing.T, sources map[string]string, srcs ...source.ModSource) (*core.Service, *domain.Game) {
+	t.Helper()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	for _, s := range srcs {
+		svc.RegisterSource(s)
+	}
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), SourceIDs: sources}
+	require.NoError(t, svc.AddGame(game))
+	return svc, game
+}
+
+func mods(sourceID string, entries ...string) []domain.Mod {
+	out := make([]domain.Mod, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, domain.Mod{ID: e, SourceID: sourceID, Name: e})
+	}
+	return out
+}
+
+func TestSearchAllSourcesMergesAndTags(t *testing.T) {
+	a := &searchStubSource{id: "alpha", result: source.SearchResult{
+		Mods: []domain.Mod{
+			{ID: "cool-a", SourceID: "alpha", Name: "Cool A", Downloads: 5},
+			{ID: "other-a", SourceID: "alpha", Name: "Unrelated", Downloads: 100},
+		},
+		TotalCount: 2,
+	}}
+	b := &searchStubSource{id: "beta", result: source.SearchResult{
+		Mods:       []domain.Mod{{ID: "cool-b", SourceID: "beta", Name: "Cool B", Downloads: 50}},
+		TotalCount: 7,
+	}}
+	svc, game := newAggregateTestService(t, map[string]string{"alpha": "", "beta": "mapped-beta"}, a, b)
+
+	res, err := svc.SearchAllSources(context.Background(), game.ID, "cool", "", nil, 0, 10)
+	require.NoError(t, err)
+	assert.Empty(t, res.Warnings)
+	assert.Equal(t, 9, res.TotalCount)
+
+	// Ranking: name matches ("Cool B" 50 > "Cool A" 5 by downloads) before
+	// non-matches ("Unrelated"), stable and deterministic.
+	require.Len(t, res.Mods, 3)
+	assert.Equal(t, "cool-b", res.Mods[0].ID)
+	assert.Equal(t, "cool-a", res.Mods[1].ID)
+	assert.Equal(t, "other-a", res.Mods[2].ID)
+
+	// Per-source game-ID mapping applied (empty mapping -> lmm game id).
+	assert.Equal(t, "testgame", a.gotGame)
+	assert.Equal(t, "mapped-beta", b.gotGame)
+}
+
+func TestSearchAllSourcesFailureIsWarning(t *testing.T) {
+	ok := &searchStubSource{id: "local", result: source.SearchResult{
+		Mods: mods("local", "modlet"), TotalCount: 1,
+	}}
+	flaky := &searchStubSource{id: "remote", err: fmt.Errorf("dial tcp: connection refused")}
+	svc, game := newAggregateTestService(t, map[string]string{"local": "", "remote": ""}, ok, flaky)
+
+	res, err := svc.SearchAllSources(context.Background(), game.ID, "mod", "", nil, 0, 10)
+	require.NoError(t, err, "one flaky source must not fail the aggregate")
+	require.Len(t, res.Mods, 1)
+	assert.Equal(t, "local", res.Mods[0].SourceID)
+	require.Len(t, res.Warnings, 1)
+	assert.Equal(t, "remote", res.Warnings[0].SourceID)
+}
+
+func TestSearchAllSourcesSkipsNonSearching(t *testing.T) {
+	searcher := &searchStubSource{id: "manifest", result: source.SearchResult{Mods: mods("manifest", "m1"), TotalCount: 1}}
+	caps := source.Capabilities{Search: false, Updates: true}
+	idOnly := &capsStubSource{&searchStubSource{id: "id-only-api", caps: &caps,
+		err: fmt.Errorf("should never be called")}}
+	svc, game := newAggregateTestService(t, map[string]string{"manifest": "", "id-only-api": ""}, searcher, idOnly)
+
+	res, err := svc.SearchAllSources(context.Background(), game.ID, "m", "", nil, 0, 10)
+	require.NoError(t, err)
+	assert.Empty(t, res.Warnings, "non-searching sources are skipped silently, not warned")
+	require.Len(t, res.Mods, 1)
+}
+
+func TestSearchAllSourcesUnregisteredMappedSourceWarns(t *testing.T) {
+	ok := &searchStubSource{id: "real", result: source.SearchResult{Mods: mods("real", "x"), TotalCount: 1}}
+	svc, game := newAggregateTestService(t, map[string]string{"real": "", "ghost": ""}, ok)
+
+	res, err := svc.SearchAllSources(context.Background(), game.ID, "x", "", nil, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, res.Warnings, 1)
+	assert.Equal(t, "ghost", res.Warnings[0].SourceID)
+	require.Len(t, res.Mods, 1)
+}
+
+func TestSearchAllSourcesAllFailedIsError(t *testing.T) {
+	f1 := &searchStubSource{id: "s1", err: errors.New("boom1")}
+	f2 := &searchStubSource{id: "s2", err: errors.New("boom2")}
+	svc, game := newAggregateTestService(t, map[string]string{"s1": "", "s2": ""}, f1, f2)
+
+	res, err := svc.SearchAllSources(context.Background(), game.ID, "x", "", nil, 0, 10)
+	require.Error(t, err)
+	assert.Len(t, res.Warnings, 2)
+	assert.Empty(t, res.Mods)
+}
+
+func TestSearchAllSourcesUnknownGame(t *testing.T) {
+	svc, _ := newAggregateTestService(t, map[string]string{})
+	_, err := svc.SearchAllSources(context.Background(), "nope", "x", "", nil, 0, 10)
+	assert.Error(t, err)
+}

--- a/internal/source/custom/api.go
+++ b/internal/source/custom/api.go
@@ -202,6 +202,11 @@ func (a *API) Search(ctx context.Context, query source.SearchQuery) (source.Sear
 		return source.SearchResult{}, fmt.Errorf("source %q: searching: %w", a.id, source.ErrNotSupported)
 	}
 
+	page := query.Page
+	if page < 0 {
+		page = 0 // match the shared searchMods clamp; never send negative paging upstream
+	}
+
 	pageSize := query.PageSize
 	if pageSize <= 0 {
 		pageSize = 20
@@ -209,9 +214,9 @@ func (a *API) Search(ctx context.Context, query source.SearchQuery) (source.Sear
 	vals := map[string]string{
 		"game_id":   query.GameID,
 		"query":     query.Query,
-		"page":      strconv.Itoa(query.Page + a.pageStart),
+		"page":      strconv.Itoa(page + a.pageStart),
 		"page_size": strconv.Itoa(pageSize),
-		"offset":    strconv.Itoa(query.Page * pageSize),
+		"offset":    strconv.Itoa(page * pageSize),
 	}
 
 	doc, err := a.getJSON(ctx, a.baseURL+buildEndpointURL(ep.Path, vals))
@@ -251,7 +256,7 @@ func (a *API) Search(ctx context.Context, query source.SearchQuery) (source.Sear
 		}
 	}
 
-	return source.SearchResult{Mods: mods, TotalCount: total, Page: query.Page, PageSize: pageSize}, nil
+	return source.SearchResult{Mods: mods, TotalCount: total, Page: page, PageSize: pageSize}, nil
 }
 
 // GetMod implements source.ModSource via the get_mod endpoint. gameID feeds

--- a/internal/source/custom/api_test.go
+++ b/internal/source/custom/api_test.go
@@ -407,3 +407,29 @@ func TestAPICheckUpdatesNoEndpoint(t *testing.T) {
 	_, err = a.CheckUpdates(context.Background(), []domain.InstalledMod{{Mod: domain.Mod{ID: "1"}}})
 	assert.True(t, errors.Is(err, source.ErrNotSupported))
 }
+
+func TestAPISearchNegativePageClamped(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.String()
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer srv.Close()
+
+	// The default validAPIDef() search path has no {offset} placeholder, so
+	// override it (as TestAPISearch does) to actually exercise the offset
+	// clamp this test is asserting on.
+	def := apiDef(srv.URL)
+	def.API.Endpoints.Search = &EndpointConfig{
+		Path: "/mods?q={query}&page={page}&skip={offset}",
+		List: "results",
+	}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+
+	_, err = a.Search(context.Background(), source.SearchQuery{Query: "x", Page: -3, PageSize: 10})
+	require.NoError(t, err)
+	// Negative pages clamp to page 0: {page} = 0 + pageStart(1) = 1, {offset} = 0.
+	assert.Contains(t, gotPath, "page=1")
+	assert.Contains(t, gotPath, "skip=0")
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -669,8 +669,9 @@ func (m Model) searchView() string {
 		// Every entry path into ScreenSearch already focuses the input (see
 		// gotoScreen), so the idle hint only needs to mention "/ focus" when
 		// Esc has since blurred it — otherwise it would tell the user to do
-		// something that's already done.
-		hint := "enter search · s source · esc unfocus"
+		// something that's already done. While focused, 's' types into the
+		// query (not a source-cycle shortcut), so exclude it from the focused hint.
+		hint := "enter search · esc unfocus"
 		if !m.search.input.Focused() {
 			hint = "/ focus · s source"
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -210,7 +210,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.gen != m.search.gen {
 			return m, nil
 		}
-		if errors.Is(msg.err, domain.ErrAuthRequired) {
+		// The sentinel source ("" == all sources) has no single source name to
+		// report; routing it here would render "Authentication required for ."
+		// and a broken "lmm auth login " hint. Fall through to searchFailed,
+		// whose rendering already names each failing source (see
+		// core.Service.SearchAllSources' joined per-source errors).
+		if msg.source != "" && errors.Is(msg.err, domain.ErrAuthRequired) {
 			m.search.state = searchAuthRequired
 			m.search.authSource = msg.source
 			return m, nil

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -569,8 +569,27 @@ func (m Model) searchHeaderLines() []string {
 	if m.search.state == searchReady {
 		source = m.search.page.Source
 	}
-	meta := m.theme.MutedText.Render(fmt.Sprintf("[source: %s  (s cycles)]", source))
+	meta := m.theme.MutedText.Render(fmt.Sprintf("[source: %s  (s cycles)]", sourceLabel(source)))
 	return []string{title + "  " + meta, m.search.input.View()}
+}
+
+// searchWarningLine renders m.search.page.Warnings — per-source failures
+// surfaced by all-sources searches, see SearchPage.Warnings — as one
+// truncated status line, or "" when there are none. Only meaningful in
+// searchReady (the only state where page is guaranteed to describe the
+// on-screen results; see searchHeaderLines's source-label comment for the
+// same reasoning applied to the source label).
+func (m Model) searchWarningLine() string {
+	warnings := m.search.page.Warnings
+	if len(warnings) == 0 {
+		return ""
+	}
+	noun := "source"
+	if len(warnings) != 1 {
+		noun = "sources"
+	}
+	line := fmt.Sprintf("⚠ %d %s unavailable: %s", len(warnings), noun, strings.Join(warnings, "; "))
+	return truncate(m.theme.WarningText.Render(line), m.availableWidth())
 }
 
 // searchSinglePanel wraps header+body lines in one full-bounds panel, used by
@@ -594,9 +613,12 @@ func (m Model) searchView() string {
 	case searchFailed:
 		return m.searchSinglePanel(append(header, m.theme.DangerText.Render(m.search.err.Error())))
 	case searchReady:
+		if warning := m.searchWarningLine(); warning != "" {
+			header = append(header, warning)
+		}
 		if len(m.search.page.Results) == 0 {
 			return m.searchSinglePanel(append(header,
-				m.theme.MutedText.Render(fmt.Sprintf("No archives matched %q on %s.", m.search.page.Query, m.search.page.Source)),
+				m.theme.MutedText.Render(fmt.Sprintf("No archives matched %q on %s.", m.search.page.Query, sourceLabel(m.search.page.Source))),
 			))
 		}
 		return m.searchReadyView(header)
@@ -644,24 +666,37 @@ func (m Model) searchReadyView(header []string) string {
 }
 
 // searchResultsPane renders the selectable result rows: name / version /
-// status, with "installed" statuses styled to pop. Column widths are derived
-// from the pane's actual content width (rather than fixed constants) and the
-// name column always absorbs whatever's left, so the three columns can never
-// sum past innerWidth. Overflowing values truncate instead of overflowing
-// into lipgloss's automatic line wrap, which would silently break the
-// exact-height layout invariant. Rows beyond maxLines are omitted for the
-// same reason (a full page of results can outnumber the available rows on a
-// short terminal).
+// status, with "installed" statuses styled to pop. In all-sources mode
+// (m.search.source() == "", i.e. the search that produced page targeted
+// every configured source), a source column is added so results from
+// different sources can be told apart; single-source mode's columns are
+// unchanged. Column widths are derived from the pane's actual content width
+// (rather than fixed constants) and the name column always absorbs
+// whatever's left, so the columns can never sum past innerWidth. Overflowing
+// values truncate instead of overflowing into lipgloss's automatic line
+// wrap, which would silently break the exact-height layout invariant. Rows
+// beyond maxLines are omitted for the same reason (a full page of results
+// can outnumber the available rows on a short terminal).
 func (m Model) searchResultsPane(width, maxLines int) string {
-	const (
-		prefixWidth = 2 // m.row()'s "> "/"  " selection marker
-		gaps        = 2 // the two separating spaces between columns
-	)
+	const prefixWidth = 2 // m.row()'s "> "/"  " selection marker
+
+	withSource := m.search.source() == ""
+	gaps := 2 // separating spaces between columns (name|version|status)
+	minAvail := 3
+	if withSource {
+		gaps = 3 // one more separator for the added source column
+		minAvail = 4
+	}
+
 	innerWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
-	avail := max(innerWidth-prefixWidth-gaps, 3)
+	avail := max(innerWidth-prefixWidth-gaps, minAvail)
 	statusWidth := min(max(avail/4, 1), 9) // "installed"/"available" are 9 runes
 	versionWidth := min(max(avail/4, 1), 8)
-	nameWidth := max(avail-statusWidth-versionWidth, 1)
+	sourceWidth := 0
+	if withSource {
+		sourceWidth = min(max(avail/5, 1), 10)
+	}
+	nameWidth := max(avail-statusWidth-versionWidth-sourceWidth, 1)
 
 	results := m.search.page.Results
 	if len(results) > maxLines {
@@ -674,10 +709,19 @@ func (m Model) searchResultsPane(width, maxLines int) string {
 		if item.Status == "installed" {
 			status = m.theme.WarningText.Render(status)
 		}
-		line := fmt.Sprintf("%-*s %-*s %s",
-			nameWidth, truncate(item.Name, nameWidth),
-			versionWidth, truncate(item.Version, versionWidth),
-			status)
+		var line string
+		if withSource {
+			line = fmt.Sprintf("%-*s %-*s %-*s %s",
+				nameWidth, truncate(item.Name, nameWidth),
+				versionWidth, truncate(item.Version, versionWidth),
+				sourceWidth, truncate(item.Source, sourceWidth),
+				status)
+		} else {
+			line = fmt.Sprintf("%-*s %-*s %s",
+				nameWidth, truncate(item.Name, nameWidth),
+				versionWidth, truncate(item.Version, versionWidth),
+				status)
+		}
 		rows = append(rows, m.row(i, line))
 	}
 	return strings.Join(rows, "\n")

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -595,12 +595,21 @@ func (m Model) searchHeaderLines() []string {
 }
 
 // searchWarningLine renders m.search.page.Warnings — per-source failures
-// surfaced by all-sources searches, see SearchPage.Warnings — as one
-// truncated status line, or "" when there are none. Only meaningful in
+// surfaced by all-sources searches, see SearchPage.Warnings — as one status
+// line truncated to width, or "" when there are none. Only meaningful in
 // searchReady (the only state where page is guaranteed to describe the
 // on-screen results; see searchHeaderLines's source-label comment for the
 // same reasoning applied to the source label).
-func (m Model) searchWarningLine() string {
+//
+// width must match where the caller places the line: searchReadyView's
+// header sits OUTSIDE any Width()-constrained panel, so it truncates to
+// m.availableWidth(); the zero-results branch of searchView places it
+// INSIDE searchSinglePanel, whose content width is narrower by the panel's
+// horizontal frame size (border + padding, see searchInputWidthFor's
+// equivalent math). Passing the wrong width lets a still-overlong line
+// reach a narrower panel, where lipgloss re-wraps it into extra physical
+// lines and grows the view past the fixed height budget.
+func (m Model) searchWarningLine(width int) string {
 	warnings := m.search.page.Warnings
 	if len(warnings) == 0 {
 		return ""
@@ -610,7 +619,7 @@ func (m Model) searchWarningLine() string {
 		noun = "sources"
 	}
 	line := fmt.Sprintf("⚠ %d %s unavailable: %s", len(warnings), noun, strings.Join(warnings, "; "))
-	return truncate(m.theme.WarningText.Render(line), m.availableWidth())
+	return truncate(m.theme.WarningText.Render(line), width)
 }
 
 // searchSinglePanel wraps header+body lines in one full-bounds panel, used by
@@ -634,13 +643,20 @@ func (m Model) searchView() string {
 	case searchFailed:
 		return m.searchSinglePanel(append(header, m.theme.DangerText.Render(m.search.err.Error())))
 	case searchReady:
-		if warning := m.searchWarningLine(); warning != "" {
-			header = append(header, warning)
-		}
 		if len(m.search.page.Results) == 0 {
+			// Placed inside searchSinglePanel below, so the warning must
+			// truncate to the panel's content width, not the full terminal
+			// width — see searchWarningLine's doc comment.
+			panelContentWidth := max(m.availableWidth()-m.theme.Panel.GetHorizontalFrameSize(), 1)
+			if warning := m.searchWarningLine(panelContentWidth); warning != "" {
+				header = append(header, warning)
+			}
 			return m.searchSinglePanel(append(header,
 				m.theme.MutedText.Render(fmt.Sprintf("No archives matched %q on %s.", m.search.page.Query, sourceLabel(m.search.page.Source))),
 			))
+		}
+		if warning := m.searchWarningLine(m.availableWidth()); warning != "" {
+			header = append(header, warning)
 		}
 		return m.searchReadyView(header)
 	default: // searchIdle

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -163,17 +163,34 @@ func (m Model) dashboardMenuRows() []string {
 	return rows
 }
 
-func (m Model) openSelectedMenuEntry() Model {
+func (m Model) openSelectedMenuEntry() (Model, tea.Cmd) {
 	if m.screen != ScreenDashboard {
-		return m
+		return m, nil
 	}
 	items := m.dashboardMenu()
 	selected := m.selected[ScreenDashboard]
 	if selected >= len(items) || !items[selected].hasTarget {
-		return m
+		return m, nil
 	}
-	m.screen = items[selected].target
-	return m
+	return m.gotoScreen(items[selected].target)
+}
+
+// gotoScreen switches to the target screen. Every entry path into
+// ScreenSearch — number/tab-cycling navigation, the dashboard menu, and "/"
+// — must leave the user ready to type immediately, so this is the single
+// place that focuses the search input on entry. Esc (the Blur binding) is
+// the only way back out of focus; once blurred, screen-level keys (s, n/p,
+// navigation) reach updateKey's outer switch again. Non-search targets are a
+// no-op beyond the screen assignment: the input is already unfocused in
+// every reachable case, since updateKey's focused-input branch swallows the
+// keys that would otherwise get here while ScreenSearch is still focused.
+func (m Model) gotoScreen(screen Screen) (Model, tea.Cmd) {
+	m.screen = screen
+	if screen != ScreenSearch {
+		return m, nil
+	}
+	m.search.input.Focus()
+	return m, textinput.Blink
 }
 
 func (m Model) Init() tea.Cmd {
@@ -269,24 +286,15 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.showHelp = !m.showHelp
 		return m, nil
 	case key.Matches(msg, m.keys.NextScreen):
-		m.screen = screenAt((m.screenIndex() + 1) % len(screens))
-		return m, nil
+		return m.gotoScreen(screenAt((m.screenIndex() + 1) % len(screens)))
 	case key.Matches(msg, m.keys.PrevScreen):
-		m.screen = screenAt((m.screenIndex() - 1 + len(screens)) % len(screens))
-		return m, nil
+		return m.gotoScreen(screenAt((m.screenIndex() - 1 + len(screens)) % len(screens)))
 	case key.Matches(msg, m.keys.Dashboard):
-		m.screen = ScreenDashboard
-		return m, nil
+		return m.gotoScreen(ScreenDashboard)
 	case key.Matches(msg, m.keys.InstalledMods):
-		m.screen = ScreenInstalledMods
-		return m, nil
-	case key.Matches(msg, m.keys.Search):
-		m.screen = ScreenSearch
-		m.search.input.Focus()
-		return m, textinput.Blink
-	case key.Matches(msg, m.keys.SearchScreen):
-		m.screen = ScreenSearch
-		return m, nil
+		return m.gotoScreen(ScreenInstalledMods)
+	case key.Matches(msg, m.keys.Search), key.Matches(msg, m.keys.SearchScreen):
+		return m.gotoScreen(ScreenSearch)
 	case key.Matches(msg, m.keys.NextPage):
 		if m.screen == ScreenSearch && m.search.state == searchReady && m.search.hasNextPage() {
 			return m.startSearch(m.search.page.Query, m.search.page.Page+1)
@@ -315,11 +323,9 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case key.Matches(msg, m.keys.Profiles):
-		m.screen = ScreenProfiles
-		return m, nil
+		return m.gotoScreen(ScreenProfiles)
 	case key.Matches(msg, m.keys.Sources):
-		m.screen = ScreenSources
-		return m, nil
+		return m.gotoScreen(ScreenSources)
 	case key.Matches(msg, m.keys.Up):
 		m.moveSelection(-1)
 		return m, nil
@@ -327,7 +333,7 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.moveSelection(1)
 		return m, nil
 	case key.Matches(msg, m.keys.Select):
-		return m.openSelectedMenuEntry(), nil
+		return m.openSelectedMenuEntry()
 	default:
 		return m, nil
 	}
@@ -660,7 +666,15 @@ func (m Model) searchView() string {
 		}
 		return m.searchReadyView(header)
 	default: // searchIdle
-		return m.searchSinglePanel(append(header, m.theme.MutedText.Render("/ focus · enter search · s source")))
+		// Every entry path into ScreenSearch already focuses the input (see
+		// gotoScreen), so the idle hint only needs to mention "/ focus" when
+		// Esc has since blurred it — otherwise it would tell the user to do
+		// something that's already done.
+		hint := "enter search · s source · esc unfocus"
+		if !m.search.input.Focused() {
+			hint = "/ focus · s source"
+		}
+		return m.searchSinglePanel(append(header, m.theme.MutedText.Render(hint)))
 	}
 }
 
@@ -889,10 +903,10 @@ func (m Model) helpView() string {
 		m.theme.PanelTitle.Render("HELP"),
 		"arrows / hjkl       move or switch screens",
 		"tab / shift+tab     cycle top-level screens",
-		"1-5                 jump to a screen",
+		"1-5                 jump to a screen (3 focuses search)",
 		"/                   search from anywhere (jumps + focuses input)",
 		"enter               search",
-		"esc                 cancel input",
+		"esc                 unfocus search input",
 		"n/p                 result pages",
 		"s                   cycle source",
 		"?                   toggle this help",

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -859,16 +859,26 @@ func (m Model) profilesView() string {
 // `lmm source list`, there is no error/status column — see SourceInfo's doc
 // comment for why definition-load failures never reach this screen.
 func (m Model) sourcesView() string {
+	// Calculate the panel's content width, which is narrower than availableWidth()
+	// by the panel's horizontal frame size (border + padding). Rows that render
+	// INSIDE this panel must be truncated to this width to prevent lipgloss from
+	// re-wrapping overlong lines and growing the view past its fixed height
+	// budget; see the fix in commit 2c075e3 for the same issue in searchView's
+	// zero-results warning.
+	panelContentWidth := max(m.availableWidth()-m.theme.Panel.GetHorizontalFrameSize(), 1)
+
 	// "  " matches m.row()'s 2-column selection-marker prefix ("> "/"  ") so
 	// the header lines up with the data columns below it instead of starting
 	// two columns to their left.
-	header := "  " + fmt.Sprintf("%-20s %-12s %-6s %s", "ID", "TYPE", "AUTH", "CAPABILITIES")
+	headerLine := "  " + fmt.Sprintf("%-20s %-12s %-6s %s", "ID", "TYPE", "AUTH", "CAPABILITIES")
+	headerLine = truncate(headerLine, panelContentWidth)
 	rows := []string{
 		m.theme.PanelTitle.Render("SOURCE REGISTRY"),
-		m.theme.MutedText.Render(header),
+		m.theme.MutedText.Render(headerLine),
 	}
 	for i, src := range m.sources {
 		line := fmt.Sprintf("%-20s %-12s %-6s %s", src.ID, src.Type, src.Auth, src.Capabilities)
+		line = truncate(line, panelContentWidth)
 		rows = append(rows, m.row(i, line))
 	}
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -62,6 +62,7 @@ type Model struct {
 	summary  Summary
 	mods     []ModItem
 	profiles []ProfileItem
+	sources  []SourceInfo
 	search   searchModel
 
 	screen   Screen
@@ -113,11 +114,17 @@ func NewModel(options Options) (Model, error) {
 		state:    stateLoading,
 		screen:   ScreenDashboard,
 		search:   newSearchModel(options.Provider, t.Panel.GetHorizontalFrameSize()),
+		// sources is seeded synchronously (like search's source list above)
+		// rather than through loadData/dataLoadedMsg: SourceInfos is a
+		// read-only view of already-registered sources, not an I/O call that
+		// can fail, so it needs no async load state or error path.
+		sources: options.Provider.SourceInfos(),
 		selected: map[Screen]int{
 			ScreenDashboard:     0,
 			ScreenInstalledMods: 0,
 			ScreenSearch:        0,
 			ScreenProfiles:      0,
+			ScreenSources:       0,
 		},
 	}, nil
 }
@@ -134,6 +141,7 @@ func (m Model) dashboardMenu() []menuItem {
 			{label: "RUN SPELLBOOK SCAN", target: ScreenInstalledMods, hasTarget: true},
 			{label: "QUERY ARCHIVE INDEX", target: ScreenSearch, hasTarget: true},
 			{label: "LOAD PROFILE ROSTER", target: ScreenProfiles, hasTarget: true},
+			{label: "SCRY SOURCE REGISTRY", target: ScreenSources, hasTarget: true},
 			{label: "ASK CONFLICT ORACLE"},
 		}
 	}
@@ -141,6 +149,7 @@ func (m Model) dashboardMenu() []menuItem {
 		{label: "Installed Mods", target: ScreenInstalledMods, hasTarget: true},
 		{label: "Search Archives", target: ScreenSearch, hasTarget: true},
 		{label: "Profiles", target: ScreenProfiles, hasTarget: true},
+		{label: "Sources", target: ScreenSources, hasTarget: true},
 		{label: "Consult Conflict Oracle"},
 	}
 }
@@ -308,6 +317,9 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Profiles):
 		m.screen = ScreenProfiles
 		return m, nil
+	case key.Matches(msg, m.keys.Sources):
+		m.screen = ScreenSources
+		return m, nil
 	case key.Matches(msg, m.keys.Up):
 		m.moveSelection(-1)
 		return m, nil
@@ -402,6 +414,8 @@ func (m Model) itemCount(screen Screen) int {
 		return len(m.search.page.Results)
 	case ScreenProfiles:
 		return len(m.profiles)
+	case ScreenSources:
+		return len(m.sources)
 	default:
 		return len(m.dashboardMenu())
 	}
@@ -445,6 +459,8 @@ func (m Model) screenView() string {
 		return m.searchView()
 	case ScreenProfiles:
 		return m.profilesView()
+	case ScreenSources:
+		return m.sourcesView()
 	default:
 		return m.dashboardView()
 	}
@@ -821,12 +837,33 @@ func (m Model) profilesView() string {
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
 }
 
+// sourcesView renders the read-only source registry: every source
+// registered with the DataProvider (built-in and user-defined), one row
+// each, in the single-pane list style profilesView uses. Unlike
+// `lmm source list`, there is no error/status column — see SourceInfo's doc
+// comment for why definition-load failures never reach this screen.
+func (m Model) sourcesView() string {
+	// "  " matches m.row()'s 2-column selection-marker prefix ("> "/"  ") so
+	// the header lines up with the data columns below it instead of starting
+	// two columns to their left.
+	header := "  " + fmt.Sprintf("%-20s %-12s %-6s %s", "ID", "TYPE", "AUTH", "CAPABILITIES")
+	rows := []string{
+		m.theme.PanelTitle.Render("SOURCE REGISTRY"),
+		m.theme.MutedText.Render(header),
+	}
+	for i, src := range m.sources {
+		line := fmt.Sprintf("%-20s %-12s %-6s %s", src.ID, src.Type, src.Auth, src.Capabilities)
+		rows = append(rows, m.row(i, line))
+	}
+	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
+}
+
 func (m Model) helpView() string {
 	return m.panel(m.availableWidth()).Render(strings.Join([]string{
 		m.theme.PanelTitle.Render("HELP"),
 		"arrows / hjkl       move or switch screens",
 		"tab / shift+tab     cycle top-level screens",
-		"1-4                 jump to a screen",
+		"1-5                 jump to a screen",
 		"/                   search from anywhere (jumps + focuses input)",
 		"enter               search",
 		"esc                 cancel input",

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -430,7 +430,7 @@ func TestEmptyStatesRenderHonestCopy(t *testing.T) {
 	require.Contains(t, model.View(), "No mods installed yet. 'lmm install <mod>' begins the quest.")
 
 	model = updateWithRunes(t, model, "3")
-	require.Contains(t, model.View(), "enter search · s source · esc unfocus", "3 already focused the input")
+	require.Contains(t, model.View(), "enter search · esc unfocus", "3 already focused the input")
 
 	model = updateWithKeyType(t, model, tea.KeyEsc)
 	require.Contains(t, model.View(), "/ focus · s source", "unfocused idle hint still tells the user how to refocus")

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -37,7 +37,11 @@ func TestNumberKeysNavigateScreens(t *testing.T) {
 
 	updated = updateWithRunes(t, updated, "3")
 	require.Equal(t, ScreenSearch, updated.CurrentScreen())
+	require.True(t, updated.search.input.Focused(), "3 focuses the search input so typing starts immediately")
 
+	// Esc blurs so the remaining screen-level number keys reach updateKey's
+	// outer switch instead of being typed into the now-focused input.
+	updated = updateWithKeyType(t, updated, tea.KeyEsc)
 	updated = updateWithRunes(t, updated, "4")
 	require.Equal(t, ScreenProfiles, updated.CurrentScreen())
 
@@ -58,6 +62,23 @@ func TestTabCyclesScreens(t *testing.T) {
 	require.Equal(t, ScreenDashboard, updated.CurrentScreen())
 }
 
+// TestTabCyclingOntoSearchFocuses covers the tab-cycling entry path into
+// ScreenSearch: like every other entry path (number keys, dashboard menu,
+// "/"), it must focus the input immediately.
+func TestTabCyclingOntoSearchFocuses(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	updated := updateWithKeyType(t, model, tea.KeyTab)
+	require.Equal(t, ScreenInstalledMods, updated.CurrentScreen())
+
+	updated = updateWithKeyType(t, updated, tea.KeyTab)
+	require.Equal(t, ScreenSearch, updated.CurrentScreen())
+	require.True(t, updated.search.input.Focused(), "tab-cycling onto search must focus the input")
+}
+
 func TestArrowAndVimKeysNavigateScreens(t *testing.T) {
 	t.Parallel()
 
@@ -69,7 +90,11 @@ func TestArrowAndVimKeysNavigateScreens(t *testing.T) {
 
 	model = updateWithRunes(t, model, "l")
 	require.Equal(t, ScreenSearch, model.CurrentScreen())
+	require.True(t, model.search.input.Focused(), "cycling onto search focuses the input")
 
+	// Esc blurs so the remaining screen-level arrow/vim keys reach updateKey's
+	// outer switch instead of moving the cursor inside the now-focused input.
+	model = updateWithKeyType(t, model, tea.KeyEsc)
 	model = updateWithKeyType(t, model, tea.KeyLeft)
 	require.Equal(t, ScreenInstalledMods, model.CurrentScreen())
 
@@ -291,10 +316,11 @@ func TestDashboardEnterOpensSelectedMenuEntry(t *testing.T) {
 	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	require.Equal(t, ScreenInstalledMods, opened.(Model).CurrentScreen())
 
-	// Second entry opens Search.
+	// Second entry opens Search, focused like every other entry path.
 	moved := updateWithRunes(t, model, "j")
 	opened, _ = moved.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	require.Equal(t, ScreenSearch, opened.(Model).CurrentScreen())
+	require.True(t, opened.(Model).search.input.Focused(), "dashboard menu entry into search must focus the input")
 }
 
 func TestDashboardEnterOnOracleEntryStaysPut(t *testing.T) {
@@ -404,7 +430,10 @@ func TestEmptyStatesRenderHonestCopy(t *testing.T) {
 	require.Contains(t, model.View(), "No mods installed yet. 'lmm install <mod>' begins the quest.")
 
 	model = updateWithRunes(t, model, "3")
-	require.Contains(t, model.View(), "/ focus · enter search · s source")
+	require.Contains(t, model.View(), "enter search · s source · esc unfocus", "3 already focused the input")
+
+	model = updateWithKeyType(t, model, tea.KeyEsc)
+	require.Contains(t, model.View(), "/ focus · s source", "unfocused idle hint still tells the user how to refocus")
 }
 
 // recordingProvider wraps a delegate DataProvider and records the context

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -304,7 +304,8 @@ func TestDashboardEnterOnOracleEntryStaysPut(t *testing.T) {
 	require.NoError(t, err)
 
 	// Move to the last entry (Conflict Oracle) — no screen exists for it yet.
-	for range 3 {
+	// 4 presses: Installed Mods -> Search -> Profiles -> Sources -> Oracle.
+	for range 4 {
 		model = updateWithRunes(t, model, "j")
 	}
 	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -329,6 +330,7 @@ func (f failingProvider) Overview(context.Context) (Summary, []ModItem, error) {
 }
 func (f failingProvider) Profiles(context.Context) ([]ProfileItem, error) { return nil, f.err }
 func (f failingProvider) Sources() []string                               { return []string{"nexusmods"} }
+func (f failingProvider) SourceInfos() []SourceInfo                       { return nil }
 func (f failingProvider) Search(context.Context, string, string, int) (SearchPage, error) {
 	return SearchPage{}, f.err
 }
@@ -384,6 +386,7 @@ func (emptyProvider) Overview(context.Context) (Summary, []ModItem, error) {
 }
 func (emptyProvider) Profiles(context.Context) ([]ProfileItem, error) { return nil, nil }
 func (emptyProvider) Sources() []string                               { return []string{"nexusmods"} }
+func (emptyProvider) SourceInfos() []SourceInfo                       { return nil }
 func (emptyProvider) Search(context.Context, string, string, int) (SearchPage, error) {
 	return SearchPage{}, nil
 }
@@ -424,6 +427,10 @@ func (r recordingProvider) Profiles(ctx context.Context) ([]ProfileItem, error) 
 
 func (r recordingProvider) Sources() []string {
 	return r.delegate.Sources()
+}
+
+func (r recordingProvider) SourceInfos() []SourceInfo {
+	return r.delegate.SourceInfos()
 }
 
 func (r recordingProvider) Search(ctx context.Context, source, query string, page int) (SearchPage, error) {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -15,6 +15,7 @@ type KeyMap struct {
 	Dashboard     key.Binding
 	InstalledMods key.Binding
 	Profiles      key.Binding
+	Sources       key.Binding
 	Select        key.Binding
 	Submit        key.Binding
 	Blur          key.Binding
@@ -69,6 +70,10 @@ func DefaultKeyMap() KeyMap {
 		Profiles: key.NewBinding(
 			key.WithKeys("4"),
 			key.WithHelp("4", "profiles"),
+		),
+		Sources: key.NewBinding(
+			key.WithKeys("5"),
+			key.WithHelp("5", "sources"),
 		),
 		Select: key.NewBinding(
 			key.WithKeys("enter"),

--- a/internal/tui/navigation.go
+++ b/internal/tui/navigation.go
@@ -10,6 +10,7 @@ const (
 	ScreenInstalledMods
 	ScreenSearch
 	ScreenProfiles
+	ScreenSources
 )
 
 var screens = []Screen{
@@ -17,6 +18,7 @@ var screens = []Screen{
 	ScreenInstalledMods,
 	ScreenSearch,
 	ScreenProfiles,
+	ScreenSources,
 }
 
 // String returns a human-readable screen name.
@@ -30,6 +32,8 @@ func (s Screen) String() string {
 		return "Search"
 	case ScreenProfiles:
 		return "Profiles"
+	case ScreenSources:
+		return "Sources"
 	default:
 		return fmt.Sprintf("Screen(%d)", s)
 	}

--- a/internal/tui/navigation_test.go
+++ b/internal/tui/navigation_test.go
@@ -10,7 +10,7 @@ func TestScreenAtClampsOutOfRangeIndexes(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, ScreenDashboard, screenAt(-1))
-	require.Equal(t, ScreenProfiles, screenAt(len(screens)))
+	require.Equal(t, ScreenSources, screenAt(len(screens)))
 	require.Equal(t, ScreenInstalledMods, screenAt(1))
 }
 

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -51,6 +51,12 @@ type searchFailedMsg struct {
 	source string
 }
 
+// errNoSourcesConfigured is surfaced whenever a game has zero real (i.e.
+// non-sentinel) configured sources, both proactively at model construction
+// (newSearchModel) and defensively if startSearch is somehow reached in that
+// state. It mirrors the CLI's noSourcesConfiguredErr diagnostic.
+var errNoSourcesConfigured = errors.New("no mod sources configured for this game; add one with 'lmm game add' or edit games.yaml")
+
 // searchInputPromptAllowance reserves room for the query input's "> " prompt
 // plus its trailing cursor cell, so searchInputWidthFor's value-viewport
 // width keeps prompt+value+cursor inside the panel's content width. Without
@@ -70,25 +76,51 @@ func searchInputWidthFor(availableWidth, panelHorizontalFrameSize int) int {
 }
 
 // newSearchModel builds the search sub-model, seeding its source list from
-// the DataProvider. The input's Width defaults from defaultContentWidth (the
-// same zero-size fallback availableWidth uses) so the input stays bounded
-// even in tests that never send a tea.WindowSizeMsg; Update's
-// tea.WindowSizeMsg case recomputes it once real terminal dimensions arrive.
+// the DataProvider with the all-sources sentinel ("") prepended, so index 0
+// — the default sourceIdx — targets "search every configured source" rather
+// than an arbitrary real one. The input's Width defaults from
+// defaultContentWidth (the same zero-size fallback availableWidth uses) so
+// the input stays bounded even in tests that never send a
+// tea.WindowSizeMsg; Update's tea.WindowSizeMsg case recomputes it once real
+// terminal dimensions arrive.
+//
+// When the provider has zero real sources, the sentinel is meaningless (there
+// is nothing to search), so the model starts in searchFailed with the
+// configured-sources diagnostic rather than silently offering a dead "All
+// sources" default (CARRIED REVIEW NOTE from issue #54 hardening).
 func newSearchModel(provider DataProvider, panelHorizontalFrameSize int) searchModel {
 	input := textinput.New()
 	input.Placeholder = "search the archives"
 	input.CharLimit = 120
 	input.Width = searchInputWidthFor(defaultContentWidth, panelHorizontalFrameSize)
-	return searchModel{input: input, sources: provider.Sources()}
+
+	realSources := provider.Sources()
+	s := searchModel{input: input, sources: append([]string{""}, realSources...)}
+	if len(realSources) == 0 {
+		s.state = searchFailed
+		s.err = errNoSourcesConfigured
+	}
+	return s
 }
 
-// source returns the currently selected source ID, or "" when the game has
-// no configured sources.
+// source returns the currently selected source ID: "" is the all-sources
+// sentinel, meaning "search every configured source". Also "" when the
+// sources list itself is empty/unset (defensive: see startSearch's guard for
+// the real "no sources configured" case).
 func (s searchModel) source() string {
 	if len(s.sources) == 0 {
 		return ""
 	}
 	return s.sources[s.sourceIdx]
+}
+
+// sourceLabel renders a source ID for display: the all-sources sentinel ""
+// becomes "All sources"; any real source ID renders as itself.
+func sourceLabel(source string) string {
+	if source == "" {
+		return "All sources"
+	}
+	return source
 }
 
 // hasNextPage reports whether another page of results is available for the
@@ -103,10 +135,14 @@ func (s searchModel) hasNextPage() bool {
 // startSearch cancels any in-flight search, bumps the generation, and returns
 // the model plus a command executing the new query.
 func (m Model) startSearch(query string, page int) (Model, tea.Cmd) {
-	// Guard: no sources configured for this game
-	if m.search.source() == "" {
+	// Guard: no REAL sources configured for this game. The "" sentinel is
+	// now a valid search target (meaning "search every configured source"),
+	// so this can no longer key off source() == "": sources always contains
+	// at least the sentinel once newSearchModel has run. The actual invalid
+	// case is zero real sources, i.e. the sentinel-only (or empty) list.
+	if len(m.search.sources) <= 1 {
 		m.search.state = searchFailed
-		m.search.err = errors.New("no mod sources configured for this game; add one with 'lmm game add' or edit games.yaml")
+		m.search.err = errNoSourcesConfigured
 		return m, nil
 	}
 

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -329,6 +329,7 @@ func (noSourcesProvider) Overview(context.Context) (Summary, []ModItem, error) {
 }
 func (noSourcesProvider) Profiles(context.Context) ([]ProfileItem, error) { return nil, nil }
 func (noSourcesProvider) Sources() []string                               { return nil }
+func (noSourcesProvider) SourceInfos() []SourceInfo                       { return nil }
 func (noSourcesProvider) Search(context.Context, string, string, int) (SearchPage, error) {
 	return SearchPage{}, nil
 }

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -23,13 +23,22 @@ func keyRunes(s string) tea.KeyMsg {
 func searchScreenModel(t *testing.T) Model {
 	t.Helper()
 	model := sizedPrototypeModel(t, "wizardry", 100, 30)
-	return updateWithRunes(t, model, "3") // jump to search screen (blurred)
+	return updateWithRunes(t, model, "3") // jump to search screen (focused)
 }
 
-func TestSlashFocusesSearchInputOnSearchScreen(t *testing.T) {
+// TestSlashRefocusesSearchInputAfterEsc covers "/"'s refocus behavior from
+// within the search screen itself: entering via "3" already focuses (see
+// TestNumberThreeJumpsAndFocuses), so this exercises the Esc-then-"/" path
+// instead of a no-op re-press of "/" on an already-focused input.
+func TestSlashRefocusesSearchInputAfterEsc(t *testing.T) {
 	t.Parallel()
 
 	model := searchScreenModel(t)
+	require.True(t, model.search.input.Focused(), "entering via 3 already focuses")
+
+	model = updateWithKeyType(t, model, tea.KeyEsc)
+	require.False(t, model.search.input.Focused())
+
 	model = updateWithRunes(t, model, "/")
 	require.True(t, model.search.input.Focused())
 }
@@ -50,20 +59,38 @@ func TestSlashFromAnyScreenJumpsAndFocuses(t *testing.T) {
 	require.Equal(t, "sky", model.search.input.Value())
 }
 
-func TestNumberThreeJumpsWithoutFocusing(t *testing.T) {
+func TestNumberThreeJumpsAndFocuses(t *testing.T) {
 	t.Parallel()
 
 	model := sizedPrototypeModel(t, "wizardry", 100, 30)
 	model = updateWithRunes(t, model, "3")
 	require.Equal(t, ScreenSearch, model.CurrentScreen())
-	require.False(t, model.search.input.Focused(), "3 is pure navigation")
+	require.True(t, model.search.input.Focused(), "3 must focus the input like every other entry path")
+}
+
+// TestEscThenSCyclesSourceProvingScreenKeysWork covers the other half of the
+// entry-focuses/Esc-blurs contract: once blurred, screen-level keys (here,
+// CycleSource's "s") must reach updateKey's outer switch instead of being
+// swallowed as literal input.
+func TestEscThenSCyclesSourceProvingScreenKeysWork(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t) // "3": ScreenSearch, focused
+	model.search.sources = []string{"curseforge", "nexusmods"}
+	require.True(t, model.search.input.Focused())
+
+	model = updateWithKeyType(t, model, tea.KeyEsc)
+	require.Equal(t, ScreenSearch, model.CurrentScreen())
+	require.False(t, model.search.input.Focused())
+
+	model = updateWithRunes(t, model, "s")
+	require.Equal(t, 1, model.search.sourceIdx, "s must cycle the source once unfocused")
 }
 
 func TestTypingWhileFocusedDoesNotTriggerGlobalKeys(t *testing.T) {
 	t.Parallel()
 
-	model := searchScreenModel(t)
-	model = updateWithRunes(t, model, "/")
+	model := searchScreenModel(t)  // "3" already focused the input
 	for _, r := range "quest124" { // q would quit; 1/2/4 would jump screens
 		model = updateWithRunes(t, model, string(r))
 	}
@@ -74,8 +101,7 @@ func TestTypingWhileFocusedDoesNotTriggerGlobalKeys(t *testing.T) {
 func TestEscBlursSearchInput(t *testing.T) {
 	t.Parallel()
 
-	model := searchScreenModel(t)
-	model = updateWithRunes(t, model, "/")
+	model := searchScreenModel(t) // "3" already focused the input
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	require.False(t, updated.(Model).search.input.Focused())
 }
@@ -83,8 +109,7 @@ func TestEscBlursSearchInput(t *testing.T) {
 func TestEnterSubmitsSearchAndRendersResults(t *testing.T) {
 	t.Parallel()
 
-	model := searchScreenModel(t)
-	model = updateWithRunes(t, model, "/")
+	model := searchScreenModel(t) // "3" already focused the input
 	for _, r := range "frost" {
 		model = updateWithRunes(t, model, string(r))
 	}
@@ -161,6 +186,7 @@ func TestCycleSourceKey(t *testing.T) {
 
 	model := searchScreenModel(t)
 	model.search.sources = []string{"curseforge", "nexusmods"}
+	model = updateWithKeyType(t, model, tea.KeyEsc) // s is a screen-level key; only reaches CycleSource once blurred
 	model = updateWithRunes(t, model, "s")
 	require.Equal(t, 1, model.search.sourceIdx)
 	model = updateWithRunes(t, model, "s")
@@ -175,6 +201,7 @@ func TestCycleSourceInvalidatesInFlightAndResults(t *testing.T) {
 	model.search.state = searchLoading
 	model.search.gen = 3
 
+	model = updateWithKeyType(t, model, tea.KeyEsc) // s is a screen-level key; only reaches CycleSource once blurred
 	model = updateWithRunes(t, model, "s")
 	require.Equal(t, searchIdle, model.search.state, "cycling resets state")
 	require.Greater(t, model.search.gen, 3, "gen bumped so in-flight results are stale")
@@ -202,8 +229,7 @@ func TestLongQueryDoesNotBreakSearchHeightInvariant(t *testing.T) {
 
 	for _, width := range []int{44, 48, 60, 80} {
 		model := sizedPrototypeModel(t, "wizardry", width, 24)
-		model = updateWithRunes(t, model, "3")
-		model = updateWithRunes(t, model, "/")
+		model = updateWithRunes(t, model, "3") // already focused
 		for range 100 {
 			model = updateWithRunes(t, model, "x")
 		}
@@ -216,6 +242,7 @@ func TestPaginationKeysRequeryWithinBounds(t *testing.T) {
 	t.Parallel()
 
 	model := searchScreenModel(t)
+	model = updateWithKeyType(t, model, tea.KeyEsc) // n/p are screen-level keys; only reach pagination once blurred
 	model.search.state = searchReady
 	model.search.page = SearchPage{Query: "q", Source: "nexusmods", Page: 0, PageSize: 10, TotalCount: 25}
 
@@ -230,8 +257,7 @@ func TestPaginationKeysRequeryWithinBounds(t *testing.T) {
 
 func TestCtrlCQuitsWhileSearchInputFocused(t *testing.T) {
 	t.Parallel()
-	model := searchScreenModel(t)
-	model = updateWithRunes(t, model, "/") // focus
+	model := searchScreenModel(t) // "3" already focused the input
 	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	require.NotNil(t, cmd)
 	require.Equal(t, tea.Quit(), cmd())
@@ -285,7 +311,7 @@ func TestSearchDefaultsToAllSources(t *testing.T) {
 	require.Equal(t, "", model.search.sources[0], "the all-sources sentinel is prepended")
 	require.Equal(t, "", model.search.source(), "default target is All sources")
 
-	model = updateWithRunes(t, model, "3") // jump to search screen (blurred)
+	model = updateWithRunes(t, model, "3") // jump to search screen (focused)
 	require.Contains(t, model.View(), "All sources", "header labels the sentinel for humans")
 }
 
@@ -297,6 +323,7 @@ func TestCycleSourceRotatesThroughAllThenReal(t *testing.T) {
 	model := searchScreenModel(t)
 	require.Equal(t, "", model.search.source(), "starts on All sources")
 
+	model = updateWithKeyType(t, model, tea.KeyEsc) // s is a screen-level key; only reaches CycleSource once blurred
 	model = updateWithRunes(t, model, "s")
 	require.Equal(t, "nexusmods", model.search.source(), "cycles to the one real source")
 
@@ -414,9 +441,8 @@ func TestTruncateIsDisplayWidthAware(t *testing.T) {
 func TestSubmitWithNoConfiguredSourcesFailsClearly(t *testing.T) {
 	t.Parallel()
 
-	model := searchScreenModel(t)
+	model := searchScreenModel(t) // "3" already focused the input
 	model.search.sources = nil
-	model = updateWithRunes(t, model, "/")
 	for _, r := range "sky" {
 		model = updateWithRunes(t, model, string(r))
 	}

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -125,6 +125,36 @@ func TestAuthRequiredBecomesFirstClassState(t *testing.T) {
 	require.Equal(t, "nexusmods", m.search.authSource)
 }
 
+// TestAllSourcesAuthFailureShowsPerSourceDetail covers the sentinel
+// ("" == all sources) case: when every source fails on auth, the joined
+// error still satisfies errors.Is(err, domain.ErrAuthRequired), but routing
+// it to searchAuthRequired would render "Authentication required for ." and
+// a broken "lmm auth login " hint (msg.source is the sentinel, not a real
+// source). It must fall through to searchFailed instead, whose rendering
+// already names each failing source.
+func TestAllSourcesAuthFailureShowsPerSourceDetail(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.gen = 1
+	joined := errors.Join(
+		fmt.Errorf("source nexusmods: %w", domain.ErrAuthRequired),
+		fmt.Errorf("source curseforge: %w", domain.ErrAuthRequired),
+	)
+	updated, _ := model.Update(searchFailedMsg{
+		gen:    1,
+		err:    fmt.Errorf("all 2 source(s) failed: %w", joined),
+		source: "",
+	})
+	m := updated.(Model)
+	require.Equal(t, searchFailed, m.search.state, "sentinel source must not route to the single-source auth state")
+
+	view := m.View()
+	require.Contains(t, view, "nexusmods", "failed view must retain the per-source detail")
+	require.NotContains(t, view, "Authentication required for .", "must not render the broken sentinel message")
+	require.NotContains(t, view, "lmm auth login '", "must not render a broken auth-login hint for an empty source")
+}
+
 func TestCycleSourceKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -370,6 +371,36 @@ func TestSearchReadyViewFitsNarrowTerminals(t *testing.T) {
 			Results: []ModItem{{Name: "SkyUI", Author: "schlangster", Version: "5.2", Status: "installed", Summary: "UI overhaul."}},
 		}
 		require.Equal(t, model.availableWidth(), lipgloss.Width(model.screenView()), "width %d", width)
+	}
+}
+
+// TestZeroResultsWarningFitsPanelWidth guards the zero-results branch of
+// searchView, where the warning line renders INSIDE searchSinglePanel
+// instead of outside a panel like searchReadyView's header. The panel's
+// content width is narrower than availableWidth() by its horizontal frame
+// size (border + padding), so a warning line truncated only to
+// availableWidth() can still overflow the panel and get re-wrapped by
+// lipgloss, growing the view past the fixed height budget — this test
+// reproduces that with a long per-source warning at a narrow terminal width.
+func TestZeroResultsWarningFitsPanelWidth(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 40, 12)
+	model = updateWithRunes(t, model, "3") // jump to search screen
+	model.search.state = searchReady
+	model.search.page = SearchPage{
+		Query:  "sky",
+		Source: "",
+		Warnings: []string{
+			`dead-repo: source "dead-repo": fetching manifest https://example.com/mods/registry/manifest.json: context deadline exceeded`,
+		},
+	}
+
+	view := model.screenView()
+	require.Equal(t, model.availableContentHeight(), lipgloss.Height(view),
+		"an overlong warning must not wrap and grow the zero-results panel past its height budget")
+	for _, line := range strings.Split(view, "\n") {
+		require.LessOrEqual(t, lipgloss.Width(line), model.availableWidth(), "no rendered line exceeds terminal width")
 	}
 }
 

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -244,6 +245,75 @@ func TestSearchViewRendersStates(t *testing.T) {
 	model.search.page = SearchPage{Query: "nothing", Source: "nexusmods", PageSize: 10}
 	view = model.View()
 	require.Contains(t, view, "No archives matched", "zero-result state renders honest copy")
+}
+
+func TestSearchDefaultsToAllSources(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 100, 30)
+	require.Equal(t, "", model.search.sources[0], "the all-sources sentinel is prepended")
+	require.Equal(t, "", model.search.source(), "default target is All sources")
+
+	model = updateWithRunes(t, model, "3") // jump to search screen (blurred)
+	require.Contains(t, model.View(), "All sources", "header labels the sentinel for humans")
+}
+
+func TestCycleSourceRotatesThroughAllThenReal(t *testing.T) {
+	t.Parallel()
+
+	// Prototype provider has exactly one real source ("nexusmods"), so the
+	// sentinel-prefixed list is ["", "nexusmods"].
+	model := searchScreenModel(t)
+	require.Equal(t, "", model.search.source(), "starts on All sources")
+
+	model = updateWithRunes(t, model, "s")
+	require.Equal(t, "nexusmods", model.search.source(), "cycles to the one real source")
+
+	model = updateWithRunes(t, model, "s")
+	require.Equal(t, "", model.search.source(), "wraps back to All sources")
+}
+
+func TestSearchWarningLineRendered(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.gen = 1
+	updated, _ := model.Update(searchResultMsg{gen: 1, page: SearchPage{
+		Query: "sky", Source: "", PageSize: 10, TotalCount: 1,
+		Results:  []ModItem{{Name: "SkyUI", Source: "nexusmods", Status: "available"}},
+		Warnings: []string{"curseforge: connection refused"},
+	}})
+	m := updated.(Model)
+
+	view := m.searchView()
+	require.Contains(t, view, "⚠", "warning marker renders")
+	require.Contains(t, view, "curseforge", "warning names the failing source")
+}
+
+// noSourcesProvider has zero configured sources, exercising the
+// zero-real-sources diagnostic path (see newSearchModel).
+type noSourcesProvider struct{}
+
+func (noSourcesProvider) Overview(context.Context) (Summary, []ModItem, error) {
+	return Summary{}, nil, nil
+}
+func (noSourcesProvider) Profiles(context.Context) ([]ProfileItem, error) { return nil, nil }
+func (noSourcesProvider) Sources() []string                               { return nil }
+func (noSourcesProvider) Search(context.Context, string, string, int) (SearchPage, error) {
+	return SearchPage{}, nil
+}
+
+func TestZeroRealSourcesShowsConfiguredSourcesDiagnosticOnConstruction(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(Options{Theme: "wizardry", Provider: noSourcesProvider{}})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+
+	model = updateWithRunes(t, model, "3") // jump to search screen; no submit
+	require.Equal(t, searchFailed, model.search.state, "diagnostic fires at construction, not just on submit")
+	require.Contains(t, model.View(), "no mod sources configured")
 }
 
 func TestSearchViewStaysWithinBounds(t *testing.T) {

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -33,6 +33,20 @@ type ModItem struct {
 	HasEndorsements bool
 }
 
+// SourceInfo is one renderable source-registry row, mirroring the columns of
+// `lmm source list` (cmd/lmm/source.go) minus its Error column: the Sources
+// screen only lists sources that are actually REGISTERED with the service.
+// Source-definition load failures (a malformed YAML file, an ID collision)
+// never produce a registered source, so they have no row here and remain a
+// CLI-only diagnostic (`lmm source list` / `lmm source validate`).
+type SourceInfo struct {
+	ID           string
+	Name         string
+	Type         string // "built-in", "directory", "manifest", or "api"
+	Auth         string // "yes", "no", or "n/a" (source has no auth capability)
+	Capabilities string // compact list, e.g. "search,updates"
+}
+
 // ProfileItem is one renderable profile row.
 type ProfileItem struct {
 	Name     string
@@ -65,6 +79,10 @@ type DataProvider interface {
 	// Sources lists the game's configured source IDs, sorted; index 0 is the
 	// default (mirrors the CLI's resolveSource).
 	Sources() []string
+	// SourceInfos lists every source registered with the service (built-in
+	// and user-defined), sorted by ID, for the read-only Sources screen. See
+	// SourceInfo's doc comment for how this differs from Sources.
+	SourceInfos() []SourceInfo
 	// Search queries one source, or every one of the game's configured
 	// sources when source is "" (the documented all-sources sentinel).
 	Search(ctx context.Context, source, query string, page int) (SearchPage, error)
@@ -95,6 +113,14 @@ func (p prototypeProvider) Overview(_ context.Context) (Summary, []ModItem, erro
 
 func (p prototypeProvider) Sources() []string {
 	return []string{"nexusmods"}
+}
+
+func (p prototypeProvider) SourceInfos() []SourceInfo {
+	return []SourceInfo{
+		{ID: "curseforge", Name: "CurseForge", Type: "built-in", Auth: "n/a", Capabilities: "search,updates"},
+		{ID: "local-mods", Name: "Local Mods", Type: "directory", Auth: "n/a", Capabilities: "search,updates"},
+		{ID: "nexusmods", Name: "Nexus Mods", Type: "built-in", Auth: "yes", Capabilities: "search,deps,updates,auth"},
+	}
 }
 
 func (p prototypeProvider) Search(_ context.Context, source, query string, _ int) (SearchPage, error) {

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -76,8 +76,11 @@ type DataProvider interface {
 	// single underlying fetch.
 	Overview(ctx context.Context) (Summary, []ModItem, error)
 	Profiles(ctx context.Context) ([]ProfileItem, error)
-	// Sources lists the game's configured source IDs, sorted; index 0 is the
-	// default (mirrors the CLI's resolveSource).
+	// Sources lists the game's configured real source IDs, sorted. The TUI
+	// prepends the all-sources sentinel ("") ahead of these (see
+	// newSearchModel); the CLI instead defaults to an aggregate search
+	// across all of them when --source is omitted (see doSearch in
+	// cmd/lmm/search.go).
 	Sources() []string
 	// SourceInfos lists every source registered with the service (built-in
 	// and user-defined), sorted by ID, for the read-only Sources screen. See

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -48,6 +48,10 @@ type SearchPage struct {
 	Page       int // 0-based
 	PageSize   int
 	TotalCount int // 0 if the source doesn't report totals
+	// Warnings holds per-source failures in all-sources mode, already
+	// formatted for display (e.g. "<sourceID>: <err>"). Empty for
+	// single-source searches.
+	Warnings []string
 }
 
 // DataProvider is the narrow, read-only boundary between the TUI and app
@@ -61,6 +65,8 @@ type DataProvider interface {
 	// Sources lists the game's configured source IDs, sorted; index 0 is the
 	// default (mirrors the CLI's resolveSource).
 	Sources() []string
+	// Search queries one source, or every one of the game's configured
+	// sources when source is "" (the documented all-sources sentinel).
 	Search(ctx context.Context, source, query string, page int) (SearchPage, error)
 }
 

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
 )
 
 // coreProvider adapts *core.Service to the read-only DataProvider boundary.
@@ -63,6 +65,82 @@ func (p *coreProvider) Sources() []string {
 	}
 	sort.Strings(sources)
 	return sources
+}
+
+// SourceInfos returns every source registered with the underlying service,
+// sorted by ID. Sorting is required, not cosmetic: registry iteration order
+// is Go map order, which is intentionally randomized, and an unsorted list
+// would jitter row order between renders (mirrors cmd/lmm/auth.go's
+// ListSources-sorting note).
+func (p *coreProvider) SourceInfos() []SourceInfo {
+	srcs := p.svc.ListSources()
+	infos := make([]SourceInfo, 0, len(srcs))
+	for _, src := range srcs {
+		infos = append(infos, SourceInfo{
+			ID:           src.ID(),
+			Name:         src.Name(),
+			Type:         customSourceType(src),
+			Auth:         sourceAuthState(src),
+			Capabilities: sourceCapabilitySummary(source.CapabilitiesOf(src)),
+		})
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].ID < infos[j].ID })
+	return infos
+}
+
+// customSourceType classifies a registered source for display. It mirrors
+// cmd/lmm/source.go's isCustomSource switch; that helper isn't reused
+// directly since cmd/lmm is a `package main` and not importable here, so the
+// classification is kept in sync by hand — extend this switch alongside
+// isCustomSource if a new custom source type ships.
+func customSourceType(src source.ModSource) string {
+	switch src.(type) {
+	case *custom.Directory:
+		return "directory"
+	case *custom.Manifest:
+		return "manifest"
+	case *custom.API:
+		return "api"
+	default:
+		return "built-in"
+	}
+}
+
+// sourceAuthState reports a source's authentication status for display.
+// Mirrors cmd/lmm/source.go's authState (see customSourceType's comment on
+// why it's duplicated rather than imported).
+func sourceAuthState(src source.ModSource) string {
+	if !source.CapabilitiesOf(src).Auth {
+		return "n/a"
+	}
+	if a, ok := src.(interface{ IsAuthenticated() bool }); ok {
+		if a.IsAuthenticated() {
+			return "yes"
+		}
+		return "no"
+	}
+	return "yes"
+}
+
+// sourceCapabilitySummary renders capabilities as a compact list, e.g.
+// "search,updates". Mirrors cmd/lmm/source.go's capabilitySummary (see
+// customSourceType's comment on why it's duplicated rather than imported).
+func sourceCapabilitySummary(c source.Capabilities) string {
+	out := ""
+	add := func(enabled bool, name string) {
+		if !enabled {
+			return
+		}
+		if out != "" {
+			out += ","
+		}
+		out += name
+	}
+	add(c.Search, "search")
+	add(c.Dependencies, "deps")
+	add(c.Updates, "updates")
+	add(c.Auth, "auth")
+	return out
 }
 
 // Search queries the given source, or every one of the game's configured

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -65,25 +65,76 @@ func (p *coreProvider) Sources() []string {
 	return sources
 }
 
-// Search queries the given source and marks results already installed in
-// the active profile.
+// Search queries the given source, or every one of the game's configured
+// sources when sourceID is "" (the all-sources sentinel), and marks results
+// already installed in the active profile.
 func (p *coreProvider) Search(ctx context.Context, sourceID, query string, page int) (SearchPage, error) {
+	if sourceID == "" {
+		agg, err := p.svc.SearchAllSources(ctx, p.game.ID, query, "", nil, page, SearchPageSize)
+		if err != nil {
+			return SearchPage{}, fmt.Errorf("searching all sources for %q: %w", query, err)
+		}
+
+		installedKeys, err := p.installedModKeys()
+		if err != nil {
+			return SearchPage{}, err
+		}
+
+		warnings := make([]string, 0, len(agg.Warnings))
+		for _, w := range agg.Warnings {
+			warnings = append(warnings, fmt.Sprintf("%s: %v", w.SourceID, w.Err))
+		}
+
+		return SearchPage{
+			Results:    p.modsToItems(agg.Mods, installedKeys),
+			Query:      query,
+			Source:     sourceID,
+			Page:       page,
+			PageSize:   SearchPageSize,
+			TotalCount: agg.TotalCount,
+			Warnings:   warnings,
+		}, nil
+	}
+
 	result, err := p.svc.SearchMods(ctx, sourceID, p.game.ID, query, "", nil, page, SearchPageSize)
 	if err != nil {
 		return SearchPage{}, fmt.Errorf("searching %s for %q: %w", sourceID, query, err)
 	}
 
-	installed, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
+	installedKeys, err := p.installedModKeys()
 	if err != nil {
-		return SearchPage{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
-	}
-	installedKeys := make(map[string]bool, len(installed))
-	for _, mod := range installed {
-		installedKeys[domain.ModKey(mod.SourceID, mod.ID)] = true
+		return SearchPage{}, err
 	}
 
-	items := make([]ModItem, 0, len(result.Mods))
-	for _, mod := range result.Mods {
+	return SearchPage{
+		Results:    p.modsToItems(result.Mods, installedKeys),
+		Query:      query,
+		Source:     sourceID,
+		Page:       page,
+		PageSize:   SearchPageSize,
+		TotalCount: result.TotalCount,
+	}, nil
+}
+
+// installedModKeys returns the set of domain.ModKey(sourceID, modID) values
+// installed in the active profile, used to mark search results as installed.
+func (p *coreProvider) installedModKeys() (map[string]bool, error) {
+	installed, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
+	if err != nil {
+		return nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
+	}
+	keys := make(map[string]bool, len(installed))
+	for _, mod := range installed {
+		keys[domain.ModKey(mod.SourceID, mod.ID)] = true
+	}
+	return keys, nil
+}
+
+// modsToItems maps source search results to renderable rows, marking each
+// as installed via domain.ModKey(sourceID, modID) against installedKeys.
+func (p *coreProvider) modsToItems(mods []domain.Mod, installedKeys map[string]bool) []ModItem {
+	items := make([]ModItem, 0, len(mods))
+	for _, mod := range mods {
 		status := "available"
 		if installedKeys[domain.ModKey(mod.SourceID, mod.ID)] {
 			status = "installed"
@@ -103,15 +154,7 @@ func (p *coreProvider) Search(ctx context.Context, sourceID, query string, page 
 		}
 		items = append(items, item)
 	}
-
-	return SearchPage{
-		Results:    items,
-		Query:      query,
-		Source:     sourceID,
-		Page:       page,
-		PageSize:   SearchPageSize,
-		TotalCount: result.TotalCount,
-	}, nil
+	return items
 }
 
 func (p *coreProvider) Profiles(_ context.Context) ([]ProfileItem, error) {

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
@@ -16,13 +17,21 @@ import (
 
 // stubSource implements source.ModSource with canned search results.
 // Only Search and identity methods matter; the rest are unreachable in
-// these tests.
+// these tests. id defaults to "stub" when unset, preserving existing
+// single-source test fixtures; set it to register multiple distinct stubs
+// (e.g. for all-sources search tests).
 type stubSource struct {
+	id     string
 	result source.SearchResult
 	err    error
 }
 
-func (s *stubSource) ID() string      { return "stub" }
+func (s *stubSource) ID() string {
+	if s.id != "" {
+		return s.id
+	}
+	return "stub"
+}
 func (s *stubSource) Name() string    { return "Stub Source" }
 func (s *stubSource) AuthURL() string { return "" }
 func (s *stubSource) ExchangeToken(context.Context, string) (*source.Token, error) {
@@ -208,4 +217,43 @@ func TestCoreProviderSearchPropagatesAuthRequired(t *testing.T) {
 
 	_, err := provider.Search(context.Background(), "stub", "x", 0)
 	require.ErrorIs(t, err, domain.ErrAuthRequired)
+}
+
+func TestCoreProviderSearchAllSources(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+	game.SourceIDs = map[string]string{"alpha": "testgame", "beta": "testgame"}
+	svc.RegisterSource(&stubSource{id: "alpha", result: source.SearchResult{
+		Mods:       []domain.Mod{{ID: "a1", SourceID: "alpha", Name: "Alpha Mod", Version: "1.0"}},
+		TotalCount: 1,
+	}})
+	svc.RegisterSource(&stubSource{id: "beta", result: source.SearchResult{
+		Mods:       []domain.Mod{{ID: "b1", SourceID: "beta", Name: "Beta Mod", Version: "1.0"}},
+		TotalCount: 1,
+	}})
+
+	page, err := provider.Search(context.Background(), "", "quer", 0)
+	require.NoError(t, err)
+	// Results from both sources present, each row's Source set:
+	sources := map[string]bool{}
+	for _, item := range page.Results {
+		sources[item.Source] = true
+	}
+	assert.Len(t, sources, 2)
+}
+
+func TestCoreProviderSearchAllSourcesWarnings(t *testing.T) {
+	const failingSourceID = "flaky"
+	provider, svc, game := newCoreProviderFixture(t)
+	game.SourceIDs = map[string]string{"good": "testgame", failingSourceID: "testgame"}
+	svc.RegisterSource(&stubSource{id: "good", result: source.SearchResult{
+		Mods:       []domain.Mod{{ID: "g1", SourceID: "good", Name: "Good Mod", Version: "1.0"}},
+		TotalCount: 1,
+	}})
+	svc.RegisterSource(&stubSource{id: failingSourceID, err: errors.New("connection refused")})
+
+	page, err := provider.Search(context.Background(), "", "quer", 0)
+	require.NoError(t, err)
+	require.Len(t, page.Warnings, 1)
+	assert.Contains(t, page.Warnings[0], failingSourceID)
+	assert.NotEmpty(t, page.Results, "good source's results survive the failure")
 }

--- a/internal/tui/service_test.go
+++ b/internal/tui/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
@@ -52,6 +53,18 @@ func TestPrototypeProviderSearchFiltersCannedResults(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, none.Results, "no match returns an empty page")
 	require.Equal(t, 0, none.TotalCount)
+}
+
+func TestPrototypeProviderSearchAllSources(t *testing.T) {
+	t.Parallel()
+
+	p := NewPrototypeProvider()
+	page, err := p.Search(context.Background(), "", "", 0)
+	require.NoError(t, err)
+	assert.NotEmpty(t, page.Results)
+	for _, item := range page.Results {
+		assert.NotEmpty(t, item.Source)
+	}
 }
 
 func TestPrototypeProviderProfiles(t *testing.T) {

--- a/internal/tui/sources_view_test.go
+++ b/internal/tui/sources_view_test.go
@@ -1,0 +1,153 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+)
+
+// TestSourcesScreenRegistered proves ScreenSources is wired into the
+// standard navigation surface: it appears in screens, has a real display
+// name, screenAt round-trips it, and "5" navigates to it from the
+// dashboard (mirroring TestNumberKeysNavigateScreens in app_test.go).
+func TestSourcesScreenRegistered(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, screens, ScreenSources)
+	require.NotContains(t, ScreenSources.String(), "Screen(")
+	require.Equal(t, ScreenSources, screenAt(screensIndexOf(t, ScreenSources)))
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	updated := updateWithRunes(t, model, "5")
+	require.Equal(t, ScreenSources, updated.CurrentScreen())
+}
+
+// screensIndexOf finds screen's index in the screens slice, failing the test
+// if it isn't registered.
+func screensIndexOf(t *testing.T, screen Screen) int {
+	t.Helper()
+	for i, s := range screens {
+		if s == screen {
+			return i
+		}
+	}
+	t.Fatalf("%s not found in screens", screen)
+	return -1
+}
+
+func TestSourceInfosPrototype(t *testing.T) {
+	t.Parallel()
+
+	p := NewPrototypeProvider()
+	infos := p.SourceInfos()
+	require.NotEmpty(t, infos)
+	for _, si := range infos {
+		assert.NotEmpty(t, si.ID)
+		assert.NotEmpty(t, si.Type)
+	}
+}
+
+func TestSourcesViewRenders(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	model = updateWithRunes(t, model, "5")
+	require.Equal(t, ScreenSources, model.CurrentScreen())
+
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+
+	view := model.screenView()
+	require.Contains(t, view, "ID")
+	require.Contains(t, view, "TYPE")
+	require.Contains(t, view, "AUTH")
+	require.Contains(t, view, "CAPABILITIES")
+
+	for _, si := range NewPrototypeProvider().SourceInfos() {
+		assert.Contains(t, view, si.ID)
+		assert.Contains(t, view, si.Type)
+	}
+}
+
+// builtinStubSource is a minimal source.ModSource with no CapabilityReporter
+// or IsAuthenticated method, exercising coreProvider.SourceInfos' defaults:
+// full capabilities (CapabilitiesOf's built-in fallback) and Auth "yes"
+// (authState's fallback for a capable source with no IsAuthenticated probe).
+type builtinStubSource struct{ id string }
+
+func (s *builtinStubSource) ID() string      { return s.id }
+func (s *builtinStubSource) Name() string    { return "Built-in Stub" }
+func (s *builtinStubSource) AuthURL() string { return "" }
+func (s *builtinStubSource) ExchangeToken(context.Context, string) (*source.Token, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *builtinStubSource) Search(context.Context, source.SearchQuery) (source.SearchResult, error) {
+	return source.SearchResult{}, nil
+}
+func (s *builtinStubSource) GetMod(context.Context, string, string) (*domain.Mod, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *builtinStubSource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *builtinStubSource) GetModFiles(context.Context, *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *builtinStubSource) GetDownloadURL(context.Context, *domain.Mod, string) (string, error) {
+	return "", errors.New("not implemented")
+}
+func (s *builtinStubSource) CheckUpdates(context.Context, []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestCoreProviderSourceInfos(t *testing.T) {
+	t.Parallel()
+
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	dir, err := custom.NewDirectory(custom.SourceDefinition{
+		ID:        "zzz-directory",
+		Name:      "Local Mods",
+		Type:      custom.TypeDirectory,
+		Directory: &custom.DirectoryConfig{Path: t.TempDir()},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(dir)
+	svc.RegisterSource(&builtinStubSource{id: "aaa-builtin"})
+
+	game := &domain.Game{ID: "test-game", Name: "Test Game", InstallPath: t.TempDir(), ModPath: t.TempDir()}
+	require.NoError(t, svc.AddGame(game))
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+
+	provider := NewCoreProvider(svc, game, "default")
+	infos := provider.SourceInfos()
+	require.Len(t, infos, 2)
+
+	// Sorted by ID: "aaa-builtin" before "zzz-directory".
+	require.Equal(t, "aaa-builtin", infos[0].ID)
+	require.Equal(t, "built-in", infos[0].Type)
+	require.Equal(t, "zzz-directory", infos[1].ID)
+	require.Equal(t, "directory", infos[1].Type)
+	require.Equal(t, "n/a", infos[1].Auth, "directory sources report no auth capability")
+}

--- a/internal/tui/sources_view_test.go
+++ b/internal/tui/sources_view_test.go
@@ -3,8 +3,11 @@ package tui
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -150,4 +153,61 @@ func TestCoreProviderSourceInfos(t *testing.T) {
 	require.Equal(t, "zzz-directory", infos[1].ID)
 	require.Equal(t, "directory", infos[1].Type)
 	require.Equal(t, "n/a", infos[1].Auth, "directory sources report no auth capability")
+}
+
+// longSourcesProvider returns sources with long IDs and capabilities to test
+// truncation in narrow terminals.
+type longSourcesProvider struct{}
+
+func (longSourcesProvider) Overview(context.Context) (Summary, []ModItem, error) {
+	return Summary{}, nil, nil
+}
+func (longSourcesProvider) Profiles(context.Context) ([]ProfileItem, error) { return nil, nil }
+func (longSourcesProvider) Sources() []string                               { return nil }
+func (longSourcesProvider) SourceInfos() []SourceInfo {
+	return []SourceInfo{
+		{
+			ID:           "extremely-long-custom-source-identifier-that-exceeds-normal-widths",
+			Name:         "Long Source",
+			Type:         "custom",
+			Auth:         "yes",
+			Capabilities: "search,deps,updates,auth,conflict-detection,manifest-verification,auto-dependencies",
+		},
+		{
+			ID:           "another-overly-verbose-identifier-for-testing-purposes-in-narrow-terminals",
+			Name:         "Another Long",
+			Type:         "built-in",
+			Auth:         "no",
+			Capabilities: "search,updates,manifest-fetching,advanced-filtering,batch-operations",
+		},
+	}
+}
+func (longSourcesProvider) Search(context.Context, string, string, int) (SearchPage, error) {
+	return SearchPage{}, nil
+}
+
+// TestSourcesViewFitsPanelWidthNarrowTerminal guards that sourcesView rows
+// truncate to the panel's content width (not the full terminal width) to
+// prevent overlong source IDs or capability lists from re-wrapping inside
+// the panel and growing the view past its fixed height budget. This mirrors
+// the fix applied to searchView's zero-results warning in commit 2c075e3.
+func TestSourcesViewFitsPanelWidthNarrowTerminal(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(Options{Theme: "wizardry", Provider: longSourcesProvider{}})
+	require.NoError(t, err)
+
+	loaded, _ := model.Update(model.Init()())
+	updated, _ := loaded.Update(tea.WindowSizeMsg{Width: 40, Height: 12})
+	model = updated.(Model)
+
+	model = updateWithRunes(t, model, "5") // jump to sources screen
+	require.Equal(t, ScreenSources, model.CurrentScreen())
+
+	view := model.screenView()
+	require.Equal(t, model.availableContentHeight(), lipgloss.Height(view),
+		"an overlong source ID or capability list must not wrap and grow the sources panel past its height budget")
+	for _, line := range strings.Split(view, "\n") {
+		require.LessOrEqual(t, lipgloss.Width(line), model.availableWidth(), "no rendered line exceeds terminal width")
+	}
 }


### PR DESCRIPTION
## Summary

Implements Phase 5 of the custom sources epic (#45): aggregate search across all of a game's sources, in both the CLI and TUI, plus the read-only TUI Sources screen.

Closes #50

### What's new
- **`lmm search` without `--source` now searches every configured source concurrently** (errgroup fan-out): results merged and labeled with a SOURCE column, ranked name-match → downloads → name; per-source failures degrade to stderr warnings — one flaky remote never hides local modlets; only all-sources-failed is an error (naming each source); non-searching sources (e.g. install-by-ID-only API definitions) are skipped silently; `--source` still narrows
- **§7 capability-gap UX**: an explicit `--source` against a non-searching source gets a clean one-line notice with the install-by-ID hint instead of a wrapped-error dump
- **TUI**: search defaults to **"All sources"** (`s` cycles All ↔ each source), results carry a source column in all-sources mode, a warning line surfaces degraded sources, and all-sources auth failures show per-source detail
- **TUI Sources screen** (key `5`): ID / TYPE / AUTH / CAPABILITIES for every registered source, mirroring `lmm source list`
- JSON output gains per-mod `source` and a `warnings` array

### Review-driven fixes included
- TUI warning line no longer rewraps inside the empty-results panel (height-invariant violation caught by live final review)
- All-sources auth failure no longer renders a broken "Authentication required for ." message (Critical caught in task review)
- Zero-configured-sources diagnostic preserved in aggregate mode; pre-existing `--limit -1` panic fixed (drive-by)

### Acceptance criteria
- Criterion 1 pinned by e2e with real sources (directory + manifest + dead remote → both labeled + one warning) and verified live through the CLI
- Criterion 2 (unsupported actions hidden in TUI): vacuously satisfied — the TUI is read-only today with no per-mod actions; per-source capabilities are visible on the Sources screen; **recorded requirement on #37: future mutation UI must consult `CapabilitiesOf`**

## Test plan
- [x] TDD throughout; full suite green under `-race` (17 packages); gofmt/vet clean; only x/sync promoted from the existing module graph
- [x] Live final review: full aggregate CLI loop with real mixed sources, §7 notice, zero-sources diagnostic, JSON shapes, pty-scripted TUI checks
- [ ] **User interactive TUI smoke test** (the TUI-phase merge gate): `lmm tui` — All-sources search, `s` cycling, warning line with a dead source, Sources screen on `5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
