### PR TITLE
docs: archive completed plan documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,9 +135,9 @@ Core types in `internal/domain/` have no external dependencies:
 
 When in doubt, bump MINOR for new functionality, PATCH for fixes.
 
-## Implementation Plan
+## Implementation Plans
 
-The detailed implementation plan is in [docs/plans/2026-01-22-lmm-implementation.md](docs/plans/2026-01-22-lmm-implementation.md). Follow TDD: write failing test → implement → verify pass.
+In-flight plan documents live in `docs/plans/`; completed plans are kept for historical reference in [docs/plans/archive/](docs/plans/archive/) (the original v1.0 implementation plan is [2026-01-22-lmm-implementation.md](docs/plans/archive/2026-01-22-lmm-implementation.md)). Follow TDD: write failing test → implement → verify pass.
 
 Both the CLI and TUI interfaces should be equally considered first-class interfaces. As such, functional modifications should be reflected in both (new commands, change in core functionality, etc.) when appropriate.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,9 +135,9 @@ Core types in `internal/domain/` have no external dependencies:
 
 When in doubt, bump MINOR for new functionality, PATCH for fixes.
 
-## Implementation Plan
+## Implementation Plans
 
-The detailed implementation plan is in [docs/plans/2026-01-22-lmm-implementation.md](docs/plans/2026-01-22-lmm-implementation.md). Follow TDD: write failing test → implement → verify pass.
+In-flight plan documents live in `docs/plans/`; completed plans are kept for historical reference in [docs/plans/archive/](docs/plans/archive/) (the original v1.0 implementation plan is [2026-01-22-lmm-implementation.md](docs/plans/archive/2026-01-22-lmm-implementation.md)). Follow TDD: write failing test → implement → verify pass.
 
 Both the CLI and TUI interfaces should be equally considered first-class interfaces. As such, functional modifications should be reflected in both (new commands, change in core functionality, etc.) when appropriate.
 

--- a/docs/plans/archive/2026-01-22-architecture-design.md
+++ b/docs/plans/archive/2026-01-22-architecture-design.md
@@ -1,0 +1,255 @@
+# lmm Architecture Design
+
+## Overview
+
+Layered monolith architecture with interface-based extensibility for mod sources.
+
+## Project Structure
+
+```text
+lmm/
+├── cmd/lmm/main.go           # Entry point, CLI parsing (cobra)
+├── internal/
+│   ├── domain/               # Core types (Mod, Profile, Game) - no deps
+│   ├── source/               # ModSource interface + implementations
+│   │   ├── source.go         # Interface definition
+│   │   ├── registry.go       # Source registry
+│   │   └── nexusmods/        # NexusMods GraphQL client
+│   ├── storage/
+│   │   ├── db/               # SQLite (mod metadata, auth tokens)
+│   │   ├── config/           # YAML parsing (games, profiles)
+│   │   └── cache/            # Central mod file cache
+│   ├── linker/               # Deploy strategies (symlink, hardlink, copy)
+│   ├── core/                 # Business logic orchestration
+│   │   ├── service.go        # Main service facade
+│   │   ├── installer.go      # Install/uninstall operations
+│   │   ├── updater.go        # Update checking & application
+│   │   └── profile.go        # Profile switching logic
+│   └── tui/                  # Bubble Tea application
+│       ├── app.go            # Main model, routing
+│       └── views/            # Individual screens
+└── docs/
+```
+
+## Core Domain Types
+
+```go
+// domain/mod.go
+type Mod struct {
+    ID           string
+    SourceID     string            // "nexusmods", "curseforge", etc.
+    Name         string
+    Version      string
+    Author       string
+    Description  string
+    GameID       string
+    Files        []ModFile
+    Dependencies []ModReference
+    UpdatePolicy UpdatePolicy
+}
+
+type ModReference struct {
+    SourceID string
+    ModID    string
+    Version  string  // Empty = latest
+}
+
+type UpdatePolicy int
+const (
+    UpdateNotify UpdatePolicy = iota  // Default
+    UpdateAuto
+    UpdatePinned
+)
+
+// domain/profile.go
+type Profile struct {
+    Name       string
+    GameID     string
+    Mods       []ModReference    // In load order
+    Overrides  map[string][]byte // Config file overrides
+    LinkMethod LinkMethod
+}
+
+// domain/game.go
+type Game struct {
+    ID          string
+    Name        string
+    InstallPath string
+    ModPath     string
+    SourceIDs   map[string]string // e.g., "nexusmods" -> "skyrimspecialedition"
+}
+```
+
+## ModSource Interface
+
+```go
+type ModSource interface {
+    ID() string
+    Name() string
+
+    // Auth
+    AuthURL() string
+    ExchangeToken(ctx context.Context, code string) (*Token, error)
+
+    // Discovery
+    Search(ctx context.Context, q SearchQuery) ([]domain.Mod, error)
+    GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error)
+    GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error)
+
+    // Downloads
+    GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error)
+
+    // Updates
+    CheckUpdates(ctx context.Context, installed []InstalledMod) ([]Update, error)
+}
+
+type SearchQuery struct {
+    GameID   string
+    Query    string
+    Category string
+    Page     int
+    PageSize int
+}
+```
+
+Sources registered at startup:
+
+```go
+sources := source.NewRegistry()
+sources.Register(nexusmods.New(db, httpClient))
+```
+
+## Storage
+
+### SQLite Schema (internal state)
+
+```sql
+CREATE TABLE installed_mods (
+    id INTEGER PRIMARY KEY,
+    source_id TEXT NOT NULL,
+    mod_id TEXT NOT NULL,
+    game_id TEXT NOT NULL,
+    profile_name TEXT NOT NULL,
+    version TEXT NOT NULL,
+    update_policy INTEGER DEFAULT 0,
+    installed_at DATETIME,
+    UNIQUE(source_id, mod_id, game_id, profile_name)
+);
+
+CREATE TABLE mod_cache (
+    source_id TEXT,
+    mod_id TEXT,
+    game_id TEXT,
+    metadata BLOB,
+    cached_at DATETIME,
+    PRIMARY KEY(source_id, mod_id, game_id)
+);
+
+CREATE TABLE auth_tokens (
+    source_id TEXT PRIMARY KEY,
+    token_data BLOB  -- Encrypted
+);
+```
+
+Location: `~/.local/share/lmm/lmm.db`
+
+### YAML Config (user-editable)
+
+```text
+~/.config/lmm/
+├── config.yaml          # Global settings
+├── games.yaml           # Game configurations
+└── games/<game-id>/
+    └── profiles/
+        └── <profile>.yaml
+```
+
+### Cache Structure
+
+```text
+~/.local/share/lmm/cache/<game-id>/<source-id>-<mod-id>/<version>/files/
+```
+
+## Linker Strategies
+
+```go
+type Linker interface {
+    Deploy(src, dst string) error
+    Undeploy(dst string) error
+    IsDeployed(dst string) (bool, error)
+    Method() domain.LinkMethod
+}
+```
+
+Implementations: `SymlinkLinker`, `HardlinkLinker`, `CopyLinker`
+
+## TUI Architecture (Bubble Tea)
+
+Elm architecture: Model → Update → View
+
+```go
+type App struct {
+    currentView View
+    game        *domain.Game
+    profile     *domain.Profile
+    core        *core.Service
+    sources     *source.Registry
+    width, height int
+}
+
+type View int
+const (
+    ViewDashboard View = iota
+    ViewGameSelect
+    ViewModBrowser
+    ViewInstalled
+    ViewProfiles
+    ViewSettings
+)
+```
+
+Each view is its own Bubble Tea model with Update/View methods.
+
+Keybindings configurable: vim-style (hjkl) or standard (arrows).
+
+## CLI Commands (Cobra)
+
+```text
+lmm                           # Launch TUI (default)
+lmm search <query> --game X   # Search mods
+lmm install <mod-id> --game X # Install mod
+lmm update [mod-id] --game X  # Check/apply updates
+lmm list --game X             # List installed
+lmm profile switch|export|import
+lmm config set|get
+lmm auth login|logout --source X
+```
+
+CLI shares `core.Service` with TUI.
+
+## Error Handling
+
+- Wrap errors with context: `fmt.Errorf("downloading mod %s: %w", modID, err)`
+- Domain errors: `ErrModNotFound`, `ErrDependencyLoop`, `ErrAuthRequired`
+- Retry with exponential backoff for network operations
+
+## Testing Strategy
+
+| Layer       | Approach                             |
+| ----------- | ------------------------------------ |
+| Domain      | Pure unit tests, no mocks            |
+| Source      | Mock HTTP client, recorded responses |
+| Storage     | In-memory SQLite, temp directories   |
+| Core        | Mock sources/storage, test logic     |
+| TUI         | Limited (complex to test)            |
+| Integration | End-to-end with mock source          |
+
+## Key Dependencies
+
+- `github.com/charmbracelet/bubbletea` - TUI framework
+- `github.com/charmbracelet/bubbles` - TUI components
+- `github.com/spf13/cobra` - CLI framework
+- `github.com/hasura/go-graphql-client` - GraphQL client
+- `modernc.org/sqlite` - Pure Go SQLite
+- `gopkg.in/yaml.v3` - YAML parsing
+- `github.com/avast/retry-go` - Retry logic

--- a/docs/plans/archive/2026-01-22-lmm-implementation.md
+++ b/docs/plans/archive/2026-01-22-lmm-implementation.md
@@ -1,0 +1,2594 @@
+# lmm Implementation Plan
+
+<!-- markdownlint-disable MD010 MD029 MD036 MD040 -->
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a terminal-based mod manager for Linux with NexusMods integration, profile support, and flexible mod deployment strategies.
+
+**Architecture:** Layered monolith with interface-based extensibility. Domain types have no dependencies, storage layer handles SQLite + YAML, source layer abstracts mod repositories, core layer orchestrates business logic, TUI/CLI provide user interfaces.
+
+**Tech Stack:** Go 1.25+, Bubble Tea (TUI), Cobra (CLI), modernc.org/sqlite (pure Go SQLite), gopkg.in/yaml.v3, hasura/go-graphql-client
+
+---
+
+## Phase 1: Core Infrastructure
+
+### Task 1.1: Project Structure and Dependencies
+
+**Files:**
+
+- Create: `cmd/lmm/main.go`
+- Create: `internal/domain/mod.go`
+- Create: `internal/domain/game.go`
+- Create: `internal/domain/profile.go`
+- Create: `internal/domain/errors.go`
+- Modify: `go.mod`
+
+**Step 1: Initialize project structure**
+
+```bash
+mkdir -p cmd/lmm internal/domain internal/source internal/storage/db internal/storage/config internal/storage/cache internal/linker internal/core internal/tui/views
+```
+
+**Step 2: Add dependencies to go.mod**
+
+```bash
+go get github.com/charmbracelet/bubbletea@latest
+go get github.com/charmbracelet/bubbles@latest
+go get github.com/charmbracelet/lipgloss@latest
+go get github.com/spf13/cobra@latest
+go get modernc.org/sqlite@latest
+go get gopkg.in/yaml.v3@latest
+go get github.com/hasura/go-graphql-client@latest
+go get github.com/avast/retry-go/v4@latest
+go get github.com/stretchr/testify@latest
+```
+
+**Step 3: Create domain error types**
+
+Create `internal/domain/errors.go`:
+
+```go
+package domain
+
+import "errors"
+
+var (
+	ErrModNotFound      = errors.New("mod not found")
+	ErrGameNotFound     = errors.New("game not found")
+	ErrProfileNotFound  = errors.New("profile not found")
+	ErrDependencyLoop   = errors.New("circular dependency detected")
+	ErrAuthRequired     = errors.New("authentication required")
+	ErrInvalidConfig    = errors.New("invalid configuration")
+	ErrFileConflict     = errors.New("file conflict detected")
+	ErrDownloadFailed   = errors.New("download failed")
+	ErrLinkFailed       = errors.New("link operation failed")
+)
+```
+
+**Step 4: Create domain types - mod.go**
+
+Create `internal/domain/mod.go`:
+
+```go
+package domain
+
+import "time"
+
+// UpdatePolicy determines how a mod handles updates
+type UpdatePolicy int
+
+const (
+	UpdateNotify UpdatePolicy = iota // Default: show available, require approval
+	UpdateAuto                       // Automatically apply updates
+	UpdatePinned                     // Never update
+)
+
+// ModFile represents a single file within a mod
+type ModFile struct {
+	Path     string // Relative path within mod archive
+	Size     int64
+	Checksum string // SHA256
+}
+
+// ModReference is a pointer to a mod (used in profiles, dependencies)
+type ModReference struct {
+	SourceID string // "nexusmods", "curseforge", etc.
+	ModID    string // Source-specific identifier
+	Version  string // Empty string means "latest"
+}
+
+// Mod represents a mod from any source
+type Mod struct {
+	ID           string
+	SourceID     string
+	Name         string
+	Version      string
+	Author       string
+	Summary      string
+	Description  string
+	GameID       string
+	Category     string
+	Downloads    int64
+	Endorsements int64
+	Files        []ModFile
+	Dependencies []ModReference
+	UpdatedAt    time.Time
+}
+
+// InstalledMod tracks a mod installed in a profile
+type InstalledMod struct {
+	Mod
+	ProfileName  string
+	UpdatePolicy UpdatePolicy
+	InstalledAt  time.Time
+	Enabled      bool
+}
+
+// Update represents an available update for an installed mod
+type Update struct {
+	InstalledMod InstalledMod
+	NewVersion   string
+	Changelog    string
+}
+```
+
+**Step 5: Create domain types - game.go**
+
+Create `internal/domain/game.go`:
+
+```go
+package domain
+
+// LinkMethod determines how mods are deployed to game directories
+type LinkMethod int
+
+const (
+	LinkSymlink  LinkMethod = iota // Default: symlink (space efficient)
+	LinkHardlink                   // Hardlink (transparent to games)
+	LinkCopy                       // Copy (maximum compatibility)
+)
+
+func (m LinkMethod) String() string {
+	switch m {
+	case LinkSymlink:
+		return "symlink"
+	case LinkHardlink:
+		return "hardlink"
+	case LinkCopy:
+		return "copy"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseLinkMethod converts a string to LinkMethod
+func ParseLinkMethod(s string) LinkMethod {
+	switch s {
+	case "hardlink":
+		return LinkHardlink
+	case "copy":
+		return LinkCopy
+	default:
+		return LinkSymlink
+	}
+}
+
+// Game represents a moddable game
+type Game struct {
+	ID          string            // Unique slug, e.g., "skyrim-se"
+	Name        string            // Display name
+	InstallPath string            // Game installation directory
+	ModPath     string            // Where mods should be deployed
+	SourceIDs   map[string]string // Map source to game ID, e.g., "nexusmods" -> "skyrimspecialedition"
+	LinkMethod  LinkMethod        // How to deploy mods
+}
+```
+
+**Step 6: Create domain types - profile.go**
+
+Create `internal/domain/profile.go`:
+
+```go
+package domain
+
+// Profile represents a collection of mods with a specific configuration
+type Profile struct {
+	Name        string            // Profile identifier
+	GameID      string            // Which game this profile is for
+	Mods        []ModReference    // Mods in load order (first = lowest priority)
+	Overrides   map[string][]byte // Config file overrides (path -> content)
+	LinkMethod  LinkMethod        // Override game's default link method (optional)
+	IsDefault   bool              // Is this the default profile for the game?
+}
+
+// ExportedProfile is the YAML-serializable format for sharing
+type ExportedProfile struct {
+	Name       string         `yaml:"name"`
+	GameID     string         `yaml:"game_id"`
+	Mods       []ModReference `yaml:"mods"`
+	LinkMethod string         `yaml:"link_method,omitempty"`
+}
+```
+
+**Step 7: Create minimal main.go**
+
+Create `cmd/lmm/main.go`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("lmm - Linux Mod Manager")
+	fmt.Println("Version: 0.1.0-dev")
+	os.Exit(0)
+}
+```
+
+**Step 8: Verify build**
+
+```bash
+go build -o lmm ./cmd/lmm
+./lmm
+```
+
+Expected output:
+
+```
+lmm - Linux Mod Manager
+Version: 0.1.0-dev
+```
+
+**Step 9: Commit**
+
+```bash
+git add .
+git commit -m "feat: initialize project structure and domain types
+
+- Add domain types: Mod, Game, Profile, UpdatePolicy, LinkMethod
+- Add domain errors for common failure cases
+- Set up package structure following layered architecture
+- Add core dependencies: bubbletea, cobra, sqlite, yaml"
+```
+
+---
+
+### Task 1.2: SQLite Database Layer
+
+**Files:**
+
+- Create: `internal/storage/db/db.go`
+- Create: `internal/storage/db/migrations.go`
+- Create: `internal/storage/db/mods.go`
+- Create: `internal/storage/db/db_test.go`
+
+**Step 1: Write the failing test for database initialization**
+
+Create `internal/storage/db/db_test.go`:
+
+```go
+package db_test
+
+import (
+	"testing"
+
+	"lmm/internal/storage/db"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_CreatesDatabase(t *testing.T) {
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer database.Close()
+
+	assert.NotNil(t, database)
+}
+
+func TestNew_RunsMigrations(t *testing.T) {
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer database.Close()
+
+	// Verify tables exist by querying them
+	var count int
+	err = database.QueryRow("SELECT COUNT(*) FROM installed_mods").Scan(&count)
+	assert.NoError(t, err)
+
+	err = database.QueryRow("SELECT COUNT(*) FROM mod_cache").Scan(&count)
+	assert.NoError(t, err)
+
+	err = database.QueryRow("SELECT COUNT(*) FROM auth_tokens").Scan(&count)
+	assert.NoError(t, err)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/storage/db/... -v
+```
+
+Expected: FAIL - package not found or types not defined
+
+**Step 3: Create database wrapper**
+
+Create `internal/storage/db/db.go`:
+
+```go
+package db
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "modernc.org/sqlite"
+)
+
+// DB wraps the SQLite database connection
+type DB struct {
+	*sql.DB
+}
+
+// New creates a new database connection and runs migrations
+func New(path string) (*DB, error) {
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("opening database: %w", err)
+	}
+
+	// Enable foreign keys and WAL mode for better performance
+	if _, err := sqlDB.Exec("PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL;"); err != nil {
+		sqlDB.Close()
+		return nil, fmt.Errorf("setting pragmas: %w", err)
+	}
+
+	database := &DB{DB: sqlDB}
+
+	if err := database.migrate(); err != nil {
+		sqlDB.Close()
+		return nil, fmt.Errorf("running migrations: %w", err)
+	}
+
+	return database, nil
+}
+```
+
+**Step 4: Create migrations**
+
+Create `internal/storage/db/migrations.go`:
+
+```go
+package db
+
+import "fmt"
+
+const currentVersion = 1
+
+func (d *DB) migrate() error {
+	// Create migrations table if it doesn't exist
+	if _, err := d.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			version INTEGER PRIMARY KEY,
+			applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`); err != nil {
+		return fmt.Errorf("creating migrations table: %w", err)
+	}
+
+	// Get current version
+	var version int
+	err := d.QueryRow("SELECT COALESCE(MAX(version), 0) FROM schema_migrations").Scan(&version)
+	if err != nil {
+		return fmt.Errorf("getting schema version: %w", err)
+	}
+
+	// Apply migrations
+	migrations := []func(*DB) error{
+		migrateV1,
+	}
+
+	for i := version; i < len(migrations); i++ {
+		if err := migrations[i](d); err != nil {
+			return fmt.Errorf("migration %d: %w", i+1, err)
+		}
+		if _, err := d.Exec("INSERT INTO schema_migrations (version) VALUES (?)", i+1); err != nil {
+			return fmt.Errorf("recording migration %d: %w", i+1, err)
+		}
+	}
+
+	return nil
+}
+
+func migrateV1(d *DB) error {
+	statements := []string{
+		`CREATE TABLE installed_mods (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			source_id TEXT NOT NULL,
+			mod_id TEXT NOT NULL,
+			game_id TEXT NOT NULL,
+			profile_name TEXT NOT NULL,
+			name TEXT NOT NULL,
+			version TEXT NOT NULL,
+			author TEXT,
+			update_policy INTEGER DEFAULT 0,
+			enabled INTEGER DEFAULT 1,
+			installed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(source_id, mod_id, game_id, profile_name)
+		)`,
+		`CREATE INDEX idx_installed_mods_game_profile ON installed_mods(game_id, profile_name)`,
+		`CREATE TABLE mod_cache (
+			source_id TEXT NOT NULL,
+			mod_id TEXT NOT NULL,
+			game_id TEXT NOT NULL,
+			metadata TEXT,
+			cached_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY(source_id, mod_id, game_id)
+		)`,
+		`CREATE TABLE auth_tokens (
+			source_id TEXT PRIMARY KEY,
+			token_data BLOB,
+			expires_at DATETIME,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+	}
+
+	for _, stmt := range statements {
+		if _, err := d.Exec(stmt); err != nil {
+			return fmt.Errorf("executing %q: %w", stmt[:50], err)
+		}
+	}
+
+	return nil
+}
+```
+
+**Step 5: Run test to verify it passes**
+
+```bash
+go test ./internal/storage/db/... -v
+```
+
+Expected: PASS
+
+**Step 6: Write tests for installed mods CRUD**
+
+Add to `internal/storage/db/db_test.go`:
+
+```go
+func TestInstalledMods_SaveAndGet(t *testing.T) {
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer database.Close()
+
+	mod := &domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "12345",
+			SourceID: "nexusmods",
+			Name:     "Test Mod",
+			Version:  "1.0.0",
+			Author:   "TestAuthor",
+			GameID:   "skyrim-se",
+		},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}
+
+	err = database.SaveInstalledMod(mod)
+	require.NoError(t, err)
+
+	retrieved, err := database.GetInstalledMods("skyrim-se", "default")
+	require.NoError(t, err)
+	require.Len(t, retrieved, 1)
+
+	assert.Equal(t, mod.ID, retrieved[0].ID)
+	assert.Equal(t, mod.Name, retrieved[0].Name)
+	assert.Equal(t, mod.Version, retrieved[0].Version)
+}
+
+func TestInstalledMods_Delete(t *testing.T) {
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer database.Close()
+
+	mod := &domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "12345",
+			SourceID: "nexusmods",
+			Name:     "Test Mod",
+			Version:  "1.0.0",
+			GameID:   "skyrim-se",
+		},
+		ProfileName: "default",
+	}
+
+	err = database.SaveInstalledMod(mod)
+	require.NoError(t, err)
+
+	err = database.DeleteInstalledMod("nexusmods", "12345", "skyrim-se", "default")
+	require.NoError(t, err)
+
+	mods, err := database.GetInstalledMods("skyrim-se", "default")
+	require.NoError(t, err)
+	assert.Empty(t, mods)
+}
+```
+
+Add import at top of test file:
+
+```go
+import (
+	"testing"
+
+	"lmm/internal/domain"
+	"lmm/internal/storage/db"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+```
+
+**Step 7: Run tests to verify they fail**
+
+```bash
+go test ./internal/storage/db/... -v
+```
+
+Expected: FAIL - SaveInstalledMod, GetInstalledMods, DeleteInstalledMod not defined
+
+**Step 8: Implement installed mods repository**
+
+Create `internal/storage/db/mods.go`:
+
+```go
+package db
+
+import (
+	"fmt"
+	"time"
+
+	"lmm/internal/domain"
+)
+
+// SaveInstalledMod inserts or updates an installed mod record
+func (d *DB) SaveInstalledMod(mod *domain.InstalledMod) error {
+	_, err := d.Exec(`
+		INSERT INTO installed_mods (source_id, mod_id, game_id, profile_name, name, version, author, update_policy, enabled, installed_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(source_id, mod_id, game_id, profile_name) DO UPDATE SET
+			name = excluded.name,
+			version = excluded.version,
+			author = excluded.author,
+			update_policy = excluded.update_policy,
+			enabled = excluded.enabled
+	`, mod.SourceID, mod.ID, mod.GameID, mod.ProfileName, mod.Name, mod.Version, mod.Author, mod.UpdatePolicy, mod.Enabled, time.Now())
+	if err != nil {
+		return fmt.Errorf("saving installed mod: %w", err)
+	}
+	return nil
+}
+
+// GetInstalledMods returns all installed mods for a game/profile combination
+func (d *DB) GetInstalledMods(gameID, profileName string) ([]domain.InstalledMod, error) {
+	rows, err := d.Query(`
+		SELECT source_id, mod_id, game_id, profile_name, name, version, author, update_policy, enabled, installed_at
+		FROM installed_mods
+		WHERE game_id = ? AND profile_name = ?
+		ORDER BY installed_at ASC
+	`, gameID, profileName)
+	if err != nil {
+		return nil, fmt.Errorf("querying installed mods: %w", err)
+	}
+	defer rows.Close()
+
+	var mods []domain.InstalledMod
+	for rows.Next() {
+		var mod domain.InstalledMod
+		err := rows.Scan(
+			&mod.SourceID, &mod.ID, &mod.GameID, &mod.ProfileName,
+			&mod.Name, &mod.Version, &mod.Author, &mod.UpdatePolicy,
+			&mod.Enabled, &mod.InstalledAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scanning installed mod: %w", err)
+		}
+		mods = append(mods, mod)
+	}
+
+	return mods, rows.Err()
+}
+
+// DeleteInstalledMod removes an installed mod record
+func (d *DB) DeleteInstalledMod(sourceID, modID, gameID, profileName string) error {
+	result, err := d.Exec(`
+		DELETE FROM installed_mods
+		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
+	`, sourceID, modID, gameID, profileName)
+	if err != nil {
+		return fmt.Errorf("deleting installed mod: %w", err)
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return domain.ErrModNotFound
+	}
+
+	return nil
+}
+
+// UpdateModPolicy updates the update policy for an installed mod
+func (d *DB) UpdateModPolicy(sourceID, modID, gameID, profileName string, policy domain.UpdatePolicy) error {
+	result, err := d.Exec(`
+		UPDATE installed_mods SET update_policy = ?
+		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
+	`, policy, sourceID, modID, gameID, profileName)
+	if err != nil {
+		return fmt.Errorf("updating mod policy: %w", err)
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return domain.ErrModNotFound
+	}
+
+	return nil
+}
+
+// SetModEnabled enables or disables a mod
+func (d *DB) SetModEnabled(sourceID, modID, gameID, profileName string, enabled bool) error {
+	result, err := d.Exec(`
+		UPDATE installed_mods SET enabled = ?
+		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
+	`, enabled, sourceID, modID, gameID, profileName)
+	if err != nil {
+		return fmt.Errorf("setting mod enabled: %w", err)
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return domain.ErrModNotFound
+	}
+
+	return nil
+}
+```
+
+**Step 9: Run tests to verify they pass**
+
+```bash
+go test ./internal/storage/db/... -v
+```
+
+Expected: PASS
+
+**Step 10: Commit**
+
+```bash
+git add .
+git commit -m "feat(storage): add SQLite database layer with migrations
+
+- DB wrapper with automatic migration support
+- Schema: installed_mods, mod_cache, auth_tokens tables
+- CRUD operations for installed mods
+- In-memory database support for testing"
+```
+
+---
+
+### Task 1.3: YAML Configuration Layer
+
+**Files:**
+
+- Create: `internal/storage/config/config.go`
+- Create: `internal/storage/config/games.go`
+- Create: `internal/storage/config/profiles.go`
+- Create: `internal/storage/config/config_test.go`
+
+**Step 1: Write the failing test for config loading**
+
+Create `internal/storage/config/config_test.go`:
+
+```go
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"lmm/internal/domain"
+	"lmm/internal/storage/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig_DefaultValues(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := config.Load(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, domain.LinkSymlink, cfg.DefaultLinkMethod)
+	assert.Equal(t, "vim", cfg.Keybindings)
+}
+
+func TestLoadConfig_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	content := `
+default_link_method: hardlink
+keybindings: standard
+`
+	err := os.WriteFile(configPath, []byte(content), 0644)
+	require.NoError(t, err)
+
+	cfg, err := config.Load(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, domain.LinkHardlink, cfg.DefaultLinkMethod)
+	assert.Equal(t, "standard", cfg.Keybindings)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/storage/config/... -v
+```
+
+Expected: FAIL - package not found
+
+**Step 3: Implement config loader**
+
+Create `internal/storage/config/config.go`:
+
+```go
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"lmm/internal/domain"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds global application settings
+type Config struct {
+	DefaultLinkMethod domain.LinkMethod `yaml:"-"`
+	LinkMethodStr     string            `yaml:"default_link_method"`
+	Keybindings       string            `yaml:"keybindings"`
+	CachePath         string            `yaml:"cache_path"`
+}
+
+// Load reads configuration from the given directory
+func Load(configDir string) (*Config, error) {
+	cfg := &Config{
+		DefaultLinkMethod: domain.LinkSymlink,
+		Keybindings:       "vim",
+	}
+
+	configPath := filepath.Join(configDir, "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cfg, nil // Return defaults
+		}
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	// Convert string to LinkMethod
+	if cfg.LinkMethodStr != "" {
+		cfg.DefaultLinkMethod = domain.ParseLinkMethod(cfg.LinkMethodStr)
+	}
+
+	return cfg, nil
+}
+
+// Save writes configuration to the given directory
+func (c *Config) Save(configDir string) error {
+	c.LinkMethodStr = c.DefaultLinkMethod.String()
+
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("creating config dir: %w", err)
+	}
+
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+
+	return nil
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/storage/config/... -v
+```
+
+Expected: PASS
+
+**Step 5: Write tests for games configuration**
+
+Add to `internal/storage/config/config_test.go`:
+
+```go
+func TestLoadGames_Empty(t *testing.T) {
+	dir := t.TempDir()
+	games, err := config.LoadGames(dir)
+	require.NoError(t, err)
+	assert.Empty(t, games)
+}
+
+func TestLoadGames_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	gamesPath := filepath.Join(dir, "games.yaml")
+
+	content := `
+games:
+  skyrim-se:
+    name: Skyrim Special Edition
+    install_path: /games/skyrim
+    mod_path: /games/skyrim/Data
+    sources:
+      nexusmods: skyrimspecialedition
+    link_method: symlink
+`
+	err := os.WriteFile(gamesPath, []byte(content), 0644)
+	require.NoError(t, err)
+
+	games, err := config.LoadGames(dir)
+	require.NoError(t, err)
+	require.Len(t, games, 1)
+
+	game := games["skyrim-se"]
+	assert.Equal(t, "Skyrim Special Edition", game.Name)
+	assert.Equal(t, "/games/skyrim", game.InstallPath)
+	assert.Equal(t, "/games/skyrim/Data", game.ModPath)
+	assert.Equal(t, "skyrimspecialedition", game.SourceIDs["nexusmods"])
+}
+
+func TestSaveGame(t *testing.T) {
+	dir := t.TempDir()
+
+	game := &domain.Game{
+		ID:          "test-game",
+		Name:        "Test Game",
+		InstallPath: "/games/test",
+		ModPath:     "/games/test/mods",
+		SourceIDs:   map[string]string{"nexusmods": "testgame"},
+		LinkMethod:  domain.LinkSymlink,
+	}
+
+	err := config.SaveGame(dir, game)
+	require.NoError(t, err)
+
+	games, err := config.LoadGames(dir)
+	require.NoError(t, err)
+	assert.Contains(t, games, "test-game")
+}
+```
+
+**Step 6: Run tests to verify they fail**
+
+```bash
+go test ./internal/storage/config/... -v
+```
+
+Expected: FAIL - LoadGames, SaveGame not defined
+
+**Step 7: Implement games configuration**
+
+Create `internal/storage/config/games.go`:
+
+```go
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"lmm/internal/domain"
+
+	"gopkg.in/yaml.v3"
+)
+
+// GameConfig is the YAML representation of a game
+type GameConfig struct {
+	Name        string            `yaml:"name"`
+	InstallPath string            `yaml:"install_path"`
+	ModPath     string            `yaml:"mod_path"`
+	Sources     map[string]string `yaml:"sources"`
+	LinkMethod  string            `yaml:"link_method"`
+}
+
+// GamesFile is the top-level games.yaml structure
+type GamesFile struct {
+	Games map[string]GameConfig `yaml:"games"`
+}
+
+// LoadGames reads all game configurations from the config directory
+func LoadGames(configDir string) (map[string]*domain.Game, error) {
+	gamesPath := filepath.Join(configDir, "games.yaml")
+	data, err := os.ReadFile(gamesPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return make(map[string]*domain.Game), nil
+		}
+		return nil, fmt.Errorf("reading games.yaml: %w", err)
+	}
+
+	var gamesFile GamesFile
+	if err := yaml.Unmarshal(data, &gamesFile); err != nil {
+		return nil, fmt.Errorf("parsing games.yaml: %w", err)
+	}
+
+	games := make(map[string]*domain.Game)
+	for id, cfg := range gamesFile.Games {
+		games[id] = &domain.Game{
+			ID:          id,
+			Name:        cfg.Name,
+			InstallPath: cfg.InstallPath,
+			ModPath:     cfg.ModPath,
+			SourceIDs:   cfg.Sources,
+			LinkMethod:  domain.ParseLinkMethod(cfg.LinkMethod),
+		}
+	}
+
+	return games, nil
+}
+
+// SaveGame adds or updates a game in games.yaml
+func SaveGame(configDir string, game *domain.Game) error {
+	games, err := LoadGames(configDir)
+	if err != nil {
+		return err
+	}
+
+	games[game.ID] = game
+
+	return saveGames(configDir, games)
+}
+
+func saveGames(configDir string, games map[string]*domain.Game) error {
+	gamesFile := GamesFile{Games: make(map[string]GameConfig)}
+
+	for id, game := range games {
+		gamesFile.Games[id] = GameConfig{
+			Name:        game.Name,
+			InstallPath: game.InstallPath,
+			ModPath:     game.ModPath,
+			Sources:     game.SourceIDs,
+			LinkMethod:  game.LinkMethod.String(),
+		}
+	}
+
+	data, err := yaml.Marshal(&gamesFile)
+	if err != nil {
+		return fmt.Errorf("marshaling games: %w", err)
+	}
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("creating config dir: %w", err)
+	}
+
+	gamesPath := filepath.Join(configDir, "games.yaml")
+	if err := os.WriteFile(gamesPath, data, 0644); err != nil {
+		return fmt.Errorf("writing games.yaml: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteGame removes a game from games.yaml
+func DeleteGame(configDir string, gameID string) error {
+	games, err := LoadGames(configDir)
+	if err != nil {
+		return err
+	}
+
+	if _, exists := games[gameID]; !exists {
+		return domain.ErrGameNotFound
+	}
+
+	delete(games, gameID)
+	return saveGames(configDir, games)
+}
+```
+
+**Step 8: Run tests to verify they pass**
+
+```bash
+go test ./internal/storage/config/... -v
+```
+
+Expected: PASS
+
+**Step 9: Write tests for profiles**
+
+Add to `internal/storage/config/config_test.go`:
+
+```go
+func TestLoadProfile(t *testing.T) {
+	dir := t.TempDir()
+	profileDir := filepath.Join(dir, "games", "skyrim-se", "profiles")
+	err := os.MkdirAll(profileDir, 0755)
+	require.NoError(t, err)
+
+	content := `
+name: default
+game_id: skyrim-se
+mods:
+  - source_id: nexusmods
+    mod_id: "12345"
+    version: "1.0.0"
+  - source_id: nexusmods
+    mod_id: "67890"
+    version: ""
+link_method: symlink
+`
+	err = os.WriteFile(filepath.Join(profileDir, "default.yaml"), []byte(content), 0644)
+	require.NoError(t, err)
+
+	profile, err := config.LoadProfile(dir, "skyrim-se", "default")
+	require.NoError(t, err)
+
+	assert.Equal(t, "default", profile.Name)
+	assert.Equal(t, "skyrim-se", profile.GameID)
+	require.Len(t, profile.Mods, 2)
+	assert.Equal(t, "12345", profile.Mods[0].ModID)
+}
+
+func TestSaveProfile(t *testing.T) {
+	dir := t.TempDir()
+
+	profile := &domain.Profile{
+		Name:   "test-profile",
+		GameID: "skyrim-se",
+		Mods: []domain.ModReference{
+			{SourceID: "nexusmods", ModID: "111", Version: "1.0"},
+		},
+		LinkMethod: domain.LinkSymlink,
+	}
+
+	err := config.SaveProfile(dir, profile)
+	require.NoError(t, err)
+
+	loaded, err := config.LoadProfile(dir, "skyrim-se", "test-profile")
+	require.NoError(t, err)
+	assert.Equal(t, profile.Name, loaded.Name)
+}
+```
+
+**Step 10: Run tests to verify they fail**
+
+```bash
+go test ./internal/storage/config/... -v
+```
+
+Expected: FAIL - LoadProfile, SaveProfile not defined
+
+**Step 11: Implement profiles configuration**
+
+Create `internal/storage/config/profiles.go`:
+
+```go
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"lmm/internal/domain"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ProfileConfig is the YAML representation of a profile
+type ProfileConfig struct {
+	Name       string                 `yaml:"name"`
+	GameID     string                 `yaml:"game_id"`
+	Mods       []ModReferenceConfig   `yaml:"mods"`
+	LinkMethod string                 `yaml:"link_method,omitempty"`
+	IsDefault  bool                   `yaml:"is_default,omitempty"`
+}
+
+// ModReferenceConfig is the YAML representation of a mod reference
+type ModReferenceConfig struct {
+	SourceID string `yaml:"source_id"`
+	ModID    string `yaml:"mod_id"`
+	Version  string `yaml:"version,omitempty"`
+}
+
+// LoadProfile reads a profile from disk
+func LoadProfile(configDir, gameID, profileName string) (*domain.Profile, error) {
+	profilePath := filepath.Join(configDir, "games", gameID, "profiles", profileName+".yaml")
+	data, err := os.ReadFile(profilePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, domain.ErrProfileNotFound
+		}
+		return nil, fmt.Errorf("reading profile: %w", err)
+	}
+
+	var cfg ProfileConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing profile: %w", err)
+	}
+
+	profile := &domain.Profile{
+		Name:       cfg.Name,
+		GameID:     cfg.GameID,
+		LinkMethod: domain.ParseLinkMethod(cfg.LinkMethod),
+		IsDefault:  cfg.IsDefault,
+		Mods:       make([]domain.ModReference, len(cfg.Mods)),
+	}
+
+	for i, m := range cfg.Mods {
+		profile.Mods[i] = domain.ModReference{
+			SourceID: m.SourceID,
+			ModID:    m.ModID,
+			Version:  m.Version,
+		}
+	}
+
+	return profile, nil
+}
+
+// SaveProfile writes a profile to disk
+func SaveProfile(configDir string, profile *domain.Profile) error {
+	cfg := ProfileConfig{
+		Name:       profile.Name,
+		GameID:     profile.GameID,
+		LinkMethod: profile.LinkMethod.String(),
+		IsDefault:  profile.IsDefault,
+		Mods:       make([]ModReferenceConfig, len(profile.Mods)),
+	}
+
+	for i, m := range profile.Mods {
+		cfg.Mods[i] = ModReferenceConfig{
+			SourceID: m.SourceID,
+			ModID:    m.ModID,
+			Version:  m.Version,
+		}
+	}
+
+	data, err := yaml.Marshal(&cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling profile: %w", err)
+	}
+
+	profileDir := filepath.Join(configDir, "games", profile.GameID, "profiles")
+	if err := os.MkdirAll(profileDir, 0755); err != nil {
+		return fmt.Errorf("creating profiles dir: %w", err)
+	}
+
+	profilePath := filepath.Join(profileDir, profile.Name+".yaml")
+	if err := os.WriteFile(profilePath, data, 0644); err != nil {
+		return fmt.Errorf("writing profile: %w", err)
+	}
+
+	return nil
+}
+
+// ListProfiles returns all profile names for a game
+func ListProfiles(configDir, gameID string) ([]string, error) {
+	profileDir := filepath.Join(configDir, "games", gameID, "profiles")
+	entries, err := os.ReadDir(profileDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading profiles dir: %w", err)
+	}
+
+	var profiles []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".yaml") {
+			profiles = append(profiles, strings.TrimSuffix(name, ".yaml"))
+		}
+	}
+
+	return profiles, nil
+}
+
+// DeleteProfile removes a profile from disk
+func DeleteProfile(configDir, gameID, profileName string) error {
+	profilePath := filepath.Join(configDir, "games", gameID, "profiles", profileName+".yaml")
+	if err := os.Remove(profilePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return domain.ErrProfileNotFound
+		}
+		return fmt.Errorf("deleting profile: %w", err)
+	}
+	return nil
+}
+
+// ExportProfile exports a profile to a portable format
+func ExportProfile(profile *domain.Profile) ([]byte, error) {
+	exported := domain.ExportedProfile{
+		Name:       profile.Name,
+		GameID:     profile.GameID,
+		Mods:       profile.Mods,
+		LinkMethod: profile.LinkMethod.String(),
+	}
+
+	data, err := yaml.Marshal(&exported)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling exported profile: %w", err)
+	}
+
+	return data, nil
+}
+
+// ImportProfile imports a profile from portable format
+func ImportProfile(data []byte) (*domain.Profile, error) {
+	var exported domain.ExportedProfile
+	if err := yaml.Unmarshal(data, &exported); err != nil {
+		return nil, fmt.Errorf("parsing exported profile: %w", err)
+	}
+
+	return &domain.Profile{
+		Name:       exported.Name,
+		GameID:     exported.GameID,
+		Mods:       exported.Mods,
+		LinkMethod: domain.ParseLinkMethod(exported.LinkMethod),
+	}, nil
+}
+```
+
+**Step 12: Run tests to verify they pass**
+
+```bash
+go test ./internal/storage/config/... -v
+```
+
+Expected: PASS
+
+**Step 13: Commit**
+
+```bash
+git add .
+git commit -m "feat(storage): add YAML configuration layer
+
+- Global config: link method, keybindings
+- Games config: game definitions with sources
+- Profiles: mod lists with load order, export/import support
+- All configs support defaults and creation on first use"
+```
+
+---
+
+### Task 1.4: Cache Manager
+
+**Files:**
+
+- Create: `internal/storage/cache/cache.go`
+- Create: `internal/storage/cache/cache_test.go`
+
+**Step 1: Write the failing test**
+
+Create `internal/storage/cache/cache_test.go`:
+
+```go
+package cache_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"lmm/internal/storage/cache"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCache_ModPath(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.New(dir)
+
+	path := c.ModPath("skyrim-se", "nexusmods", "12345", "1.0.0")
+	expected := filepath.Join(dir, "skyrim-se", "nexusmods-12345", "1.0.0")
+	assert.Equal(t, expected, path)
+}
+
+func TestCache_Store(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.New(dir)
+
+	content := []byte("test mod content")
+	err := c.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "testfile.txt", content)
+	require.NoError(t, err)
+
+	// Verify file exists
+	storedPath := filepath.Join(c.ModPath("skyrim-se", "nexusmods", "12345", "1.0.0"), "testfile.txt")
+	data, err := os.ReadFile(storedPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, data)
+}
+
+func TestCache_Exists(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.New(dir)
+
+	assert.False(t, c.Exists("skyrim-se", "nexusmods", "12345", "1.0.0"))
+
+	err := c.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "test.txt", []byte("data"))
+	require.NoError(t, err)
+
+	assert.True(t, c.Exists("skyrim-se", "nexusmods", "12345", "1.0.0"))
+}
+
+func TestCache_ListFiles(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.New(dir)
+
+	// Store multiple files
+	err := c.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "file1.txt", []byte("1"))
+	require.NoError(t, err)
+	err = c.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "subdir/file2.txt", []byte("2"))
+	require.NoError(t, err)
+
+	files, err := c.ListFiles("skyrim-se", "nexusmods", "12345", "1.0.0")
+	require.NoError(t, err)
+	assert.Len(t, files, 2)
+}
+
+func TestCache_Delete(t *testing.T) {
+	dir := t.TempDir()
+	c := cache.New(dir)
+
+	err := c.Store("skyrim-se", "nexusmods", "12345", "1.0.0", "test.txt", []byte("data"))
+	require.NoError(t, err)
+	assert.True(t, c.Exists("skyrim-se", "nexusmods", "12345", "1.0.0"))
+
+	err = c.Delete("skyrim-se", "nexusmods", "12345", "1.0.0")
+	require.NoError(t, err)
+	assert.False(t, c.Exists("skyrim-se", "nexusmods", "12345", "1.0.0"))
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/storage/cache/... -v
+```
+
+Expected: FAIL - package not found
+
+**Step 3: Implement cache manager**
+
+Create `internal/storage/cache/cache.go`:
+
+```go
+package cache
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Cache manages the central mod file cache
+type Cache struct {
+	basePath string
+}
+
+// New creates a new cache manager
+func New(basePath string) *Cache {
+	return &Cache{basePath: basePath}
+}
+
+// ModPath returns the path where a mod version's files are stored
+func (c *Cache) ModPath(gameID, sourceID, modID, version string) string {
+	return filepath.Join(c.basePath, gameID, fmt.Sprintf("%s-%s", sourceID, modID), version)
+}
+
+// Exists checks if a mod version is cached
+func (c *Cache) Exists(gameID, sourceID, modID, version string) bool {
+	path := c.ModPath(gameID, sourceID, modID, version)
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// Store saves a file to the cache
+func (c *Cache) Store(gameID, sourceID, modID, version, relativePath string, content []byte) error {
+	modPath := c.ModPath(gameID, sourceID, modID, version)
+	fullPath := filepath.Join(modPath, relativePath)
+
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("creating cache dir: %w", err)
+	}
+
+	if err := os.WriteFile(fullPath, content, 0644); err != nil {
+		return fmt.Errorf("writing cached file: %w", err)
+	}
+
+	return nil
+}
+
+// ListFiles returns all files in a cached mod version
+func (c *Cache) ListFiles(gameID, sourceID, modID, version string) ([]string, error) {
+	modPath := c.ModPath(gameID, sourceID, modID, version)
+
+	var files []string
+	err := filepath.WalkDir(modPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(modPath, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, relPath)
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("listing cached files: %w", err)
+	}
+
+	return files, nil
+}
+
+// Delete removes a cached mod version
+func (c *Cache) Delete(gameID, sourceID, modID, version string) error {
+	modPath := c.ModPath(gameID, sourceID, modID, version)
+	if err := os.RemoveAll(modPath); err != nil {
+		return fmt.Errorf("deleting cached mod: %w", err)
+	}
+	return nil
+}
+
+// GetFilePath returns the full path to a cached file
+func (c *Cache) GetFilePath(gameID, sourceID, modID, version, relativePath string) string {
+	return filepath.Join(c.ModPath(gameID, sourceID, modID, version), relativePath)
+}
+
+// Size returns the total size of cached files for a mod version
+func (c *Cache) Size(gameID, sourceID, modID, version string) (int64, error) {
+	modPath := c.ModPath(gameID, sourceID, modID, version)
+
+	var totalSize int64
+	err := filepath.WalkDir(modPath, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		totalSize += info.Size()
+		return nil
+	})
+
+	if err != nil {
+		return 0, fmt.Errorf("calculating cache size: %w", err)
+	}
+
+	return totalSize, nil
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/storage/cache/... -v
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add .
+git commit -m "feat(storage): add mod file cache manager
+
+- Central cache storage organized by game/source/mod/version
+- Store, retrieve, list, and delete cached mod files
+- Size calculation for cache management"
+```
+
+---
+
+### Task 1.5: Linker Strategies
+
+**Files:**
+
+- Create: `internal/linker/linker.go`
+- Create: `internal/linker/symlink.go`
+- Create: `internal/linker/hardlink.go`
+- Create: `internal/linker/copy.go`
+- Create: `internal/linker/linker_test.go`
+
+**Step 1: Write the failing tests**
+
+Create `internal/linker/linker_test.go`:
+
+```go
+package linker_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"lmm/internal/domain"
+	"lmm/internal/linker"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSymlinkLinker_Deploy(t *testing.T) {
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	dstDir := filepath.Join(dir, "dst")
+	require.NoError(t, os.MkdirAll(srcDir, 0755))
+	require.NoError(t, os.MkdirAll(dstDir, 0755))
+
+	srcFile := filepath.Join(srcDir, "test.txt")
+	require.NoError(t, os.WriteFile(srcFile, []byte("content"), 0644))
+
+	l := linker.NewSymlink()
+	dstFile := filepath.Join(dstDir, "test.txt")
+	err := l.Deploy(srcFile, dstFile)
+	require.NoError(t, err)
+
+	// Verify it's a symlink
+	info, err := os.Lstat(dstFile)
+	require.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink != 0)
+
+	// Verify content accessible
+	content, err := os.ReadFile(dstFile)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("content"), content)
+}
+
+func TestSymlinkLinker_Undeploy(t *testing.T) {
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "src.txt")
+	dstFile := filepath.Join(dir, "dst.txt")
+	require.NoError(t, os.WriteFile(srcFile, []byte("content"), 0644))
+
+	l := linker.NewSymlink()
+	require.NoError(t, l.Deploy(srcFile, dstFile))
+	require.NoError(t, l.Undeploy(dstFile))
+
+	_, err := os.Stat(dstFile)
+	assert.True(t, os.IsNotExist(err))
+
+	// Source should still exist
+	_, err = os.Stat(srcFile)
+	assert.NoError(t, err)
+}
+
+func TestHardlinkLinker_Deploy(t *testing.T) {
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "src.txt")
+	dstFile := filepath.Join(dir, "dst.txt")
+	require.NoError(t, os.WriteFile(srcFile, []byte("content"), 0644))
+
+	l := linker.NewHardlink()
+	err := l.Deploy(srcFile, dstFile)
+	require.NoError(t, err)
+
+	// Verify content
+	content, err := os.ReadFile(dstFile)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("content"), content)
+
+	// Verify same inode (hardlink)
+	srcInfo, _ := os.Stat(srcFile)
+	dstInfo, _ := os.Stat(dstFile)
+	assert.Equal(t, srcInfo.Size(), dstInfo.Size())
+}
+
+func TestCopyLinker_Deploy(t *testing.T) {
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "src.txt")
+	dstFile := filepath.Join(dir, "dst.txt")
+	require.NoError(t, os.WriteFile(srcFile, []byte("content"), 0644))
+
+	l := linker.NewCopy()
+	err := l.Deploy(srcFile, dstFile)
+	require.NoError(t, err)
+
+	// Verify content
+	content, err := os.ReadFile(dstFile)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("content"), content)
+}
+
+func TestNew_ReturnsCorrectLinker(t *testing.T) {
+	assert.Equal(t, domain.LinkSymlink, linker.New(domain.LinkSymlink).Method())
+	assert.Equal(t, domain.LinkHardlink, linker.New(domain.LinkHardlink).Method())
+	assert.Equal(t, domain.LinkCopy, linker.New(domain.LinkCopy).Method())
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/linker/... -v
+```
+
+Expected: FAIL - package not found
+
+**Step 3: Create linker interface**
+
+Create `internal/linker/linker.go`:
+
+```go
+package linker
+
+import "lmm/internal/domain"
+
+// Linker deploys and undeploys mod files to game directories
+type Linker interface {
+	Deploy(src, dst string) error
+	Undeploy(dst string) error
+	IsDeployed(dst string) (bool, error)
+	Method() domain.LinkMethod
+}
+
+// New creates a linker for the given method
+func New(method domain.LinkMethod) Linker {
+	switch method {
+	case domain.LinkHardlink:
+		return NewHardlink()
+	case domain.LinkCopy:
+		return NewCopy()
+	default:
+		return NewSymlink()
+	}
+}
+```
+
+**Step 4: Implement symlink linker**
+
+Create `internal/linker/symlink.go`:
+
+```go
+package linker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"lmm/internal/domain"
+)
+
+// SymlinkLinker deploys mods using symbolic links
+type SymlinkLinker struct{}
+
+// NewSymlink creates a new symlink linker
+func NewSymlink() *SymlinkLinker {
+	return &SymlinkLinker{}
+}
+
+// Deploy creates a symlink from src to dst
+func (l *SymlinkLinker) Deploy(src, dst string) error {
+	// Ensure destination directory exists
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("creating destination dir: %w", err)
+	}
+
+	// Remove existing file/link if present
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing existing file: %w", err)
+	}
+
+	if err := os.Symlink(src, dst); err != nil {
+		return fmt.Errorf("creating symlink: %w", err)
+	}
+
+	return nil
+}
+
+// Undeploy removes the symlink at dst
+func (l *SymlinkLinker) Undeploy(dst string) error {
+	info, err := os.Lstat(dst)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // Already removed
+		}
+		return fmt.Errorf("checking file: %w", err)
+	}
+
+	// Only remove if it's a symlink
+	if info.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf("not a symlink: %s", dst)
+	}
+
+	if err := os.Remove(dst); err != nil {
+		return fmt.Errorf("removing symlink: %w", err)
+	}
+
+	return nil
+}
+
+// IsDeployed checks if dst is a symlink
+func (l *SymlinkLinker) IsDeployed(dst string) (bool, error) {
+	info, err := os.Lstat(dst)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.Mode()&os.ModeSymlink != 0, nil
+}
+
+// Method returns the link method
+func (l *SymlinkLinker) Method() domain.LinkMethod {
+	return domain.LinkSymlink
+}
+```
+
+**Step 5: Implement hardlink linker**
+
+Create `internal/linker/hardlink.go`:
+
+```go
+package linker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"lmm/internal/domain"
+)
+
+// HardlinkLinker deploys mods using hard links
+type HardlinkLinker struct{}
+
+// NewHardlink creates a new hardlink linker
+func NewHardlink() *HardlinkLinker {
+	return &HardlinkLinker{}
+}
+
+// Deploy creates a hard link from src to dst
+func (l *HardlinkLinker) Deploy(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("creating destination dir: %w", err)
+	}
+
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing existing file: %w", err)
+	}
+
+	if err := os.Link(src, dst); err != nil {
+		return fmt.Errorf("creating hardlink: %w", err)
+	}
+
+	return nil
+}
+
+// Undeploy removes the file at dst
+func (l *HardlinkLinker) Undeploy(dst string) error {
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing file: %w", err)
+	}
+	return nil
+}
+
+// IsDeployed checks if dst exists (hardlinks are indistinguishable from regular files)
+func (l *HardlinkLinker) IsDeployed(dst string) (bool, error) {
+	_, err := os.Stat(dst)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// Method returns the link method
+func (l *HardlinkLinker) Method() domain.LinkMethod {
+	return domain.LinkHardlink
+}
+```
+
+**Step 6: Implement copy linker**
+
+Create `internal/linker/copy.go`:
+
+```go
+package linker
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"lmm/internal/domain"
+)
+
+// CopyLinker deploys mods by copying files
+type CopyLinker struct{}
+
+// NewCopy creates a new copy linker
+func NewCopy() *CopyLinker {
+	return &CopyLinker{}
+}
+
+// Deploy copies src to dst
+func (l *CopyLinker) Deploy(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("creating destination dir: %w", err)
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening source: %w", err)
+	}
+	defer srcFile.Close()
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("creating destination: %w", err)
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("copying file: %w", err)
+	}
+
+	return nil
+}
+
+// Undeploy removes the file at dst
+func (l *CopyLinker) Undeploy(dst string) error {
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing file: %w", err)
+	}
+	return nil
+}
+
+// IsDeployed checks if dst exists
+func (l *CopyLinker) IsDeployed(dst string) (bool, error) {
+	_, err := os.Stat(dst)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// Method returns the link method
+func (l *CopyLinker) Method() domain.LinkMethod {
+	return domain.LinkCopy
+}
+```
+
+**Step 7: Run tests to verify they pass**
+
+```bash
+go test ./internal/linker/... -v
+```
+
+Expected: PASS
+
+**Step 8: Commit**
+
+```bash
+git add .
+git commit -m "feat(linker): add mod deployment strategies
+
+- Linker interface for deploy/undeploy operations
+- SymlinkLinker: space-efficient, easy to identify
+- HardlinkLinker: transparent to games, same filesystem
+- CopyLinker: maximum compatibility"
+```
+
+---
+
+### Task 1.6: Run All Tests and Verify Phase 1
+
+**Step 1: Run all tests**
+
+```bash
+go test ./... -v
+```
+
+Expected: All tests PASS
+
+**Step 2: Verify build**
+
+```bash
+go build -o lmm ./cmd/lmm
+./lmm
+```
+
+**Step 3: Commit phase completion**
+
+```bash
+git add .
+git commit -m "chore: complete Phase 1 - Core Infrastructure
+
+Phase 1 complete:
+- Domain types (Mod, Game, Profile)
+- SQLite database with migrations
+- YAML configuration (config, games, profiles)
+- Central mod cache manager
+- Linker strategies (symlink, hardlink, copy)"
+```
+
+---
+
+## Phase 2: NexusMods Integration
+
+### Task 2.1: ModSource Interface and Registry
+
+**Files:**
+
+- Create: `internal/source/source.go`
+- Create: `internal/source/registry.go`
+- Create: `internal/source/registry_test.go`
+
+**Step 1: Write failing test for registry**
+
+Create `internal/source/registry_test.go`:
+
+```go
+package source_test
+
+import (
+	"context"
+	"testing"
+
+	"lmm/internal/domain"
+	"lmm/internal/source"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSource struct {
+	id string
+}
+
+func (m *mockSource) ID() string                                                            { return m.id }
+func (m *mockSource) Name() string                                                          { return "Mock" }
+func (m *mockSource) AuthURL() string                                                       { return "" }
+func (m *mockSource) ExchangeToken(context.Context, string) (*source.Token, error)          { return nil, nil }
+func (m *mockSource) Search(context.Context, source.SearchQuery) ([]domain.Mod, error)      { return nil, nil }
+func (m *mockSource) GetMod(context.Context, string, string) (*domain.Mod, error)           { return nil, nil }
+func (m *mockSource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) { return nil, nil }
+func (m *mockSource) GetDownloadURL(context.Context, *domain.Mod, string) (string, error)   { return "", nil }
+func (m *mockSource) CheckUpdates(context.Context, []domain.InstalledMod) ([]domain.Update, error) { return nil, nil }
+
+func TestRegistry_Register(t *testing.T) {
+	reg := source.NewRegistry()
+	mock := &mockSource{id: "mock"}
+
+	reg.Register(mock)
+
+	src, err := reg.Get("mock")
+	require.NoError(t, err)
+	assert.Equal(t, "mock", src.ID())
+}
+
+func TestRegistry_Get_NotFound(t *testing.T) {
+	reg := source.NewRegistry()
+
+	_, err := reg.Get("nonexistent")
+	assert.Error(t, err)
+}
+
+func TestRegistry_List(t *testing.T) {
+	reg := source.NewRegistry()
+	reg.Register(&mockSource{id: "source1"})
+	reg.Register(&mockSource{id: "source2"})
+
+	sources := reg.List()
+	assert.Len(t, sources, 2)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/source/... -v
+```
+
+Expected: FAIL - package not found
+
+**Step 3: Create source interface**
+
+Create `internal/source/source.go`:
+
+```go
+package source
+
+import (
+	"context"
+	"time"
+
+	"lmm/internal/domain"
+)
+
+// Token represents an OAuth token
+type Token struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    time.Time
+}
+
+// SearchQuery parameters for searching mods
+type SearchQuery struct {
+	GameID   string
+	Query    string
+	Category string
+	Page     int
+	PageSize int
+}
+
+// ModSource is the interface for mod repositories
+type ModSource interface {
+	// Identity
+	ID() string
+	Name() string
+
+	// Authentication
+	AuthURL() string
+	ExchangeToken(ctx context.Context, code string) (*Token, error)
+
+	// Discovery
+	Search(ctx context.Context, query SearchQuery) ([]domain.Mod, error)
+	GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error)
+	GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error)
+
+	// Downloads
+	GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error)
+
+	// Updates
+	CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error)
+}
+```
+
+**Step 4: Create registry**
+
+Create `internal/source/registry.go`:
+
+```go
+package source
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Registry manages available mod sources
+type Registry struct {
+	mu      sync.RWMutex
+	sources map[string]ModSource
+}
+
+// NewRegistry creates a new source registry
+func NewRegistry() *Registry {
+	return &Registry{
+		sources: make(map[string]ModSource),
+	}
+}
+
+// Register adds a source to the registry
+func (r *Registry) Register(source ModSource) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sources[source.ID()] = source
+}
+
+// Get retrieves a source by ID
+func (r *Registry) Get(id string) (ModSource, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	source, ok := r.sources[id]
+	if !ok {
+		return nil, fmt.Errorf("source not found: %s", id)
+	}
+	return source, nil
+}
+
+// List returns all registered sources
+func (r *Registry) List() []ModSource {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	sources := make([]ModSource, 0, len(r.sources))
+	for _, s := range r.sources {
+		sources = append(sources, s)
+	}
+	return sources
+}
+```
+
+**Step 5: Run tests to verify they pass**
+
+```bash
+go test ./internal/source/... -v
+```
+
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add .
+git commit -m "feat(source): add ModSource interface and registry
+
+- ModSource interface for mod repositories
+- Token type for OAuth authentication
+- SearchQuery for mod searches
+- Registry for managing multiple sources"
+```
+
+---
+
+### Task 2.2: NexusMods GraphQL Client
+
+**Files:**
+
+- Create: `internal/source/nexusmods/client.go`
+- Create: `internal/source/nexusmods/queries.go`
+- Create: `internal/source/nexusmods/types.go`
+- Create: `internal/source/nexusmods/nexusmods.go`
+
+**Step 1: Create NexusMods types**
+
+Create `internal/source/nexusmods/types.go`:
+
+```go
+package nexusmods
+
+import "time"
+
+// GraphQL response types
+
+type ModResponse struct {
+	Mod ModData `graphql:"mod(gameId: $gameId, modId: $modId)"`
+}
+
+type ModData struct {
+	UID         string `graphql:"uid"`
+	ModID       int    `graphql:"modId"`
+	Name        string `graphql:"name"`
+	Summary     string `graphql:"summary"`
+	Description string `graphql:"description"`
+	Author      string `graphql:"author"`
+	Version     string `graphql:"version"`
+	Category    struct {
+		Name string `graphql:"name"`
+	} `graphql:"category"`
+	ModDownloadCount int `graphql:"modDownloadCount"`
+	EndorsementCount int `graphql:"endorsementCount"`
+	UpdatedAt        time.Time `graphql:"updatedAt"`
+}
+
+type SearchResponse struct {
+	Mods struct {
+		Nodes []ModData `graphql:"nodes"`
+	} `graphql:"mods(gameId: $gameId, filter: $filter, first: $first, offset: $offset)"`
+}
+
+type ModFilter struct {
+	Name string `json:"name,omitempty"`
+}
+
+type FileResponse struct {
+	ModFiles struct {
+		Nodes []FileData `graphql:"nodes"`
+	} `graphql:"modFiles(modId: $modId, gameId: $gameId)"`
+}
+
+type FileData struct {
+	FileID      int    `graphql:"fileId"`
+	Name        string `graphql:"name"`
+	Version     string `graphql:"version"`
+	Size        int64  `graphql:"size"`
+	IsPrimary   bool   `graphql:"isPrimary"`
+	UploadedAt  time.Time `graphql:"uploadedAt"`
+}
+```
+
+**Step 2: Create NexusMods client**
+
+Create `internal/source/nexusmods/client.go`:
+
+```go
+package nexusmods
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hasura/go-graphql-client"
+)
+
+const (
+	graphqlEndpoint = "https://api.nexusmods.com/v2/graphql"
+	oauthAuthorize  = "https://www.nexusmods.com/oauth/authorize"
+	oauthToken      = "https://www.nexusmods.com/oauth/token"
+)
+
+// Client wraps the NexusMods GraphQL API
+type Client struct {
+	gql        *graphql.Client
+	httpClient *http.Client
+	apiKey     string
+}
+
+// NewClient creates a new NexusMods API client
+func NewClient(httpClient *http.Client, apiKey string) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	// Create transport that adds API key header
+	transport := &apiKeyTransport{
+		base:   httpClient.Transport,
+		apiKey: apiKey,
+	}
+	authedClient := &http.Client{Transport: transport}
+
+	return &Client{
+		gql:        graphql.NewClient(graphqlEndpoint, authedClient),
+		httpClient: httpClient,
+		apiKey:     apiKey,
+	}
+}
+
+type apiKeyTransport struct {
+	base   http.RoundTripper
+	apiKey string
+}
+
+func (t *apiKeyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.apiKey != "" {
+		req.Header.Set("apikey", t.apiKey)
+	}
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
+// GetMod fetches a mod by ID
+func (c *Client) GetMod(ctx context.Context, gameID string, modID int) (*ModData, error) {
+	var query struct {
+		Mod ModData `graphql:"mod(gameId: $gameId, modId: $modId)"`
+	}
+
+	variables := map[string]interface{}{
+		"gameId": graphql.String(gameID),
+		"modId":  graphql.Int(modID),
+	}
+
+	if err := c.gql.Query(ctx, &query, variables); err != nil {
+		return nil, fmt.Errorf("querying mod: %w", err)
+	}
+
+	return &query.Mod, nil
+}
+
+// SearchMods searches for mods
+func (c *Client) SearchMods(ctx context.Context, gameID, search string, limit, offset int) ([]ModData, error) {
+	var query struct {
+		Mods struct {
+			Nodes []ModData `graphql:"nodes"`
+		} `graphql:"mods(gameId: $gameId, filter: {name: $name}, first: $first, offset: $offset)"`
+	}
+
+	variables := map[string]interface{}{
+		"gameId": graphql.String(gameID),
+		"name":   graphql.String(search),
+		"first":  graphql.Int(limit),
+		"offset": graphql.Int(offset),
+	}
+
+	if err := c.gql.Query(ctx, &query, variables); err != nil {
+		return nil, fmt.Errorf("searching mods: %w", err)
+	}
+
+	return query.Mods.Nodes, nil
+}
+
+// GetModFiles fetches files for a mod
+func (c *Client) GetModFiles(ctx context.Context, gameID string, modID int) ([]FileData, error) {
+	var query struct {
+		ModFiles struct {
+			Nodes []FileData `graphql:"nodes"`
+		} `graphql:"modFiles(modId: $modId, gameId: $gameId)"`
+	}
+
+	variables := map[string]interface{}{
+		"gameId": graphql.String(gameID),
+		"modId":  graphql.Int(modID),
+	}
+
+	if err := c.gql.Query(ctx, &query, variables); err != nil {
+		return nil, fmt.Errorf("querying mod files: %w", err)
+	}
+
+	return query.ModFiles.Nodes, nil
+}
+```
+
+**Step 3: Create NexusMods source implementation**
+
+Create `internal/source/nexusmods/nexusmods.go`:
+
+```go
+package nexusmods
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"lmm/internal/domain"
+	"lmm/internal/source"
+)
+
+// NexusMods implements the ModSource interface
+type NexusMods struct {
+	client *Client
+}
+
+// New creates a new NexusMods source
+func New(httpClient *http.Client, apiKey string) *NexusMods {
+	return &NexusMods{
+		client: NewClient(httpClient, apiKey),
+	}
+}
+
+// ID returns the source identifier
+func (n *NexusMods) ID() string {
+	return "nexusmods"
+}
+
+// Name returns the display name
+func (n *NexusMods) Name() string {
+	return "Nexus Mods"
+}
+
+// AuthURL returns the OAuth authorization URL
+func (n *NexusMods) AuthURL() string {
+	return oauthAuthorize
+}
+
+// ExchangeToken exchanges an OAuth code for tokens
+func (n *NexusMods) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
+	// TODO: Implement OAuth token exchange
+	return nil, fmt.Errorf("OAuth not yet implemented")
+}
+
+// Search finds mods matching the query
+func (n *NexusMods) Search(ctx context.Context, query source.SearchQuery) ([]domain.Mod, error) {
+	pageSize := query.PageSize
+	if pageSize == 0 {
+		pageSize = 20
+	}
+	offset := query.Page * pageSize
+
+	results, err := n.client.SearchMods(ctx, query.GameID, query.Query, pageSize, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	mods := make([]domain.Mod, len(results))
+	for i, r := range results {
+		mods[i] = modDataToDomain(r, query.GameID)
+	}
+
+	return mods, nil
+}
+
+// GetMod retrieves a specific mod
+func (n *NexusMods) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	id, err := strconv.Atoi(modID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid mod ID: %w", err)
+	}
+
+	data, err := n.client.GetMod(ctx, gameID, id)
+	if err != nil {
+		return nil, err
+	}
+
+	mod := modDataToDomain(*data, gameID)
+	return &mod, nil
+}
+
+// GetDependencies returns mod dependencies
+func (n *NexusMods) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	// TODO: Implement dependency fetching from NexusMods
+	return nil, nil
+}
+
+// GetDownloadURL gets the download URL for a mod file
+func (n *NexusMods) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	// TODO: Implement download URL generation
+	return "", fmt.Errorf("download URLs not yet implemented")
+}
+
+// CheckUpdates checks for available updates
+func (n *NexusMods) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	// TODO: Implement update checking
+	return nil, nil
+}
+
+func modDataToDomain(data ModData, gameID string) domain.Mod {
+	return domain.Mod{
+		ID:           strconv.Itoa(data.ModID),
+		SourceID:     "nexusmods",
+		Name:         data.Name,
+		Version:      data.Version,
+		Author:       data.Author,
+		Summary:      data.Summary,
+		Description:  data.Description,
+		GameID:       gameID,
+		Category:     data.Category.Name,
+		Downloads:    int64(data.ModDownloadCount),
+		Endorsements: int64(data.EndorsementCount),
+		UpdatedAt:    data.UpdatedAt,
+	}
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add .
+git commit -m "feat(source): add NexusMods GraphQL client
+
+- GraphQL client with API key authentication
+- ModSource implementation for NexusMods
+- Search and GetMod operations
+- Type mappings from GraphQL to domain types
+- TODO: OAuth flow, downloads, updates"
+```
+
+---
+
+_[Document continues with Phases 3-6...]_
+
+---
+
+## Phase 3-6 Summary
+
+Due to length, remaining phases are summarized. Each follows the same TDD pattern.
+
+### Phase 3: Mod Management
+
+- **Task 3.1**: Core service facade (`internal/core/service.go`)
+- **Task 3.2**: Installer with download, extract, deploy (`internal/core/installer.go`)
+- **Task 3.3**: Updater with version comparison (`internal/core/updater.go`)
+- **Task 3.4**: Dependency resolver with cycle detection (`internal/core/dependencies.go`)
+
+### Phase 4: Profile System
+
+- **Task 4.1**: Profile manager (`internal/core/profile.go`)
+- **Task 4.2**: Profile switching (full swap)
+- **Task 4.3**: Export/import functionality
+
+### Phase 5: TUI
+
+- **Task 5.1**: App shell with Bubble Tea (`internal/tui/app.go`)
+- **Task 5.2**: Game selector view
+- **Task 5.3**: Mod browser view with search
+- **Task 5.4**: Installed mods view with load order
+- **Task 5.5**: Profile management view
+- **Task 5.6**: Settings view
+- **Task 5.7**: Keybinding configuration
+
+### Phase 6: CLI
+
+- **Task 6.1**: Cobra command structure (`cmd/lmm/`)
+- **Task 6.2**: Search command
+- **Task 6.3**: Install/uninstall commands
+- **Task 6.4**: Update command
+- **Task 6.5**: Profile commands
+- **Task 6.6**: Status/list commands
+
+---
+
+## Verification Checklist
+
+After each phase, verify:
+
+1. **All tests pass**: `go test ./... -v`
+2. **Build succeeds**: `go build -o lmm ./cmd/lmm`
+3. **No lint errors**: `go vet ./...`
+4. **Code formatted**: `go fmt ./...`
+
+## End-to-End Testing
+
+After Phase 6, test the complete flow:
+
+```bash
+# 1. Add a game
+lmm config add-game skyrim-se \
+  --name "Skyrim Special Edition" \
+  --path "/path/to/skyrim" \
+  --mod-path "/path/to/skyrim/Data" \
+  --nexus-id "skyrimspecialedition"
+
+# 2. Search for mods
+lmm search "skyui" --game skyrim-se
+
+# 3. Install a mod
+lmm install <mod-id> --game skyrim-se
+
+# 4. List installed mods
+lmm list --game skyrim-se
+
+# 5. Create and switch profiles
+lmm profile create survival --game skyrim-se
+lmm profile switch survival --game skyrim-se
+
+# 6. Export profile
+lmm profile export survival --game skyrim-se --output survival.yaml
+
+# 7. Launch TUI
+lmm
+```

--- a/docs/plans/archive/2026-01-23-update-management-design.md
+++ b/docs/plans/archive/2026-01-23-update-management-design.md
@@ -1,0 +1,246 @@
+# Update Management Design
+
+<!-- markdownlint-disable MD040 -->
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement complete update management with per-mod update policies, actual update application, and rollback capability.
+
+**Date:** 2026-01-23
+
+---
+
+## Overview
+
+Currently, `lmm update` can check for available updates but cannot apply them. This design adds:
+
+1. Actual update application (download new version, redeploy)
+2. Per-mod update policies (auto/notify/pin) with CLI control
+3. Rollback to previous version
+4. Dry-run mode
+
+## Data Model
+
+### Schema Changes (Migration V2)
+
+Add `previous_version` column to `installed_mods` to enable rollback:
+
+```sql
+ALTER TABLE installed_mods ADD COLUMN previous_version TEXT;
+```
+
+The cache already stores mods by version (`<game>/<source>-<mod>/<version>/`), so old versions remain available for rollback as long as they exist in cache.
+
+### Version Tracking
+
+- `version`: Current installed version
+- `previous_version`: Version before last update (NULL if never updated)
+
+When updating: `previous_version = version`, then `version = new_version`
+When rolling back: swap `version` and `previous_version`
+
+---
+
+## User Flow
+
+### Check for Updates
+
+```
+$ lmm update --game skyrim-se
+
+Checking 5 mod(s) for updates...
+
+MOD                      CURRENT    AVAILABLE   POLICY
+---                      -------    ---------   ------
+SkyUI                    5.2.0      5.3.0       notify
+SKSE64                   2.2.3      2.2.4       auto ✓
+Better Dialogue          1.8.0      1.8.1       pinned
+
+2 update(s) available.
+1 auto-update applied: SKSE64 2.2.3 → 2.2.4
+```
+
+### Apply Specific Update
+
+```
+$ lmm update skyui --game skyrim-se
+
+Updating SkyUI 5.2.0 → 5.3.0...
+  Downloading SkyUI-5.3.0.zip...
+  [████████████████████] 100% (2.1 MB)
+  Extracting to cache...
+  Deploying to game directory...
+
+✓ Updated: SkyUI 5.2.0 → 5.3.0
+  Previous version preserved for rollback
+```
+
+### Dry Run
+
+```
+$ lmm update --game skyrim-se --dry-run
+
+Would apply the following updates:
+
+MOD                      CURRENT    NEW
+---                      -------    ---
+SKSE64 (auto)           2.2.3      2.2.4
+SkyUI                   5.2.0      5.3.0
+
+2 update(s) would be applied. Use without --dry-run to apply.
+```
+
+### Change Update Policy
+
+```
+$ lmm mod set-update skyui --game skyrim-se --auto
+✓ SkyUI update policy: auto
+
+$ lmm mod set-update skyui --game skyrim-se --pin
+✓ SkyUI update policy: pinned (v5.3.0)
+```
+
+### Rollback
+
+```
+$ lmm update rollback skyui --game skyrim-se
+
+Rolling back SkyUI 5.3.0 → 5.2.0...
+  Undeploying current files...
+  Deploying previous version...
+
+✓ Rolled back: SkyUI 5.3.0 → 5.2.0
+```
+
+---
+
+## Implementation
+
+### Task 1: Database Migration V2
+
+**File:** `internal/storage/db/migrations.go`
+
+Add `migrateV2` to add `previous_version` column:
+
+```go
+func migrateV2(d *DB) error {
+    _, err := d.Exec(`ALTER TABLE installed_mods ADD COLUMN previous_version TEXT`)
+    return err
+}
+```
+
+Update `currentVersion` and migrations slice.
+
+### Task 2: Database Layer Updates
+
+**File:** `internal/storage/db/mods.go`
+
+Add methods:
+
+```go
+// UpdateModVersion updates a mod's version, preserving previous for rollback
+func (d *DB) UpdateModVersion(sourceID, modID, gameID, profileName, newVersion string) error
+
+// GetInstalledMod retrieves a single installed mod
+func (d *DB) GetInstalledMod(sourceID, modID, gameID, profileName string) (*domain.InstalledMod, error)
+
+// SwapModVersions swaps version and previous_version (for rollback)
+func (d *DB) SwapModVersions(sourceID, modID, gameID, profileName string) error
+```
+
+Update `GetInstalledMods` and `SaveInstalledMod` to handle `previous_version`.
+
+### Task 3: Updater Enhancement
+
+**File:** `internal/core/updater.go`
+
+Add methods:
+
+```go
+// ApplyUpdate downloads and deploys a mod update
+func (u *Updater) ApplyUpdate(ctx context.Context, svc *Service, game *domain.Game,
+    installed *domain.InstalledMod, update *domain.Update, progressFn ProgressFunc) error
+
+// Rollback reverts to the previous version
+func (u *Updater) Rollback(ctx context.Context, svc *Service, game *domain.Game,
+    installed *domain.InstalledMod) error
+```
+
+### Task 4: Service Layer
+
+**File:** `internal/core/service.go`
+
+Add methods:
+
+```go
+// UpdateMod updates a single mod to a new version
+func (s *Service) UpdateMod(ctx context.Context, sourceID string, game *domain.Game,
+    installed *domain.InstalledMod, newVersion string, progressFn ProgressFunc) error
+
+// RollbackMod reverts a mod to its previous version
+func (s *Service) RollbackMod(ctx context.Context, game *domain.Game,
+    installed *domain.InstalledMod) error
+```
+
+### Task 5: Update Command Enhancement
+
+**File:** `cmd/lmm/update.go`
+
+Add:
+
+- `--dry-run` flag
+- Actual update application when `--all` is used
+- Single mod update when mod ID is provided
+- Show update policy in output
+
+### Task 6: New `mod set-update` Command
+
+**File:** `cmd/lmm/mod.go`
+
+New command structure:
+
+```
+lmm mod set-update <mod-id> --game <game> [--auto|--notify|--pin]
+```
+
+### Task 7: New `update rollback` Subcommand
+
+**File:** `cmd/lmm/update.go` or new `cmd/lmm/rollback.go`
+
+New command:
+
+```
+lmm update rollback <mod-id> --game <game>
+```
+
+---
+
+## Files Summary
+
+| File                                | Action | Purpose                               |
+| ----------------------------------- | ------ | ------------------------------------- |
+| `internal/storage/db/migrations.go` | Modify | Add V2 migration for previous_version |
+| `internal/storage/db/mods.go`       | Modify | Add version management methods        |
+| `internal/storage/db/mods_test.go`  | Modify | Test new methods                      |
+| `internal/core/updater.go`          | Modify | Add ApplyUpdate, Rollback             |
+| `internal/core/updater_test.go`     | Modify | Test new methods                      |
+| `internal/core/service.go`          | Modify | Add UpdateMod, RollbackMod            |
+| `internal/core/service_test.go`     | Modify | Test new methods                      |
+| `cmd/lmm/update.go`                 | Modify | Add --dry-run, actual updates         |
+| `cmd/lmm/mod.go`                    | Create | mod set-update subcommand             |
+| `cmd/lmm/update_test.go`            | Modify | Test CLI changes                      |
+
+---
+
+## Verification
+
+1. `go test ./...` - All tests pass
+2. Manual testing flow:
+   - Install a mod: `lmm install "mod name" -g <game>`
+   - Check for updates: `lmm update -g <game>`
+   - Dry run: `lmm update -g <game> --dry-run`
+   - Change policy: `lmm mod set-update <mod> -g <game> --pin`
+   - Apply update: `lmm update <mod> -g <game>`
+   - Rollback: `lmm update rollback <mod> -g <game>`
+3. Verify previous version preserved in cache
+4. Verify database tracks previous_version correctly

--- a/docs/plans/archive/2026-01-24-profile-completion-design.md
+++ b/docs/plans/archive/2026-01-24-profile-completion-design.md
@@ -1,0 +1,189 @@
+# Profile Completion Design
+
+<!-- markdownlint-disable MD040 -->
+
+## Overview
+
+Complete the profile functionality so profiles serve as the source of truth for mod state. Installing mods adds them to the current profile, switching profiles reconciles mod state, and importing profiles can install missing mods on new machines.
+
+## Requirements
+
+1. Installing a mod always adds it to the current profile
+2. Uninstalling a mod removes it from the current profile
+3. Switching profiles installs/enables/disables mods to match target profile
+4. Importing profiles previews and optionally installs missing mods
+5. New commands to handle manual edits and sync issues
+
+## Design
+
+### 1. Auto-add mods to profile on install
+
+When `lmm install` completes successfully, the mod is automatically added to the current profile's mod list.
+
+**Changes:**
+
+- `cmd/lmm/install.go`: After saving to database, call `ProfileManager.AddMod()` with the mod reference
+- Handle the case where profile doesn't exist yet (create "default" profile if needed)
+- The `ModReference` stored includes: sourceID, modID, and version
+
+**Uninstall behavior:**
+
+- When `lmm uninstall` runs, also remove the mod from the current profile via `ProfileManager.RemoveMod()`
+
+### 2. Profile switch with mod installation
+
+When switching profiles via `lmm profile switch <name>`, the system reconciles the current state with the target profile.
+
+**Steps:**
+
+1. Load target profile's mod list
+2. Get currently installed/enabled mods from database
+3. Calculate diff:
+   - **To disable**: Mods enabled now but not in target profile
+   - **To enable**: Mods in target profile, installed but disabled
+   - **To install**: Mods in target profile, not installed locally
+4. If mods need installing, show preview and prompt for confirmation
+5. Execute changes:
+   - Disable mods (undeploy symlinks, update DB)
+   - Enable mods (deploy from cache, update DB)
+   - Download/install missing mods (reuse existing install logic)
+6. Update default profile marker
+
+**Output example:**
+
+```
+Switching to profile: survival
+
+Will disable 2 mods:
+  - SkyUI (2847)
+  - Immersive HUD (3222)
+
+Will enable 1 mod:
+  - Frostfall (11163)
+
+Will install 2 mods:
+  - Campfire (64798)
+  - iNeed (10111)
+
+Proceed? [Y/n]:
+```
+
+### 3. Profile import with mod installation
+
+When importing a profile via `lmm profile import <file>`, the system previews and optionally installs missing mods.
+
+**Steps:**
+
+1. Parse the YAML file to get profile data
+2. Check if profile name already exists (error if so, unless `--force`)
+3. For each mod reference in the profile:
+   - Check if installed locally (in database)
+   - If not, add to "missing" list
+4. If missing mods exist:
+   - Display preview of what will be installed
+   - Prompt for confirmation
+   - On confirm: download/install each mod
+   - On decline: still save the profile, just skip installing
+5. Save profile to config
+
+**Output example:**
+
+```
+Importing profile: survival
+
+Found 8 mods in profile.
+  5 already installed
+  3 need to be downloaded:
+    - Campfire v1.12.1 (nexusmods:64798)
+    - iNeed v2.0 (nexusmods:10111)
+    - Frostfall v3.4.1 (nexusmods:11163)
+
+Download and install missing mods? [Y/n]:
+```
+
+**Flags:**
+
+- `--force`: Overwrite if profile already exists
+- `--no-install`: Skip the install prompt entirely (just import profile config)
+
+### 4. Profile apply and sync commands
+
+Two new commands to handle manual edits and out-of-sync situations.
+
+**`lmm profile apply [name]`** - Make system match profile
+
+- If no name given, uses current/default profile
+- Same logic as profile switch but for current profile
+- Use case: User edited profile YAML manually, wants to apply those changes
+
+```
+$ lmm profile apply
+
+Applying profile: default
+
+Will disable 1 mod:
+  - Old Mod (1234)
+
+Will install 1 mod:
+  - New Mod (5678)
+
+Proceed? [Y/n]:
+```
+
+**`lmm profile sync [name]`** - Make profile match system
+
+- Updates profile YAML to reflect current installed/enabled mods in database
+- Use case: Profile got out of sync, or migrating from pre-profile installs
+
+```
+$ lmm profile sync
+
+Syncing profile: default
+
+Will add to profile:
+  - Recently Installed Mod (9999)
+
+Will remove from profile:
+  - Uninstalled Mod (1111)
+
+Proceed? [Y/n]:
+```
+
+Both show preview and require confirmation.
+
+### 5. Export format
+
+No changes needed. Current minimal format is sufficient:
+
+- name
+- game_id
+- mods (source_id, mod_id, version)
+
+### 6. Error handling
+
+- **Install fails during switch/import**: Continue with remaining mods, report failures at end, don't roll back successful installs
+- **Mod no longer exists on source**: Skip it, warn user, continue with others
+- **Network unavailable**: Fail early with clear message before making any changes
+- **Version mismatch**: If profile specifies version X but source only has Y, prompt user: "Version 1.0 not found, install latest (1.2) instead?"
+
+### 7. Edge cases
+
+- **Empty profile**: Valid - switching to it disables all mods
+- **Profile with no game set**: Reject on import, require `--game` flag
+- **Circular profile switching**: Not an issue - each switch is independent
+
+## Implementation Order
+
+1. Auto-add/remove mods to profile on install/uninstall
+2. Profile sync command (DB → profile)
+3. Profile apply command (profile → system)
+4. Enhanced profile switch (with install capability)
+5. Enhanced profile import (with install capability)
+
+## Files to Modify
+
+- `cmd/lmm/install.go` - Add to profile after install
+- `cmd/lmm/uninstall.go` - Remove from profile after uninstall
+- `cmd/lmm/profile.go` - Add apply/sync commands, enhance import with --force/--no-install
+- `internal/core/profile.go` - Add reconciliation logic, install missing mods support
+- `internal/domain/profile.go` - No changes expected

--- a/docs/plans/archive/2026-01-28-p1-checksum-verification-design.md
+++ b/docs/plans/archive/2026-01-28-p1-checksum-verification-design.md
@@ -1,0 +1,222 @@
+# P1: Checksum Verification Design
+
+<!-- markdownlint-disable MD040 -->
+
+**Date**: 2026-01-28
+**Priority**: 1 of 7
+**Phase**: Storage Foundation
+**Related Issue**: #8
+
+---
+
+## Overview
+
+Calculate MD5 checksum after download, store in database, and provide verification command for cache integrity checking.
+
+**Why this approach**: NexusMods API does not provide MD5 hashes when querying files by ID. The API only supports reverse lookup (find file info BY hash). Pre-download verification is not possible, so we calculate and store checksums for post-download cache integrity.
+
+---
+
+## Data Model
+
+### Database Migration V6
+
+```sql
+-- Batch with P2 (conflict detection) in single migration
+ALTER TABLE installed_mod_files ADD COLUMN checksum TEXT;
+```
+
+### Domain Type
+
+Add to `DownloadableFile` in `internal/domain/mod.go`:
+
+```go
+type DownloadableFile struct {
+    // ... existing fields ...
+    Checksum string  // MD5 hash (populated after download)
+}
+```
+
+---
+
+## Download Flow
+
+### Modified Downloader Signature
+
+```go
+// DownloadResult contains the outcome of a download
+type DownloadResult struct {
+    Path     string // Final file path
+    Size     int64  // Bytes downloaded
+    Checksum string // MD5 hash of downloaded file
+}
+
+// Download fetches a file and returns its checksum
+func (d *Downloader) Download(ctx context.Context, url, destPath string, progressFn ProgressFunc) (*DownloadResult, error)
+```
+
+### Implementation
+
+Hash during copy using `TeeReader` (avoids reading file twice):
+
+```go
+// Create a TeeReader that writes to both file and hash
+hasher := md5.New()
+teeReader := io.TeeReader(progressReader, hasher)
+
+_, err = io.Copy(file, teeReader)
+// ...
+checksum := hex.EncodeToString(hasher.Sum(nil))
+```
+
+---
+
+## Installer Integration
+
+After download succeeds:
+
+1. Store checksum in `installed_mod_files` table
+2. Display verification success to user
+
+```go
+result, err := s.downloader.Download(ctx, downloadURL, archivePath, progressFn)
+if err != nil {
+    return err
+}
+
+// Store checksum with file record
+err = s.db.SaveFileChecksum(gameID, profileName, sourceID, modID, fileID, result.Checksum)
+```
+
+### User Output
+
+```
+Downloading SkyUI-12345-5.2.zip (2.3 MB)...
+[████████████████████████████████] 100%
+✓ Checksum: a1b2c3d4e5f6...
+Extracting...
+```
+
+### Skip Flag
+
+```bash
+lmm install "skyui" --skip-verify
+```
+
+When set, download normally but skip checksum calculation and storage.
+
+---
+
+## Verify Command
+
+### Usage
+
+```bash
+# Verify all cached mods for a game
+lmm verify --game skyrim-se
+
+# Verify specific mod
+lmm verify 12345 --game skyrim-se
+
+# Auto-fix corrupted/missing files
+lmm verify --fix --game skyrim-se
+```
+
+### Output
+
+```
+Verifying 24 cached mods...
+✓ SkyUI (12345) - OK
+✓ USSEP (266) - OK
+✗ RaceMenu (789) - CORRUPTED (expected a1b2c3..., got 9z8y7x...)
+✗ ENB Helper (456) - MISSING (cache deleted)
+⚠ Old Mod (111) - NO CHECKSUM (installed before v1.0)
+
+2 issues, 1 warning found.
+```
+
+### Logic
+
+1. Get installed mods from DB with their checksums
+2. For each mod's files:
+   - If cache missing → report MISSING
+   - If no stored checksum → report NO CHECKSUM (warning)
+   - If checksum mismatch → report CORRUPTED
+3. With `--fix`: re-download CORRUPTED and MISSING files
+
+---
+
+## Error Handling
+
+### Download Failures
+
+- Network error during download → existing retry logic, no checksum stored
+- Partial download → temp file cleaned up, no checksum stored
+
+### Verification Failures (with `--fix`)
+
+```
+✗ RaceMenu (789) - CORRUPTED
+  Re-downloading...
+  [████████████████████████████████] 100%
+  ✓ Fixed (new checksum: d4e5f6...)
+```
+
+### Edge Cases
+
+| Scenario                         | Behavior                                                              |
+| -------------------------------- | --------------------------------------------------------------------- |
+| Mod installed before v1.0        | No checksum in DB, verify shows warning, `--fix` downloads and stores |
+| Cache manually deleted           | verify shows MISSING, `--fix` re-downloads                            |
+| DB has checksum but file missing | Same as above                                                         |
+| `--skip-verify` used on install  | No checksum stored, verify shows warning                              |
+| Local import (P4)                | Calculate checksum on import, store normally                          |
+
+---
+
+## Files to Modify
+
+| File                                | Changes                                       |
+| ----------------------------------- | --------------------------------------------- |
+| `internal/storage/db/migrations.go` | V6 migration adding checksum column           |
+| `internal/storage/db/files.go`      | `SaveFileChecksum`, `GetFileChecksum` methods |
+| `internal/core/downloader.go`       | Return `DownloadResult` with checksum         |
+| `internal/core/installer.go`        | Store checksum, support `--skip-verify`       |
+| `cmd/lmm/verify.go`                 | New verify command                            |
+| `cmd/lmm/install.go`                | Add `--skip-verify` flag                      |
+
+---
+
+## Testing Strategy
+
+### Unit Tests (`internal/core/downloader_test.go`)
+
+- `TestDownload_ReturnsChecksum` - verify MD5 calculated correctly
+- `TestDownload_ChecksumMatchesContent` - download known content, verify hash
+- `TestDownload_SkipVerify` - verify no checksum when flag set
+
+### Integration Tests (`internal/core/installer_test.go`)
+
+- `TestInstall_StoresChecksum` - verify checksum saved to DB after install
+- `TestInstall_SkipVerifyFlag` - verify no checksum with flag
+
+### Verify Command Tests (`cmd/lmm/verify_test.go`)
+
+- `TestVerify_DetectsCorruption` - modify cached file, verify detection
+- `TestVerify_DetectsMissing` - delete cached file, verify detection
+- `TestVerify_NoChecksum` - old install without checksum, verify warning
+- `TestVerify_Fix` - verify re-download on `--fix`
+
+### DB Tests (`internal/storage/db/files_test.go`)
+
+- `TestSaveFileChecksum` - store and retrieve checksum
+- `TestMigrationV6` - verify column added correctly
+
+---
+
+## Not Included (YAGNI)
+
+- **Pre-download verification** - API doesn't support it
+- **API lookup after download** - Extra calls, limited value
+- **SHA256** - MD5 sufficient for corruption detection
+- **Checksum in profile export** - Not needed for portability

--- a/docs/plans/archive/2026-01-28-p1-checksum-verification-impl.md
+++ b/docs/plans/archive/2026-01-28-p1-checksum-verification-impl.md
@@ -1,0 +1,1063 @@
+# P1: Checksum Verification Implementation Plan
+
+<!-- markdownlint-disable MD029 MD036 -->
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Calculate MD5 checksum during download, store in database, and provide `lmm verify` command for cache integrity checking.
+
+**Architecture:** Hash is calculated using `io.TeeReader` during download (zero extra I/O), stored per-file in `installed_mod_files.checksum`, and verified on-demand via new `verify` command.
+
+**Tech Stack:** `crypto/md5`, `io.TeeReader`, SQLite migrations, Cobra CLI
+
+**Related Design:** `docs/plans/2026-01-28-p1-checksum-verification-design.md`
+
+---
+
+## Task 1: Database Migration V6
+
+Add `checksum` column to `installed_mod_files` table.
+
+**Files:**
+
+- Modify: `internal/storage/db/migrations.go:5` (update currentVersion)
+- Modify: `internal/storage/db/migrations.go:26-31` (add migrateV6 to list)
+- Modify: `internal/storage/db/migrations.go` (add migrateV6 function)
+- Test: `internal/storage/db/db_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `internal/storage/db/db_test.go`:
+
+```go
+func TestMigrationV6_ChecksumColumn(t *testing.T) {
+    database, err := db.New(":memory:")
+    require.NoError(t, err)
+    defer database.Close()
+
+    // Verify checksum column exists by querying it
+    var checksum interface{}
+    err = database.QueryRow(`
+        SELECT checksum FROM installed_mod_files LIMIT 1
+    `).Scan(&checksum)
+    // This should not error on column not found - only on no rows
+    assert.ErrorContains(t, err, "no rows")
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/storage/db/... -run TestMigrationV6_ChecksumColumn -v`
+Expected: FAIL with "no such column: checksum"
+
+**Step 3: Write minimal implementation**
+
+In `internal/storage/db/migrations.go`:
+
+1. Update `const currentVersion = 5` to `const currentVersion = 6`
+
+2. Add `migrateV6` to the migrations slice:
+
+```go
+migrations := []func(*DB) error{
+    migrateV1,
+    migrateV2,
+    migrateV3,
+    migrateV4,
+    migrateV5,
+    migrateV6,
+}
+```
+
+3. Add the migration function:
+
+```go
+func migrateV6(d *DB) error {
+    // Add checksum column for cache integrity verification
+    _, err := d.Exec(`ALTER TABLE installed_mod_files ADD COLUMN checksum TEXT`)
+    return err
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/storage/db/... -run TestMigrationV6_ChecksumColumn -v`
+Expected: PASS
+
+**Step 5: Run all DB tests**
+
+Run: `go test ./internal/storage/db/... -v`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/storage/db/migrations.go internal/storage/db/db_test.go
+git commit -m "feat(db): add migration V6 for checksum column"
+```
+
+---
+
+## Task 2: Database Checksum Methods
+
+Add methods to save and retrieve checksums for installed mod files.
+
+**Files:**
+
+- Modify: `internal/storage/db/mods.go` (add checksum methods)
+- Test: `internal/storage/db/db_test.go`
+
+**Step 1: Write the failing tests**
+
+Add to `internal/storage/db/db_test.go`:
+
+```go
+func TestSaveFileChecksum(t *testing.T) {
+    database, err := db.New(":memory:")
+    require.NoError(t, err)
+    defer database.Close()
+
+    // Create a mod first
+    mod := &domain.InstalledMod{
+        Mod: domain.Mod{
+            ID:       "12345",
+            SourceID: "nexusmods",
+            Name:     "Test Mod",
+            Version:  "1.0.0",
+            GameID:   "skyrim-se",
+        },
+        ProfileName: "default",
+        FileIDs:     []string{"67890"},
+    }
+    err = database.SaveInstalledMod(mod)
+    require.NoError(t, err)
+
+    // Save checksum
+    err = database.SaveFileChecksum("nexusmods", "12345", "skyrim-se", "default", "67890", "a1b2c3d4e5f6")
+    require.NoError(t, err)
+
+    // Retrieve checksum
+    checksum, err := database.GetFileChecksum("nexusmods", "12345", "skyrim-se", "default", "67890")
+    require.NoError(t, err)
+    assert.Equal(t, "a1b2c3d4e5f6", checksum)
+}
+
+func TestGetFileChecksum_NotFound(t *testing.T) {
+    database, err := db.New(":memory:")
+    require.NoError(t, err)
+    defer database.Close()
+
+    checksum, err := database.GetFileChecksum("nexusmods", "nonexistent", "skyrim-se", "default", "99999")
+    require.NoError(t, err)
+    assert.Equal(t, "", checksum) // Empty string for missing checksum
+}
+
+func TestGetFilesWithChecksums(t *testing.T) {
+    database, err := db.New(":memory:")
+    require.NoError(t, err)
+    defer database.Close()
+
+    // Create a mod with multiple files
+    mod := &domain.InstalledMod{
+        Mod: domain.Mod{
+            ID:       "12345",
+            SourceID: "nexusmods",
+            Name:     "Test Mod",
+            Version:  "1.0.0",
+            GameID:   "skyrim-se",
+        },
+        ProfileName: "default",
+        FileIDs:     []string{"111", "222"},
+    }
+    err = database.SaveInstalledMod(mod)
+    require.NoError(t, err)
+
+    // Save checksums
+    err = database.SaveFileChecksum("nexusmods", "12345", "skyrim-se", "default", "111", "hash111")
+    require.NoError(t, err)
+    err = database.SaveFileChecksum("nexusmods", "12345", "skyrim-se", "default", "222", "hash222")
+    require.NoError(t, err)
+
+    // Retrieve all files with checksums
+    files, err := database.GetFilesWithChecksums("skyrim-se", "default")
+    require.NoError(t, err)
+    require.Len(t, files, 2)
+
+    // Verify both files have checksums
+    checksumMap := make(map[string]string)
+    for _, f := range files {
+        checksumMap[f.FileID] = f.Checksum
+    }
+    assert.Equal(t, "hash111", checksumMap["111"])
+    assert.Equal(t, "hash222", checksumMap["222"])
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/storage/db/... -run "TestSaveFileChecksum|TestGetFileChecksum_NotFound|TestGetFilesWithChecksums" -v`
+Expected: FAIL with "database.SaveFileChecksum undefined" or similar
+
+**Step 3: Write minimal implementation**
+
+Add to `internal/storage/db/mods.go`:
+
+```go
+// FileWithChecksum represents a file record with its checksum
+type FileWithChecksum struct {
+    SourceID    string
+    ModID       string
+    FileID      string
+    Checksum    string
+}
+
+// SaveFileChecksum stores the MD5 checksum for a downloaded file
+func (d *DB) SaveFileChecksum(sourceID, modID, gameID, profileName, fileID, checksum string) error {
+    _, err := d.Exec(`
+        UPDATE installed_mod_files SET checksum = ?
+        WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ? AND file_id = ?
+    `, checksum, sourceID, modID, gameID, profileName, fileID)
+    if err != nil {
+        return fmt.Errorf("saving file checksum: %w", err)
+    }
+    return nil
+}
+
+// GetFileChecksum retrieves the checksum for a specific file
+// Returns empty string if file not found or has no checksum
+func (d *DB) GetFileChecksum(sourceID, modID, gameID, profileName, fileID string) (string, error) {
+    var checksum *string
+    err := d.QueryRow(`
+        SELECT checksum FROM installed_mod_files
+        WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ? AND file_id = ?
+    `, sourceID, modID, gameID, profileName, fileID).Scan(&checksum)
+    if err != nil {
+        if errors.Is(err, sql.ErrNoRows) {
+            return "", nil
+        }
+        return "", fmt.Errorf("getting file checksum: %w", err)
+    }
+    if checksum == nil {
+        return "", nil
+    }
+    return *checksum, nil
+}
+
+// GetFilesWithChecksums returns all files for a game/profile with their checksums
+func (d *DB) GetFilesWithChecksums(gameID, profileName string) ([]FileWithChecksum, error) {
+    rows, err := d.Query(`
+        SELECT source_id, mod_id, file_id, checksum
+        FROM installed_mod_files
+        WHERE game_id = ? AND profile_name = ?
+    `, gameID, profileName)
+    if err != nil {
+        return nil, fmt.Errorf("querying files with checksums: %w", err)
+    }
+    defer rows.Close()
+
+    var files []FileWithChecksum
+    for rows.Next() {
+        var f FileWithChecksum
+        var checksum *string
+        if err := rows.Scan(&f.SourceID, &f.ModID, &f.FileID, &checksum); err != nil {
+            return nil, fmt.Errorf("scanning file with checksum: %w", err)
+        }
+        if checksum != nil {
+            f.Checksum = *checksum
+        }
+        files = append(files, f)
+    }
+
+    return files, rows.Err()
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/storage/db/... -run "TestSaveFileChecksum|TestGetFileChecksum_NotFound|TestGetFilesWithChecksums" -v`
+Expected: PASS
+
+**Step 5: Run all DB tests**
+
+Run: `go test ./internal/storage/db/... -v`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/storage/db/mods.go internal/storage/db/db_test.go
+git commit -m "feat(db): add checksum save/retrieve methods"
+```
+
+---
+
+## Task 3: DownloadResult Type
+
+Create `DownloadResult` struct to return checksum from downloads.
+
+**Files:**
+
+- Modify: `internal/core/downloader.go` (add DownloadResult type)
+- Test: `internal/core/downloader_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `internal/core/downloader_test.go`:
+
+```go
+func TestDownloader_Download_ReturnsChecksum(t *testing.T) {
+    content := []byte("test file content for checksum")
+    // Pre-calculated MD5 of "test file content for checksum"
+    expectedMD5 := "d41d8cd98f00b204e9800998ecf8427e" // placeholder - will calculate
+
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Write(content)
+    }))
+    defer server.Close()
+
+    downloader := core.NewDownloader(nil)
+    destPath := filepath.Join(t.TempDir(), "test.txt")
+
+    result, err := downloader.Download(context.Background(), server.URL, destPath, nil)
+    require.NoError(t, err)
+
+    assert.Equal(t, destPath, result.Path)
+    assert.Equal(t, int64(len(content)), result.Size)
+    assert.NotEmpty(t, result.Checksum)
+    assert.Len(t, result.Checksum, 32) // MD5 produces 32 hex chars
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/core/... -run TestDownloader_Download_ReturnsChecksum -v`
+Expected: FAIL with type error (Download returns error, not \*DownloadResult)
+
+**Step 3: Write minimal implementation**
+
+In `internal/core/downloader.go`:
+
+1. Add the DownloadResult type after ProgressFunc:
+
+```go
+// DownloadResult contains the outcome of a download
+type DownloadResult struct {
+    Path     string // Final file path
+    Size     int64  // Bytes downloaded
+    Checksum string // MD5 hash of downloaded file
+}
+```
+
+2. Update the Download method signature and implementation:
+
+```go
+// Download fetches a file from the URL and saves it to destPath
+// Progress updates are sent to the optional progressFn callback
+// Returns DownloadResult with checksum on success
+func (d *Downloader) Download(ctx context.Context, url, destPath string, progressFn ProgressFunc) (*DownloadResult, error) {
+```
+
+3. Add import for crypto/md5 and encoding/hex:
+
+```go
+import (
+    "context"
+    "crypto/md5"
+    "encoding/hex"
+    "fmt"
+    "io"
+    "net/http"
+    "os"
+    "path/filepath"
+)
+```
+
+4. Update the copy section to use TeeReader for hashing:
+
+```go
+    // Create MD5 hasher
+    hasher := md5.New()
+
+    // Create a progress tracking reader
+    reader := &progressReader{
+        reader:     resp.Body,
+        totalBytes: totalBytes,
+        progressFn: progressFn,
+    }
+
+    // TeeReader writes to both file and hasher
+    teeReader := io.TeeReader(reader, hasher)
+
+    // Copy the data
+    written, err := io.Copy(file, teeReader)
+    if err != nil {
+        return nil, fmt.Errorf("downloading file: %w", err)
+    }
+```
+
+5. Update the return statement:
+
+```go
+    // Atomically move temp file to final destination
+    if err := os.Rename(tempPath, destPath); err != nil {
+        return nil, fmt.Errorf("renaming file: %w", err)
+    }
+
+    return &DownloadResult{
+        Path:     destPath,
+        Size:     written,
+        Checksum: hex.EncodeToString(hasher.Sum(nil)),
+    }, nil
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/core/... -run TestDownloader_Download_ReturnsChecksum -v`
+Expected: PASS
+
+**Step 5: Fix other tests that use Download**
+
+All existing tests call `Download` expecting just `error`. Update them to use the new signature.
+
+Run: `go test ./internal/core/... -v`
+Fix compilation errors by updating all Download calls from:
+
+```go
+err := downloader.Download(...)
+```
+
+to:
+
+```go
+_, err := downloader.Download(...)
+```
+
+**Step 6: Run all core tests**
+
+Run: `go test ./internal/core/... -v`
+Expected: All tests PASS
+
+**Step 7: Commit**
+
+```bash
+git add internal/core/downloader.go internal/core/downloader_test.go
+git commit -m "feat(core): return DownloadResult with MD5 checksum from Download"
+```
+
+---
+
+## Task 4: Update Service to Use DownloadResult
+
+Update `Service.DownloadMod` to capture and return checksum.
+
+**Files:**
+
+- Modify: `internal/core/service.go:156` (DownloadMod method)
+- Test: `internal/core/service_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `internal/core/service_test.go` (or create if minimal):
+
+```go
+func TestDownloadMod_ReturnsChecksum(t *testing.T) {
+    // This test verifies the service properly passes through the checksum
+    // The actual download is tested in downloader_test.go
+    // Here we just verify the plumbing works
+
+    // Skip if no mock server setup exists
+    // The key verification is that DownloadMod returns checksum
+    t.Skip("Integration test - verify manually")
+}
+```
+
+Since `Service.DownloadMod` returns `(int, error)` and needs to also expose the checksum, we need to decide on the approach. Looking at the design doc, the checksum is stored in the DB by the caller (install command), so we need to return it.
+
+**Step 2: Update DownloadMod signature**
+
+Change `DownloadMod` to return a struct with both file count and checksum.
+
+In `internal/core/service.go`:
+
+1. Add a new type:
+
+```go
+// DownloadModResult contains the outcome of downloading a mod file
+type DownloadModResult struct {
+    FilesExtracted int    // Number of files extracted
+    Checksum       string // MD5 hash of downloaded archive
+}
+```
+
+2. Update `DownloadMod` signature:
+
+```go
+func (s *Service) DownloadMod(ctx context.Context, sourceID string, game *domain.Game, mod *domain.Mod, file *domain.DownloadableFile, progressFn ProgressFunc) (*DownloadModResult, error) {
+```
+
+3. Update the implementation to capture checksum:
+
+```go
+    // Download the file
+    archivePath := filepath.Join(tempDir, file.FileName)
+    downloader := NewDownloader(nil)
+    result, err := downloader.Download(ctx, url, archivePath, progressFn)
+    if err != nil {
+        return nil, fmt.Errorf("downloading mod: %w", err)
+    }
+```
+
+4. Update return statements:
+
+```go
+    // For non-archive files:
+    return &DownloadModResult{
+        FilesExtracted: 1,
+        Checksum:       result.Checksum,
+    }, nil
+
+    // For archives:
+    return &DownloadModResult{
+        FilesExtracted: len(files),
+        Checksum:       result.Checksum,
+    }, nil
+```
+
+**Step 3: Update callers of DownloadMod**
+
+Find and update all callers of `DownloadMod`:
+
+Run: `grep -r "DownloadMod" --include="*.go" .`
+
+Update `cmd/lmm/install.go` to use the new return type. Change:
+
+```go
+fileCount, err := svc.DownloadMod(...)
+```
+
+to:
+
+```go
+downloadResult, err := svc.DownloadMod(...)
+// ...
+fileCount := downloadResult.FilesExtracted
+```
+
+**Step 4: Run all tests**
+
+Run: `go test ./... -v`
+Expected: All tests PASS (may have compilation errors to fix first)
+
+**Step 5: Commit**
+
+```bash
+git add internal/core/service.go cmd/lmm/install.go
+git commit -m "feat(core): expose checksum from DownloadMod result"
+```
+
+---
+
+## Task 5: Store Checksum on Install
+
+Update install command to store checksum in database after download.
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go` (store checksum after download)
+- Test: Manual verification (integration test)
+
+**Step 1: Update install.go to store checksum**
+
+After each file is downloaded, save its checksum:
+
+```go
+// After successful download
+downloadResult, err := svc.DownloadMod(ctx, source.ID(), game, mod, &selectedFiles[i], progressFn)
+if err != nil {
+    return fmt.Errorf("downloading %s: %w", selectedFiles[i].Name, err)
+}
+
+// Store checksum in database
+if downloadResult.Checksum != "" {
+    if err := svc.DB().SaveFileChecksum(
+        source.ID(), mod.ID, game.ID, profile,
+        selectedFiles[i].ID, downloadResult.Checksum,
+    ); err != nil {
+        // Log warning but don't fail install
+        fmt.Fprintf(os.Stderr, "Warning: failed to save checksum: %v\n", err)
+    }
+}
+```
+
+**Step 2: Add checksum display in output**
+
+After download, show the checksum to the user:
+
+```go
+fmt.Printf("✓ Checksum: %s\n", downloadResult.Checksum[:12]+"...")
+```
+
+**Step 3: Run manual test**
+
+```bash
+go build -o lmm ./cmd/lmm
+./lmm install "skyui" --game skyrim-se
+# Should show checksum in output
+```
+
+**Step 4: Verify checksum stored in DB**
+
+```bash
+sqlite3 ~/.local/share/lmm/lmm.db "SELECT file_id, checksum FROM installed_mod_files WHERE checksum IS NOT NULL LIMIT 5"
+```
+
+**Step 5: Commit**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "feat(install): store and display MD5 checksum after download"
+```
+
+---
+
+## Task 6: Add --skip-verify Flag
+
+Add flag to skip checksum calculation during install.
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go` (add flag)
+- Test: Manual verification
+
+**Step 1: Add the flag**
+
+Add near other flags in install.go:
+
+```go
+var skipVerify bool
+
+func init() {
+    // ... existing flags ...
+    installCmd.Flags().BoolVar(&skipVerify, "skip-verify", false, "Skip checksum calculation")
+}
+```
+
+**Step 2: Conditionally skip checksum storage**
+
+```go
+// Store checksum in database (unless --skip-verify)
+if !skipVerify && downloadResult.Checksum != "" {
+    if err := svc.DB().SaveFileChecksum(...); err != nil {
+        fmt.Fprintf(os.Stderr, "Warning: failed to save checksum: %v\n", err)
+    }
+    fmt.Printf("✓ Checksum: %s\n", downloadResult.Checksum[:12]+"...")
+}
+```
+
+Note: The checksum is still calculated (unavoidable with TeeReader), but we don't store or display it.
+
+**Step 3: Test flag**
+
+```bash
+./lmm install "some-mod" --game skyrim-se --skip-verify
+# Should NOT show checksum output
+```
+
+**Step 4: Commit**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "feat(install): add --skip-verify flag to skip checksum storage"
+```
+
+---
+
+## Task 7: Verify Command - Basic Structure
+
+Create the verify command with basic structure.
+
+**Files:**
+
+- Create: `cmd/lmm/verify.go`
+- Test: `cmd/lmm/verify_test.go`
+
+**Step 1: Write the failing test**
+
+Create `cmd/lmm/verify_test.go`:
+
+```go
+package main
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestVerifyCommand_Exists(t *testing.T) {
+    // Verify the command is registered
+    cmd := rootCmd
+    verifyCmd, _, err := cmd.Find([]string{"verify"})
+    assert.NoError(t, err)
+    assert.Equal(t, "verify", verifyCmd.Name())
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/lmm/... -run TestVerifyCommand_Exists -v`
+Expected: FAIL with "unknown command \"verify\""
+
+**Step 3: Create basic verify command**
+
+Create `cmd/lmm/verify.go`:
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/spf13/cobra"
+)
+
+var verifyCmd = &cobra.Command{
+    Use:   "verify [mod-id]",
+    Short: "Verify cached mod files",
+    Long: `Verify the integrity of cached mod files using stored checksums.
+
+Without arguments, verifies all cached mods for the specified game.
+With a mod ID, verifies only that specific mod.
+
+Examples:
+  lmm verify --game skyrim-se           # Verify all mods
+  lmm verify 12345 --game skyrim-se     # Verify specific mod
+  lmm verify --fix --game skyrim-se     # Re-download corrupted files`,
+    Args: cobra.MaximumNArgs(1),
+    RunE: runVerify,
+}
+
+var verifyFix bool
+
+func init() {
+    rootCmd.AddCommand(verifyCmd)
+    verifyCmd.Flags().StringVarP(&gameFlag, "game", "g", "", "Game ID (required)")
+    verifyCmd.Flags().BoolVar(&verifyFix, "fix", false, "Re-download corrupted or missing files")
+    verifyCmd.MarkFlagRequired("game")
+}
+
+func runVerify(cmd *cobra.Command, args []string) error {
+    fmt.Println("Verify command not yet implemented")
+    return nil
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/lmm/... -run TestVerifyCommand_Exists -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add cmd/lmm/verify.go cmd/lmm/verify_test.go
+git commit -m "feat(cli): add verify command skeleton"
+```
+
+---
+
+## Task 8: Verify Command - Implementation
+
+Implement the full verify logic.
+
+**Files:**
+
+- Modify: `cmd/lmm/verify.go`
+- Modify: `internal/core/service.go` (add helper methods if needed)
+
+**Step 1: Write tests for verify scenarios**
+
+Add to `cmd/lmm/verify_test.go`:
+
+```go
+func TestVerifyCommand_RequiresGame(t *testing.T) {
+    cmd := rootCmd
+    cmd.SetArgs([]string{"verify"})
+    err := cmd.Execute()
+    assert.Error(t, err)
+    assert.Contains(t, err.Error(), "required flag")
+}
+```
+
+**Step 2: Implement verify logic**
+
+Update `runVerify` in `cmd/lmm/verify.go`:
+
+```go
+func runVerify(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+
+    svc, err := initService()
+    if err != nil {
+        return err
+    }
+    defer svc.Close()
+
+    game, err := svc.GetGame(gameFlag)
+    if err != nil {
+        return fmt.Errorf("game not found: %s", gameFlag)
+    }
+
+    profile := getActiveProfile(svc, game.ID)
+
+    // Get all files with checksums for this game/profile
+    files, err := svc.DB().GetFilesWithChecksums(game.ID, profile)
+    if err != nil {
+        return fmt.Errorf("getting files: %w", err)
+    }
+
+    if len(files) == 0 {
+        fmt.Println("No installed mods to verify.")
+        return nil
+    }
+
+    // Filter to specific mod if provided
+    var modFilter string
+    if len(args) > 0 {
+        modFilter = args[0]
+    }
+
+    gameCache := svc.GetGameCache(game)
+    var issues, warnings int
+
+    fmt.Printf("Verifying %d files...\n", len(files))
+
+    for _, f := range files {
+        if modFilter != "" && f.ModID != modFilter {
+            continue
+        }
+
+        // Get mod info for display
+        mod, err := svc.GetInstalledMod(f.SourceID, f.ModID, game.ID, profile)
+        if err != nil {
+            fmt.Printf("⚠ Unknown mod %s - SKIPPED\n", f.ModID)
+            warnings++
+            continue
+        }
+
+        status := verifyFile(gameCache, game, mod, f)
+        switch status {
+        case "OK":
+            fmt.Printf("✓ %s (%s) - OK\n", mod.Name, f.FileID)
+        case "MISSING":
+            fmt.Printf("✗ %s (%s) - MISSING\n", mod.Name, f.FileID)
+            issues++
+            if verifyFix {
+                if err := redownloadFile(ctx, svc, game, mod, f.FileID); err != nil {
+                    fmt.Printf("  Failed to fix: %v\n", err)
+                } else {
+                    fmt.Printf("  ✓ Fixed\n")
+                    issues--
+                }
+            }
+        case "CORRUPTED":
+            fmt.Printf("✗ %s (%s) - CORRUPTED\n", mod.Name, f.FileID)
+            issues++
+            if verifyFix {
+                if err := redownloadFile(ctx, svc, game, mod, f.FileID); err != nil {
+                    fmt.Printf("  Failed to fix: %v\n", err)
+                } else {
+                    fmt.Printf("  ✓ Fixed\n")
+                    issues--
+                }
+            }
+        case "NO_CHECKSUM":
+            fmt.Printf("⚠ %s (%s) - NO CHECKSUM\n", mod.Name, f.FileID)
+            warnings++
+        }
+    }
+
+    if issues > 0 || warnings > 0 {
+        fmt.Printf("\n%d issues, %d warnings found.\n", issues, warnings)
+        if issues > 0 && !verifyFix {
+            fmt.Println("Run with --fix to re-download corrupted/missing files.")
+        }
+    } else {
+        fmt.Println("\nAll files verified OK.")
+    }
+
+    return nil
+}
+
+func verifyFile(cache *cache.Cache, game *domain.Game, mod *domain.InstalledMod, f db.FileWithChecksum) string {
+    // Check if cache exists
+    if !cache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version) {
+        return "MISSING"
+    }
+
+    // If no checksum stored, can't verify
+    if f.Checksum == "" {
+        return "NO_CHECKSUM"
+    }
+
+    // Calculate current checksum of cached archive
+    // Note: We need to find the archive file in cache
+    // This is tricky because we extract archives - we'd need to track the original archive
+    // For now, we'll mark this as a limitation and just check existence
+
+    // TODO: Implement full checksum verification
+    // This requires either:
+    // 1. Keeping the original archive in cache
+    // 2. Storing checksums of individual extracted files
+
+    return "OK" // Placeholder - existence check only for now
+}
+
+func redownloadFile(ctx context.Context, svc *core.Service, game *domain.Game, mod *domain.InstalledMod, fileID string) error {
+    // Get source
+    src, err := svc.GetSource(mod.SourceID)
+    if err != nil {
+        return err
+    }
+
+    // Get file info
+    files, err := src.GetModFiles(ctx, &mod.Mod)
+    if err != nil {
+        return err
+    }
+
+    // Find the specific file
+    var targetFile *domain.DownloadableFile
+    for i := range files {
+        if files[i].ID == fileID {
+            targetFile = &files[i]
+            break
+        }
+    }
+    if targetFile == nil {
+        return fmt.Errorf("file %s not found on source", fileID)
+    }
+
+    // Re-download
+    result, err := svc.DownloadMod(ctx, mod.SourceID, game, &mod.Mod, targetFile, nil)
+    if err != nil {
+        return err
+    }
+
+    // Update checksum
+    return svc.DB().SaveFileChecksum(mod.SourceID, mod.ID, game.ID, mod.ProfileName, fileID, result.Checksum)
+}
+```
+
+**Step 3: Add required imports**
+
+```go
+import (
+    "context"
+    "fmt"
+
+    "github.com/DonovanMods/linux-mod-manager/internal/core"
+    "github.com/DonovanMods/linux-mod-manager/internal/domain"
+    "github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+    "github.com/DonovanMods/linux-mod-manager/internal/storage/db"
+    "github.com/spf13/cobra"
+)
+```
+
+**Step 4: Build and test manually**
+
+```bash
+go build -o lmm ./cmd/lmm
+./lmm verify --game skyrim-se
+```
+
+**Step 5: Commit**
+
+```bash
+git add cmd/lmm/verify.go
+git commit -m "feat(cli): implement verify command for cache integrity"
+```
+
+---
+
+## Task 9: Final Testing and Polish
+
+Run full test suite and clean up.
+
+**Files:**
+
+- All modified files
+
+**Step 1: Run full test suite**
+
+```bash
+go test ./... -v
+```
+
+Fix any failures.
+
+**Step 2: Run linter**
+
+```bash
+go vet ./...
+trunk check
+```
+
+Fix any issues.
+
+**Step 3: Manual end-to-end test**
+
+```bash
+# Fresh install with checksum
+./lmm install "skyui" --game skyrim-se
+# Should show checksum
+
+# Verify
+./lmm verify --game skyrim-se
+# Should show OK
+
+# Skip verify flag
+./lmm install "some-mod" --game skyrim-se --skip-verify
+# Should NOT show checksum
+
+# Verify shows warning for no checksum
+./lmm verify --game skyrim-se
+# Should show NO CHECKSUM warning for the mod installed with --skip-verify
+```
+
+**Step 4: Update version**
+
+In `cmd/lmm/root.go`, bump version:
+
+```go
+const version = "0.7.9"  // or appropriate next version
+```
+
+**Step 5: Update CHANGELOG**
+
+Add entry for new features.
+
+**Step 6: Final commit**
+
+```bash
+git add .
+git commit -m "chore: bump version to 0.7.9"
+```
+
+---
+
+## Summary
+
+| Task | Description             | Key Files     |
+| ---- | ----------------------- | ------------- |
+| 1    | DB Migration V6         | migrations.go |
+| 2    | Checksum DB methods     | mods.go       |
+| 3    | DownloadResult type     | downloader.go |
+| 4    | Service integration     | service.go    |
+| 5    | Store on install        | install.go    |
+| 6    | --skip-verify flag      | install.go    |
+| 7    | Verify command skeleton | verify.go     |
+| 8    | Verify implementation   | verify.go     |
+| 9    | Testing and polish      | all           |
+
+**Estimated commits:** 9

--- a/docs/plans/archive/2026-01-28-p2-conflict-detection-impl.md
+++ b/docs/plans/archive/2026-01-28-p2-conflict-detection-impl.md
@@ -1,0 +1,1182 @@
+# P2: Conflict Detection Implementation Plan
+
+<!-- markdownlint-disable MD010 MD036 -->
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Warn users when installing a mod that overwrites files from an existing mod, and provide commands to view file ownership and conflicts.
+
+**Architecture:** Add a `deployed_files` table to track which mod owns each file path in the game directory. Before deploying, check for conflicts and prompt the user. Add `lmm conflicts` command and `lmm mod files` subcommand.
+
+**Tech Stack:** Go, SQLite, Cobra CLI
+
+**GitHub Issue:** #6
+
+---
+
+## Task 1: Database Migration V7 - deployed_files Table
+
+**Files:**
+
+- Modify: `internal/storage/db/migrations.go`
+- Modify: `internal/storage/db/migrations_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `migrations_test.go`:
+
+```go
+func TestMigrationV7_DeployedFilesTable(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// Verify deployed_files table exists
+	var tableName string
+	err := db.QueryRow(`
+		SELECT name FROM sqlite_master
+		WHERE type='table' AND name='deployed_files'
+	`).Scan(&tableName)
+	require.NoError(t, err)
+	assert.Equal(t, "deployed_files", tableName)
+
+	// Verify we can insert and query
+	_, err = db.Exec(`
+		INSERT INTO deployed_files (game_id, profile_name, relative_path, source_id, mod_id)
+		VALUES ('skyrim-se', 'default', 'meshes/test.nif', 'nexusmods', '12345')
+	`)
+	require.NoError(t, err)
+
+	var path, sourceID, modID string
+	err = db.QueryRow(`
+		SELECT relative_path, source_id, mod_id FROM deployed_files
+		WHERE game_id = 'skyrim-se' AND profile_name = 'default'
+	`).Scan(&path, &sourceID, &modID)
+	require.NoError(t, err)
+	assert.Equal(t, "meshes/test.nif", path)
+	assert.Equal(t, "nexusmods", sourceID)
+	assert.Equal(t, "12345", modID)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/storage/db/... -run TestMigrationV7 -v`
+Expected: FAIL (table doesn't exist)
+
+**Step 3: Write minimal implementation**
+
+In `migrations.go`, change `currentVersion` and add migration:
+
+```go
+const currentVersion = 7
+```
+
+Add `migrateV7` to the migrations slice:
+
+```go
+migrations := []func(*DB) error{
+	migrateV1,
+	migrateV2,
+	migrateV3,
+	migrateV4,
+	migrateV5,
+	migrateV6,
+	migrateV7,
+}
+```
+
+Add the migration function:
+
+```go
+func migrateV7(d *DB) error {
+	_, err := d.Exec(`
+		CREATE TABLE deployed_files (
+			game_id TEXT NOT NULL,
+			profile_name TEXT NOT NULL,
+			relative_path TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			mod_id TEXT NOT NULL,
+			deployed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (game_id, profile_name, relative_path)
+		)
+	`)
+	return err
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/storage/db/... -run TestMigrationV7 -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/storage/db/migrations.go internal/storage/db/migrations_test.go
+git commit -m "feat(db): add migration V7 for deployed_files table"
+```
+
+---
+
+## Task 2: Database Methods for Deployed Files
+
+**Files:**
+
+- Create: `internal/storage/db/files.go`
+- Create: `internal/storage/db/files_test.go`
+
+**Step 1: Write the failing tests**
+
+Create `files_test.go`:
+
+```go
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveDeployedFile(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	err := db.SaveDeployedFile("skyrim-se", "default", "meshes/test.nif", "nexusmods", "12345")
+	require.NoError(t, err)
+
+	// Verify it was saved
+	owner, err := db.GetFileOwner("skyrim-se", "default", "meshes/test.nif")
+	require.NoError(t, err)
+	assert.Equal(t, "nexusmods", owner.SourceID)
+	assert.Equal(t, "12345", owner.ModID)
+}
+
+func TestSaveDeployedFile_Upsert(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// Save initial owner
+	err := db.SaveDeployedFile("skyrim-se", "default", "meshes/test.nif", "nexusmods", "111")
+	require.NoError(t, err)
+
+	// Overwrite with new owner
+	err = db.SaveDeployedFile("skyrim-se", "default", "meshes/test.nif", "nexusmods", "222")
+	require.NoError(t, err)
+
+	// Verify new owner
+	owner, err := db.GetFileOwner("skyrim-se", "default", "meshes/test.nif")
+	require.NoError(t, err)
+	assert.Equal(t, "222", owner.ModID)
+}
+
+func TestGetFileOwner_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	owner, err := db.GetFileOwner("skyrim-se", "default", "nonexistent.nif")
+	require.NoError(t, err)
+	assert.Nil(t, owner)
+}
+
+func TestDeleteDeployedFiles(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// Save some files
+	db.SaveDeployedFile("skyrim-se", "default", "meshes/a.nif", "nexusmods", "123")
+	db.SaveDeployedFile("skyrim-se", "default", "meshes/b.nif", "nexusmods", "123")
+	db.SaveDeployedFile("skyrim-se", "default", "meshes/c.nif", "nexusmods", "456")
+
+	// Delete files for mod 123
+	err := db.DeleteDeployedFiles("skyrim-se", "default", "nexusmods", "123")
+	require.NoError(t, err)
+
+	// Verify 123's files are gone
+	owner, _ := db.GetFileOwner("skyrim-se", "default", "meshes/a.nif")
+	assert.Nil(t, owner)
+	owner, _ = db.GetFileOwner("skyrim-se", "default", "meshes/b.nif")
+	assert.Nil(t, owner)
+
+	// Verify 456's files remain
+	owner, _ = db.GetFileOwner("skyrim-se", "default", "meshes/c.nif")
+	assert.NotNil(t, owner)
+	assert.Equal(t, "456", owner.ModID)
+}
+
+func TestGetDeployedFilesForMod(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	db.SaveDeployedFile("skyrim-se", "default", "meshes/a.nif", "nexusmods", "123")
+	db.SaveDeployedFile("skyrim-se", "default", "meshes/b.nif", "nexusmods", "123")
+	db.SaveDeployedFile("skyrim-se", "default", "meshes/c.nif", "nexusmods", "456")
+
+	files, err := db.GetDeployedFilesForMod("skyrim-se", "default", "nexusmods", "123")
+	require.NoError(t, err)
+	assert.Len(t, files, 2)
+	assert.Contains(t, files, "meshes/a.nif")
+	assert.Contains(t, files, "meshes/b.nif")
+}
+
+func TestCheckFileConflicts(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// Mod 123 owns some files
+	db.SaveDeployedFile("skyrim-se", "default", "meshes/shared.nif", "nexusmods", "123")
+	db.SaveDeployedFile("skyrim-se", "default", "meshes/only123.nif", "nexusmods", "123")
+
+	// Check conflicts for new mod that wants to deploy shared.nif and newfile.nif
+	paths := []string{"meshes/shared.nif", "meshes/newfile.nif"}
+	conflicts, err := db.CheckFileConflicts("skyrim-se", "default", paths)
+	require.NoError(t, err)
+
+	// Only shared.nif should conflict
+	assert.Len(t, conflicts, 1)
+	assert.Equal(t, "meshes/shared.nif", conflicts[0].RelativePath)
+	assert.Equal(t, "123", conflicts[0].ModID)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/storage/db/... -run TestSaveDeployedFile -v`
+Run: `go test ./internal/storage/db/... -run TestGetFileOwner -v`
+Run: `go test ./internal/storage/db/... -run TestDeleteDeployedFiles -v`
+Run: `go test ./internal/storage/db/... -run TestGetDeployedFilesForMod -v`
+Run: `go test ./internal/storage/db/... -run TestCheckFileConflicts -v`
+Expected: FAIL (functions don't exist)
+
+**Step 3: Write minimal implementation**
+
+Create `files.go`:
+
+```go
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// FileOwner represents the mod that owns a deployed file
+type FileOwner struct {
+	SourceID string
+	ModID    string
+}
+
+// FileConflict represents a file that would be overwritten
+type FileConflict struct {
+	RelativePath string
+	SourceID     string
+	ModID        string
+}
+
+// SaveDeployedFile records that a file is deployed by a specific mod.
+// Uses upsert to handle overwrites (new mod takes ownership).
+func (d *DB) SaveDeployedFile(gameID, profileName, relativePath, sourceID, modID string) error {
+	_, err := d.Exec(`
+		INSERT INTO deployed_files (game_id, profile_name, relative_path, source_id, mod_id)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(game_id, profile_name, relative_path) DO UPDATE SET
+			source_id = excluded.source_id,
+			mod_id = excluded.mod_id,
+			deployed_at = CURRENT_TIMESTAMP
+	`, gameID, profileName, relativePath, sourceID, modID)
+	if err != nil {
+		return fmt.Errorf("saving deployed file: %w", err)
+	}
+	return nil
+}
+
+// GetFileOwner returns the mod that owns a specific file path.
+// Returns nil if no mod owns the file.
+func (d *DB) GetFileOwner(gameID, profileName, relativePath string) (*FileOwner, error) {
+	var owner FileOwner
+	err := d.QueryRow(`
+		SELECT source_id, mod_id FROM deployed_files
+		WHERE game_id = ? AND profile_name = ? AND relative_path = ?
+	`, gameID, profileName, relativePath).Scan(&owner.SourceID, &owner.ModID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("getting file owner: %w", err)
+	}
+	return &owner, nil
+}
+
+// DeleteDeployedFiles removes all deployed file records for a specific mod.
+func (d *DB) DeleteDeployedFiles(gameID, profileName, sourceID, modID string) error {
+	_, err := d.Exec(`
+		DELETE FROM deployed_files
+		WHERE game_id = ? AND profile_name = ? AND source_id = ? AND mod_id = ?
+	`, gameID, profileName, sourceID, modID)
+	if err != nil {
+		return fmt.Errorf("deleting deployed files: %w", err)
+	}
+	return nil
+}
+
+// GetDeployedFilesForMod returns all file paths deployed by a specific mod.
+func (d *DB) GetDeployedFilesForMod(gameID, profileName, sourceID, modID string) ([]string, error) {
+	rows, err := d.Query(`
+		SELECT relative_path FROM deployed_files
+		WHERE game_id = ? AND profile_name = ? AND source_id = ? AND mod_id = ?
+		ORDER BY relative_path
+	`, gameID, profileName, sourceID, modID)
+	if err != nil {
+		return nil, fmt.Errorf("querying deployed files: %w", err)
+	}
+	defer rows.Close()
+
+	var paths []string
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			return nil, fmt.Errorf("scanning path: %w", err)
+		}
+		paths = append(paths, path)
+	}
+	return paths, rows.Err()
+}
+
+// CheckFileConflicts checks which of the given paths are already owned by other mods.
+// Returns a slice of conflicts (empty if no conflicts).
+func (d *DB) CheckFileConflicts(gameID, profileName string, paths []string) ([]FileConflict, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	// Build placeholders for IN clause
+	placeholders := make([]string, len(paths))
+	args := make([]interface{}, 0, len(paths)+2)
+	args = append(args, gameID, profileName)
+	for i, p := range paths {
+		placeholders[i] = "?"
+		args = append(args, p)
+	}
+
+	query := fmt.Sprintf(`
+		SELECT relative_path, source_id, mod_id FROM deployed_files
+		WHERE game_id = ? AND profile_name = ? AND relative_path IN (%s)
+		ORDER BY relative_path
+	`, strings.Join(placeholders, ","))
+
+	rows, err := d.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("checking conflicts: %w", err)
+	}
+	defer rows.Close()
+
+	var conflicts []FileConflict
+	for rows.Next() {
+		var c FileConflict
+		if err := rows.Scan(&c.RelativePath, &c.SourceID, &c.ModID); err != nil {
+			return nil, fmt.Errorf("scanning conflict: %w", err)
+		}
+		conflicts = append(conflicts, c)
+	}
+	return conflicts, rows.Err()
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/storage/db/... -run "TestSaveDeployed|TestGetFile|TestDeleteDeployed|TestCheckFile" -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/storage/db/files.go internal/storage/db/files_test.go
+git commit -m "feat(db): add deployed file tracking methods"
+```
+
+---
+
+## Task 3: Track Files on Deploy
+
+**Files:**
+
+- Modify: `internal/core/installer.go`
+- Modify: `internal/core/installer_test.go`
+
+**Step 1: Update Installer to accept DB**
+
+The Installer needs access to the database to track deployed files. Modify the struct and constructor.
+
+In `installer.go`, update the struct:
+
+```go
+type Installer struct {
+	cache  *cache.Cache
+	linker linker.Linker
+	db     *db.DB
+}
+
+func NewInstaller(cache *cache.Cache, linker linker.Linker, db *db.DB) *Installer {
+	return &Installer{
+		cache:  cache,
+		linker: linker,
+		db:     db,
+	}
+}
+```
+
+**Step 2: Update Install method to track files**
+
+Modify the `Install` method to save deployed files to the database:
+
+```go
+func (i *Installer) Install(ctx context.Context, game *domain.Game, mod *domain.Mod, profileName string) error {
+	// Check if mod is cached
+	if !i.cache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version) {
+		return fmt.Errorf("mod not in cache: %s/%s@%s", mod.SourceID, mod.ID, mod.Version)
+	}
+
+	// Get list of files in the cached mod
+	files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	if err != nil {
+		return fmt.Errorf("listing cached files: %w", err)
+	}
+
+	// Deploy each file
+	for _, file := range files {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		srcPath := i.cache.GetFilePath(game.ID, mod.SourceID, mod.ID, mod.Version, file)
+		dstPath := filepath.Join(game.ModPath, file)
+
+		if err := i.linker.Deploy(srcPath, dstPath); err != nil {
+			return fmt.Errorf("deploying %s: %w", file, err)
+		}
+
+		// Track file ownership in database
+		if i.db != nil {
+			if err := i.db.SaveDeployedFile(game.ID, profileName, file, mod.SourceID, mod.ID); err != nil {
+				return fmt.Errorf("tracking deployed file %s: %w", file, err)
+			}
+		}
+	}
+
+	return nil
+}
+```
+
+**Step 3: Update Uninstall method to remove file tracking**
+
+Modify the `Uninstall` method to remove deployed file records:
+
+```go
+func (i *Installer) Uninstall(ctx context.Context, game *domain.Game, mod *domain.Mod, profileName string) error {
+	// Get list of files in the cached mod
+	files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	if err != nil {
+		return fmt.Errorf("listing cached files: %w", err)
+	}
+
+	// Undeploy each file
+	for _, file := range files {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		dstPath := filepath.Join(game.ModPath, file)
+
+		if err := i.linker.Undeploy(dstPath); err != nil {
+			return fmt.Errorf("undeploying %s: %w", file, err)
+		}
+	}
+
+	// Remove file tracking from database
+	if i.db != nil {
+		if err := i.db.DeleteDeployedFiles(game.ID, profileName, mod.SourceID, mod.ID); err != nil {
+			return fmt.Errorf("removing file tracking: %w", err)
+		}
+	}
+
+	// Clean up any empty directories left behind
+	linker.CleanupEmptyDirs(game.ModPath)
+
+	return nil
+}
+```
+
+Note: The `Uninstall` method signature needs to add `profileName` parameter.
+
+**Step 4: Update all callers of NewInstaller and Uninstall**
+
+Search for all uses of `NewInstaller` and `Uninstall` and update them:
+
+- `cmd/lmm/deploy.go`: Update `NewInstaller` calls to pass `service.DB()`
+- `cmd/lmm/install.go`: Update `NewInstaller` calls to pass `service.DB()`
+- `cmd/lmm/uninstall.go`: Update `Uninstall` calls to pass `profileName`
+- `internal/core/service.go`: Update `GetInstaller` to pass DB
+
+**Step 5: Run all tests**
+
+Run: `go test ./... -v`
+Expected: PASS (or identify and fix any compile errors)
+
+**Step 6: Commit**
+
+```bash
+git add internal/core/installer.go internal/core/service.go cmd/lmm/deploy.go cmd/lmm/install.go cmd/lmm/uninstall.go
+git commit -m "feat(core): track deployed files in database"
+```
+
+---
+
+## Task 4: Conflict Detection in Installer
+
+**Files:**
+
+- Modify: `internal/core/installer.go`
+- Create: `internal/core/installer_test.go` (add conflict tests)
+
+**Step 1: Add GetConflicts method**
+
+Add a method to check for conflicts before installing:
+
+```go
+// Conflict represents a file that would be overwritten by installing a mod
+type Conflict struct {
+	RelativePath    string
+	CurrentSourceID string
+	CurrentModID    string
+}
+
+// GetConflicts checks if installing a mod would overwrite files from other mods.
+// Returns conflicts for files owned by OTHER mods (not the mod being installed).
+func (i *Installer) GetConflicts(ctx context.Context, game *domain.Game, mod *domain.Mod, profileName string) ([]Conflict, error) {
+	if i.db == nil {
+		return nil, nil
+	}
+
+	// Check if mod is cached
+	if !i.cache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version) {
+		return nil, fmt.Errorf("mod not in cache: %s/%s@%s", mod.SourceID, mod.ID, mod.Version)
+	}
+
+	// Get list of files in the cached mod
+	files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	if err != nil {
+		return nil, fmt.Errorf("listing cached files: %w", err)
+	}
+
+	// Check for conflicts
+	dbConflicts, err := i.db.CheckFileConflicts(game.ID, profileName, files)
+	if err != nil {
+		return nil, fmt.Errorf("checking conflicts: %w", err)
+	}
+
+	// Filter out conflicts with self (re-installing same mod)
+	var conflicts []Conflict
+	for _, c := range dbConflicts {
+		if c.SourceID != mod.SourceID || c.ModID != mod.ID {
+			conflicts = append(conflicts, Conflict{
+				RelativePath:    c.RelativePath,
+				CurrentSourceID: c.SourceID,
+				CurrentModID:    c.ModID,
+			})
+		}
+	}
+
+	return conflicts, nil
+}
+```
+
+**Step 2: Write tests**
+
+Add to `installer_test.go`:
+
+```go
+func TestGetConflicts(t *testing.T) {
+	// Setup test with in-memory DB and temp cache
+	tempDir := t.TempDir()
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer database.Close()
+
+	c := cache.New(tempDir)
+	lnk := linker.NewSymlink()
+	inst := NewInstaller(c, lnk, database)
+
+	game := &domain.Game{ID: "test-game", ModPath: filepath.Join(tempDir, "mods")}
+	os.MkdirAll(game.ModPath, 0755)
+
+	// Create cached mod files for mod A
+	modAPath := c.ModPath(game.ID, "nexusmods", "111", "1.0")
+	os.MkdirAll(modAPath, 0755)
+	os.WriteFile(filepath.Join(modAPath, "shared.txt"), []byte("a"), 0644)
+
+	// Deploy mod A
+	modA := &domain.Mod{SourceID: "nexusmods", ID: "111", Version: "1.0"}
+	err = inst.Install(context.Background(), game, modA, "default")
+	require.NoError(t, err)
+
+	// Create cached mod files for mod B (with overlapping file)
+	modBPath := c.ModPath(game.ID, "nexusmods", "222", "1.0")
+	os.MkdirAll(modBPath, 0755)
+	os.WriteFile(filepath.Join(modBPath, "shared.txt"), []byte("b"), 0644)
+	os.WriteFile(filepath.Join(modBPath, "unique.txt"), []byte("b"), 0644)
+
+	// Check conflicts for mod B
+	modB := &domain.Mod{SourceID: "nexusmods", ID: "222", Version: "1.0"}
+	conflicts, err := inst.GetConflicts(context.Background(), game, modB, "default")
+	require.NoError(t, err)
+
+	assert.Len(t, conflicts, 1)
+	assert.Equal(t, "shared.txt", conflicts[0].RelativePath)
+	assert.Equal(t, "111", conflicts[0].CurrentModID)
+}
+
+func TestGetConflicts_ReinstallSelf(t *testing.T) {
+	// Setup
+	tempDir := t.TempDir()
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer database.Close()
+
+	c := cache.New(tempDir)
+	lnk := linker.NewSymlink()
+	inst := NewInstaller(c, lnk, database)
+
+	game := &domain.Game{ID: "test-game", ModPath: filepath.Join(tempDir, "mods")}
+	os.MkdirAll(game.ModPath, 0755)
+
+	// Create and deploy mod A
+	modAPath := c.ModPath(game.ID, "nexusmods", "111", "1.0")
+	os.MkdirAll(modAPath, 0755)
+	os.WriteFile(filepath.Join(modAPath, "file.txt"), []byte("a"), 0644)
+
+	modA := &domain.Mod{SourceID: "nexusmods", ID: "111", Version: "1.0"}
+	err = inst.Install(context.Background(), game, modA, "default")
+	require.NoError(t, err)
+
+	// Check conflicts for same mod (re-install) - should be empty
+	conflicts, err := inst.GetConflicts(context.Background(), game, modA, "default")
+	require.NoError(t, err)
+	assert.Empty(t, conflicts)
+}
+```
+
+**Step 3: Run tests**
+
+Run: `go test ./internal/core/... -run TestGetConflicts -v`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add internal/core/installer.go internal/core/installer_test.go
+git commit -m "feat(core): add conflict detection to installer"
+```
+
+---
+
+## Task 5: Integrate Conflict Detection into Install Command
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go`
+
+**Step 1: Add --force flag**
+
+Add the flag variable and register it:
+
+```go
+var (
+	// ... existing flags ...
+	installForce bool
+)
+
+func init() {
+	// ... existing flags ...
+	installCmd.Flags().BoolVarP(&installForce, "force", "f", false, "install without conflict prompts")
+	// ...
+}
+```
+
+**Step 2: Add conflict checking before deploy**
+
+After downloading and before deploying, check for conflicts:
+
+```go
+// After extraction, before deploying...
+
+// Check for conflicts (unless --force)
+if !installForce {
+	conflicts, err := installer.GetConflicts(ctx, game, mod, profileName)
+	if err != nil {
+		if verbose {
+			fmt.Printf("Warning: could not check conflicts: %v\n", err)
+		}
+	} else if len(conflicts) > 0 {
+		fmt.Printf("\n⚠ File conflicts detected:\n")
+
+		// Group conflicts by mod
+		modConflicts := make(map[string][]string) // modID -> []paths
+		for _, c := range conflicts {
+			key := c.CurrentSourceID + ":" + c.CurrentModID
+			modConflicts[key] = append(modConflicts[key], c.RelativePath)
+		}
+
+		for key, paths := range modConflicts {
+			parts := strings.SplitN(key, ":", 2)
+			sourceID, modID := parts[0], parts[1]
+
+			// Try to get mod name
+			conflictMod, _ := service.GetInstalledMod(sourceID, modID, gameID, profileName)
+			modName := modID
+			if conflictMod != nil {
+				modName = conflictMod.Name
+			}
+
+			fmt.Printf("  From %s (%s):\n", modName, modID)
+			maxShow := 5
+			for i, p := range paths {
+				if i >= maxShow {
+					fmt.Printf("    ... and %d more\n", len(paths)-maxShow)
+					break
+				}
+				fmt.Printf("    - %s\n", p)
+			}
+		}
+
+		fmt.Printf("\n%d file(s) will be overwritten. Continue? [y/N]: ", len(conflicts))
+		reader := bufio.NewReader(os.Stdin)
+		input, _ := reader.ReadString('\n')
+		input = strings.TrimSpace(strings.ToLower(input))
+		if input != "y" && input != "yes" {
+			return fmt.Errorf("installation cancelled")
+		}
+	}
+}
+```
+
+**Step 3: Run tests and manual verification**
+
+Run: `go test ./cmd/lmm/... -v`
+Run: `go build -o lmm ./cmd/lmm && ./lmm install --help`
+Expected: Shows --force flag
+
+**Step 4: Commit**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "feat(cli): add conflict detection with --force flag to install"
+```
+
+---
+
+## Task 6: Add lmm mod files Subcommand
+
+**Files:**
+
+- Modify: `cmd/lmm/mod.go`
+- Modify: `cmd/lmm/mod_test.go`
+
+**Step 1: Read existing mod.go structure**
+
+First understand the current mod command structure, then add a `files` subcommand.
+
+**Step 2: Add files subcommand**
+
+Add to `mod.go`:
+
+```go
+var (
+	modFilesSource  string
+	modFilesProfile string
+)
+
+var modFilesCmd = &cobra.Command{
+	Use:   "files <mod-id>",
+	Short: "List files deployed by a mod",
+	Long: `Show all files that a mod has deployed to the game directory.
+
+This helps identify which files a mod owns, useful for debugging
+conflicts or understanding mod contents.
+
+Examples:
+  lmm mod files 12345 --game skyrim-se
+  lmm mod files 12345 --game skyrim-se --profile survival`,
+	Args: cobra.ExactArgs(1),
+	RunE: runModFiles,
+}
+
+func init() {
+	// ... existing init code ...
+
+	modFilesCmd.Flags().StringVarP(&modFilesSource, "source", "s", "nexusmods", "mod source")
+	modFilesCmd.Flags().StringVarP(&modFilesProfile, "profile", "p", "", "profile (default: default)")
+
+	modCmd.AddCommand(modFilesCmd)
+}
+
+func runModFiles(cmd *cobra.Command, args []string) error {
+	if err := requireGame(cmd); err != nil {
+		return err
+	}
+
+	modID := args[0]
+	profileName := profileOrDefault(modFilesProfile)
+
+	svc, err := initService()
+	if err != nil {
+		return fmt.Errorf("initializing service: %w", err)
+	}
+	defer svc.Close()
+
+	// Get mod info for display
+	mod, err := svc.GetInstalledMod(modFilesSource, modID, gameID, profileName)
+	if err != nil {
+		return fmt.Errorf("mod not found: %s", modID)
+	}
+
+	// Get deployed files from database
+	files, err := svc.DB().GetDeployedFilesForMod(gameID, profileName, modFilesSource, modID)
+	if err != nil {
+		return fmt.Errorf("getting deployed files: %w", err)
+	}
+
+	fmt.Printf("Files deployed by %s (%s):\n\n", mod.Name, modID)
+
+	if len(files) == 0 {
+		fmt.Println("  No deployed files tracked.")
+		fmt.Println("  (Files are tracked on install; existing mods may need to be redeployed)")
+		return nil
+	}
+
+	for _, f := range files {
+		fmt.Printf("  %s\n", f)
+	}
+	fmt.Printf("\nTotal: %d file(s)\n", len(files))
+
+	return nil
+}
+```
+
+**Step 3: Run tests**
+
+Run: `go build -o lmm ./cmd/lmm && ./lmm mod files --help`
+Expected: Shows help for files subcommand
+
+**Step 4: Commit**
+
+```bash
+git add cmd/lmm/mod.go
+git commit -m "feat(cli): add 'lmm mod files' subcommand"
+```
+
+---
+
+## Task 7: Add lmm conflicts Command
+
+**Files:**
+
+- Create: `cmd/lmm/conflicts.go`
+- Create: `cmd/lmm/conflicts_test.go`
+
+**Step 1: Create the conflicts command**
+
+Create `conflicts.go`:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var conflictsProfile string
+
+var conflictsCmd = &cobra.Command{
+	Use:   "conflicts",
+	Short: "Show all file conflicts in the current profile",
+	Long: `Display all file conflicts in the current profile.
+
+A conflict occurs when multiple mods deploy the same file path.
+The mod listed as "owner" is the one whose file is currently deployed.
+
+Examples:
+  lmm conflicts --game skyrim-se
+  lmm conflicts --game skyrim-se --profile survival`,
+	RunE: runConflicts,
+}
+
+func init() {
+	conflictsCmd.Flags().StringVarP(&conflictsProfile, "profile", "p", "", "profile (default: default)")
+
+	rootCmd.AddCommand(conflictsCmd)
+}
+
+func runConflicts(cmd *cobra.Command, args []string) error {
+	if err := requireGame(cmd); err != nil {
+		return err
+	}
+
+	profileName := profileOrDefault(conflictsProfile)
+
+	svc, err := initService()
+	if err != nil {
+		return fmt.Errorf("initializing service: %w", err)
+	}
+	defer svc.Close()
+
+	// Get all installed mods
+	mods, err := svc.GetInstalledMods(gameID, profileName)
+	if err != nil {
+		return fmt.Errorf("getting installed mods: %w", err)
+	}
+
+	if len(mods) == 0 {
+		fmt.Println("No installed mods.")
+		return nil
+	}
+
+	// Build map of mod ID to name for display
+	modNames := make(map[string]string)
+	for _, m := range mods {
+		key := m.SourceID + ":" + m.ID
+		modNames[key] = m.Name
+	}
+
+	// For each mod, get its files and check if any are owned by another mod
+	type conflictInfo struct {
+		path     string
+		ownerKey string
+		wantKeys []string // mods that want this file
+	}
+
+	// Map of relative_path -> mod keys that have this file
+	fileMods := make(map[string][]string)
+
+	for _, m := range mods {
+		files, err := svc.DB().GetDeployedFilesForMod(gameID, profileName, m.SourceID, m.ID)
+		if err != nil {
+			continue
+		}
+		key := m.SourceID + ":" + m.ID
+		for _, f := range files {
+			fileMods[f] = append(fileMods[f], key)
+		}
+	}
+
+	// Find files with multiple mods
+	var conflicts []conflictInfo
+	for path, keys := range fileMods {
+		if len(keys) > 1 {
+			// Get current owner from database
+			owner, err := svc.DB().GetFileOwner(gameID, profileName, path)
+			if err != nil || owner == nil {
+				continue
+			}
+			ownerKey := owner.SourceID + ":" + owner.ModID
+
+			// Other mods that wanted this file
+			var wantKeys []string
+			for _, k := range keys {
+				if k != ownerKey {
+					wantKeys = append(wantKeys, k)
+				}
+			}
+
+			conflicts = append(conflicts, conflictInfo{
+				path:     path,
+				ownerKey: ownerKey,
+				wantKeys: wantKeys,
+			})
+		}
+	}
+
+	if len(conflicts) == 0 {
+		fmt.Println("No conflicts found.")
+		return nil
+	}
+
+	fmt.Printf("Found %d conflicting file(s):\n\n", len(conflicts))
+
+	for _, c := range conflicts {
+		ownerName := modNames[c.ownerKey]
+		if ownerName == "" {
+			ownerName = c.ownerKey
+		}
+
+		fmt.Printf("  %s\n", c.path)
+		fmt.Printf("    Owner: %s\n", ownerName)
+		fmt.Printf("    Also in: ")
+		for i, wk := range c.wantKeys {
+			wantName := modNames[wk]
+			if wantName == "" {
+				wantName = wk
+			}
+			if i > 0 {
+				fmt.Print(", ")
+			}
+			fmt.Print(wantName)
+		}
+		fmt.Println()
+		fmt.Println()
+	}
+
+	return nil
+}
+```
+
+**Step 2: Run manual test**
+
+Run: `go build -o lmm ./cmd/lmm && ./lmm conflicts --help`
+Expected: Shows help for conflicts command
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/conflicts.go
+git commit -m "feat(cli): add 'lmm conflicts' command"
+```
+
+---
+
+## Task 8: Update Deploy Command for File Tracking
+
+**Files:**
+
+- Modify: `cmd/lmm/deploy.go`
+
+The deploy command creates a new Installer and calls Install, but needs to pass the DB. Update to match the new Installer signature.
+
+**Step 1: Update deploy.go**
+
+Update the Installer creation to pass DB:
+
+```go
+installer := core.NewInstaller(service.GetGameCache(game), lnk, service.DB())
+```
+
+Also update the Uninstall call to pass profileName:
+
+```go
+if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
+```
+
+**Step 2: Run tests**
+
+Run: `go test ./cmd/lmm/... -v`
+Run: `go build -o lmm ./cmd/lmm`
+Expected: Builds successfully
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/deploy.go
+git commit -m "fix(cli): pass DB to installer in deploy command"
+```
+
+---
+
+## Task 9: Update Uninstall Command
+
+**Files:**
+
+- Modify: `cmd/lmm/uninstall.go`
+
+**Step 1: Update uninstall to pass profileName**
+
+The Uninstall method now requires profileName. Update all calls.
+
+**Step 2: Run tests**
+
+Run: `go test ./cmd/lmm/... -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/uninstall.go
+git commit -m "fix(cli): pass profile name to installer.Uninstall"
+```
+
+---
+
+## Task 10: Final Testing and Version Bump
+
+**Files:**
+
+- Modify: `cmd/lmm/root.go`
+- Modify: `CHANGELOG.md`
+
+**Step 1: Run full test suite**
+
+Run: `go test ./... -v`
+Expected: All tests pass
+
+**Step 2: Run linter**
+
+Run: `trunk check`
+Expected: No errors (warnings OK)
+
+**Step 3: Bump version**
+
+In `root.go`, change:
+
+```go
+version = "0.9.0"
+```
+
+**Step 4: Update CHANGELOG.md**
+
+Add to CHANGELOG.md under `## [0.9.0] - 2026-01-28`:
+
+```markdown
+### Added
+
+- **Conflict detection**: Warns when installing mods that overwrite files from other mods
+  - Shows which files conflict and which mod currently owns them
+  - Prompts for confirmation before proceeding
+  - Use `--force` flag to skip conflict prompts
+- New `lmm conflicts` command to view all file conflicts in a profile
+- New `lmm mod files <mod-id>` subcommand to see files deployed by a mod
+- Database tracks which mod owns each deployed file
+
+### Changed
+
+- Installer now tracks file ownership in database during deploy/undeploy
+- Deploy command properly tracks files when re-deploying mods
+```
+
+**Step 5: Commit version bump**
+
+```bash
+git add cmd/lmm/root.go CHANGELOG.md
+git commit -m "chore: bump version to 0.9.0"
+```
+
+---
+
+## Summary
+
+This plan implements P2: Conflict Detection with:
+
+1. **Database migration V7** - Creates `deployed_files` table
+2. **File tracking methods** - CRUD operations for deployed files
+3. **Installer integration** - Track files on install/uninstall
+4. **Conflict detection** - GetConflicts method checks for overwrites
+5. **CLI integration** - `--force` flag, conflict prompts
+6. **New commands** - `lmm mod files` and `lmm conflicts`
+
+All existing tests should continue to pass, and new functionality is fully tested.

--- a/docs/plans/archive/2026-01-28-p3-auto-dependencies-design.md
+++ b/docs/plans/archive/2026-01-28-p3-auto-dependencies-design.md
@@ -1,0 +1,167 @@
+# P3 Auto-Dependencies Design
+
+<!-- markdownlint-disable MD040 -->
+
+**Date**: 2026-01-28
+**Priority**: P3 (after Checksum Verification and Conflict Detection)
+**Goal**: Automatically resolve and install mod dependencies during installation
+
+---
+
+## Overview
+
+When installing a mod, automatically resolve and install its required dependencies. Uses existing `DependencyResolver` for cycle detection and topological ordering.
+
+## Command Interface
+
+```bash
+lmm install "skyui" --game skyrim-se
+```
+
+**New flags:**
+
+- `--no-deps` - Skip dependency installation (install only the requested mod)
+
+**Existing flags used:**
+
+- `-y` / `--yes` - Auto-confirm dependency installation
+
+**Example output:**
+
+```
+Resolving dependencies for SkyUI (12604)...
+
+Install plan (2 mods):
+  1. SKSE64 v2.2.6 (ID: 30379) [dependency]
+  2. SkyUI v5.2SE (ID: 12604) [target]
+
+Install 2 mod(s)? [Y/n]:
+```
+
+## Design Decisions
+
+| Decision                | Choice              | Rationale                                           |
+| ----------------------- | ------------------- | --------------------------------------------------- |
+| Where to add logic      | Install command     | Keeps change scoped, reuses existing infrastructure |
+| File selection for deps | Auto-select primary | Avoids complex multi-mod file selection UX          |
+| Unavailable deps        | Warn and continue   | External deps (SKSE) aren't on NexusMods            |
+| Version matching        | Install latest      | NexusMods doesn't provide version constraints       |
+| Already-installed deps  | Skip                | Don't auto-upgrade dependencies                     |
+| Partial failure         | Continue others     | Report failures in summary                          |
+
+## Command Flow
+
+```
+Current:  select mod → select files → download → deploy
+
+New:      select mod → resolve deps → show install plan → confirm → download all → deploy all
+```
+
+**Insertion point:** After mod selection, before file selection.
+
+**Detailed flow:**
+
+1. User selects mod to install
+2. Fetch dependencies via `source.GetDependencies()`
+3. Filter out already-installed dependencies
+4. If missing deps exist and `--no-deps` not set:
+   - Show install plan (deps + target mod in order)
+   - Prompt for confirmation (or auto-confirm with `-y`)
+5. For each mod in install order:
+   - Auto-select primary file
+   - Download and deploy
+6. Save all to database/profile
+
+## Dependency Resolution Logic
+
+**Helper function:**
+
+```go
+func resolveDependencies(ctx context.Context, svc *core.Service, source string, mod *domain.Mod, installedIDs map[string]bool) (*installPlan, error)
+```
+
+**Data structure:**
+
+```go
+type installPlan struct {
+    mods    []*domain.Mod  // In install order (deps first)
+    missing []string       // Dependencies that couldn't be fetched
+}
+```
+
+**Algorithm:**
+
+1. Call `source.GetDependencies(ctx, mod)` → `[]ModReference`
+2. For each dependency:
+   - Skip if already in `installedIDs`
+   - Fetch full mod info via `service.GetMod()`
+   - Recursively resolve its dependencies
+3. Use existing `DependencyResolver.Resolve()` for topological order
+4. Return ordered list (dependencies first, target mod last)
+
+## Behavior Matrix
+
+| Scenario         | `--no-deps` | `-y`  | Behavior                        |
+| ---------------- | ----------- | ----- | ------------------------------- |
+| Has missing deps | false       | false | Show plan, prompt               |
+| Has missing deps | false       | true  | Show plan, auto-confirm         |
+| Has missing deps | true        | any   | Skip deps, install target only  |
+| No missing deps  | any         | any   | Install target only (no prompt) |
+
+## Edge Cases
+
+| Edge Case                        | Handling                                         |
+| -------------------------------- | ------------------------------------------------ |
+| Circular dependency              | `ErrDependencyLoop` → clear error message, abort |
+| Dependency not on NexusMods      | Warn and continue (external deps like SKSE)      |
+| Dependency fetch fails (network) | Warn and continue                                |
+| Dependency already installed     | Skip, don't reinstall                            |
+| Dependency has older version     | Skip (don't auto-upgrade deps)                   |
+| Target mod already installed     | Existing behavior: uninstall old, install new    |
+| One dependency fails to install  | Continue with others, report in summary          |
+| Local mod as target              | No dependency resolution                         |
+
+## Conflict Handling
+
+Reuse existing conflict detection:
+
+- Check conflicts for all mods in install plan
+- Show all conflicts grouped by mod
+- Single confirmation for entire plan
+- `--force` bypasses for all
+
+## Modified Files
+
+### `cmd/lmm/install.go`
+
+- Add `--no-deps` flag
+- Add `resolveDependencies()` helper function
+- Add `installPlan` struct
+- Modify `runInstall()` to call dependency resolution
+- Reuse `installMultipleMods()` for batch installation
+
+## Testing Strategy
+
+**Unit tests:**
+
+- `resolveDependencies()` with mock source
+- Cycle detection (reuse existing patterns)
+- `--no-deps` flag behavior
+- Already-installed filtering
+
+**Integration tests:**
+
+- Multi-mod install with temp directories
+- Verify all files deployed in correct order
+
+**Test fixtures:**
+
+- Mock mod with 2 dependencies (one installed, one not)
+- Mock mod with circular dependency
+- Mock mod with unavailable dependency
+
+## Code Locations
+
+- `internal/core/dependencies.go` - Existing resolver (no changes needed)
+- `internal/source/nexusmods/nexusmods.go` - Existing `GetDependencies()` (no changes needed)
+- `cmd/lmm/install.go` - Main changes here

--- a/docs/plans/archive/2026-01-28-p3-auto-dependencies-impl.md
+++ b/docs/plans/archive/2026-01-28-p3-auto-dependencies-impl.md
@@ -1,0 +1,951 @@
+# P3 Auto-Dependencies Implementation Plan
+
+<!-- markdownlint-disable MD010 MD036 -->
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Automatically resolve and install mod dependencies during `lmm install`.
+
+**Architecture:** Add dependency resolution to the install command after mod selection. Fetch dependencies via existing `ModSource.GetDependencies()`, filter out installed mods, use existing `DependencyResolver` for topological ordering, then batch-install all mods.
+
+**Tech Stack:** Go, Cobra CLI, existing DependencyResolver
+
+---
+
+## Task 1: Add `--no-deps` Flag
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go:19-29` (flag variables)
+- Modify: `cmd/lmm/install.go:52-63` (init function)
+
+**Step 1: Add the flag variable**
+
+In `cmd/lmm/install.go`, add to the var block (after line 28):
+
+```go
+var (
+	installSource       string
+	installProfile      string
+	installVersion      string
+	installModID        string
+	installFileID       string
+	installYes          bool
+	installShowArchived bool
+	skipVerify          bool
+	installForce        bool
+	installNoDeps       bool  // NEW
+)
+```
+
+**Step 2: Register the flag in init()**
+
+Add after line 61 (after `installForce` flag):
+
+```go
+installCmd.Flags().BoolVar(&installNoDeps, "no-deps", false, "skip automatic dependency installation")
+```
+
+**Step 3: Run tests to verify no regression**
+
+Run: `go test ./cmd/lmm/... -v -run TestInstallCmd`
+Expected: All existing tests pass
+
+**Step 4: Commit**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "feat(install): add --no-deps flag for skipping dependency installation"
+```
+
+---
+
+## Task 2: Add `installPlan` Type
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go` (add after imports, before var block)
+
+**Step 1: Add the type definition**
+
+Add after the imports block (around line 17):
+
+```go
+// installPlan contains the ordered list of mods to install
+type installPlan struct {
+	mods    []*domain.Mod // In install order (dependencies first, target last)
+	missing []string      // Dependencies that couldn't be fetched (warning only)
+}
+```
+
+**Step 2: Verify compilation**
+
+Run: `go build ./cmd/lmm`
+Expected: Compiles without errors
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "feat(install): add installPlan type for dependency resolution"
+```
+
+---
+
+## Task 3: Write `resolveDependencies` Function - Tests First
+
+**Files:**
+
+- Create: `cmd/lmm/install_deps_test.go`
+
+**Step 1: Write the test file**
+
+Create `cmd/lmm/install_deps_test.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDepSource implements a minimal source for testing dependency resolution
+type mockDepSource struct {
+	mods map[string]*domain.Mod           // modID -> Mod
+	deps map[string][]domain.ModReference // modID -> dependencies
+}
+
+func (m *mockDepSource) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	if mod, ok := m.mods[modID]; ok {
+		return mod, nil
+	}
+	return nil, domain.ErrModNotFound
+}
+
+func (m *mockDepSource) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	if deps, ok := m.deps[mod.ID]; ok {
+		return deps, nil
+	}
+	return nil, nil
+}
+
+func TestResolveDependencies_NoDeps(t *testing.T) {
+	src := &mockDepSource{
+		mods: map[string]*domain.Mod{
+			"100": {ID: "100", SourceID: "nexusmods", Name: "Target Mod"},
+		},
+		deps: map[string][]domain.ModReference{},
+	}
+
+	target := src.mods["100"]
+	installed := make(map[string]bool)
+
+	plan, err := resolveDependencies(context.Background(), src, target, installed)
+	require.NoError(t, err)
+	assert.Len(t, plan.mods, 1)
+	assert.Equal(t, "100", plan.mods[0].ID)
+	assert.Empty(t, plan.missing)
+}
+
+func TestResolveDependencies_WithDeps(t *testing.T) {
+	src := &mockDepSource{
+		mods: map[string]*domain.Mod{
+			"100": {ID: "100", SourceID: "nexusmods", Name: "Target Mod"},
+			"200": {ID: "200", SourceID: "nexusmods", Name: "Dependency A"},
+			"300": {ID: "300", SourceID: "nexusmods", Name: "Dependency B"},
+		},
+		deps: map[string][]domain.ModReference{
+			"100": {
+				{SourceID: "nexusmods", ModID: "200"},
+				{SourceID: "nexusmods", ModID: "300"},
+			},
+		},
+	}
+
+	target := src.mods["100"]
+	installed := make(map[string]bool)
+
+	plan, err := resolveDependencies(context.Background(), src, target, installed)
+	require.NoError(t, err)
+	assert.Len(t, plan.mods, 3)
+	// Target should be last
+	assert.Equal(t, "100", plan.mods[len(plan.mods)-1].ID)
+	assert.Empty(t, plan.missing)
+}
+
+func TestResolveDependencies_SkipsInstalled(t *testing.T) {
+	src := &mockDepSource{
+		mods: map[string]*domain.Mod{
+			"100": {ID: "100", SourceID: "nexusmods", Name: "Target Mod"},
+			"200": {ID: "200", SourceID: "nexusmods", Name: "Already Installed"},
+		},
+		deps: map[string][]domain.ModReference{
+			"100": {{SourceID: "nexusmods", ModID: "200"}},
+		},
+	}
+
+	target := src.mods["100"]
+	installed := map[string]bool{"nexusmods:200": true}
+
+	plan, err := resolveDependencies(context.Background(), src, target, installed)
+	require.NoError(t, err)
+	assert.Len(t, plan.mods, 1) // Only target, dep is skipped
+	assert.Equal(t, "100", plan.mods[0].ID)
+}
+
+func TestResolveDependencies_MissingDep(t *testing.T) {
+	src := &mockDepSource{
+		mods: map[string]*domain.Mod{
+			"100": {ID: "100", SourceID: "nexusmods", Name: "Target Mod"},
+			// "200" is missing (external dependency like SKSE)
+		},
+		deps: map[string][]domain.ModReference{
+			"100": {{SourceID: "nexusmods", ModID: "200"}},
+		},
+	}
+
+	target := src.mods["100"]
+	installed := make(map[string]bool)
+
+	plan, err := resolveDependencies(context.Background(), src, target, installed)
+	require.NoError(t, err)
+	assert.Len(t, plan.mods, 1) // Only target
+	assert.Contains(t, plan.missing, "nexusmods:200")
+}
+
+func TestResolveDependencies_TransitiveDeps(t *testing.T) {
+	src := &mockDepSource{
+		mods: map[string]*domain.Mod{
+			"100": {ID: "100", SourceID: "nexusmods", Name: "Target"},
+			"200": {ID: "200", SourceID: "nexusmods", Name: "Direct Dep"},
+			"300": {ID: "300", SourceID: "nexusmods", Name: "Transitive Dep"},
+		},
+		deps: map[string][]domain.ModReference{
+			"100": {{SourceID: "nexusmods", ModID: "200"}},
+			"200": {{SourceID: "nexusmods", ModID: "300"}},
+		},
+	}
+
+	target := src.mods["100"]
+	installed := make(map[string]bool)
+
+	plan, err := resolveDependencies(context.Background(), src, target, installed)
+	require.NoError(t, err)
+	assert.Len(t, plan.mods, 3)
+	// Order should be: 300 (transitive), 200 (direct), 100 (target)
+	assert.Equal(t, "300", plan.mods[0].ID)
+	assert.Equal(t, "200", plan.mods[1].ID)
+	assert.Equal(t, "100", plan.mods[2].ID)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/lmm/... -v -run TestResolveDependencies`
+Expected: FAIL - `resolveDependencies` undefined
+
+**Step 3: Commit test file**
+
+```bash
+git add cmd/lmm/install_deps_test.go
+git commit -m "test(install): add tests for dependency resolution"
+```
+
+---
+
+## Task 4: Implement `resolveDependencies` Function
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go` (add function at end of file)
+
+**Step 1: Add the depFetcher interface**
+
+Add after the `installPlan` type:
+
+```go
+// depFetcher is the interface needed for dependency resolution
+type depFetcher interface {
+	GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error)
+	GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error)
+}
+```
+
+**Step 2: Implement resolveDependencies**
+
+Add at the end of `cmd/lmm/install.go`:
+
+```go
+// resolveDependencies fetches all dependencies for a mod and returns them in install order.
+// Dependencies are fetched recursively. Already-installed mods are skipped.
+// Missing dependencies (not found on source) are recorded but don't cause failure.
+func resolveDependencies(ctx context.Context, fetcher depFetcher, target *domain.Mod, installedIDs map[string]bool) (*installPlan, error) {
+	plan := &installPlan{}
+	visited := make(map[string]bool)
+
+	var collect func(mod *domain.Mod) error
+	collect = func(mod *domain.Mod) error {
+		key := mod.SourceID + ":" + mod.ID
+		if visited[key] {
+			return nil
+		}
+		visited[key] = true
+
+		// Fetch dependencies for this mod
+		deps, err := fetcher.GetDependencies(ctx, mod)
+		if err != nil {
+			// Log but continue - dependency info might not be available
+			return nil
+		}
+
+		// Process each dependency
+		for _, ref := range deps {
+			depKey := ref.SourceID + ":" + ref.ModID
+
+			// Skip already installed
+			if installedIDs[depKey] {
+				continue
+			}
+
+			// Skip already visited (handles cycles)
+			if visited[depKey] {
+				continue
+			}
+
+			// Fetch the dependency mod
+			depMod, err := fetcher.GetMod(ctx, mod.GameID, ref.ModID)
+			if err != nil {
+				// Dependency not available (external like SKSE)
+				plan.missing = append(plan.missing, depKey)
+				continue
+			}
+			depMod.SourceID = ref.SourceID
+
+			// Recursively collect transitive dependencies
+			if err := collect(depMod); err != nil {
+				return err
+			}
+
+			// Add dependency after its dependencies (topological order)
+			plan.mods = append(plan.mods, depMod)
+		}
+
+		return nil
+	}
+
+	// Collect all dependencies
+	if err := collect(target); err != nil {
+		return nil, err
+	}
+
+	// Add target mod last
+	plan.mods = append(plan.mods, target)
+
+	return plan, nil
+}
+```
+
+**Step 3: Run tests to verify they pass**
+
+Run: `go test ./cmd/lmm/... -v -run TestResolveDependencies`
+Expected: All tests pass
+
+**Step 4: Commit**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "feat(install): implement resolveDependencies for automatic dependency resolution"
+```
+
+---
+
+## Task 5: Add `showInstallPlan` Helper Function
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go` (add after resolveDependencies)
+
+**Step 1: Implement showInstallPlan**
+
+Add after `resolveDependencies`:
+
+```go
+// showInstallPlan displays the install plan to the user
+func showInstallPlan(plan *installPlan, targetModID string) {
+	fmt.Printf("\nInstall plan (%d mod(s)):\n", len(plan.mods))
+	for i, mod := range plan.mods {
+		label := "[dependency]"
+		if mod.ID == targetModID {
+			label = "[target]"
+		}
+		fmt.Printf("  %d. %s v%s (ID: %s) %s\n", i+1, mod.Name, mod.Version, mod.ID, label)
+	}
+
+	if len(plan.missing) > 0 {
+		fmt.Printf("\n⚠ Warning: %d dependency(ies) not available on source:\n", len(plan.missing))
+		for _, m := range plan.missing {
+			fmt.Printf("  - %s (may require manual install)\n", m)
+		}
+	}
+}
+```
+
+**Step 2: Verify compilation**
+
+Run: `go build ./cmd/lmm`
+Expected: Compiles without errors
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "feat(install): add showInstallPlan helper for displaying dependency plan"
+```
+
+---
+
+## Task 6: Create Service Wrapper for depFetcher
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go` (add wrapper type)
+
+**Step 1: Add serviceDepFetcher wrapper**
+
+Add after `depFetcher` interface:
+
+```go
+// serviceDepFetcher wraps core.Service to implement depFetcher
+type serviceDepFetcher struct {
+	svc      *core.Service
+	sourceID string
+}
+
+func (s *serviceDepFetcher) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	return s.svc.GetMod(ctx, s.sourceID, gameID, modID)
+}
+
+func (s *serviceDepFetcher) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	return s.svc.GetDependencies(ctx, s.sourceID, mod)
+}
+```
+
+**Step 2: Add GetDependencies to Service (if not present)**
+
+Check if `service.GetDependencies` exists. If not, add to `internal/core/service.go`:
+
+```go
+// GetDependencies returns dependencies for a mod from the specified source
+func (s *Service) GetDependencies(ctx context.Context, sourceID string, mod *domain.Mod) ([]domain.ModReference, error) {
+	src, err := s.registry.Get(sourceID)
+	if err != nil {
+		return nil, err
+	}
+	return src.GetDependencies(ctx, mod)
+}
+```
+
+**Step 3: Verify compilation**
+
+Run: `go build ./cmd/lmm && go build ./...`
+Expected: Compiles without errors
+
+**Step 4: Commit**
+
+```bash
+git add cmd/lmm/install.go internal/core/service.go
+git commit -m "feat(install): add serviceDepFetcher wrapper for dependency resolution"
+```
+
+---
+
+## Task 7: Integrate Dependency Resolution into runInstall
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go:168-170` (after mod selection, before file selection)
+
+**Step 1: Add dependency resolution after mod selection**
+
+Find the line `fmt.Printf("\nSelected: %s v%s by %s\n", mod.Name, mod.Version, mod.Author)` (around line 170).
+
+Replace the section from there through to file selection with:
+
+```go
+	fmt.Printf("\nSelected: %s v%s by %s\n", mod.Name, mod.Version, mod.Author)
+
+	// Determine profile name early
+	profileName := profileOrDefault(installProfile)
+
+	// Resolve dependencies (unless --no-deps or local mod)
+	var modsToInstall []*domain.Mod
+	if !installNoDeps && mod.SourceID != domain.SourceLocal {
+		fmt.Println("\nResolving dependencies...")
+
+		// Get already-installed mods
+		installedMods, _ := service.GetInstalledMods(gameID, profileName)
+		installedIDs := make(map[string]bool)
+		for _, im := range installedMods {
+			installedIDs[im.SourceID+":"+im.ID] = true
+		}
+
+		// Resolve dependencies
+		fetcher := &serviceDepFetcher{svc: service, sourceID: installSource}
+		plan, err := resolveDependencies(ctx, fetcher, mod, installedIDs)
+		if err != nil {
+			return fmt.Errorf("resolving dependencies: %w", err)
+		}
+
+		// If there are dependencies to install, show plan and confirm
+		if len(plan.mods) > 1 || len(plan.missing) > 0 {
+			showInstallPlan(plan, mod.ID)
+
+			if !installYes {
+				fmt.Printf("\nInstall %d mod(s)? [Y/n]: ", len(plan.mods))
+				reader := bufio.NewReader(os.Stdin)
+				input, _ := reader.ReadString('\n')
+				input = strings.TrimSpace(strings.ToLower(input))
+				if input == "n" || input == "no" {
+					return fmt.Errorf("installation cancelled")
+				}
+			}
+		}
+
+		modsToInstall = plan.mods
+	} else {
+		modsToInstall = []*domain.Mod{mod}
+	}
+
+	// If multiple mods to install (target + deps), use batch install
+	if len(modsToInstall) > 1 {
+		return installModsWithDeps(ctx, service, game, modsToInstall, profileName)
+	}
+
+	// Single mod install - continue with existing flow
+	// (rest of runInstall continues here for single mod case)
+```
+
+**Step 2: Verify compilation**
+
+Run: `go build ./cmd/lmm`
+Expected: Compiles (will have errors about installModsWithDeps - that's Task 8)
+
+**Step 3: Commit partial progress**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "feat(install): integrate dependency resolution into install flow (WIP)"
+```
+
+---
+
+## Task 8: Implement `installModsWithDeps` Function
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go` (add new function)
+
+**Step 1: Implement installModsWithDeps**
+
+Add after `showInstallPlan`:
+
+```go
+// installModsWithDeps installs multiple mods in order (dependencies first)
+func installModsWithDeps(ctx context.Context, service *core.Service, game *domain.Game, mods []*domain.Mod, profileName string) error {
+	fmt.Printf("\nInstalling %d mod(s)...\n", len(mods))
+
+	// Get profile manager and ensure profile exists
+	pm := getProfileManager(service)
+	if _, err := pm.Get(game.ID, profileName); err != nil {
+		if err == domain.ErrProfileNotFound {
+			if _, err := pm.Create(game.ID, profileName); err != nil {
+				return fmt.Errorf("could not create profile: %w", err)
+			}
+		}
+	}
+
+	// Get link method for this game
+	linkMethod := service.GetGameLinkMethod(game)
+
+	var installed []string
+	var failed []string
+
+	for i, mod := range mods {
+		fmt.Printf("\n[%d/%d] Installing: %s v%s\n", i+1, len(mods), mod.Name, mod.Version)
+
+		// Set up installer
+		linker := service.GetLinker(linkMethod)
+		installer := core.NewInstaller(service.GetGameCache(game), linker, service.DB())
+
+		// Check if mod is already installed - if so, uninstall old files first
+		existingMod, err := service.GetInstalledMod(mod.SourceID, mod.ID, game.ID, profileName)
+		if err == nil && existingMod != nil {
+			fmt.Printf("  Removing previous installation...\n")
+			if err := installer.Uninstall(ctx, game, &existingMod.Mod, profileName); err != nil {
+				if verbose {
+					fmt.Printf("  Warning: could not remove old files: %v\n", err)
+				}
+			}
+			if err := service.GetGameCache(game).Delete(game.ID, existingMod.SourceID, existingMod.ID, existingMod.Version); err != nil {
+				if verbose {
+					fmt.Printf("  Warning: could not clear old cache: %v\n", err)
+				}
+			}
+		}
+
+		// Get available files
+		files, err := service.GetModFiles(ctx, mod.SourceID, mod)
+		if err != nil {
+			fmt.Printf("  Error: failed to get mod files: %v\n", err)
+			failed = append(failed, mod.Name)
+			continue
+		}
+
+		// Filter and sort files
+		files = filterAndSortFiles(files, installShowArchived)
+
+		if len(files) == 0 {
+			fmt.Printf("  Error: no downloadable files available\n")
+			failed = append(failed, mod.Name)
+			continue
+		}
+
+		// Auto-select primary or first file
+		var selectedFile *domain.DownloadableFile
+		for j := range files {
+			if files[j].IsPrimary {
+				selectedFile = &files[j]
+				break
+			}
+		}
+		if selectedFile == nil {
+			selectedFile = &files[0]
+		}
+
+		fmt.Printf("  File: %s\n", selectedFile.FileName)
+
+		// Download the mod
+		progressFn := func(p core.DownloadProgress) {
+			if p.TotalBytes > 0 {
+				bar := progressBar(p.Percentage, 20)
+				fmt.Printf("\r  [%s] %.1f%%", bar, p.Percentage)
+			}
+		}
+
+		downloadResult, err := service.DownloadMod(ctx, mod.SourceID, game, mod, selectedFile, progressFn)
+		if err != nil {
+			fmt.Println()
+			fmt.Printf("  Error: download failed: %v\n", err)
+			failed = append(failed, mod.Name)
+			continue
+		}
+		fmt.Println()
+
+		// Display checksum unless --skip-verify
+		if !skipVerify && downloadResult.Checksum != "" {
+			displayChecksum := downloadResult.Checksum
+			if len(displayChecksum) > 12 {
+				displayChecksum = displayChecksum[:12] + "..."
+			}
+			fmt.Printf("  Checksum: %s\n", displayChecksum)
+		}
+
+		// Check for conflicts (unless --force)
+		if !installForce {
+			conflicts, err := installer.GetConflicts(ctx, game, mod, profileName)
+			if err == nil && len(conflicts) > 0 {
+				fmt.Printf("  ⚠ %d file conflict(s) - will overwrite\n", len(conflicts))
+			}
+		}
+
+		if err := installer.Install(ctx, game, mod, profileName); err != nil {
+			fmt.Printf("  Error: deployment failed: %v\n", err)
+			failed = append(failed, mod.Name)
+			continue
+		}
+
+		// Save to database
+		installedMod := &domain.InstalledMod{
+			Mod:          *mod,
+			ProfileName:  profileName,
+			UpdatePolicy: domain.UpdateNotify,
+			Enabled:      true,
+			Deployed:     true,
+			LinkMethod:   linkMethod,
+			FileIDs:      []string{selectedFile.ID},
+		}
+
+		if err := service.DB().SaveInstalledMod(installedMod); err != nil {
+			fmt.Printf("  Error: failed to save mod: %v\n", err)
+			failed = append(failed, mod.Name)
+			continue
+		}
+
+		// Store checksum in database
+		if !skipVerify && downloadResult.Checksum != "" {
+			if err := service.DB().SaveFileChecksum(
+				mod.SourceID, mod.ID, game.ID, profileName, selectedFile.ID, downloadResult.Checksum,
+			); err != nil {
+				fmt.Fprintf(os.Stderr, "  Warning: failed to save checksum: %v\n", err)
+			}
+		}
+
+		// Add to profile
+		modRef := domain.ModReference{
+			SourceID: mod.SourceID,
+			ModID:    mod.ID,
+			Version:  mod.Version,
+			FileIDs:  []string{selectedFile.ID},
+		}
+		if err := pm.UpsertMod(game.ID, profileName, modRef); err != nil {
+			if verbose {
+				fmt.Printf("  Warning: could not update profile: %v\n", err)
+			}
+		}
+
+		fmt.Printf("  ✓ Installed (%d files)\n", downloadResult.FilesExtracted)
+		installed = append(installed, mod.Name)
+	}
+
+	// Summary
+	fmt.Printf("\n--- Summary ---\n")
+	fmt.Printf("Installed: %d\n", len(installed))
+	if len(failed) > 0 {
+		fmt.Printf("Failed: %d (%s)\n", len(failed), strings.Join(failed, ", "))
+	}
+
+	return nil
+}
+```
+
+**Step 2: Run full test suite**
+
+Run: `go test ./... -v`
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "feat(install): implement installModsWithDeps for batch dependency installation"
+```
+
+---
+
+## Task 9: Add Integration Test for Dependency Resolution
+
+**Files:**
+
+- Modify: `cmd/lmm/install_deps_test.go` (add integration test)
+
+**Step 1: Add integration test**
+
+Add to `cmd/lmm/install_deps_test.go`:
+
+```go
+func TestResolveDependencies_CyclicDeps(t *testing.T) {
+	// Mod A depends on B, B depends on A
+	src := &mockDepSource{
+		mods: map[string]*domain.Mod{
+			"100": {ID: "100", SourceID: "nexusmods", Name: "Mod A", GameID: "skyrim"},
+			"200": {ID: "200", SourceID: "nexusmods", Name: "Mod B", GameID: "skyrim"},
+		},
+		deps: map[string][]domain.ModReference{
+			"100": {{SourceID: "nexusmods", ModID: "200"}},
+			"200": {{SourceID: "nexusmods", ModID: "100"}},
+		},
+	}
+
+	target := src.mods["100"]
+	installed := make(map[string]bool)
+
+	// Should not infinite loop - visited map prevents it
+	plan, err := resolveDependencies(context.Background(), src, target, installed)
+	require.NoError(t, err)
+	// Both mods should be in plan (cycle is handled by visited check)
+	assert.Len(t, plan.mods, 2)
+}
+
+func TestResolveDependencies_DeepTransitive(t *testing.T) {
+	// A -> B -> C -> D (4 levels deep)
+	src := &mockDepSource{
+		mods: map[string]*domain.Mod{
+			"A": {ID: "A", SourceID: "nexusmods", Name: "Mod A", GameID: "skyrim"},
+			"B": {ID: "B", SourceID: "nexusmods", Name: "Mod B", GameID: "skyrim"},
+			"C": {ID: "C", SourceID: "nexusmods", Name: "Mod C", GameID: "skyrim"},
+			"D": {ID: "D", SourceID: "nexusmods", Name: "Mod D", GameID: "skyrim"},
+		},
+		deps: map[string][]domain.ModReference{
+			"A": {{SourceID: "nexusmods", ModID: "B"}},
+			"B": {{SourceID: "nexusmods", ModID: "C"}},
+			"C": {{SourceID: "nexusmods", ModID: "D"}},
+		},
+	}
+
+	target := src.mods["A"]
+	installed := make(map[string]bool)
+
+	plan, err := resolveDependencies(context.Background(), src, target, installed)
+	require.NoError(t, err)
+	assert.Len(t, plan.mods, 4)
+	// Order should be D, C, B, A (deepest first)
+	assert.Equal(t, "D", plan.mods[0].ID)
+	assert.Equal(t, "C", plan.mods[1].ID)
+	assert.Equal(t, "B", plan.mods[2].ID)
+	assert.Equal(t, "A", plan.mods[3].ID)
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go test ./cmd/lmm/... -v -run TestResolveDependencies`
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/install_deps_test.go
+git commit -m "test(install): add tests for cyclic and deep transitive dependencies"
+```
+
+---
+
+## Task 10: Update Command Help Text
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go:34-47` (Long description)
+
+**Step 1: Update help text**
+
+Update the `Long` field of `installCmd`:
+
+```go
+	Long: `Install a mod from the configured source.
+
+The mod will be searched for by name and added to the specified profile
+(or default profile if not specified).
+
+Dependencies are automatically resolved and installed. Use --no-deps to skip.
+
+When selecting files, you can choose multiple files (e.g., main + optional patches)
+using comma-separated values or ranges: 1,3,5 or 1-3 or 1,3-5
+
+Examples:
+  lmm install "ore stack" --game starrupture
+  lmm install "skyui" --game skyrim-se --profile survival
+  lmm install --id 12345 --game skyrim-se
+  lmm install "mod name" -g skyrim-se -y       # Auto-select and auto-confirm
+  lmm install "mod name" -g skyrim-se --no-deps  # Skip dependencies`,
+```
+
+**Step 2: Verify help output**
+
+Run: `go build ./cmd/lmm && ./lmm install --help`
+Expected: Shows updated help with dependency info
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "docs(install): update help text to mention automatic dependency resolution"
+```
+
+---
+
+## Task 11: Run Full Test Suite and Lint
+
+**Files:** None (verification only)
+
+**Step 1: Run all tests**
+
+Run: `go test ./... -v`
+Expected: All tests pass
+
+**Step 2: Run linter**
+
+Run: `trunk check`
+Expected: No errors (warnings OK)
+
+**Step 3: Fix any issues**
+
+If lint errors, fix them and re-run.
+
+**Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: address lint issues"
+```
+
+---
+
+## Task 12: Version Bump and Changelog
+
+**Files:**
+
+- Modify: `cmd/lmm/root.go:16` (version)
+- Modify: `CHANGELOG.md`
+
+**Step 1: Bump version to 0.11.0**
+
+In `cmd/lmm/root.go`, change:
+
+```go
+version = "0.11.0"
+```
+
+**Step 2: Update CHANGELOG.md**
+
+Add new section at top (after `# Changelog`):
+
+```markdown
+## [0.11.0] - 2026-01-28
+
+### Added
+
+- **Automatic dependency installation**: `lmm install` now resolves and installs mod dependencies automatically
+  - Shows install plan with dependencies in topological order
+  - Warns about dependencies not available on source (external deps like SKSE)
+  - `--no-deps` flag to skip dependency installation
+  - `-y` flag auto-confirms dependency installation
+```
+
+Update comparison links at bottom.
+
+**Step 3: Commit version bump**
+
+```bash
+git add cmd/lmm/root.go CHANGELOG.md
+git commit -m "chore: bump version to 0.11.0"
+```
+
+---
+
+## Task 13: Final Verification
+
+**Step 1: Build and test**
+
+Run: `go build ./cmd/lmm && go test ./... -v`
+Expected: All pass
+
+**Step 2: Manual smoke test (if game configured)**
+
+```bash
+./lmm install "skyui" --game skyrim-se --no-deps  # Should work without deps
+./lmm install "skyui" --game skyrim-se -y         # Should resolve deps
+```
+
+**Step 3: Verify git status**
+
+Run: `git status`
+Expected: Clean working tree
+
+**Step 4: Done!**
+
+All tasks complete. Ready for code review.

--- a/docs/plans/archive/2026-01-28-p4-local-import-design.md
+++ b/docs/plans/archive/2026-01-28-p4-local-import-design.md
@@ -1,0 +1,186 @@
+# P4 Local Mod Import Design
+
+**Date**: 2026-01-28
+**Priority**: P4 (after Checksum Verification, Conflict Detection, and Auto-Dependencies)
+**Goal**: Allow users to install mods from local archive files downloaded manually
+
+---
+
+## Overview
+
+Enable importing mods from local archive files (zip, 7z, rar) without going through NexusMods download flow. Supports auto-linking to NexusMods for update tracking when filename matches their naming pattern.
+
+## Command Interface
+
+```bash
+lmm import <archive-path> [--game <game-id>] [--profile <name>] [--force]
+```
+
+**Arguments:**
+
+- `archive-path` - Path to local archive file (required)
+
+**Flags:**
+
+- `--game, -g` - Target game (optional if default game is set)
+- `--profile, -p` - Target profile (default: "default")
+- `--source, -s` - Explicit source for linking (default: auto-detect or "local")
+- `--id` - Explicit mod ID for linking to NexusMods
+- `--force, -f` - Install without conflict prompts
+
+**Examples:**
+
+```bash
+lmm import ~/Downloads/SkyUI-12604-5-2SE.zip --game skyrim-se
+lmm import mod.7z                              # uses default game
+lmm import mod.zip --id 12345 --source nexusmods  # explicit linking
+```
+
+## Design Decisions
+
+| Decision             | Choice                                              | Rationale                               |
+| -------------------- | --------------------------------------------------- | --------------------------------------- |
+| Mod identity         | Smart filename parsing with fallback                | Best UX - auto-links when possible      |
+| Mod name             | Extracted folder name, fallback to archive basename | Folder names are often more descriptive |
+| Version              | Parse from filename, fallback to "unknown"          | Automatic, no user friction             |
+| Original archive     | Leave untouched                                     | Safest, least surprising                |
+| Local source type    | Hardcoded string constant                           | No-op interface is a code smell         |
+| Multi-file support   | Single file only                                    | Simple, shell tools handle batch        |
+| Archive path storage | Don't store                                         | Avoids stale references                 |
+
+## Filename Parsing
+
+NexusMods downloads follow pattern: `ModName-ModID-Version.ext`
+
+**Examples:**
+
+- `SkyUI_5_2_SE-12604-5-2SE.zip` → mod_id: 12604, version: 5.2SE
+- `Unofficial Skyrim Special Edition Patch-266-4-3-0a-1725557498.7z` → mod_id: 266, version: 4.3.0a
+- `SKSE64-30379-2-2-6-1703618069.7z` → mod_id: 30379, version: 2.2.6
+
+**Parsing logic:**
+
+1. Strip extension
+2. Regex match: `^(.+)-(\d+)-(.+)$` (name, mod ID, version)
+3. Strip trailing timestamps (10+ digit suffixes)
+4. Normalize version: replace `-` with `.`
+
+**Fallbacks:**
+
+- No pattern match → source_id: "local", mod_id: generated UUID
+- No version detected → version: "unknown"
+
+## Local Source Handling
+
+No `LocalSource` interface implementation. Just a string constant:
+
+```go
+// In internal/domain/mod.go
+const SourceLocal = "local"
+```
+
+Handling in code:
+
+- Import command sets `mod.SourceID = domain.SourceLocal`
+- Update checker skips mods where `SourceID == domain.SourceLocal`
+- List command displays "(local)" for these mods
+
+## Import Flow
+
+1. Validate archive exists and format is supported (.zip, .7z, .rar)
+2. Parse filename for NexusMods pattern (or use explicit `--id`/`--source`)
+3. If linked to NexusMods, fetch mod metadata via API for accurate name/info
+4. Extract archive to temp directory
+5. Detect mod name from top-level folder structure
+6. Move extracted files to cache location
+7. Check for conflicts (use existing `installer.GetConflicts()`)
+8. If conflicts and no `--force`, prompt user
+9. Deploy via existing `installer.Install()`
+10. Save to database and profile
+
+## New Files
+
+### `cmd/lmm/import.go`
+
+Import command implementation with flag handling and user interaction.
+
+### `internal/core/filename_parser.go`
+
+```go
+// ParsedFilename contains extracted info from a NexusMods-style filename
+type ParsedFilename struct {
+    ModID    string
+    Version  string
+    BaseName string
+}
+
+// ParseNexusModsFilename attempts to extract mod ID and version
+func ParseNexusModsFilename(filename string) *ParsedFilename
+
+// DetectModName returns a display name from extracted archive contents
+func DetectModName(extractedPath, archiveBasename string) string
+```
+
+## Modified Files
+
+### `internal/core/service.go`
+
+Add `ImportMod()` method:
+
+```go
+type ImportOptions struct {
+    SourceID    string
+    ModID       string
+    ProfileName string
+}
+
+type ImportResult struct {
+    Mod            *domain.Mod
+    FilesExtracted int
+    LinkedSource   string
+    AutoDetected   bool
+}
+
+func (s *Service) ImportMod(ctx context.Context, archivePath string, game *domain.Game, opts ImportOptions) (*ImportResult, error)
+```
+
+### `internal/domain/mod.go`
+
+Add constant:
+
+```go
+const SourceLocal = "local"
+```
+
+## Testing Strategy
+
+**Unit tests:**
+
+- `filename_parser_test.go` - table-driven tests for filename patterns
+- `service_test.go` - ImportMod with various scenarios
+
+**Integration tests:**
+
+- End-to-end import with temp directories
+- Conflict handling verification
+- NexusMods linking verification
+
+**Test fixtures:**
+
+- Small test archives in `testdata/`
+- Mock NexusMods responses for linked imports
+
+## Edge Cases
+
+- Archive with no top-level folder → use archive basename for name
+- Archive contains only one file (not an archive structure) → treat as single-file mod
+- NexusMods API unavailable when linked → warn and continue with parsed info
+- Mod ID collision with existing local mod → generate new UUID
+- Unsupported archive format → clear error message
+
+## Future Considerations (Not in Scope)
+
+- Directory watching for auto-import
+- Batch import from directory
+- Archive path storage for re-import
+- Local mod "update" via file replacement

--- a/docs/plans/archive/2026-01-28-p4-local-import-impl.md
+++ b/docs/plans/archive/2026-01-28-p4-local-import-impl.md
@@ -1,0 +1,1099 @@
+# P4 Local Mod Import Implementation Plan
+
+<!-- markdownlint-disable MD010 MD036 -->
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow users to install mods from local archive files with smart NexusMods filename detection for update tracking.
+
+**Architecture:** New `import` command extracts local archives to cache, auto-detects NexusMods mod IDs from filenames, and reuses existing installer for deployment. Local mods without NexusMods links use `source_id = "local"` and skip update checks.
+
+**Tech Stack:** Go, Cobra CLI, regex for filename parsing, existing extractor/installer infrastructure
+
+---
+
+## Task 1: Add SourceLocal Constant
+
+**Files:**
+
+- Modify: `internal/domain/mod.go`
+- Test: `internal/domain/mod_test.go`
+
+**Step 1: Write the test**
+
+Create `internal/domain/mod_test.go` (if it doesn't exist) or add to it:
+
+```go
+package domain
+
+import "testing"
+
+func TestSourceLocal_IsExpectedValue(t *testing.T) {
+	if SourceLocal != "local" {
+		t.Errorf("SourceLocal = %q, want %q", SourceLocal, "local")
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/domain/... -v -run TestSourceLocal`
+Expected: FAIL with "undefined: SourceLocal"
+
+**Step 3: Add the constant**
+
+Add to `internal/domain/mod.go` near the top with other constants:
+
+```go
+// SourceLocal is the source ID for mods imported from local files
+const SourceLocal = "local"
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/domain/... -v -run TestSourceLocal`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/domain/mod.go internal/domain/mod_test.go
+git commit -m "feat(domain): add SourceLocal constant for local mod imports"
+```
+
+---
+
+## Task 2: Create Filename Parser with Tests
+
+**Files:**
+
+- Create: `internal/core/filename_parser.go`
+- Create: `internal/core/filename_parser_test.go`
+
+**Step 1: Write the failing tests**
+
+Create `internal/core/filename_parser_test.go`:
+
+```go
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNexusModsFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     *ParsedFilename
+	}{
+		{
+			name:     "standard nexusmods pattern",
+			filename: "SkyUI-12604-5-2SE.zip",
+			want:     &ParsedFilename{ModID: "12604", Version: "5.2SE", BaseName: "SkyUI"},
+		},
+		{
+			name:     "pattern with underscores in name",
+			filename: "SkyUI_5_2_SE-12604-5-2SE.zip",
+			want:     &ParsedFilename{ModID: "12604", Version: "5.2SE", BaseName: "SkyUI_5_2_SE"},
+		},
+		{
+			name:     "pattern with timestamp suffix",
+			filename: "SKSE64-30379-2-2-6-1703618069.7z",
+			want:     &ParsedFilename{ModID: "30379", Version: "2.2.6", BaseName: "SKSE64"},
+		},
+		{
+			name:     "pattern with spaces replaced by dashes",
+			filename: "Unofficial-Skyrim-Patch-266-4-3-0a.zip",
+			want:     &ParsedFilename{ModID: "266", Version: "4.3.0a", BaseName: "Unofficial-Skyrim-Patch"},
+		},
+		{
+			name:     "no pattern - simple name",
+			filename: "my-cool-mod.zip",
+			want:     nil,
+		},
+		{
+			name:     "no pattern - no version after id",
+			filename: "ModName-12345.zip",
+			want:     nil,
+		},
+		{
+			name:     "7z extension",
+			filename: "TestMod-99999-1-0.7z",
+			want:     &ParsedFilename{ModID: "99999", Version: "1.0", BaseName: "TestMod"},
+		},
+		{
+			name:     "rar extension",
+			filename: "TestMod-88888-2-1.rar",
+			want:     &ParsedFilename{ModID: "88888", Version: "2.1", BaseName: "TestMod"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseNexusModsFilename(tt.filename)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectModName(t *testing.T) {
+	// This will be tested with actual directories in integration tests
+	// For now, test the fallback behavior
+	t.Run("empty path returns archive basename", func(t *testing.T) {
+		got := DetectModName("", "MyMod-123-1-0.zip")
+		assert.Equal(t, "MyMod-123-1-0", got)
+	})
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/... -v -run "TestParseNexus|TestDetectMod"`
+Expected: FAIL with "undefined: ParseNexusModsFilename"
+
+**Step 3: Implement the parser**
+
+Create `internal/core/filename_parser.go`:
+
+```go
+package core
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ParsedFilename contains extracted info from a NexusMods-style filename
+type ParsedFilename struct {
+	ModID    string // NexusMods mod ID
+	Version  string // Mod version (normalized)
+	BaseName string // Mod name portion before the ID
+}
+
+// nexusPattern matches NexusMods filename format: Name-ModID-Version.ext
+// Example: SkyUI-12604-5-2SE.zip -> groups: SkyUI, 12604, 5-2SE
+var nexusPattern = regexp.MustCompile(`^(.+)-(\d+)-([^.]+)\.[a-zA-Z0-9]+$`)
+
+// timestampSuffix matches trailing timestamps (10+ digits at end of version)
+var timestampSuffix = regexp.MustCompile(`-\d{10,}$`)
+
+// ParseNexusModsFilename attempts to extract mod ID and version from a
+// NexusMods-style filename like "SkyUI-12604-5-2SE.zip".
+// Returns nil if the filename doesn't match the expected pattern.
+func ParseNexusModsFilename(filename string) *ParsedFilename {
+	// Get just the filename without path
+	filename = filepath.Base(filename)
+
+	matches := nexusPattern.FindStringSubmatch(filename)
+	if matches == nil {
+		return nil
+	}
+
+	baseName := matches[1]
+	modID := matches[2]
+	version := matches[3]
+
+	// Strip trailing timestamp from version (e.g., -1703618069)
+	version = timestampSuffix.ReplaceAllString(version, "")
+
+	// Normalize version: replace dashes with dots
+	version = strings.ReplaceAll(version, "-", ".")
+
+	return &ParsedFilename{
+		ModID:    modID,
+		Version:  version,
+		BaseName: baseName,
+	}
+}
+
+// DetectModName determines a display name for an imported mod.
+// It checks for a single top-level directory in the extracted content,
+// falling back to the archive basename if not found.
+func DetectModName(extractedPath, archiveFilename string) string {
+	// If no extracted path provided, use archive basename
+	if extractedPath == "" {
+		return stripExtension(archiveFilename)
+	}
+
+	// Try to find a single top-level directory
+	entries, err := filepath.Glob(filepath.Join(extractedPath, "*"))
+	if err != nil || len(entries) == 0 {
+		return stripExtension(archiveFilename)
+	}
+
+	// If there's exactly one entry and it's a directory, use its name
+	if len(entries) == 1 {
+		info, err := filepath.Abs(entries[0])
+		if err == nil {
+			// Check if it's a directory by trying to list it
+			subEntries, err := filepath.Glob(filepath.Join(info, "*"))
+			if err == nil && len(subEntries) > 0 {
+				return filepath.Base(entries[0])
+			}
+		}
+	}
+
+	// Fallback to archive basename
+	return stripExtension(archiveFilename)
+}
+
+// stripExtension removes the file extension from a filename
+func stripExtension(filename string) string {
+	filename = filepath.Base(filename)
+	ext := filepath.Ext(filename)
+	return strings.TrimSuffix(filename, ext)
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/... -v -run "TestParseNexus|TestDetectMod"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/core/filename_parser.go internal/core/filename_parser_test.go
+git commit -m "feat(core): add NexusMods filename parser for local imports"
+```
+
+---
+
+## Task 3: Add ImportMod Method to Service
+
+**Files:**
+
+- Modify: `internal/core/service.go`
+- Create: `internal/core/service_import_test.go`
+
+**Step 1: Write the failing test**
+
+Create `internal/core/service_import_test.go`:
+
+```go
+package core_test
+
+import (
+	"archive/zip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/db"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestZip creates a simple zip archive for testing
+func createTestZip(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	w := zip.NewWriter(f)
+	defer w.Close()
+
+	for name, content := range files {
+		fw, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = fw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+}
+
+func TestImportMod_LocalArchive(t *testing.T) {
+	// Setup temp directories
+	tempDir := t.TempDir()
+	cacheDir := filepath.Join(tempDir, "cache")
+	archivePath := filepath.Join(tempDir, "TestMod.zip")
+
+	// Create test archive
+	createTestZip(t, archivePath, map[string]string{
+		"data/plugin.esp":   "test plugin",
+		"data/textures.dds": "test texture",
+	})
+
+	// Create cache and database
+	modCache := cache.New(cacheDir)
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer database.Close()
+
+	game := &domain.Game{
+		ID:      "testgame",
+		Name:    "Test Game",
+		ModPath: filepath.Join(tempDir, "game", "mods"),
+	}
+
+	// Create importer
+	importer := core.NewImporter(modCache, database)
+
+	// Import the mod
+	ctx := context.Background()
+	result, err := importer.Import(ctx, archivePath, game, core.ImportOptions{
+		ProfileName: "default",
+	})
+	require.NoError(t, err)
+
+	// Verify result
+	assert.Equal(t, domain.SourceLocal, result.Mod.SourceID)
+	assert.Equal(t, "TestMod", result.Mod.Name)
+	assert.Equal(t, 2, result.FilesExtracted)
+	assert.False(t, result.AutoDetected)
+
+	// Verify files are in cache
+	assert.True(t, modCache.Exists(game.ID, domain.SourceLocal, result.Mod.ID, result.Mod.Version))
+}
+
+func TestImportMod_NexusModsFilename(t *testing.T) {
+	// Setup temp directories
+	tempDir := t.TempDir()
+	cacheDir := filepath.Join(tempDir, "cache")
+	archivePath := filepath.Join(tempDir, "SkyUI-12604-5-2SE.zip")
+
+	// Create test archive
+	createTestZip(t, archivePath, map[string]string{
+		"SkyUI/plugin.esp": "test plugin",
+	})
+
+	modCache := cache.New(cacheDir)
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer database.Close()
+
+	game := &domain.Game{
+		ID:      "skyrim-se",
+		Name:    "Skyrim SE",
+		ModPath: filepath.Join(tempDir, "game", "mods"),
+	}
+
+	importer := core.NewImporter(modCache, database)
+
+	ctx := context.Background()
+	result, err := importer.Import(ctx, archivePath, game, core.ImportOptions{
+		ProfileName: "default",
+	})
+	require.NoError(t, err)
+
+	// Should detect NexusMods pattern but use "local" since we can't verify
+	// (no API call in basic import - linking happens in command layer)
+	assert.Equal(t, "12604", result.Mod.ID)
+	assert.Equal(t, "5.2SE", result.Mod.Version)
+	assert.True(t, result.AutoDetected)
+}
+
+func TestImportMod_UnsupportedFormat(t *testing.T) {
+	tempDir := t.TempDir()
+	cacheDir := filepath.Join(tempDir, "cache")
+	archivePath := filepath.Join(tempDir, "mod.txt")
+
+	// Create a non-archive file
+	require.NoError(t, os.WriteFile(archivePath, []byte("not an archive"), 0644))
+
+	modCache := cache.New(cacheDir)
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer database.Close()
+
+	game := &domain.Game{ID: "testgame"}
+
+	importer := core.NewImporter(modCache, database)
+
+	ctx := context.Background()
+	_, err = importer.Import(ctx, archivePath, game, core.ImportOptions{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported")
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/... -v -run TestImportMod`
+Expected: FAIL with "undefined: core.NewImporter"
+
+**Step 3: Implement the Importer**
+
+Add to `internal/core/service.go` (or create new file `internal/core/importer.go`):
+
+```go
+// Add to internal/core/importer.go (new file)
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/db"
+	"github.com/google/uuid"
+)
+
+// ImportOptions configures the import operation
+type ImportOptions struct {
+	SourceID    string // Explicit source (empty = auto-detect or "local")
+	ModID       string // Explicit mod ID (empty = auto-detect or generate)
+	ProfileName string // Target profile
+}
+
+// ImportResult contains the outcome of importing a local mod
+type ImportResult struct {
+	Mod            *domain.Mod
+	FilesExtracted int
+	LinkedSource   string // "nexusmods", "local", etc.
+	AutoDetected   bool   // true if source/ID was parsed from filename
+}
+
+// Importer handles importing mods from local archive files
+type Importer struct {
+	cache     *cache.Cache
+	db        *db.DB
+	extractor *Extractor
+}
+
+// NewImporter creates a new Importer
+func NewImporter(cache *cache.Cache, database *db.DB) *Importer {
+	return &Importer{
+		cache:     cache,
+		db:        database,
+		extractor: NewExtractor(),
+	}
+}
+
+// Import imports a mod from a local archive file
+func (i *Importer) Import(ctx context.Context, archivePath string, game *domain.Game, opts ImportOptions) (*ImportResult, error) {
+	// Validate archive exists
+	if _, err := os.Stat(archivePath); err != nil {
+		return nil, fmt.Errorf("archive not found: %w", err)
+	}
+
+	// Validate format is supported
+	if !i.extractor.CanExtract(archivePath) {
+		return nil, fmt.Errorf("unsupported archive format: %s", filepath.Ext(archivePath))
+	}
+
+	filename := filepath.Base(archivePath)
+
+	// Try to parse NexusMods filename pattern
+	var sourceID, modID, version string
+	var autoDetected bool
+
+	if opts.SourceID != "" && opts.ModID != "" {
+		// Explicit linking provided
+		sourceID = opts.SourceID
+		modID = opts.ModID
+		version = "unknown"
+	} else if parsed := ParseNexusModsFilename(filename); parsed != nil {
+		// Auto-detected from filename
+		sourceID = domain.SourceLocal // Still local until verified via API
+		modID = parsed.ModID
+		version = parsed.Version
+		autoDetected = true
+	} else {
+		// No pattern - pure local mod
+		sourceID = domain.SourceLocal
+		modID = uuid.New().String()
+		version = "unknown"
+	}
+
+	// Extract to temp directory first
+	tempDir, err := os.MkdirTemp("", "lmm-import-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	extractedPath := filepath.Join(tempDir, "extracted")
+	if err := i.extractor.Extract(archivePath, extractedPath); err != nil {
+		return nil, fmt.Errorf("extracting archive: %w", err)
+	}
+
+	// Detect mod name from extracted content
+	modName := DetectModName(extractedPath, filename)
+
+	// Move extracted files to cache
+	cachePath := i.cache.ModPath(game.ID, sourceID, modID, version)
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err != nil {
+		return nil, fmt.Errorf("creating cache directory: %w", err)
+	}
+
+	// Remove existing cache if present (re-import case)
+	os.RemoveAll(cachePath)
+
+	if err := os.Rename(extractedPath, cachePath); err != nil {
+		// If rename fails (cross-device), fall back to copy
+		if err := copyDir(extractedPath, cachePath); err != nil {
+			return nil, fmt.Errorf("moving to cache: %w", err)
+		}
+	}
+
+	// Count extracted files
+	files, err := i.cache.ListFiles(game.ID, sourceID, modID, version)
+	if err != nil {
+		return nil, fmt.Errorf("listing cached files: %w", err)
+	}
+
+	mod := &domain.Mod{
+		ID:       modID,
+		SourceID: sourceID,
+		Name:     modName,
+		Version:  version,
+		GameID:   game.ID,
+	}
+
+	return &ImportResult{
+		Mod:            mod,
+		FilesExtracted: len(files),
+		LinkedSource:   sourceID,
+		AutoDetected:   autoDetected,
+	}, nil
+}
+
+// copyDir recursively copies a directory
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(dstPath, data, info.Mode())
+	})
+}
+```
+
+**Step 4: Add uuid dependency**
+
+Run: `go get github.com/google/uuid`
+
+**Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/core/... -v -run TestImportMod`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/core/importer.go internal/core/service_import_test.go go.mod go.sum
+git commit -m "feat(core): add Importer for local mod imports"
+```
+
+---
+
+## Task 4: Create Import Command
+
+**Files:**
+
+- Create: `cmd/lmm/import.go`
+
+**Step 1: Create the import command**
+
+Create `cmd/lmm/import.go`:
+
+```go
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	importProfile string
+	importSource  string
+	importModID   string
+	importForce   bool
+)
+
+var importCmd = &cobra.Command{
+	Use:   "import <archive-path>",
+	Short: "Import a mod from a local archive file",
+	Long: `Import a mod from a local archive file (zip, 7z, rar).
+
+If the filename matches NexusMods naming pattern (ModName-ModID-Version.ext),
+the mod ID and version will be auto-detected. Otherwise, it's tracked as a
+local mod with no update checking.
+
+Supported formats: .zip, .7z, .rar
+
+Examples:
+  lmm import ~/Downloads/SkyUI-12604-5-2SE.zip --game skyrim-se
+  lmm import mod.7z                              # uses default game
+  lmm import mod.zip --id 12345 --source nexusmods  # explicit linking`,
+	Args: cobra.ExactArgs(1),
+	RunE: runImport,
+}
+
+func init() {
+	importCmd.Flags().StringVarP(&importProfile, "profile", "p", "", "profile to import to (default: default)")
+	importCmd.Flags().StringVarP(&importSource, "source", "s", "", "source for update tracking (default: auto-detect or local)")
+	importCmd.Flags().StringVar(&importModID, "id", "", "mod ID for linking (requires --source)")
+	importCmd.Flags().BoolVarP(&importForce, "force", "f", false, "import without conflict prompts")
+
+	rootCmd.AddCommand(importCmd)
+}
+
+func runImport(cmd *cobra.Command, args []string) error {
+	if err := requireGame(cmd); err != nil {
+		return err
+	}
+
+	archivePath := args[0]
+
+	// Validate archive exists
+	if _, err := os.Stat(archivePath); err != nil {
+		return fmt.Errorf("archive not found: %s", archivePath)
+	}
+
+	service, err := initService()
+	if err != nil {
+		return fmt.Errorf("initializing service: %w", err)
+	}
+	defer service.Close()
+
+	// Get game
+	game, err := service.GetGame(gameID)
+	if err != nil {
+		return fmt.Errorf("game not found: %s", gameID)
+	}
+
+	profileName := profileOrDefault(importProfile)
+
+	// Validate explicit linking options
+	if (importSource != "" && importModID == "") || (importSource == "" && importModID != "") {
+		return fmt.Errorf("--source and --id must be used together")
+	}
+
+	ctx := context.Background()
+
+	// Create importer
+	importer := core.NewImporter(service.GetGameCache(game), service.DB())
+
+	// Import the mod
+	fmt.Printf("Importing %s...\n", archivePath)
+
+	result, err := importer.Import(ctx, archivePath, game, core.ImportOptions{
+		SourceID:    importSource,
+		ModID:       importModID,
+		ProfileName: profileName,
+	})
+	if err != nil {
+		return fmt.Errorf("import failed: %w", err)
+	}
+
+	// Show what was detected
+	if result.AutoDetected {
+		fmt.Printf("  Detected NexusMods ID: %s\n", result.Mod.ID)
+		fmt.Printf("  Detected version: %s\n", result.Mod.Version)
+	}
+	fmt.Printf("  Mod name: %s\n", result.Mod.Name)
+	fmt.Printf("  Files extracted: %d\n", result.FilesExtracted)
+
+	// Check for conflicts
+	linkMethod := service.GetGameLinkMethod(game)
+	installer := core.NewInstaller(service.GetGameCache(game), service.GetLinker(linkMethod), service.DB())
+
+	if !importForce {
+		conflicts, err := installer.GetConflicts(ctx, game, result.Mod, profileName)
+		if err != nil {
+			if verbose {
+				fmt.Printf("  Warning: could not check conflicts: %v\n", err)
+			}
+		} else if len(conflicts) > 0 {
+			fmt.Printf("\n⚠ File conflicts detected:\n")
+
+			// Group conflicts by mod
+			modConflicts := make(map[string][]string)
+			for _, c := range conflicts {
+				key := c.CurrentSourceID + ":" + c.CurrentModID
+				modConflicts[key] = append(modConflicts[key], c.RelativePath)
+			}
+
+			for key, paths := range modConflicts {
+				parts := strings.SplitN(key, ":", 2)
+				sourceID, modID := parts[0], parts[1]
+
+				conflictMod, _ := service.GetInstalledMod(sourceID, modID, gameID, profileName)
+				modName := modID
+				if conflictMod != nil {
+					modName = conflictMod.Name
+				}
+
+				fmt.Printf("  From %s (%s):\n", modName, modID)
+				maxShow := 5
+				for i, p := range paths {
+					if i >= maxShow {
+						fmt.Printf("    ... and %d more\n", len(paths)-maxShow)
+						break
+					}
+					fmt.Printf("    - %s\n", p)
+				}
+			}
+
+			fmt.Printf("\n%d file(s) will be overwritten. Continue? [y/N]: ", len(conflicts))
+			reader := bufio.NewReader(os.Stdin)
+			input, _ := reader.ReadString('\n')
+			input = strings.TrimSpace(strings.ToLower(input))
+			if input != "y" && input != "yes" {
+				return fmt.Errorf("import cancelled")
+			}
+		}
+	}
+
+	// Deploy to game directory
+	fmt.Println("\nDeploying to game directory...")
+
+	if err := installer.Install(ctx, game, result.Mod, profileName); err != nil {
+		return fmt.Errorf("deployment failed: %w", err)
+	}
+
+	// Save to database
+	installedMod := &domain.InstalledMod{
+		Mod:          *result.Mod,
+		ProfileName:  profileName,
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+		Deployed:     true,
+		LinkMethod:   linkMethod,
+	}
+
+	if err := service.DB().SaveInstalledMod(installedMod); err != nil {
+		return fmt.Errorf("failed to save mod: %w", err)
+	}
+
+	// Add to profile
+	pm := getProfileManager(service)
+	modRef := domain.ModReference{
+		SourceID: result.Mod.SourceID,
+		ModID:    result.Mod.ID,
+		Version:  result.Mod.Version,
+	}
+
+	if _, err := pm.Get(gameID, profileName); err != nil {
+		if err == domain.ErrProfileNotFound {
+			if _, err := pm.Create(gameID, profileName); err != nil {
+				if verbose {
+					fmt.Printf("  Warning: could not create profile: %v\n", err)
+				}
+			}
+		}
+	}
+
+	if err := pm.UpsertMod(gameID, profileName, modRef); err != nil {
+		if verbose {
+			fmt.Printf("  Warning: could not update profile: %v\n", err)
+		}
+	}
+
+	// Success message
+	sourceDisplay := result.Mod.SourceID
+	if sourceDisplay == domain.SourceLocal {
+		sourceDisplay = "local"
+	}
+
+	fmt.Printf("\n✓ Imported: %s v%s (%s)\n", result.Mod.Name, result.Mod.Version, sourceDisplay)
+	fmt.Printf("  Added to profile: %s\n", profileName)
+
+	return nil
+}
+```
+
+**Step 2: Verify build**
+
+Run: `go build -o lmm ./cmd/lmm`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/import.go
+git commit -m "feat(cli): add import command for local mod archives"
+```
+
+---
+
+## Task 5: Update List Command to Show Local Source
+
+**Files:**
+
+- Modify: `cmd/lmm/list.go`
+
+**Step 1: Find and update the list display**
+
+In `cmd/lmm/list.go`, find where mods are displayed and update to show "(local)" for local mods. Look for the format string that displays source info.
+
+Update the display to handle local source:
+
+```go
+// Find the line that displays source and update it to something like:
+sourceDisplay := m.SourceID
+if m.SourceID == domain.SourceLocal {
+    sourceDisplay = "local"
+}
+// Then use sourceDisplay in the output
+```
+
+**Step 2: Verify the change**
+
+Run: `go build -o lmm ./cmd/lmm && ./lmm list --help`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/list.go
+git commit -m "feat(cli): show (local) source in list output"
+```
+
+---
+
+## Task 6: Skip Local Mods in Update Check
+
+**Files:**
+
+- Modify: `cmd/lmm/update.go` (or wherever update checking happens)
+
+**Step 1: Find update check logic**
+
+Search for where `CheckUpdates` is called and add a filter to skip local mods:
+
+```go
+// Filter out local mods before checking updates
+var modsToCheck []domain.InstalledMod
+for _, m := range installedMods {
+    if m.SourceID != domain.SourceLocal {
+        modsToCheck = append(modsToCheck, m)
+    }
+}
+```
+
+**Step 2: Verify build**
+
+Run: `go build -o lmm ./cmd/lmm`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/update.go
+git commit -m "fix(cli): skip local mods when checking for updates"
+```
+
+---
+
+## Task 7: Add Integration Test for Full Import Flow
+
+**Files:**
+
+- Create: `cmd/lmm/import_test.go`
+
+**Step 1: Create end-to-end test**
+
+Create `cmd/lmm/import_test.go`:
+
+```go
+package main
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportCommand_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// This is a placeholder for manual testing
+	// Full integration tests would require:
+	// 1. Setting up a test config directory
+	// 2. Creating a test game config
+	// 3. Running the import command
+	// 4. Verifying files are deployed
+
+	t.Log("Import command integration test - run manually with: ./lmm import testmod.zip -g testgame")
+}
+
+func createTestArchive(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	w := zip.NewWriter(f)
+	for name, content := range files {
+		fw, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = fw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add cmd/lmm/import_test.go
+git commit -m "test(cli): add import command integration test placeholder"
+```
+
+---
+
+## Task 8: Run Full Test Suite and Lint
+
+**Step 1: Run all tests**
+
+Run: `go test ./... -v`
+Expected: All tests PASS
+
+**Step 2: Run linter**
+
+Run: `trunk check`
+Expected: No errors (or only pre-existing ones)
+
+**Step 3: Format code**
+
+Run: `go fmt ./...`
+
+**Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "chore: fix lint issues" --allow-empty
+```
+
+---
+
+## Task 9: Update Version and Changelog
+
+**Files:**
+
+- Modify: `cmd/lmm/root.go`
+- Modify: `CHANGELOG.md`
+
+**Step 1: Bump version**
+
+In `cmd/lmm/root.go`, update:
+
+```go
+version = "0.10.0"
+```
+
+**Step 2: Update changelog**
+
+Add to `CHANGELOG.md` under a new `## [0.10.0]` section:
+
+```markdown
+## [0.10.0] - 2026-01-28
+
+### Added
+
+- `lmm import` command for importing mods from local archive files
+- Smart NexusMods filename detection (parses ModName-ModID-Version.ext pattern)
+- Local mods tracked with `source_id = "local"` (no update checking)
+- Support for .zip, .7z, and .rar archives
+
+### Changed
+
+- `lmm list` now shows "(local)" for locally imported mods
+- Update checking skips local mods
+```
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/root.go CHANGELOG.md
+git commit -m "chore: bump version to 0.10.0"
+```
+
+---
+
+## Task 10: Final Verification
+
+**Step 1: Build and test manually**
+
+```bash
+go build -o lmm ./cmd/lmm
+./lmm --version
+./lmm import --help
+```
+
+**Step 2: Test with a real archive (if available)**
+
+```bash
+# Create a test archive
+mkdir -p /tmp/testmod/data
+echo "test" > /tmp/testmod/data/test.esp
+cd /tmp/testmod && zip -r ../TestMod-99999-1-0.zip . && cd -
+
+# Import it
+./lmm import /tmp/TestMod-99999-1-0.zip --game <your-test-game>
+./lmm list --game <your-test-game>
+```
+
+**Step 3: Push changes**
+
+```bash
+git push
+```
+
+---
+
+## Summary
+
+**Files created:**
+
+- `internal/core/filename_parser.go`
+- `internal/core/filename_parser_test.go`
+- `internal/core/importer.go`
+- `internal/core/service_import_test.go`
+- `cmd/lmm/import.go`
+- `cmd/lmm/import_test.go`
+
+**Files modified:**
+
+- `internal/domain/mod.go` (add SourceLocal constant)
+- `internal/domain/mod_test.go` (add test)
+- `cmd/lmm/list.go` (show local source)
+- `cmd/lmm/update.go` (skip local mods)
+- `cmd/lmm/root.go` (version bump)
+- `CHANGELOG.md`
+- `go.mod` / `go.sum` (uuid dependency)

--- a/docs/plans/archive/2026-01-28-p5-installation-hooks-design.md
+++ b/docs/plans/archive/2026-01-28-p5-installation-hooks-design.md
@@ -1,0 +1,183 @@
+# P5 Installation Hooks Design
+
+**Date**: 2026-01-28
+**Priority**: P5 (after Auto-Dependencies)
+**Goal**: Run user-defined scripts at key points during mod operations
+
+---
+
+## Overview
+
+Enable users to run custom scripts before/after mod installation and uninstallation. Hooks are configured per-game with optional per-profile overrides. Uses a beforeAll/afterAll/beforeEach/afterEach pattern familiar from test frameworks.
+
+## Hook Points
+
+| Hook                    | When                       | Use Case                         |
+| ----------------------- | -------------------------- | -------------------------------- |
+| `install.before_all`    | Once before batch starts   | Close game, create backup        |
+| `install.before_each`   | Before each mod            | Validation, mod-specific prep    |
+| `install.after_each`    | After each mod             | Run FNIS for animation mods      |
+| `install.after_all`     | Once after batch completes | LOOT sort, regenerate load order |
+| `uninstall.before_all`  | Once before batch starts   | Close game                       |
+| `uninstall.before_each` | Before each mod            | Cleanup prep                     |
+| `uninstall.after_each`  | After each mod             | Mod-specific cleanup             |
+| `uninstall.after_all`   | Once after batch completes | Regenerate load order            |
+
+## Configuration
+
+### Game-level hooks (`games.yaml`)
+
+```yaml
+games:
+  skyrim-se:
+    name: "Skyrim Special Edition"
+    install_path: "/path/to/skyrim"
+    mod_path: "/path/to/skyrim/Data"
+    sources:
+      nexusmods: "skyrimspecialedition"
+    hooks:
+      install:
+        before_all: ~/.config/lmm/hooks/backup.sh
+        after_each: ~/.config/lmm/hooks/fnis.sh
+        after_all: ~/.config/lmm/hooks/loot-sort.sh
+      uninstall:
+        after_all: ~/.config/lmm/hooks/loot-sort.sh
+```
+
+### Profile-level overrides (`profiles/<name>.yaml`)
+
+```yaml
+name: minimal
+mods: [...]
+hooks:
+  install:
+    after_all: "" # disable LOOT sort for this profile
+```
+
+**Merge behavior**: Profile hooks merge with game hooks. Empty string `""` disables a hook. Unspecified hooks inherit from game.
+
+### Global timeout (`config.yaml`)
+
+```yaml
+hook_timeout: 60 # seconds, default 60
+```
+
+## Environment Variables
+
+Scripts receive these environment variables:
+
+| Variable          | Description                       | Example                             |
+| ----------------- | --------------------------------- | ----------------------------------- |
+| `LMM_GAME_ID`     | Game identifier                   | `skyrim-se`                         |
+| `LMM_GAME_PATH`   | Game install path                 | `/home/user/.steam/.../Skyrim`      |
+| `LMM_MOD_PATH`    | Mod deployment path               | `/home/user/.steam/.../Skyrim/Data` |
+| `LMM_MOD_ID`      | Mod ID (`*_each` hooks only)      | `12604`                             |
+| `LMM_MOD_NAME`    | Mod name (`*_each` hooks only)    | `SkyUI`                             |
+| `LMM_MOD_VERSION` | Mod version (`*_each` hooks only) | `5.2SE`                             |
+| `LMM_HOOK`        | Hook being run                    | `install.after_each`                |
+
+## Failure Behavior
+
+| Hook Type     | On Failure                     | Rationale                  |
+| ------------- | ------------------------------ | -------------------------- |
+| `before_all`  | Abort entire operation         | Pre-condition not met      |
+| `before_each` | Skip that mod, continue others | One mod might be special   |
+| `after_each`  | Warn and continue              | Mod already installed      |
+| `after_all`   | Warn only                      | All mods already installed |
+
+**`--force` flag**: Bypasses `before_*` hook failures (treats as warnings).
+
+**`--no-hooks` flag**: Global flag to skip all hooks at runtime.
+
+## Command Integration
+
+| Command     | Hooks Fired                                  |
+| ----------- | -------------------------------------------- |
+| `install`   | `install.*` hooks around batch               |
+| `uninstall` | `uninstall.*` hooks (batch of 1)             |
+| `import`    | `install.*` hooks (batch of 1)               |
+| `purge`     | `uninstall.*` hooks around batch             |
+| `deploy`    | `uninstall.*` then `install.*` (two batches) |
+| `update`    | `uninstall.*` then `install.*` per mod       |
+
+## New Installer Methods
+
+```go
+type BatchOptions struct {
+    Hooks       *ResolvedHooks
+    HookRunner  *HookRunner
+    HookContext HookContext
+}
+
+func (i *Installer) InstallBatch(ctx context.Context, game *domain.Game,
+    mods []*domain.Mod, profileName string, opts BatchOptions) BatchResult
+
+func (i *Installer) UninstallBatch(ctx context.Context, game *domain.Game,
+    mods []*domain.Mod, profileName string, opts BatchOptions) BatchResult
+```
+
+## Code Organization
+
+### New Files
+
+| File                          | Purpose                                                         |
+| ----------------------------- | --------------------------------------------------------------- |
+| `internal/core/hooks.go`      | `HookRunner`, `HookConfig`, `ResolvedHooks` types and execution |
+| `internal/core/hooks_test.go` | Unit tests for hook runner                                      |
+
+### Modified Files
+
+| File                                 | Changes                                  |
+| ------------------------------------ | ---------------------------------------- |
+| `internal/storage/config/games.go`   | Add `Hooks` field to `GameConfig`        |
+| `internal/storage/config/profile.go` | Add `Hooks` field to profile YAML        |
+| `internal/storage/config/config.go`  | Add `HookTimeout` to app config          |
+| `internal/domain/game.go`            | Add `Hooks` field to `Game` struct       |
+| `internal/core/installer.go`         | Add `InstallBatch()`, `UninstallBatch()` |
+| `cmd/lmm/root.go`                    | Add `--no-hooks` global flag             |
+| `cmd/lmm/install.go`                 | Use `InstallBatch()` with hooks          |
+| `cmd/lmm/uninstall.go`               | Use `UninstallBatch()` with hooks        |
+| `cmd/lmm/deploy.go`                  | Use batch methods with hooks             |
+| `cmd/lmm/purge.go`                   | Use `UninstallBatch()` with hooks        |
+| `cmd/lmm/update.go`                  | Use batch methods with hooks             |
+| `cmd/lmm/import.go`                  | Use `InstallBatch()` with hooks          |
+
+## Edge Cases
+
+| Scenario              | Handling                                 |
+| --------------------- | ---------------------------------------- |
+| Hook script not found | Error, abort/warn based on hook type     |
+| Script not executable | Error, abort/warn based on hook type     |
+| Script times out      | Kill process, error with timeout message |
+| Script exits non-zero | Error includes exit code and stderr      |
+| Empty hook path `""`  | Hook disabled (profile override)         |
+| No hooks configured   | No-op, operation proceeds normally       |
+| Hook path with `~`    | Expand to home directory                 |
+| Relative hook path    | Resolve relative to config directory     |
+
+## Testing Strategy
+
+### Unit Tests
+
+- `TestHookRunner_Success` - Script runs, returns stdout/stderr
+- `TestHookRunner_ExitCode` - Non-zero exit returns error with code
+- `TestHookRunner_Timeout` - Script killed after timeout
+- `TestHookRunner_NotFound` - Missing script returns clear error
+- `TestHookRunner_NotExecutable` - Non-executable returns clear error
+- `TestHookRunner_EnvVars` - All env vars passed correctly
+- `TestResolveHooks_*` - Game/profile merge scenarios
+
+### Integration Tests
+
+- `TestInstall_WithHooks` - Hooks fire in correct order
+- `TestInstall_BeforeAllFails` - Operation aborts
+- `TestInstall_BeforeEachFails` - Mod skipped, others continue
+- `TestInstall_AfterEachFails` - Warning logged, continues
+- `TestInstall_NoHooksFlag` - `--no-hooks` skips all hooks
+
+### Test Fixtures
+
+- `testdata/hooks/success.sh` - exits 0
+- `testdata/hooks/fail.sh` - exits 1
+- `testdata/hooks/slow.sh` - sleeps longer than timeout
+- `testdata/hooks/env-check.sh` - prints env vars

--- a/docs/plans/archive/2026-01-28-p5-installation-hooks-impl.md
+++ b/docs/plans/archive/2026-01-28-p5-installation-hooks-impl.md
@@ -1,0 +1,2065 @@
+# P5 Installation Hooks Implementation Plan
+
+<!-- markdownlint-disable MD001 MD029 MD036 -->
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable user-defined scripts to run before/after mod installation and uninstallation operations.
+
+**Architecture:** Add a HookRunner to execute scripts with environment variables. Extend config parsing to read hooks from games.yaml and profiles. Add batch methods to Installer that wrap hook execution around existing Install/Uninstall logic.
+
+**Tech Stack:** Go standard library (os/exec for scripts), existing YAML parsing (gopkg.in/yaml.v3)
+
+---
+
+### Task 1: Add hook types to domain
+
+**Files:**
+
+- Create: `internal/domain/hooks.go`
+- Test: `internal/domain/hooks_test.go`
+
+**Step 1: Write the test**
+
+```go
+// internal/domain/hooks_test.go
+package domain
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestHookConfig_IsEmpty(t *testing.T) {
+    tests := []struct {
+        name     string
+        config   HookConfig
+        expected bool
+    }{
+        {"all empty", HookConfig{}, true},
+        {"has before_all", HookConfig{BeforeAll: "/path/to/script"}, false},
+        {"has after_each", HookConfig{AfterEach: "/path/to/script"}, false},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            assert.Equal(t, tt.expected, tt.config.IsEmpty())
+        })
+    }
+}
+
+func TestGameHooks_IsEmpty(t *testing.T) {
+    tests := []struct {
+        name     string
+        hooks    GameHooks
+        expected bool
+    }{
+        {"all empty", GameHooks{}, true},
+        {"has install hook", GameHooks{Install: HookConfig{BeforeAll: "/path"}}, false},
+        {"has uninstall hook", GameHooks{Uninstall: HookConfig{AfterAll: "/path"}}, false},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            assert.Equal(t, tt.expected, tt.hooks.IsEmpty())
+        })
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/domain/... -run TestHookConfig -v`
+Expected: FAIL - types not defined
+
+**Step 3: Write the implementation**
+
+```go
+// internal/domain/hooks.go
+package domain
+
+// HookConfig defines scripts for a single operation type (install or uninstall)
+type HookConfig struct {
+    BeforeAll  string `yaml:"before_all"`
+    BeforeEach string `yaml:"before_each"`
+    AfterEach  string `yaml:"after_each"`
+    AfterAll   string `yaml:"after_all"`
+}
+
+// IsEmpty returns true if no hooks are configured
+func (h HookConfig) IsEmpty() bool {
+    return h.BeforeAll == "" && h.BeforeEach == "" && h.AfterEach == "" && h.AfterAll == ""
+}
+
+// GameHooks contains all hooks for a game
+type GameHooks struct {
+    Install   HookConfig `yaml:"install"`
+    Uninstall HookConfig `yaml:"uninstall"`
+}
+
+// IsEmpty returns true if no hooks are configured
+func (h GameHooks) IsEmpty() bool {
+    return h.Install.IsEmpty() && h.Uninstall.IsEmpty()
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/domain/... -run TestHookConfig -v && go test ./internal/domain/... -run TestGameHooks -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/domain/hooks.go internal/domain/hooks_test.go
+git commit -m "feat(hooks): add HookConfig and GameHooks domain types"
+```
+
+---
+
+### Task 2: Add Hooks field to Game struct
+
+**Files:**
+
+- Modify: `internal/domain/game.go`
+
+**Step 1: Add Hooks field to Game struct**
+
+In `internal/domain/game.go`, add the Hooks field to the Game struct:
+
+```go
+// Game represents a moddable game
+type Game struct {
+    ID                 string            // Unique slug, e.g., "skyrim-se"
+    Name               string            // Display name
+    InstallPath        string            // Game installation directory
+    ModPath            string            // Where mods should be deployed
+    SourceIDs          map[string]string // Map source to game ID, e.g., "nexusmods" -> "skyrimspecialedition"
+    LinkMethod         LinkMethod        // How to deploy mods
+    LinkMethodExplicit bool              // True if LinkMethod was explicitly set in config
+    CachePath          string            // Optional: custom cache path for this game's mods
+    Hooks              GameHooks         // Optional: hooks for install/uninstall operations
+}
+```
+
+**Step 2: Run existing tests to verify no regression**
+
+Run: `go test ./internal/domain/... -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/domain/game.go
+git commit -m "feat(hooks): add Hooks field to Game struct"
+```
+
+---
+
+### Task 3: Parse hooks from games.yaml
+
+**Files:**
+
+- Modify: `internal/storage/config/games.go`
+- Test: `internal/storage/config/games_test.go` (create if needed)
+
+**Step 1: Write the test**
+
+```go
+// internal/storage/config/games_hooks_test.go
+package config
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestLoadGames_WithHooks(t *testing.T) {
+    tempDir := t.TempDir()
+
+    gamesYAML := `games:
+  skyrim-se:
+    name: "Skyrim Special Edition"
+    install_path: "/path/to/skyrim"
+    mod_path: "/path/to/skyrim/Data"
+    sources:
+      nexusmods: "skyrimspecialedition"
+    hooks:
+      install:
+        before_all: "~/.config/lmm/hooks/backup.sh"
+        after_each: "/absolute/path/fnis.sh"
+        after_all: "./relative/loot.sh"
+      uninstall:
+        after_all: "~/.config/lmm/hooks/cleanup.sh"
+`
+    require.NoError(t, os.WriteFile(filepath.Join(tempDir, "games.yaml"), []byte(gamesYAML), 0644))
+
+    games, err := LoadGames(tempDir)
+    require.NoError(t, err)
+
+    game := games["skyrim-se"]
+    require.NotNil(t, game)
+
+    // Verify hooks are parsed and paths expanded
+    assert.NotEmpty(t, game.Hooks.Install.BeforeAll)
+    assert.Contains(t, game.Hooks.Install.BeforeAll, "/.config/lmm/hooks/backup.sh")
+    assert.Equal(t, "/absolute/path/fnis.sh", game.Hooks.Install.AfterEach)
+    assert.Equal(t, "./relative/loot.sh", game.Hooks.Install.AfterAll)
+    assert.NotEmpty(t, game.Hooks.Uninstall.AfterAll)
+}
+
+func TestLoadGames_NoHooks(t *testing.T) {
+    tempDir := t.TempDir()
+
+    gamesYAML := `games:
+  skyrim-se:
+    name: "Skyrim Special Edition"
+    install_path: "/path/to/skyrim"
+    mod_path: "/path/to/skyrim/Data"
+`
+    require.NoError(t, os.WriteFile(filepath.Join(tempDir, "games.yaml"), []byte(gamesYAML), 0644))
+
+    games, err := LoadGames(tempDir)
+    require.NoError(t, err)
+
+    game := games["skyrim-se"]
+    require.NotNil(t, game)
+    assert.True(t, game.Hooks.IsEmpty())
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/storage/config/... -run TestLoadGames_WithHooks -v`
+Expected: FAIL - hooks not parsed
+
+**Step 3: Update GameConfig and LoadGames**
+
+In `internal/storage/config/games.go`:
+
+1. Add HookConfigYAML and GameHooksYAML types:
+
+```go
+// HookConfigYAML is the YAML representation of hook configuration
+type HookConfigYAML struct {
+    BeforeAll  string `yaml:"before_all"`
+    BeforeEach string `yaml:"before_each"`
+    AfterEach  string `yaml:"after_each"`
+    AfterAll   string `yaml:"after_all"`
+}
+
+// GameHooksYAML is the YAML representation of game hooks
+type GameHooksYAML struct {
+    Install   HookConfigYAML `yaml:"install"`
+    Uninstall HookConfigYAML `yaml:"uninstall"`
+}
+```
+
+2. Add Hooks field to GameConfig:
+
+```go
+type GameConfig struct {
+    Name        string            `yaml:"name"`
+    InstallPath string            `yaml:"install_path"`
+    ModPath     string            `yaml:"mod_path"`
+    Sources     map[string]string `yaml:"sources"`
+    LinkMethod  string            `yaml:"link_method"`
+    CachePath   string            `yaml:"cache_path"`
+    Hooks       GameHooksYAML     `yaml:"hooks"`
+}
+```
+
+3. Update LoadGames to parse hooks:
+
+```go
+// In the loop where games are created, add:
+games[id] = &domain.Game{
+    ID:                 id,
+    Name:               cfg.Name,
+    InstallPath:        ExpandPath(cfg.InstallPath),
+    ModPath:            ExpandPath(cfg.ModPath),
+    SourceIDs:          cfg.Sources,
+    LinkMethod:         domain.ParseLinkMethod(cfg.LinkMethod),
+    LinkMethodExplicit: cfg.LinkMethod != "",
+    CachePath:          ExpandPath(cfg.CachePath),
+    Hooks: domain.GameHooks{
+        Install: domain.HookConfig{
+            BeforeAll:  ExpandPath(cfg.Hooks.Install.BeforeAll),
+            BeforeEach: ExpandPath(cfg.Hooks.Install.BeforeEach),
+            AfterEach:  ExpandPath(cfg.Hooks.Install.AfterEach),
+            AfterAll:   ExpandPath(cfg.Hooks.Install.AfterAll),
+        },
+        Uninstall: domain.HookConfig{
+            BeforeAll:  ExpandPath(cfg.Hooks.Uninstall.BeforeAll),
+            BeforeEach: ExpandPath(cfg.Hooks.Uninstall.BeforeEach),
+            AfterEach:  ExpandPath(cfg.Hooks.Uninstall.AfterEach),
+            AfterAll:   ExpandPath(cfg.Hooks.Uninstall.AfterAll),
+        },
+    },
+}
+```
+
+4. Update saveGames to preserve hooks:
+
+```go
+// In the loop where configs are created, add:
+cfg := GameConfig{
+    Name:        game.Name,
+    InstallPath: game.InstallPath,
+    ModPath:     game.ModPath,
+    Sources:     game.SourceIDs,
+    CachePath:   game.CachePath,
+    Hooks: GameHooksYAML{
+        Install: HookConfigYAML{
+            BeforeAll:  game.Hooks.Install.BeforeAll,
+            BeforeEach: game.Hooks.Install.BeforeEach,
+            AfterEach:  game.Hooks.Install.AfterEach,
+            AfterAll:   game.Hooks.Install.AfterAll,
+        },
+        Uninstall: HookConfigYAML{
+            BeforeAll:  game.Hooks.Uninstall.BeforeAll,
+            BeforeEach: game.Hooks.Uninstall.BeforeEach,
+            AfterEach:  game.Hooks.Uninstall.AfterEach,
+            AfterAll:   game.Hooks.Uninstall.AfterAll,
+        },
+    },
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/storage/config/... -run TestLoadGames -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/storage/config/games.go internal/storage/config/games_hooks_test.go
+git commit -m "feat(hooks): parse hooks from games.yaml"
+```
+
+---
+
+### Task 4: Add HookTimeout to config
+
+**Files:**
+
+- Modify: `internal/storage/config/config.go`
+- Test: `internal/storage/config/config_test.go`
+
+**Step 1: Write the test**
+
+```go
+// Add to internal/storage/config/config_test.go
+func TestLoad_HookTimeout(t *testing.T) {
+    tempDir := t.TempDir()
+
+    t.Run("default timeout", func(t *testing.T) {
+        cfg, err := Load(tempDir)
+        require.NoError(t, err)
+        assert.Equal(t, 60, cfg.HookTimeout)
+    })
+
+    t.Run("custom timeout", func(t *testing.T) {
+        configYAML := `hook_timeout: 120`
+        require.NoError(t, os.WriteFile(filepath.Join(tempDir, "config.yaml"), []byte(configYAML), 0644))
+
+        cfg, err := Load(tempDir)
+        require.NoError(t, err)
+        assert.Equal(t, 120, cfg.HookTimeout)
+    })
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/storage/config/... -run TestLoad_HookTimeout -v`
+Expected: FAIL - HookTimeout field doesn't exist
+
+**Step 3: Add HookTimeout to Config**
+
+In `internal/storage/config/config.go`:
+
+1. Add field to Config struct:
+
+```go
+type Config struct {
+    DefaultLinkMethod domain.LinkMethod `yaml:"-"`
+    LinkMethodStr     string            `yaml:"default_link_method"`
+    DefaultGame       string            `yaml:"default_game"`
+    Keybindings       string            `yaml:"keybindings"`
+    CachePath         string            `yaml:"cache_path"`
+    HookTimeout       int               `yaml:"hook_timeout"`
+}
+```
+
+2. Update Load to set default:
+
+```go
+func Load(configDir string) (*Config, error) {
+    cfg := &Config{
+        DefaultLinkMethod: domain.LinkSymlink,
+        Keybindings:       "vim",
+        HookTimeout:       60, // Default 60 seconds
+    }
+    // ... rest unchanged
+}
+```
+
+**Step 4: Run test**
+
+Run: `go test ./internal/storage/config/... -run TestLoad_HookTimeout -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/storage/config/config.go internal/storage/config/config_test.go
+git commit -m "feat(hooks): add HookTimeout to config with 60s default"
+```
+
+---
+
+### Task 5: Add hooks to Profile struct and parsing
+
+**Files:**
+
+- Modify: `internal/domain/profile.go`
+- Modify: `internal/storage/config/profiles.go`
+- Test: `internal/storage/config/profiles_test.go`
+
+**Step 1: Write the test**
+
+```go
+// internal/storage/config/profiles_hooks_test.go
+package config
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestLoadProfile_WithHooks(t *testing.T) {
+    tempDir := t.TempDir()
+    profileDir := filepath.Join(tempDir, "games", "skyrim-se", "profiles")
+    require.NoError(t, os.MkdirAll(profileDir, 0755))
+
+    profileYAML := `name: modded
+game_id: skyrim-se
+mods: []
+hooks:
+  install:
+    after_all: "" # disable game hook
+  uninstall:
+    after_all: "~/.config/lmm/hooks/custom-cleanup.sh"
+`
+    require.NoError(t, os.WriteFile(filepath.Join(profileDir, "modded.yaml"), []byte(profileYAML), 0644))
+
+    profile, err := LoadProfile(tempDir, "skyrim-se", "modded")
+    require.NoError(t, err)
+
+    // Empty string means explicitly disabled
+    assert.Equal(t, "", profile.Hooks.Install.AfterAll)
+    assert.True(t, profile.HooksExplicit.Install.AfterAll)
+
+    // Custom hook
+    assert.Contains(t, profile.Hooks.Uninstall.AfterAll, "custom-cleanup.sh")
+    assert.True(t, profile.HooksExplicit.Uninstall.AfterAll)
+
+    // Unset hooks should not be marked explicit
+    assert.False(t, profile.HooksExplicit.Install.BeforeAll)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/storage/config/... -run TestLoadProfile_WithHooks -v`
+Expected: FAIL - Hooks field doesn't exist on Profile
+
+**Step 3: Add Hooks to Profile in domain**
+
+In `internal/domain/profile.go`, add:
+
+```go
+// HookExplicitFlags tracks which hooks were explicitly set in profile config
+// This allows distinguishing between "not set" (inherit from game) and "set to empty" (disable)
+type HookExplicitFlags struct {
+    BeforeAll  bool
+    BeforeEach bool
+    AfterEach  bool
+    AfterAll   bool
+}
+
+// GameHooksExplicit tracks which hooks were explicitly set
+type GameHooksExplicit struct {
+    Install   HookExplicitFlags
+    Uninstall HookExplicitFlags
+}
+```
+
+Then add to Profile struct:
+
+```go
+type Profile struct {
+    Name          string
+    GameID        string
+    Mods          []ModReference
+    LinkMethod    LinkMethod
+    IsDefault     bool
+    Hooks         GameHooks         // Profile-level hook overrides
+    HooksExplicit GameHooksExplicit // Tracks which hooks were explicitly set
+}
+```
+
+**Step 4: Update profiles.go to parse hooks**
+
+In `internal/storage/config/profiles.go`:
+
+1. Add YAML types for hook config with pointer fields to detect explicit setting:
+
+```go
+// ProfileHookConfigYAML uses pointers to distinguish "not set" from "set to empty"
+type ProfileHookConfigYAML struct {
+    BeforeAll  *string `yaml:"before_all"`
+    BeforeEach *string `yaml:"before_each"`
+    AfterEach  *string `yaml:"after_each"`
+    AfterAll   *string `yaml:"after_all"`
+}
+
+type ProfileHooksYAML struct {
+    Install   ProfileHookConfigYAML `yaml:"install"`
+    Uninstall ProfileHookConfigYAML `yaml:"uninstall"`
+}
+```
+
+2. Add Hooks field to ProfileConfig:
+
+```go
+type ProfileConfig struct {
+    Name       string               `yaml:"name"`
+    GameID     string               `yaml:"game_id"`
+    Mods       []ModReferenceConfig `yaml:"mods"`
+    LinkMethod string               `yaml:"link_method,omitempty"`
+    IsDefault  bool                 `yaml:"is_default,omitempty"`
+    Hooks      ProfileHooksYAML     `yaml:"hooks,omitempty"`
+}
+```
+
+3. Update LoadProfile to parse hooks:
+
+```go
+// After creating profile, add hook parsing:
+profile.Hooks, profile.HooksExplicit = parseProfileHooks(cfg.Hooks)
+```
+
+4. Add helper function:
+
+```go
+func parseProfileHooks(yaml ProfileHooksYAML) (domain.GameHooks, domain.GameHooksExplicit) {
+    hooks := domain.GameHooks{}
+    explicit := domain.GameHooksExplicit{}
+
+    // Install hooks
+    if yaml.Install.BeforeAll != nil {
+        hooks.Install.BeforeAll = ExpandPath(*yaml.Install.BeforeAll)
+        explicit.Install.BeforeAll = true
+    }
+    if yaml.Install.BeforeEach != nil {
+        hooks.Install.BeforeEach = ExpandPath(*yaml.Install.BeforeEach)
+        explicit.Install.BeforeEach = true
+    }
+    if yaml.Install.AfterEach != nil {
+        hooks.Install.AfterEach = ExpandPath(*yaml.Install.AfterEach)
+        explicit.Install.AfterEach = true
+    }
+    if yaml.Install.AfterAll != nil {
+        hooks.Install.AfterAll = ExpandPath(*yaml.Install.AfterAll)
+        explicit.Install.AfterAll = true
+    }
+
+    // Uninstall hooks
+    if yaml.Uninstall.BeforeAll != nil {
+        hooks.Uninstall.BeforeAll = ExpandPath(*yaml.Uninstall.BeforeAll)
+        explicit.Uninstall.BeforeAll = true
+    }
+    if yaml.Uninstall.BeforeEach != nil {
+        hooks.Uninstall.BeforeEach = ExpandPath(*yaml.Uninstall.BeforeEach)
+        explicit.Uninstall.BeforeEach = true
+    }
+    if yaml.Uninstall.AfterEach != nil {
+        hooks.Uninstall.AfterEach = ExpandPath(*yaml.Uninstall.AfterEach)
+        explicit.Uninstall.AfterEach = true
+    }
+    if yaml.Uninstall.AfterAll != nil {
+        hooks.Uninstall.AfterAll = ExpandPath(*yaml.Uninstall.AfterAll)
+        explicit.Uninstall.AfterAll = true
+    }
+
+    return hooks, explicit
+}
+```
+
+**Step 5: Run tests**
+
+Run: `go test ./internal/storage/config/... -run TestLoadProfile -v`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/domain/profile.go internal/storage/config/profiles.go internal/storage/config/profiles_hooks_test.go
+git commit -m "feat(hooks): add hooks to Profile with explicit tracking for overrides"
+```
+
+---
+
+### Task 6: Create HookRunner
+
+**Files:**
+
+- Create: `internal/core/hooks.go`
+- Test: `internal/core/hooks_test.go`
+
+**Step 1: Write the test**
+
+```go
+// internal/core/hooks_test.go
+package core
+
+import (
+    "context"
+    "os"
+    "path/filepath"
+    "testing"
+    "time"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestHookRunner_Success(t *testing.T) {
+    tempDir := t.TempDir()
+    scriptPath := filepath.Join(tempDir, "success.sh")
+    script := `#!/bin/bash
+echo "stdout message"
+echo "stderr message" >&2
+exit 0
+`
+    require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0755))
+
+    runner := NewHookRunner(60 * time.Second)
+    ctx := context.Background()
+    hc := HookContext{
+        GameID:   "skyrim-se",
+        GamePath: "/path/to/game",
+        ModPath:  "/path/to/mods",
+        HookName: "install.before_all",
+    }
+
+    result, err := runner.Run(ctx, scriptPath, hc)
+    require.NoError(t, err)
+    assert.Contains(t, result.Stdout, "stdout message")
+    assert.Contains(t, result.Stderr, "stderr message")
+    assert.Equal(t, 0, result.ExitCode)
+}
+
+func TestHookRunner_NonZeroExit(t *testing.T) {
+    tempDir := t.TempDir()
+    scriptPath := filepath.Join(tempDir, "fail.sh")
+    script := `#!/bin/bash
+echo "error occurred" >&2
+exit 42
+`
+    require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0755))
+
+    runner := NewHookRunner(60 * time.Second)
+    ctx := context.Background()
+    hc := HookContext{GameID: "test", HookName: "test.hook"}
+
+    result, err := runner.Run(ctx, scriptPath, hc)
+    require.Error(t, err)
+    assert.Equal(t, 42, result.ExitCode)
+    assert.Contains(t, result.Stderr, "error occurred")
+}
+
+func TestHookRunner_Timeout(t *testing.T) {
+    tempDir := t.TempDir()
+    scriptPath := filepath.Join(tempDir, "slow.sh")
+    script := `#!/bin/bash
+sleep 10
+`
+    require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0755))
+
+    runner := NewHookRunner(100 * time.Millisecond)
+    ctx := context.Background()
+    hc := HookContext{GameID: "test", HookName: "test.hook"}
+
+    _, err := runner.Run(ctx, scriptPath, hc)
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "timed out")
+}
+
+func TestHookRunner_NotFound(t *testing.T) {
+    runner := NewHookRunner(60 * time.Second)
+    ctx := context.Background()
+    hc := HookContext{GameID: "test", HookName: "test.hook"}
+
+    _, err := runner.Run(ctx, "/nonexistent/script.sh", hc)
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "not found")
+}
+
+func TestHookRunner_NotExecutable(t *testing.T) {
+    tempDir := t.TempDir()
+    scriptPath := filepath.Join(tempDir, "noexec.sh")
+    require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/bash\necho hi"), 0644)) // no exec bit
+
+    runner := NewHookRunner(60 * time.Second)
+    ctx := context.Background()
+    hc := HookContext{GameID: "test", HookName: "test.hook"}
+
+    _, err := runner.Run(ctx, scriptPath, hc)
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "not executable")
+}
+
+func TestHookRunner_EnvVars(t *testing.T) {
+    tempDir := t.TempDir()
+    scriptPath := filepath.Join(tempDir, "env.sh")
+    script := `#!/bin/bash
+echo "GAME_ID=$LMM_GAME_ID"
+echo "GAME_PATH=$LMM_GAME_PATH"
+echo "MOD_PATH=$LMM_MOD_PATH"
+echo "MOD_ID=$LMM_MOD_ID"
+echo "MOD_NAME=$LMM_MOD_NAME"
+echo "MOD_VERSION=$LMM_MOD_VERSION"
+echo "HOOK=$LMM_HOOK"
+`
+    require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0755))
+
+    runner := NewHookRunner(60 * time.Second)
+    ctx := context.Background()
+    hc := HookContext{
+        GameID:     "skyrim-se",
+        GamePath:   "/path/to/game",
+        ModPath:    "/path/to/mods",
+        ModID:      "12345",
+        ModName:    "SkyUI",
+        ModVersion: "5.2",
+        HookName:   "install.after_each",
+    }
+
+    result, err := runner.Run(ctx, scriptPath, hc)
+    require.NoError(t, err)
+    assert.Contains(t, result.Stdout, "GAME_ID=skyrim-se")
+    assert.Contains(t, result.Stdout, "MOD_ID=12345")
+    assert.Contains(t, result.Stdout, "MOD_NAME=SkyUI")
+    assert.Contains(t, result.Stdout, "HOOK=install.after_each")
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/... -run TestHookRunner -v`
+Expected: FAIL - types not defined
+
+**Step 3: Write the implementation**
+
+```go
+// internal/core/hooks.go
+package core
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "os"
+    "os/exec"
+    "time"
+
+    "github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// HookContext provides environment information for hook scripts
+type HookContext struct {
+    GameID     string
+    GamePath   string
+    ModPath    string
+    ModID      string // Empty for *_all hooks
+    ModName    string // Empty for *_all hooks
+    ModVersion string // Empty for *_all hooks
+    HookName   string // e.g., "install.before_all"
+}
+
+// HookResult contains the output from running a hook
+type HookResult struct {
+    Stdout   string
+    Stderr   string
+    ExitCode int
+}
+
+// HookRunner executes hook scripts with timeout and environment
+type HookRunner struct {
+    timeout time.Duration
+}
+
+// NewHookRunner creates a new hook runner with the given timeout
+func NewHookRunner(timeout time.Duration) *HookRunner {
+    return &HookRunner{timeout: timeout}
+}
+
+// Run executes a hook script and returns its output
+func (r *HookRunner) Run(ctx context.Context, scriptPath string, hc HookContext) (*HookResult, error) {
+    result := &HookResult{}
+
+    // Check script exists
+    info, err := os.Stat(scriptPath)
+    if os.IsNotExist(err) {
+        return result, fmt.Errorf("hook script not found: %s", scriptPath)
+    }
+    if err != nil {
+        return result, fmt.Errorf("checking hook script: %w", err)
+    }
+
+    // Check script is executable
+    if info.Mode()&0111 == 0 {
+        return result, fmt.Errorf("hook script not executable: %s", scriptPath)
+    }
+
+    // Create timeout context
+    ctx, cancel := context.WithTimeout(ctx, r.timeout)
+    defer cancel()
+
+    // Build command
+    cmd := exec.CommandContext(ctx, scriptPath)
+    cmd.Env = append(os.Environ(),
+        "LMM_GAME_ID="+hc.GameID,
+        "LMM_GAME_PATH="+hc.GamePath,
+        "LMM_MOD_PATH="+hc.ModPath,
+        "LMM_MOD_ID="+hc.ModID,
+        "LMM_MOD_NAME="+hc.ModName,
+        "LMM_MOD_VERSION="+hc.ModVersion,
+        "LMM_HOOK="+hc.HookName,
+    )
+
+    var stdout, stderr bytes.Buffer
+    cmd.Stdout = &stdout
+    cmd.Stderr = &stderr
+
+    // Run command
+    err = cmd.Run()
+    result.Stdout = stdout.String()
+    result.Stderr = stderr.String()
+
+    // Handle exit code
+    if err != nil {
+        if ctx.Err() == context.DeadlineExceeded {
+            return result, fmt.Errorf("hook timed out after %v: %s", r.timeout, scriptPath)
+        }
+        if exitErr, ok := err.(*exec.ExitError); ok {
+            result.ExitCode = exitErr.ExitCode()
+            return result, fmt.Errorf("hook failed with exit code %d: %s", result.ExitCode, scriptPath)
+        }
+        return result, fmt.Errorf("running hook: %w", err)
+    }
+
+    return result, nil
+}
+
+// ResolvedHooks contains the final merged hooks for an operation
+type ResolvedHooks struct {
+    Install   domain.HookConfig
+    Uninstall domain.HookConfig
+}
+
+// ResolveHooks merges game-level hooks with profile-level overrides
+func ResolveHooks(game *domain.Game, profile *domain.Profile) *ResolvedHooks {
+    if game == nil {
+        return nil
+    }
+
+    resolved := &ResolvedHooks{
+        Install:   game.Hooks.Install,
+        Uninstall: game.Hooks.Uninstall,
+    }
+
+    if profile == nil {
+        return resolved
+    }
+
+    // Apply profile overrides (only if explicitly set)
+    if profile.HooksExplicit.Install.BeforeAll {
+        resolved.Install.BeforeAll = profile.Hooks.Install.BeforeAll
+    }
+    if profile.HooksExplicit.Install.BeforeEach {
+        resolved.Install.BeforeEach = profile.Hooks.Install.BeforeEach
+    }
+    if profile.HooksExplicit.Install.AfterEach {
+        resolved.Install.AfterEach = profile.Hooks.Install.AfterEach
+    }
+    if profile.HooksExplicit.Install.AfterAll {
+        resolved.Install.AfterAll = profile.Hooks.Install.AfterAll
+    }
+
+    if profile.HooksExplicit.Uninstall.BeforeAll {
+        resolved.Uninstall.BeforeAll = profile.Hooks.Uninstall.BeforeAll
+    }
+    if profile.HooksExplicit.Uninstall.BeforeEach {
+        resolved.Uninstall.BeforeEach = profile.Hooks.Uninstall.BeforeEach
+    }
+    if profile.HooksExplicit.Uninstall.AfterEach {
+        resolved.Uninstall.AfterEach = profile.Hooks.Uninstall.AfterEach
+    }
+    if profile.HooksExplicit.Uninstall.AfterAll {
+        resolved.Uninstall.AfterAll = profile.Hooks.Uninstall.AfterAll
+    }
+
+    return resolved
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/core/... -run TestHookRunner -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/core/hooks.go internal/core/hooks_test.go
+git commit -m "feat(hooks): add HookRunner with timeout, env vars, and error handling"
+```
+
+---
+
+### Task 7: Add ResolveHooks tests
+
+**Files:**
+
+- Test: `internal/core/hooks_test.go`
+
+**Step 1: Add tests for ResolveHooks**
+
+```go
+// Add to internal/core/hooks_test.go
+
+func TestResolveHooks_GameOnly(t *testing.T) {
+    game := &domain.Game{
+        Hooks: domain.GameHooks{
+            Install: domain.HookConfig{
+                BeforeAll: "/game/before.sh",
+                AfterAll:  "/game/after.sh",
+            },
+        },
+    }
+
+    resolved := ResolveHooks(game, nil)
+
+    assert.Equal(t, "/game/before.sh", resolved.Install.BeforeAll)
+    assert.Equal(t, "/game/after.sh", resolved.Install.AfterAll)
+}
+
+func TestResolveHooks_ProfileOverride(t *testing.T) {
+    game := &domain.Game{
+        Hooks: domain.GameHooks{
+            Install: domain.HookConfig{
+                BeforeAll: "/game/before.sh",
+                AfterAll:  "/game/after.sh",
+                AfterEach: "/game/each.sh",
+            },
+        },
+    }
+
+    profile := &domain.Profile{
+        Hooks: domain.GameHooks{
+            Install: domain.HookConfig{
+                AfterAll: "/profile/after.sh", // override
+            },
+        },
+        HooksExplicit: domain.GameHooksExplicit{
+            Install: domain.HookExplicitFlags{
+                AfterAll: true, // only this is explicitly set
+            },
+        },
+    }
+
+    resolved := ResolveHooks(game, profile)
+
+    assert.Equal(t, "/game/before.sh", resolved.Install.BeforeAll) // inherited
+    assert.Equal(t, "/profile/after.sh", resolved.Install.AfterAll) // overridden
+    assert.Equal(t, "/game/each.sh", resolved.Install.AfterEach)    // inherited
+}
+
+func TestResolveHooks_ProfileDisable(t *testing.T) {
+    game := &domain.Game{
+        Hooks: domain.GameHooks{
+            Install: domain.HookConfig{
+                AfterAll: "/game/loot.sh",
+            },
+        },
+    }
+
+    profile := &domain.Profile{
+        Hooks: domain.GameHooks{
+            Install: domain.HookConfig{
+                AfterAll: "", // explicitly disabled
+            },
+        },
+        HooksExplicit: domain.GameHooksExplicit{
+            Install: domain.HookExplicitFlags{
+                AfterAll: true,
+            },
+        },
+    }
+
+    resolved := ResolveHooks(game, profile)
+
+    assert.Equal(t, "", resolved.Install.AfterAll) // disabled
+}
+
+func TestResolveHooks_NilGame(t *testing.T) {
+    resolved := ResolveHooks(nil, nil)
+    assert.Nil(t, resolved)
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go test ./internal/core/... -run TestResolveHooks -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/core/hooks_test.go
+git commit -m "test(hooks): add ResolveHooks unit tests for merge and override behavior"
+```
+
+---
+
+### Task 8: Add --no-hooks global flag
+
+**Files:**
+
+- Modify: `cmd/lmm/root.go`
+
+**Step 1: Add the flag**
+
+In `cmd/lmm/root.go`:
+
+1. Add variable:
+
+```go
+var (
+    // ... existing vars
+    noHooks bool
+)
+```
+
+2. Add flag in init():
+
+```go
+func init() {
+    // ... existing flags
+    rootCmd.PersistentFlags().BoolVar(&noHooks, "no-hooks", false, "skip all hook scripts")
+}
+```
+
+**Step 2: Run existing tests**
+
+Run: `go test ./cmd/lmm/... -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/root.go
+git commit -m "feat(hooks): add --no-hooks global flag to skip hook execution"
+```
+
+---
+
+### Task 9: Add InstallBatch and UninstallBatch to Installer
+
+**Files:**
+
+- Modify: `internal/core/installer.go`
+- Test: `internal/core/installer_test.go`
+
+**Step 1: Write the test**
+
+```go
+// internal/core/installer_hooks_test.go
+package core
+
+import (
+    "context"
+    "os"
+    "path/filepath"
+    "testing"
+    "time"
+
+    "github.com/DonovanMods/linux-mod-manager/internal/domain"
+    "github.com/DonovanMods/linux-mod-manager/internal/linker"
+    "github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestInstaller_InstallBatch_WithHooks(t *testing.T) {
+    // Setup temp directories
+    tempDir := t.TempDir()
+    cacheDir := filepath.Join(tempDir, "cache")
+    modDir := filepath.Join(tempDir, "mods")
+    hookDir := filepath.Join(tempDir, "hooks")
+    logFile := filepath.Join(tempDir, "hook.log")
+
+    require.NoError(t, os.MkdirAll(cacheDir, 0755))
+    require.NoError(t, os.MkdirAll(modDir, 0755))
+    require.NoError(t, os.MkdirAll(hookDir, 0755))
+
+    // Create hook scripts that log when called
+    beforeAllScript := filepath.Join(hookDir, "before_all.sh")
+    afterEachScript := filepath.Join(hookDir, "after_each.sh")
+    afterAllScript := filepath.Join(hookDir, "after_all.sh")
+
+    require.NoError(t, os.WriteFile(beforeAllScript, []byte("#!/bin/bash\necho before_all >> "+logFile), 0755))
+    require.NoError(t, os.WriteFile(afterEachScript, []byte("#!/bin/bash\necho after_each:$LMM_MOD_ID >> "+logFile), 0755))
+    require.NoError(t, os.WriteFile(afterAllScript, []byte("#!/bin/bash\necho after_all >> "+logFile), 0755))
+
+    // Setup cache with a test mod
+    c := cache.New(cacheDir)
+    game := &domain.Game{ID: "test-game", ModPath: modDir}
+    mod := &domain.Mod{ID: "123", SourceID: "test", Version: "1.0", Name: "TestMod"}
+
+    // Create mod files in cache
+    modCachePath := filepath.Join(cacheDir, "test-game", "test-123", "1.0")
+    require.NoError(t, os.MkdirAll(modCachePath, 0755))
+    require.NoError(t, os.WriteFile(filepath.Join(modCachePath, "test.txt"), []byte("content"), 0644))
+
+    // Create installer
+    lnk := linker.New(domain.LinkSymlink)
+    installer := NewInstaller(c, lnk, nil)
+
+    // Setup hooks
+    hooks := &ResolvedHooks{
+        Install: domain.HookConfig{
+            BeforeAll: beforeAllScript,
+            AfterEach: afterEachScript,
+            AfterAll:  afterAllScript,
+        },
+    }
+
+    hookRunner := NewHookRunner(60 * time.Second)
+    hookCtx := HookContext{
+        GameID:   game.ID,
+        GamePath: game.InstallPath,
+        ModPath:  game.ModPath,
+    }
+
+    opts := BatchOptions{
+        Hooks:       hooks,
+        HookRunner:  hookRunner,
+        HookContext: hookCtx,
+    }
+
+    // Run install batch
+    ctx := context.Background()
+    result := installer.InstallBatch(ctx, game, []*domain.Mod{mod}, "default", opts)
+
+    assert.Equal(t, 1, result.Succeeded)
+    assert.Equal(t, 0, result.Failed)
+
+    // Verify hooks were called in order
+    logContent, err := os.ReadFile(logFile)
+    require.NoError(t, err)
+    assert.Contains(t, string(logContent), "before_all")
+    assert.Contains(t, string(logContent), "after_each:123")
+    assert.Contains(t, string(logContent), "after_all")
+}
+
+func TestInstaller_InstallBatch_BeforeAllFails(t *testing.T) {
+    tempDir := t.TempDir()
+    hookDir := filepath.Join(tempDir, "hooks")
+    require.NoError(t, os.MkdirAll(hookDir, 0755))
+
+    // Create failing before_all hook
+    beforeAllScript := filepath.Join(hookDir, "before_all.sh")
+    require.NoError(t, os.WriteFile(beforeAllScript, []byte("#!/bin/bash\nexit 1"), 0755))
+
+    c := cache.New(filepath.Join(tempDir, "cache"))
+    lnk := linker.New(domain.LinkSymlink)
+    installer := NewInstaller(c, lnk, nil)
+
+    hooks := &ResolvedHooks{
+        Install: domain.HookConfig{BeforeAll: beforeAllScript},
+    }
+
+    opts := BatchOptions{
+        Hooks:       hooks,
+        HookRunner:  NewHookRunner(60 * time.Second),
+        HookContext: HookContext{GameID: "test"},
+    }
+
+    game := &domain.Game{ID: "test", ModPath: filepath.Join(tempDir, "mods")}
+    mod := &domain.Mod{ID: "123", SourceID: "test", Version: "1.0"}
+
+    ctx := context.Background()
+    result := installer.InstallBatch(ctx, game, []*domain.Mod{mod}, "default", opts)
+
+    assert.Equal(t, 0, result.Succeeded)
+    assert.NotNil(t, result.Error)
+    assert.Contains(t, result.Error.Error(), "before_all")
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/core/... -run TestInstaller_InstallBatch -v`
+Expected: FAIL - InstallBatch doesn't exist
+
+**Step 3: Add BatchOptions and BatchResult types, and batch methods**
+
+In `internal/core/installer.go`, add:
+
+```go
+// BatchOptions configures batch install/uninstall operations
+type BatchOptions struct {
+    Hooks       *ResolvedHooks
+    HookRunner  *HookRunner
+    HookContext HookContext
+    Force       bool // If true, continue on before_* hook failures
+}
+
+// BatchResult contains the outcome of a batch operation
+type BatchResult struct {
+    Succeeded int
+    Failed    int
+    Skipped   []SkippedMod
+    Error     error // Non-nil if operation aborted (e.g., before_all failed)
+}
+
+// SkippedMod records a mod that was skipped due to hook failure
+type SkippedMod struct {
+    Mod    *domain.Mod
+    Reason string
+}
+
+// InstallBatch installs multiple mods with hook support
+func (i *Installer) InstallBatch(ctx context.Context, game *domain.Game, mods []*domain.Mod, profileName string, opts BatchOptions) BatchResult {
+    result := BatchResult{}
+
+    // Run before_all hook
+    if opts.Hooks != nil && opts.Hooks.Install.BeforeAll != "" && opts.HookRunner != nil {
+        hookCtx := opts.HookContext
+        hookCtx.HookName = "install.before_all"
+
+        _, err := opts.HookRunner.Run(ctx, opts.Hooks.Install.BeforeAll, hookCtx)
+        if err != nil {
+            if opts.Force {
+                // Log warning but continue
+            } else {
+                result.Error = fmt.Errorf("install.before_all hook failed: %w", err)
+                return result
+            }
+        }
+    }
+
+    // Install each mod
+    for _, mod := range mods {
+        // Run before_each hook
+        if opts.Hooks != nil && opts.Hooks.Install.BeforeEach != "" && opts.HookRunner != nil {
+            hookCtx := opts.HookContext
+            hookCtx.HookName = "install.before_each"
+            hookCtx.ModID = mod.ID
+            hookCtx.ModName = mod.Name
+            hookCtx.ModVersion = mod.Version
+
+            _, err := opts.HookRunner.Run(ctx, opts.Hooks.Install.BeforeEach, hookCtx)
+            if err != nil {
+                if opts.Force {
+                    // Log warning but continue
+                } else {
+                    result.Skipped = append(result.Skipped, SkippedMod{
+                        Mod:    mod,
+                        Reason: fmt.Sprintf("before_each hook failed: %v", err),
+                    })
+                    continue
+                }
+            }
+        }
+
+        // Install the mod
+        if err := i.Install(ctx, game, mod, profileName); err != nil {
+            result.Failed++
+            continue
+        }
+
+        result.Succeeded++
+
+        // Run after_each hook (warn only on failure)
+        if opts.Hooks != nil && opts.Hooks.Install.AfterEach != "" && opts.HookRunner != nil {
+            hookCtx := opts.HookContext
+            hookCtx.HookName = "install.after_each"
+            hookCtx.ModID = mod.ID
+            hookCtx.ModName = mod.Name
+            hookCtx.ModVersion = mod.Version
+
+            _, _ = opts.HookRunner.Run(ctx, opts.Hooks.Install.AfterEach, hookCtx)
+            // Ignore error - after hooks only warn
+        }
+    }
+
+    // Run after_all hook (warn only on failure)
+    if opts.Hooks != nil && opts.Hooks.Install.AfterAll != "" && opts.HookRunner != nil {
+        hookCtx := opts.HookContext
+        hookCtx.HookName = "install.after_all"
+
+        _, _ = opts.HookRunner.Run(ctx, opts.Hooks.Install.AfterAll, hookCtx)
+        // Ignore error - after hooks only warn
+    }
+
+    return result
+}
+
+// UninstallBatch uninstalls multiple mods with hook support
+func (i *Installer) UninstallBatch(ctx context.Context, game *domain.Game, mods []*domain.Mod, profileName string, opts BatchOptions) BatchResult {
+    result := BatchResult{}
+
+    // Run before_all hook
+    if opts.Hooks != nil && opts.Hooks.Uninstall.BeforeAll != "" && opts.HookRunner != nil {
+        hookCtx := opts.HookContext
+        hookCtx.HookName = "uninstall.before_all"
+
+        _, err := opts.HookRunner.Run(ctx, opts.Hooks.Uninstall.BeforeAll, hookCtx)
+        if err != nil {
+            if opts.Force {
+                // Log warning but continue
+            } else {
+                result.Error = fmt.Errorf("uninstall.before_all hook failed: %w", err)
+                return result
+            }
+        }
+    }
+
+    // Uninstall each mod
+    for _, mod := range mods {
+        // Run before_each hook
+        if opts.Hooks != nil && opts.Hooks.Uninstall.BeforeEach != "" && opts.HookRunner != nil {
+            hookCtx := opts.HookContext
+            hookCtx.HookName = "uninstall.before_each"
+            hookCtx.ModID = mod.ID
+            hookCtx.ModName = mod.Name
+            hookCtx.ModVersion = mod.Version
+
+            _, err := opts.HookRunner.Run(ctx, opts.Hooks.Uninstall.BeforeEach, hookCtx)
+            if err != nil {
+                if opts.Force {
+                    // Log warning but continue
+                } else {
+                    result.Skipped = append(result.Skipped, SkippedMod{
+                        Mod:    mod,
+                        Reason: fmt.Sprintf("before_each hook failed: %v", err),
+                    })
+                    continue
+                }
+            }
+        }
+
+        // Uninstall the mod
+        if err := i.Uninstall(ctx, game, mod, profileName); err != nil {
+            result.Failed++
+            continue
+        }
+
+        result.Succeeded++
+
+        // Run after_each hook (warn only on failure)
+        if opts.Hooks != nil && opts.Hooks.Uninstall.AfterEach != "" && opts.HookRunner != nil {
+            hookCtx := opts.HookContext
+            hookCtx.HookName = "uninstall.after_each"
+            hookCtx.ModID = mod.ID
+            hookCtx.ModName = mod.Name
+            hookCtx.ModVersion = mod.Version
+
+            _, _ = opts.HookRunner.Run(ctx, opts.Hooks.Uninstall.AfterEach, hookCtx)
+        }
+    }
+
+    // Run after_all hook (warn only on failure)
+    if opts.Hooks != nil && opts.Hooks.Uninstall.AfterAll != "" && opts.HookRunner != nil {
+        hookCtx := opts.HookContext
+        hookCtx.HookName = "uninstall.after_all"
+
+        _, _ = opts.HookRunner.Run(ctx, opts.Hooks.Uninstall.AfterAll, hookCtx)
+    }
+
+    return result
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/core/... -run TestInstaller_InstallBatch -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/core/installer.go internal/core/installer_hooks_test.go
+git commit -m "feat(hooks): add InstallBatch and UninstallBatch with hook support"
+```
+
+---
+
+### Task 10: Add hook helper to commands
+
+**Files:**
+
+- Create: `cmd/lmm/hooks.go`
+
+**Step 1: Create helper file**
+
+```go
+// cmd/lmm/hooks.go
+package main
+
+import (
+    "fmt"
+    "time"
+
+    "github.com/DonovanMods/linux-mod-manager/internal/core"
+    "github.com/DonovanMods/linux-mod-manager/internal/domain"
+    "github.com/DonovanMods/linux-mod-manager/internal/storage/config"
+)
+
+// getHookRunner returns a HookRunner with the configured timeout, or nil if hooks are disabled
+func getHookRunner(svc *core.Service) *core.HookRunner {
+    if noHooks {
+        return nil
+    }
+
+    cfg, err := config.Load(svc.ConfigDir())
+    timeout := 60 // default
+    if err == nil && cfg.HookTimeout > 0 {
+        timeout = cfg.HookTimeout
+    }
+
+    return core.NewHookRunner(time.Duration(timeout) * time.Second)
+}
+
+// getResolvedHooks returns merged game+profile hooks, or nil if hooks are disabled
+func getResolvedHooks(game *domain.Game, profile *domain.Profile) *core.ResolvedHooks {
+    if noHooks {
+        return nil
+    }
+    return core.ResolveHooks(game, profile)
+}
+
+// makeHookContext creates a HookContext for a game
+func makeHookContext(game *domain.Game) core.HookContext {
+    return core.HookContext{
+        GameID:   game.ID,
+        GamePath: game.InstallPath,
+        ModPath:  game.ModPath,
+    }
+}
+
+// printHookWarnings displays any hook-related warnings from a batch result
+func printHookWarnings(result core.BatchResult) {
+    for _, skipped := range result.Skipped {
+        fmt.Printf("  ⚠ %s - skipped: %s\n", skipped.Mod.Name, skipped.Reason)
+    }
+}
+```
+
+**Step 2: Add ConfigDir method to Service if not present**
+
+Check if `svc.ConfigDir()` exists. If not, add to `internal/core/service.go`:
+
+```go
+// ConfigDir returns the configuration directory path
+func (s *Service) ConfigDir() string {
+    return s.configDir
+}
+```
+
+**Step 3: Run build**
+
+Run: `go build ./cmd/lmm/...`
+Expected: Success
+
+**Step 4: Commit**
+
+```bash
+git add cmd/lmm/hooks.go internal/core/service.go
+git commit -m "feat(hooks): add hook helpers for CLI commands"
+```
+
+---
+
+### Task 11: Integrate hooks into install command
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go`
+
+**Step 1: Update installMultipleMods to use InstallBatch**
+
+In `cmd/lmm/install.go`, find the `installMultipleMods` function and update it to use hooks:
+
+1. At the start of the function, get hooks:
+
+```go
+// Get hooks
+profile, _ := config.LoadProfile(svc.ConfigDir(), game.ID, profileName)
+hooks := getResolvedHooks(game, profile)
+hookRunner := getHookRunner(svc)
+
+opts := core.BatchOptions{
+    Hooks:       hooks,
+    HookRunner:  hookRunner,
+    HookContext: makeHookContext(game),
+    Force:       installForce,
+}
+```
+
+2. Replace the manual loop with InstallBatch call, or wrap it appropriately.
+
+Note: The current `installMultipleMods` does more than just install (conflict checking, downloading). We need to integrate hooks at the right points:
+
+- `before_all` at the very start
+- `before_each` / `after_each` around each mod's deploy step
+- `after_all` at the very end
+
+For now, a simpler approach is to run `before_all` at start and `after_all` at end in `installMultipleMods`, and run `before_each`/`after_each` in the per-mod loop.
+
+**Step 2: Add hook calls to installMultipleMods**
+
+Add at the start of `installMultipleMods`:
+
+```go
+// Get hooks
+profile, _ := config.LoadProfile(getServiceConfig().ConfigDir, game.ID, profileName)
+hooks := getResolvedHooks(game, profile)
+hookRunner := getHookRunner(svc)
+
+// Run install.before_all hook
+if hooks != nil && hooks.Install.BeforeAll != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "install.before_all"
+    if _, err := hookRunner.Run(ctx, hooks.Install.BeforeAll, hookCtx); err != nil {
+        if !installForce {
+            return fmt.Errorf("install.before_all hook failed: %w", err)
+        }
+        fmt.Printf("⚠ install.before_all hook failed (continuing with --force): %v\n", err)
+    }
+}
+```
+
+Add around each mod installation:
+
+```go
+// Run install.before_each hook
+if hooks != nil && hooks.Install.BeforeEach != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "install.before_each"
+    hookCtx.ModID = mod.ID
+    hookCtx.ModName = mod.Name
+    hookCtx.ModVersion = mod.Version
+    if _, err := hookRunner.Run(ctx, hooks.Install.BeforeEach, hookCtx); err != nil {
+        if !installForce {
+            fmt.Printf("  ⚠ %s - skipped (before_each hook failed)\n", mod.Name)
+            failed++
+            continue
+        }
+    }
+}
+
+// ... existing install logic ...
+
+// Run install.after_each hook (warn only)
+if hooks != nil && hooks.Install.AfterEach != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "install.after_each"
+    hookCtx.ModID = mod.ID
+    hookCtx.ModName = mod.Name
+    hookCtx.ModVersion = mod.Version
+    if _, err := hookRunner.Run(ctx, hooks.Install.AfterEach, hookCtx); err != nil {
+        fmt.Printf("  ⚠ %s - after_each hook failed: %v\n", mod.Name, err)
+    }
+}
+```
+
+Add at the end:
+
+```go
+// Run install.after_all hook (warn only)
+if hooks != nil && hooks.Install.AfterAll != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "install.after_all"
+    if _, err := hookRunner.Run(ctx, hooks.Install.AfterAll, hookCtx); err != nil {
+        fmt.Printf("⚠ install.after_all hook failed: %v\n", err)
+    }
+}
+```
+
+**Step 3: Run tests**
+
+Run: `go test ./cmd/lmm/... -v && go build ./cmd/lmm/...`
+Expected: PASS and successful build
+
+**Step 4: Commit**
+
+```bash
+git add cmd/lmm/install.go
+git commit -m "feat(hooks): integrate hooks into install command"
+```
+
+---
+
+### Task 12: Integrate hooks into uninstall command
+
+**Files:**
+
+- Modify: `cmd/lmm/uninstall.go`
+
+**Step 1: Add hook calls**
+
+Update `runUninstall` to add hooks around the uninstall operation:
+
+```go
+// After getting the installedMod, before uninstalling:
+
+// Get hooks
+profile, _ := config.LoadProfile(getServiceConfig().ConfigDir, gameID, profileName)
+hooks := getResolvedHooks(game, profile)
+hookRunner := getHookRunner(service)
+
+// Run uninstall.before_all hook
+if hooks != nil && hooks.Uninstall.BeforeAll != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "uninstall.before_all"
+    if _, err := hookRunner.Run(ctx, hooks.Uninstall.BeforeAll, hookCtx); err != nil {
+        return fmt.Errorf("uninstall.before_all hook failed: %w", err)
+    }
+}
+
+// Run uninstall.before_each hook
+if hooks != nil && hooks.Uninstall.BeforeEach != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "uninstall.before_each"
+    hookCtx.ModID = installedMod.ID
+    hookCtx.ModName = installedMod.Name
+    hookCtx.ModVersion = installedMod.Version
+    if _, err := hookRunner.Run(ctx, hooks.Uninstall.BeforeEach, hookCtx); err != nil {
+        return fmt.Errorf("uninstall.before_each hook failed: %w", err)
+    }
+}
+
+// ... existing uninstall logic ...
+
+// Run uninstall.after_each hook (warn only)
+if hooks != nil && hooks.Uninstall.AfterEach != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "uninstall.after_each"
+    hookCtx.ModID = installedMod.ID
+    hookCtx.ModName = installedMod.Name
+    hookCtx.ModVersion = installedMod.Version
+    if _, err := hookRunner.Run(ctx, hooks.Uninstall.AfterEach, hookCtx); err != nil {
+        fmt.Printf("⚠ uninstall.after_each hook failed: %v\n", err)
+    }
+}
+
+// Run uninstall.after_all hook (warn only)
+if hooks != nil && hooks.Uninstall.AfterAll != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "uninstall.after_all"
+    if _, err := hookRunner.Run(ctx, hooks.Uninstall.AfterAll, hookCtx); err != nil {
+        fmt.Printf("⚠ uninstall.after_all hook failed: %v\n", err)
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go test ./cmd/lmm/... -v && go build ./cmd/lmm/...`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/uninstall.go
+git commit -m "feat(hooks): integrate hooks into uninstall command"
+```
+
+---
+
+### Task 13: Integrate hooks into deploy command
+
+**Files:**
+
+- Modify: `cmd/lmm/deploy.go`
+
+**Step 1: Add hook calls**
+
+The deploy command does uninstall+install per mod. Add hooks around the batch:
+
+1. At start of `runDeploy`, after getting game/profile, add uninstall hooks (since it undeploys first):
+
+```go
+profile, _ := config.LoadProfile(getServiceConfig().ConfigDir, game.ID, profileName)
+hooks := getResolvedHooks(game, profile)
+hookRunner := getHookRunner(service)
+
+// If doing purge, run uninstall.before_all
+if deployPurge && hooks != nil && hooks.Uninstall.BeforeAll != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "uninstall.before_all"
+    if _, err := hookRunner.Run(ctx, hooks.Uninstall.BeforeAll, hookCtx); err != nil {
+        if !installForce { // reuse --force logic
+            return fmt.Errorf("uninstall.before_all hook failed: %w", err)
+        }
+        fmt.Printf("⚠ uninstall.before_all hook failed (continuing): %v\n", err)
+    }
+}
+```
+
+2. Before deploying mods, run install.before_all:
+
+```go
+if hooks != nil && hooks.Install.BeforeAll != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "install.before_all"
+    if _, err := hookRunner.Run(ctx, hooks.Install.BeforeAll, hookCtx); err != nil {
+        return fmt.Errorf("install.before_all hook failed: %w", err)
+    }
+}
+```
+
+3. Around each mod in the loop, add before_each/after_each for install
+
+4. At end, run install.after_all
+
+**Step 2: Run tests**
+
+Run: `go build ./cmd/lmm/...`
+Expected: Success
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/deploy.go
+git commit -m "feat(hooks): integrate hooks into deploy command"
+```
+
+---
+
+### Task 14: Integrate hooks into purge command
+
+**Files:**
+
+- Modify: `cmd/lmm/purge.go`
+
+**Step 1: Add hook calls**
+
+Update `runPurge` to add uninstall hooks:
+
+```go
+// After getting mods list:
+profile, _ := config.LoadProfile(getServiceConfig().ConfigDir, game.ID, profileName)
+hooks := getResolvedHooks(game, profile)
+hookRunner := getHookRunner(service)
+
+// Run uninstall.before_all hook
+if hooks != nil && hooks.Uninstall.BeforeAll != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "uninstall.before_all"
+    if _, err := hookRunner.Run(ctx, hooks.Uninstall.BeforeAll, hookCtx); err != nil {
+        if !purgeYes { // Could add --force to purge, or just warn
+            fmt.Printf("⚠ uninstall.before_all hook failed: %v\n", err)
+        }
+    }
+}
+
+// In the loop, around each Uninstall call:
+// before_each and after_each hooks
+
+// At end:
+// Run uninstall.after_all hook
+if hooks != nil && hooks.Uninstall.AfterAll != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "uninstall.after_all"
+    if _, err := hookRunner.Run(ctx, hooks.Uninstall.AfterAll, hookCtx); err != nil {
+        fmt.Printf("⚠ uninstall.after_all hook failed: %v\n", err)
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go build ./cmd/lmm/...`
+Expected: Success
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/purge.go
+git commit -m "feat(hooks): integrate hooks into purge command"
+```
+
+---
+
+### Task 15: Integrate hooks into update command
+
+**Files:**
+
+- Modify: `cmd/lmm/update.go`
+
+**Step 1: Add hook calls**
+
+The update command does uninstall old + install new. Add hooks around each update:
+
+In `applyUpdate`:
+
+```go
+// Get hooks (pass as parameter or get fresh)
+profile, _ := config.LoadProfile(getServiceConfig().ConfigDir, game.ID, profileName)
+hooks := getResolvedHooks(game, profile)
+hookRunner := getHookRunner(service)
+
+// Before uninstalling old version:
+if hooks != nil && hooks.Uninstall.BeforeEach != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "uninstall.before_each"
+    hookCtx.ModID = mod.ID
+    hookCtx.ModName = mod.Name
+    hookCtx.ModVersion = mod.Version
+    if _, err := hookRunner.Run(ctx, hooks.Uninstall.BeforeEach, hookCtx); err != nil {
+        return fmt.Errorf("uninstall.before_each hook failed: %w", err)
+    }
+}
+
+// ... uninstall old ...
+
+// After uninstalling old version:
+if hooks != nil && hooks.Uninstall.AfterEach != "" && hookRunner != nil {
+    // run after_each (warn only)
+}
+
+// Before installing new version:
+if hooks != nil && hooks.Install.BeforeEach != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "install.before_each"
+    hookCtx.ModID = newMod.ID
+    hookCtx.ModName = newMod.Name
+    hookCtx.ModVersion = newVersion
+    if _, err := hookRunner.Run(ctx, hooks.Install.BeforeEach, hookCtx); err != nil {
+        return fmt.Errorf("install.before_each hook failed: %w", err)
+    }
+}
+
+// ... install new ...
+
+// After installing new version:
+if hooks != nil && hooks.Install.AfterEach != "" && hookRunner != nil {
+    // run after_each (warn only)
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go build ./cmd/lmm/...`
+Expected: Success
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/update.go
+git commit -m "feat(hooks): integrate hooks into update command"
+```
+
+---
+
+### Task 16: Integrate hooks into import command
+
+**Files:**
+
+- Modify: `cmd/lmm/import.go`
+
+**Step 1: Add hook calls**
+
+Update `runImport` to add install hooks around the deployment:
+
+```go
+// After setting up installer, before deploying:
+profile, _ := config.LoadProfile(getServiceConfig().ConfigDir, gameID, profileName)
+hooks := getResolvedHooks(game, profile)
+hookRunner := getHookRunner(service)
+
+// Run install.before_all hook
+if hooks != nil && hooks.Install.BeforeAll != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "install.before_all"
+    if _, err := hookRunner.Run(ctx, hooks.Install.BeforeAll, hookCtx); err != nil {
+        if !importForce {
+            return fmt.Errorf("install.before_all hook failed: %w", err)
+        }
+        fmt.Printf("⚠ install.before_all hook failed (continuing with --force): %v\n", err)
+    }
+}
+
+// Run install.before_each hook
+if hooks != nil && hooks.Install.BeforeEach != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "install.before_each"
+    hookCtx.ModID = result.Mod.ID
+    hookCtx.ModName = result.Mod.Name
+    hookCtx.ModVersion = result.Mod.Version
+    if _, err := hookRunner.Run(ctx, hooks.Install.BeforeEach, hookCtx); err != nil {
+        if !importForce {
+            return fmt.Errorf("install.before_each hook failed: %w", err)
+        }
+    }
+}
+
+// ... existing Install call ...
+
+// Run install.after_each hook (warn only)
+if hooks != nil && hooks.Install.AfterEach != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "install.after_each"
+    hookCtx.ModID = result.Mod.ID
+    hookCtx.ModName = result.Mod.Name
+    hookCtx.ModVersion = result.Mod.Version
+    if _, err := hookRunner.Run(ctx, hooks.Install.AfterEach, hookCtx); err != nil {
+        fmt.Printf("⚠ install.after_each hook failed: %v\n", err)
+    }
+}
+
+// Run install.after_all hook (warn only)
+if hooks != nil && hooks.Install.AfterAll != "" && hookRunner != nil {
+    hookCtx := makeHookContext(game)
+    hookCtx.HookName = "install.after_all"
+    if _, err := hookRunner.Run(ctx, hooks.Install.AfterAll, hookCtx); err != nil {
+        fmt.Printf("⚠ install.after_all hook failed: %v\n", err)
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go build ./cmd/lmm/...`
+Expected: Success
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/import.go
+git commit -m "feat(hooks): integrate hooks into import command"
+```
+
+---
+
+### Task 17: Run all tests and lint
+
+**Step 1: Run all tests**
+
+Run: `go test ./... -v`
+Expected: All PASS
+
+**Step 2: Run linter**
+
+Run: `trunk check`
+Expected: No errors (warnings acceptable)
+
+**Step 3: Fix any issues**
+
+If there are failures, fix them.
+
+**Step 4: Commit fixes if needed**
+
+```bash
+git add -A
+git commit -m "fix: address test and lint issues for hooks"
+```
+
+---
+
+### Task 18: Update version and changelog
+
+**Files:**
+
+- Modify: `cmd/lmm/root.go`
+- Modify: `CHANGELOG.md`
+
+**Step 1: Bump version**
+
+In `cmd/lmm/root.go`, update:
+
+```go
+version = "0.12.0"
+```
+
+**Step 2: Update CHANGELOG.md**
+
+Add new section:
+
+```markdown
+## [0.12.0] - 2026-01-28
+
+### Added
+
+- Installation hooks support - run custom scripts before/after mod operations
+- New hook points: `install.before_all`, `install.before_each`, `install.after_each`, `install.after_all` and corresponding `uninstall.*` hooks
+- Hooks configurable per-game in `games.yaml` with profile-level overrides
+- Environment variables passed to hook scripts: `LMM_GAME_ID`, `LMM_MOD_ID`, `LMM_MOD_NAME`, etc.
+- Contextual failure handling: `before_*` hooks abort on failure, `after_*` hooks warn only
+- `--no-hooks` global flag to skip all hooks at runtime
+- `hook_timeout` config option (default: 60 seconds)
+```
+
+**Step 3: Commit**
+
+```bash
+git add cmd/lmm/root.go CHANGELOG.md
+git commit -m "chore: bump version to 0.12.0"
+```
+
+---
+
+### Task 19: Final verification
+
+**Step 1: Build and test**
+
+Run: `go build ./cmd/lmm && go test ./... -v`
+Expected: All pass
+
+**Step 2: Manual smoke test**
+
+```bash
+# Create a test hook
+mkdir -p ~/.config/lmm/hooks
+echo '#!/bin/bash
+echo "Hook $LMM_HOOK called for game $LMM_GAME_ID"
+' > ~/.config/lmm/hooks/test.sh
+chmod +x ~/.config/lmm/hooks/test.sh
+
+# Test with --no-hooks
+./lmm --no-hooks list --game your-game
+
+# Verify hook is skipped (no output from hook)
+```
+
+**Step 3: Done**
+
+All tasks complete. Ready for code review.

--- a/docs/plans/archive/2026-01-28-v1.0-mvp-design.md
+++ b/docs/plans/archive/2026-01-28-v1.0-mvp-design.md
@@ -1,0 +1,344 @@
+# v1.0 MVP Design
+
+**Date**: 2026-01-28
+**Target**: Power users comfortable with CLI
+**Goal**: Production-ready mod manager with NexusMods + local import, automatic dependencies, hooks, conflict detection, and Steam auto-detection.
+
+---
+
+## Scope Summary
+
+### Already Complete (v0.7.8)
+
+- NexusMods search, download, install (multi-file support)
+- Update management with policies (auto/notify/pinned) + rollback
+- Profile system (create, switch, export, import, sync, apply)
+- Deployment strategies (symlink, hardlink, copy)
+- Enable/disable mods, purge, deploy commands
+- Per-game config (link method, cache path)
+- File ID tracking for re-downloads
+- Deployed vs enabled state tracking
+
+### New Features for v1.0
+
+| Feature                  | Effort     | Priority |
+| ------------------------ | ---------- | -------- |
+| Local mod import         | Medium     | High     |
+| Auto dependency install  | Medium     | High     |
+| Installation hooks       | Low-Medium | High     |
+| Conflict detection       | Medium     | Medium   |
+| Steam auto-detection     | Low        | Medium   |
+| Checksum verification    | Low        | Medium   |
+| `--json` output flag     | Low        | Medium   |
+| Production test coverage | High       | High     |
+| Man pages + docs         | Medium     | High     |
+
+---
+
+## Feature Designs
+
+### 1. Local Mod Import
+
+**Purpose**: Allow users to install mods from local archive files downloaded manually.
+
+**Commands**:
+
+```bash
+# Import a single mod archive
+lmm import /path/to/mod.zip --game skyrim-se
+
+# Import with metadata (if known)
+lmm import /path/to/mod.7z --game skyrim-se --id 12345 --source nexusmods
+```
+
+**Behavior**:
+
+1. **Archive detection**: Support same formats as install (zip, 7z, rar)
+2. **NexusMods matching**: Parse filename for patterns like `ModName-ModID-Version.zip` and auto-link for update tracking
+3. **Manual metadata**: Allow specifying `--id` and `--source` for update tracking
+4. **Unknown mods**: If source can't be determined, track as "local" source with no update checking
+
+**Data Model Changes**:
+
+- Add `local` as a valid source type
+- Store original file path for local mods (for update detection via file modification time)
+
+**Code Location**: New `cmd/lmm/import.go` command, extend `internal/core/installer.go`
+
+---
+
+### 2. Automatic Dependency Installation
+
+**Purpose**: When installing a mod, automatically install its required dependencies.
+
+**Behavior**:
+
+```bash
+lmm install "skyui" --game skyrim-se
+
+# Output:
+# Resolving dependencies for SkyUI (12345)...
+# Required dependencies:
+#   - SKSE64 (30379) [not installed]
+#   - Address Library (32444) [installed]
+#
+# Install 1 missing dependency? [Y/n]
+```
+
+**Flow**:
+
+1. Fetch mod from NexusMods
+2. Call `GetDependencies()` to get required mods
+3. Check which are already installed
+4. For missing deps, recursively resolve their dependencies (with cycle detection)
+5. Present full install list in topological order (deps first)
+6. Prompt for confirmation
+7. Install in order: dependencies → target mod
+
+**Flags**:
+
+- `--no-deps` - Skip dependency installation
+- `-y` / `--yes` - Auto-confirm dependency installation
+
+**Edge Cases**:
+
+- **Circular dependencies**: Use existing cycle detection - fail with clear error
+- **Dependency not on NexusMods**: Warn and continue
+- **Version requirements**: NexusMods doesn't provide version constraints, install latest
+
+**Code Location**: Extend `internal/core/installer.go` with dependency resolution
+
+---
+
+### 3. Installation Hooks
+
+**Purpose**: Run user-defined scripts at key points during mod operations.
+
+**Hook Points**:
+
+| Hook             | When it runs                    | Use case              |
+| ---------------- | ------------------------------- | --------------------- |
+| `pre-install`    | Before any mod is installed     | Backup, close game    |
+| `post-install`   | After each mod is installed     | Run FNIS, LOOT sort   |
+| `pre-uninstall`  | Before mod is removed           | Cleanup scripts       |
+| `post-uninstall` | After mod is removed            | Regenerate load order |
+| `post-deploy`    | After deploy/redeploy completes | Final validation      |
+
+**Configuration** (`games.yaml`):
+
+```yaml
+games:
+  skyrim-se:
+    name: "Skyrim Special Edition"
+    install_path: "/path/to/skyrim"
+    mod_path: "/path/to/skyrim/Data"
+    sources:
+      nexusmods: "skyrimspecialedition"
+    hooks:
+      post-install: ~/.config/lmm/hooks/skyrim-post-install.sh
+      post-deploy: ~/.config/lmm/hooks/skyrim-loot-sort.sh
+```
+
+**Environment Variables** (passed to scripts):
+
+- `LMM_GAME_ID` - Game identifier
+- `LMM_GAME_PATH` - Game install path
+- `LMM_MOD_PATH` - Mod deployment path
+- `LMM_MOD_ID` - Mod being installed (for per-mod hooks)
+- `LMM_MOD_NAME` - Mod name
+- `LMM_MOD_VERSION` - Mod version
+- `LMM_HOOK` - Which hook is running
+
+**Behavior**:
+
+- Scripts must be executable
+- Non-zero exit code aborts the operation (with `--force` to override)
+- Timeout after 60 seconds (configurable)
+- stdout/stderr shown to user
+
+**Code Location**: New `internal/core/hooks.go`
+
+---
+
+### 4. Conflict Detection
+
+**Purpose**: Warn users when installing a mod that overwrites files from an existing mod.
+
+**Behavior**:
+
+```bash
+lmm install "unofficial patch" --game skyrim-se
+
+# Output:
+# Analyzing files...
+# ⚠ File conflicts detected:
+#   - Data/meshes/actors/character/facegen.nif
+#     Currently from: RaceMenu (123)
+#     Will be overwritten by: Unofficial Patch (456)
+#
+# 2 files will be overwritten. Continue? [y/N]
+```
+
+**Implementation**:
+
+1. **Track deployed files**: New DB table
+
+   ```sql
+   CREATE TABLE deployed_files (
+     game_id TEXT,
+     profile_name TEXT,
+     relative_path TEXT,
+     source_id TEXT,
+     mod_id TEXT,
+     deployed_at DATETIME,
+     PRIMARY KEY (game_id, profile_name, relative_path)
+   );
+   ```
+
+2. **On install**: Before deploying, query which files already exist and from which mod
+
+3. **On uninstall**: Remove entries from `deployed_files`
+
+**Flags**:
+
+- `--force` - Install without conflict prompts
+
+**New Commands**:
+
+```bash
+lmm mod files <mod-id> --game skyrim-se  # See what files a mod owns
+lmm conflicts --game skyrim-se            # See all conflicts in profile
+```
+
+**Code Location**: New `internal/storage/db/files.go`, extend installer
+
+---
+
+### 5. Steam Game Auto-Detection
+
+**Purpose**: Automatically find installed Steam games and their paths.
+
+**Command**:
+
+```bash
+lmm game detect
+
+# Output:
+# Scanning Steam libraries...
+# Found 3 moddable games:
+#   1. Skyrim Special Edition (489830)
+#      Path: ~/.steam/steam/steamapps/common/Skyrim Special Edition
+#   2. Starfield (1716740)
+#      Path: ~/.steam/steam/steamapps/common/Starfield
+#
+# Add games to config? [1,2/all/none]: 1,2
+```
+
+**Implementation**:
+
+1. **Find Steam root**: Check `~/.steam/steam/`, `~/.local/share/Steam/`, `$STEAM_ROOT`
+
+2. **Parse library folders**: Read `steamapps/libraryfolders.vdf`
+
+3. **Scan for games**: Parse `appmanifest_*.acf` files
+
+4. **Match to known games**: Map Steam App IDs to NexusMods game slugs
+
+**Known Games Database** (`internal/source/steam/games.go`):
+
+```go
+var KnownGames = map[string]GameInfo{
+    "489830":  {Slug: "skyrim-se", NexusID: "skyrimspecialedition", ModPath: "Data"},
+    "1716740": {Slug: "starfield", NexusID: "starfield", ModPath: "Data"},
+    // ... 10-20 popular moddable games
+}
+```
+
+**Code Location**: New `internal/source/steam/` package, new `cmd/lmm/game_detect.go`
+
+---
+
+### 6. Checksum Verification
+
+**Purpose**: Verify downloaded files match NexusMods checksums.
+
+**Behavior**:
+
+```bash
+lmm install "skyui" --game skyrim-se
+
+# Downloading SkyUI-12345-5.2.zip (2.3 MB)...
+# [████████████████████████████████] 100%
+# Verifying checksum... ✓ OK
+```
+
+**Implementation**:
+
+1. Fetch MD5 checksum from NexusMods REST API
+2. Verify after download, before extraction
+3. Retry on failure (up to 3 attempts)
+4. Store verified checksum in DB
+
+**New Command**:
+
+```bash
+lmm verify --game skyrim-se       # Verify cached mods
+lmm verify --fix --game skyrim-se # Re-download corrupted files
+```
+
+**Flags**:
+
+- `--skip-verify` - Skip checksum verification on install
+
+**Code Location**: Extend `internal/core/downloader.go`, new `cmd/lmm/verify.go`
+
+---
+
+### 7. Production Quality
+
+#### Testing Requirements
+
+| Layer   | Coverage Target | Approach                    |
+| ------- | --------------- | --------------------------- |
+| Domain  | 90%+            | Pure unit tests             |
+| Storage | 85%+            | In-memory SQLite, temp dirs |
+| Core    | 80%+            | Mock sources/storage        |
+| Source  | 75%+            | Recorded HTTP responses     |
+| CLI     | Key paths       | End-to-end tests            |
+
+#### Documentation
+
+1. **Man pages** - `lmm(1)`, `lmm-install(1)`, etc.
+2. **Configuration reference** - All config.yaml and games.yaml options
+3. **CONTRIBUTING.md** - Contribution guidelines
+
+#### CLI Polish
+
+- Consistent error messages with actionable hints
+- `--json` flag on list/status/search for scripting
+- Color output with `--no-color` and `NO_COLOR` support
+- Exit codes: 0=success, 1=error, 2=user cancelled
+
+---
+
+## Implementation Order
+
+Recommended sequence based on dependencies:
+
+1. **Checksum verification** - Low risk, foundational
+2. **Conflict detection** - Requires DB migration, used by later features
+3. **Local mod import** - Builds on existing install flow
+4. **Auto dependencies** - Extends install, needs conflict detection
+5. **Installation hooks** - Independent, can parallelize
+6. **Steam auto-detection** - Independent, can parallelize
+7. **Production quality** - Ongoing throughout, final push at end
+
+---
+
+## Version Milestone
+
+When all features are complete and tested:
+
+- Bump version to `1.0.0`
+- Update CHANGELOG.md with full release notes
+- Tag release and publish to GitHub Releases

--- a/docs/plans/archive/2026-01-29-v1.0-todo-implementation.md
+++ b/docs/plans/archive/2026-01-29-v1.0-todo-implementation.md
@@ -1,0 +1,54 @@
+# v1.0 TODO.local.md Implementation Plan
+
+This plan addresses the items in `TODO.local.md` for v1.0 PRD gaps. Order follows Do now (Urgent + Important) then Schedule (Important + Not Urgent). Deferred/Eliminate/Delegate items are not implemented.
+
+## Do now (Urgent + Important)
+
+1. **Download retry with exponential backoff**  
+   Add retry logic in `internal/core/downloader.go`: retry on transient errors (network, 5xx, 429, timeout) with exponential backoff; max attempts 3; do not retry on 4xx (except 429) or context cancel. All callers (install, deploy, update, verify --fix) get it via `Downloader.Download`.
+
+2. **Load order management + mod reordering**
+   - Deploy/switch must use profile load order (profile.Mods order: first = lowest priority). Currently `GetInstalledMods` returns by `installed_at`; deploy should order by profile.Mods.
+   - Add CLI: `lmm mod order` or profile subcommand to reorder mods (e.g. move up/down, or accept ordered list).
+   - Ensure `ReorderMods` in core/profile.go is used and that deploy fetches mods in profile order.
+
+3. **Profile configuration overrides (INI / overrides dir)**
+   - Persist `Profile.Overrides` in profile YAML (path → content or path → base64).
+   - Define overrides dir semantics (e.g. `overrides/` under game config or profile-specific).
+   - On deploy/switch: write overrides to game directory (or designated overrides path).
+   - Config/storage: add overrides to ProfileConfig in config/profiles.go; Load/Save; apply in deploy flow.
+
+4. **Profile export/import: load order + overrides + link preferences**
+   - Export: already has mods (load order) and link_method. Add `overrides` (map or list of path+content).
+   - Import: parse overrides; set profile.Overrides; link_method already applied.
+   - Domain: ExportedProfile already has LinkMethod; add Overrides field. Config ExportProfile/ImportProfile to include overrides.
+
+5. **Mod details view (description, images, changelog)**
+   - CLI: `lmm mod show <mod-id> --game <id>` (or similar) that fetches mod by ID and prints description, changelog, image URLs (or “open in browser” for images).
+   - Source: ensure NexusMods (or source) exposes description, changelog, image URLs in Mod or via GetModDetails.
+   - Output: human-readable text; optional --json.
+
+## Schedule (Important + Not Urgent)
+
+1. **Verify: per-mod file-count mismatch**
+   In `cmd/lmm/verify.go`: for each mod with checksums, compare expected file count (e.g. from DB or from re-listing cache) vs actual cached files; report mismatch (e.g. “ModName – expected N files, found M”).
+
+1. **Search filters (category/tags)**
+   CLI: `lmm search --category X --tag Y` (or similar). Source: extend SearchMods/query to pass category/tags to NexusMods (or source) and surface in results.
+
+1. **CLI: lmm list --profiles**
+   When `--profiles` is set, list profile names for the game (and optionally default) instead of listing mods. Simple flag on list command.
+
+1. **Update check: display changelogs**
+   When showing available updates, include changelog text where available (Update struct has Changelog; ensure NexusMods populates it and CLI prints it).
+
+1. **Dependency tree before install + circular dependency warnings**
+   Before installing: print dependency tree (or flat list in dependency order). Detect and warn on circular dependencies (resolver already exists; add cycle detection and explicit warning in install CLI).
+
+---
+
+## Implementation order
+
+- **Phase 1 (this session):** 1 (download retry), then 8 (list --profiles), then 6 (verify file-count).
+- **Phase 2:** 2 (load order + deploy order + CLI reorder), 3 (overrides persist + apply), 4 (export/import overrides).
+- **Phase 3:** 5 (mod details view), 7 (search filters), 9 (changelogs on update), 10 (dependency tree + circular warning).

--- a/docs/plans/archive/2026-02-05-curseforge-source-design.md
+++ b/docs/plans/archive/2026-02-05-curseforge-source-design.md
@@ -1,0 +1,187 @@
+# CurseForge Source Implementation Design
+
+## Overview
+
+Add CurseForge as a mod source, implementing the `ModSource` interface to enable searching, downloading, and managing mods from CurseForge alongside NexusMods.
+
+## CurseForge API
+
+**Base URL:** `https://api.curseforge.com`
+
+**Authentication:** API key via `x-api-key` header. Keys obtained from [CurseForge Console](https://console.curseforge.com/).
+
+**Key differences from NexusMods:**
+- Uses numeric game IDs (e.g., 432 for Minecraft) vs slugs
+- REST API vs GraphQL
+- Different data structures (downloadCount vs endorsements)
+- File dependencies embedded in file data vs separate endpoint
+
+## API Endpoints
+
+| Endpoint | Purpose | Notes |
+|----------|---------|-------|
+| `GET /v1/games` | List available games | For discovery |
+| `GET /v1/mods/search?gameId={id}&searchFilter={query}` | Search mods | Max 50 per page |
+| `GET /v1/mods/{modId}` | Get mod details | Includes authors, categories |
+| `GET /v1/mods/{modId}/files` | List mod files | For download selection |
+| `GET /v1/mods/{modId}/files/{fileId}/download-url` | Get CDN URL | Direct download link |
+
+## Response Structures
+
+### Mod Response
+```json
+{
+  "data": {
+    "id": 12345,
+    "gameId": 432,
+    "name": "Just Enough Items (JEI)",
+    "slug": "jei",
+    "summary": "View Items and Recipes",
+    "downloadCount": 1234567,
+    "authors": [{"id": 1, "name": "mezz", "url": "..."}],
+    "logo": {"thumbnailUrl": "..."},
+    "latestFiles": [...],
+    "dateModified": "2024-01-01T00:00:00Z"
+  }
+}
+```
+
+### File Response
+```json
+{
+  "data": {
+    "id": 54321,
+    "modId": 12345,
+    "displayName": "jei-1.20.1-15.3.0.4.jar",
+    "fileName": "jei-1.20.1-15.3.0.4.jar",
+    "fileLength": 1234567,
+    "downloadUrl": "https://edge.forgecdn.net/files/...",
+    "dependencies": [{"modId": 111, "relationType": 3}]
+  }
+}
+```
+
+## Implementation Structure
+
+```text
+internal/source/curseforge/
+├── curseforge.go     # ModSource implementation
+├── curseforge_test.go
+├── client.go         # HTTP client, request/response handling
+├── client_test.go
+└── types.go          # API response structs
+```
+
+## Type Mappings
+
+| CurseForge Field | Domain Field | Notes |
+|------------------|--------------|-------|
+| `id` | `Mod.ID` | Convert int to string |
+| `name` | `Mod.Name` | Direct |
+| `summary` | `Mod.Summary` | Direct |
+| `authors[0].name` | `Mod.Author` | First author |
+| `downloadCount` | `Mod.Downloads` | Use instead of endorsements |
+| `logo.thumbnailUrl` | `Mod.PictureURL` | Image URL |
+| `dateModified` | `Mod.UpdatedAt` | Parse ISO8601 |
+| `latestFiles[0].displayName` | `Mod.Version` | Extract from filename |
+
+## Configuration
+
+### games.yaml
+```yaml
+games:
+  minecraft:
+    name: "Minecraft"
+    install_path: "~/.minecraft"
+    mod_path: "~/.minecraft/mods"
+    sources:
+      nexusmods: "minecraft"
+      curseforge: "432"  # CurseForge game ID
+
+  skyrim-se:
+    name: "Skyrim Special Edition"
+    install_path: "..."
+    sources:
+      nexusmods: "skyrimspecialedition"
+      # curseforge: "..." # CurseForge ID if available
+```
+
+### Auth Token Storage
+Store API key in SQLite `auth_tokens` table:
+- `source_id`: "curseforge"
+- `token_data`: encrypted API key
+
+## CLI Integration
+
+### Auth Commands
+```bash
+# Login with API key
+lmm auth login --source curseforge
+# Prompts for API key
+
+# Check auth status
+lmm auth status
+# Shows: curseforge: authenticated
+
+# Logout
+lmm auth logout --source curseforge
+```
+
+### Search with Source
+```bash
+# Search defaults to all configured sources for game
+lmm search "jei" --game minecraft
+
+# Filter to specific source
+lmm search "jei" --game minecraft --source curseforge
+```
+
+## Implementation Steps
+
+### Phase 1: Core Implementation
+1. [ ] Create `internal/source/curseforge/types.go` - API response structs
+2. [ ] Create `internal/source/curseforge/client.go` - HTTP client
+3. [ ] Create `internal/source/curseforge/client_test.go` - Client tests with recorded responses
+4. [ ] Create `internal/source/curseforge/curseforge.go` - ModSource interface impl
+5. [ ] Create `internal/source/curseforge/curseforge_test.go` - Integration tests
+
+### Phase 2: CLI Integration
+6. [ ] Register CurseForge source in `cmd/lmm/main.go`
+7. [ ] Update `auth login` to support `--source curseforge`
+8. [ ] Update `auth status` to show all sources
+9. [ ] Add `--source` flag to search/install commands
+
+### Phase 3: Documentation
+10. [ ] Update README.md with CurseForge support
+11. [ ] Update docs/configuration.md with curseforge source mapping
+12. [ ] Add CurseForge API key instructions
+
+## Testing Strategy
+
+1. **Unit tests** - Mock HTTP client with recorded responses
+2. **Integration tests** - Test full ModSource interface
+3. **Manual testing** - Real API calls with test games
+
+### Test Data
+Use well-known mods for testing:
+- Minecraft: JEI (id: 238222), Fabric API (id: 306612)
+- Record API responses for reproducible tests
+
+## Error Handling
+
+- API key invalid/expired: `ErrAuthRequired` with helpful message
+- Rate limiting (429): Exponential backoff, max 3 retries
+- Mod not found (404): `ErrModNotFound`
+- Network errors: Wrap with context
+
+## Known Limitations
+
+1. **Game ID mapping** - Users must know CurseForge game IDs
+2. **No OAuth** - API key only (simpler but less secure)
+3. **Download URLs may expire** - Fetch fresh URL before each download
+
+## Future Enhancements
+
+- Auto-discover CurseForge game IDs from game name
+- Support mod dependencies from file data
+- Changelog parsing from mod description

--- a/docs/plans/archive/2026-04-25-code-smell-remediation.md
+++ b/docs/plans/archive/2026-04-25-code-smell-remediation.md
@@ -1,0 +1,174 @@
+# Code Smell Remediation Plan
+
+**Date:** 2026-04-25
+**Scope:** Structural and correctness-level code smells in the lmm Go codebase (~25.8k LOC, 109 files).
+**Out of scope:** Naming, doc gaps, dead-code sweep, TUI work, CurseForge batch endpoint, performance.
+
+The plan is staged so each phase ends with a green build and updated/added tests. Phases are
+ordered low-risk → high-risk so churn compounds in our favour.
+
+---
+
+## Audit findings (high priority only)
+
+1. **Leaky `Service.DB()` abstraction.** `internal/core/service.go:392` exposes `*db.DB`. CLI
+   commands (e.g. `cmd/lmm/profile.go:451`, `cmd/lmm/uninstall.go:157`) reach into the storage
+   layer directly with `service.DB().X()`, bypassing the orchestration boundary.
+
+2. **God functions in `cmd/lmm/`.**
+   - `runInstall` — 609 lines (`install.go:141`)
+   - `runProfileSwitch` — 293 lines (`profile.go:289`)
+   - `runProfileApply` — 288 lines (`profile.go:645`)
+   - `runProfileImport` — 255 lines (`profile.go:535`)
+
+3. **`context.Background()` invented mid-stack.** ~18 production sites in `cmd/lmm/*.go`
+   (e.g. `install.go:173`, `profile.go:441,737,1298`). Cobra already exposes `cmd.Context()`,
+   but nothing is threaded from the entry point, so SIGINT and timeouts cannot propagate.
+
+4. **Duplicated CLI boilerplate.** `requireGame()` + `initService()` + `defer service.Close()`
+   appears verbatim in ~10 command files. The `errors.Is(err, domain.ErrAuthRequired)` block
+   is copied verbatim 5×.
+
+5. **Inconsistent compound-error wrapping.** `internal/core/installer.go:61,78,138,150,163,165,168,178,189`
+   mix `%w` for the primary error with `%v` for rollback / cleanup errors in the same string,
+   collapsing the chain on the secondary errors.
+
+6. **Duplicate HTTP client patterns.** `internal/source/nexusmods/client.go` and
+   `internal/source/curseforge/client.go` (`doRequest` at L52–125) implement the same
+   auth / error-mapping shape twice with no shared base.
+
+7. **Global mutable CLI flag vars.** `cmd/lmm/root.go:21–31` plus per-command file-scope
+   duplicates make tests order-dependent and complicate parallelisation.
+
+8. **Stale `TODO`s with no issue refs** (e.g. `cmd/lmm/import.go:366`,
+   `internal/source/curseforge/client.go:265`).
+
+---
+
+## Phase 1 — Plumbing (mechanical, low risk)
+
+Goal: stop inventing context mid-stack and remove the most common boilerplate.
+
+- **1a. Thread `cmd.Context()` from entry to leaf.**
+  - In `Execute()`, build a signal-aware context via `signal.NotifyContext` (SIGINT, SIGTERM)
+    and call `rootCmd.ExecuteContext(ctx)` instead of `rootCmd.Execute()`.
+  - Replace each `ctx := context.Background()` in `cmd/lmm/*.go` (production paths only) with
+    `ctx := cmd.Context()`.
+  - Add a regression test that cancelling the parent context aborts a long-running command.
+  - Leave `internal/core/extractor.go:218` alone for now — it derives a timeout from a
+    constant; a follow-up phase can promote it to a derived `WithTimeout(ctx, …)`.
+
+- **1b. `withService` middleware.**
+  - Add `withService(cmd *cobra.Command, fn func(ctx context.Context, svc *core.Service) error) error`
+    in `cmd/lmm/helpers.go`. It handles `requireGame`, `initService`, `defer service.Close()`
+    with the existing stderr warning, and forwards `cmd.Context()`.
+  - Convert `uninstall.go` first as the reference implementation, then sweep the remaining
+    commands one PR-sized batch at a time.
+
+- **1c. `handleAuthError` helper.**
+  - Add `handleAuthError(sourceID string, cause error) error` in `cmd/lmm/helpers.go`.
+  - Replace the 5 duplicated `errors.Is(err, domain.ErrAuthRequired)` blocks in `search.go`,
+    `install.go`, `update.go`.
+
+**Exit criteria:** `go test ./...` green; no `context.Background()` in `cmd/lmm/*.go` outside tests;
+auth-error formatting routed through one function.
+
+---
+
+## Phase 2 — Error wrapping consistency
+
+Goal: every error chain stays inspectable.
+
+- **2a.** Introduce a typed composite error in `internal/domain/errors.go`, e.g.:
+  ```go
+  type DeployError struct {
+      Op       string // "deploy", "remove", ...
+      File     string
+      Primary  error
+      Rollback error // optional
+      Cleanup  error // optional
+  }
+  func (e *DeployError) Error() string
+  func (e *DeployError) Unwrap() []error
+  ```
+- **2b.** Replace the 9 `%w; … %v` strings in `internal/core/installer.go` with the new type.
+  Verify existing tests still match via `errors.Is/As`; update any that string-match.
+
+**Exit criteria:** no `%w; … %v` patterns remain in `internal/core/`. `errors.Is`/`As` works
+through composite errors.
+
+---
+
+## Phase 3 — Tighten the `Service` boundary
+
+Goal: nothing outside `internal/core/` may reach into `*db.DB`.
+
+- **3a.** Audit every external caller of `service.DB()`. For each, add a focused method on
+  `*core.Service` (e.g. `SetModEnabled(ctx, ref, profile, enabled)`,
+  `DeleteInstalledMod(ctx, ref, profile)`) and migrate the callers.
+- **3b.** Lower-case `DB()` to `db()` (or remove). Same audit for `Registry()` if it leaks
+  similarly.
+- **3c.** Add tests that exercise the new service methods directly so the behaviour is
+  pinned at the service boundary, not the storage one.
+
+**Exit criteria:** `grep -r "service.DB()" cmd/ internal/` returns zero hits outside
+`internal/core/`. Tests still green.
+
+---
+
+## Phase 4 — Decompose the god functions
+
+Goal: no `RunE` over ~150 lines; each step is independently testable.
+
+- **4a. `runInstall` (609 → ~120).** Extract:
+  - `selectMod(ctx, svc, source, query) (*Mod, error)`
+  - `resolveAndConfirmDeps(ctx, svc, mod) (*installPlan, error)`
+  - `downloadAndStage(ctx, svc, plan) ([]Staged, error)`
+  - `deployAndRecord(ctx, svc, staged, profile) error`
+
+- **4b. Profile commands.** Move orchestration into `internal/core/profile.go` as
+  `SwitchProfile(ctx, …)`, `ApplyProfile(ctx, …)`, `ImportProfile(ctx, …)`. The CLI files become
+  presenters: arg parsing → call core → format output.
+
+**Exit criteria:** all `runX` functions ≤150 lines. New core functions covered by table-driven
+tests.
+
+---
+
+## Phase 5 — Source client base
+
+Goal: shared HTTP plumbing for `nexusmods` and `curseforge`.
+
+- **5a.** Extract `internal/source/httpclient` with auth-header injection, retry,
+  JSON decode, and error mapping (incl. `domain.ErrAuthRequired` translation).
+- **5b.** Refactor `nexusmods` and `curseforge` clients to use it. Recorded-response tests
+  must still pass without modification (proves no behavioural change).
+
+**Exit criteria:** `doRequest`-style duplication gone. Adding a third source costs only
+endpoint + types.
+
+---
+
+## Phase 6 — Cleanup
+
+- **6a.** Convert remaining `TODO` comments to GitHub issues (or delete if obsolete).
+- **6b.** Move per-command flag globals into command-scoped structs bound via Cobra; only
+  `--config`, `--data`, `-g`, `-v`, `--no-hooks`, `--json`, `--no-color` stay persistent on root.
+
+**Exit criteria:** no top-level mutable flag vars in command files; root.go retains only
+the persistent flag struct.
+
+---
+
+## Versioning
+
+Each phase is a MINOR-or-PATCH bump per `CLAUDE.md`:
+
+- Phase 1 — PATCH (refactor; no user-visible change apart from Ctrl+C now cancelling).
+- Phase 2 — PATCH (errors still match `Is/As`).
+- Phase 3 — PATCH.
+- Phase 4 — PATCH.
+- Phase 5 — PATCH.
+- Phase 6 — MINOR if any flag rebind alters CLI surface; otherwise PATCH.
+
+Bump and update `CHANGELOG.md` in a separate commit at the end of each phase.

--- a/docs/plans/archive/2026-07-13-custom-sources-design.md
+++ b/docs/plans/archive/2026-07-13-custom-sources-design.md
@@ -1,0 +1,376 @@
+# User-Defined Mod Sources — Design
+
+**Date:** 2026-07-13
+**Status:** Approved design, pending implementation plan
+**Target version:** v1.6.0 (MINOR)
+
+## Problem
+
+Mod sources are hardcoded: `registerSources()` in `cmd/lmm/root.go` instantiates
+NexusMods and CurseForge and registers them with the source registry. Users cannot
+add their own sources without writing Go code.
+
+Motivating example: a user maintains their own 7 Days to Die modlets in
+`~/Projects/mods/7dtd/donovan-7d2d-modlets/` and wants that directory to be a
+first-class mod source alongside NexusMods for the same game — searchable,
+installable, and update-checked like any remote mod.
+
+## Goals
+
+- Users define custom sources declaratively in YAML config files — no code, no plugins.
+- Three source types: **directory** (local mod folders), **manifest** (a published
+  mod list file), and **api** (declarative REST API description).
+- Sources may support a subset of operations; CLI and TUI degrade gracefully.
+- Optional API-key auth reusing the existing token store / env-var machinery.
+- Searching a game spans all its configured sources by default (aggregate search).
+- Both CLI and TUI treat custom sources as first-class.
+
+## Non-Goals (v1)
+
+- Programmable plugins (external executables, embedded scripting).
+- OAuth flows, POST/GraphQL APIs, HTML scraping in the `api` type.
+- Dependency resolution for the `api` type.
+- `lmm source import <url>` / community definition registry (may come later;
+  nothing in this design precludes it).
+- Interactive `lmm source add` wizard.
+- Migrating built-in sources (NexusMods, CurseForge) to the declarative format.
+- Global re-ranking of aggregate search results.
+
+## Existing Architecture (relevant facts)
+
+- `ModSource` interface (`internal/source/source.go`): ID, Name, AuthURL,
+  ExchangeToken, Search, GetMod, GetDependencies, GetModFiles, GetDownloadURL,
+  CheckUpdates.
+- `source.Registry` is already generic (register/get/list by ID).
+- The data model is already **per-mod source**: `Mod.SourceID`,
+  `InstalledMod` (embeds Mod), and profile `ModReference.SourceID`. No schema
+  migration is needed to mix sources within one game/profile.
+- `Game.SourceIDs map[string]string` maps source ID → source-specific game ID
+  (e.g. `"nexusmods" -> "skyrimspecialedition"`); it already supports multiple
+  sources per game.
+- `lmm search` currently queries a single source (`--source`, defaulting to the
+  game's first configured source).
+- Local import machinery exists (`internal/core/importer.go`): filename
+  version extraction, mod-name detection, cache copy helpers, `domain.SourceLocal`.
+- API keys resolve env-var-first, then the DB token store
+  (`getSourceAPIKey` in `cmd/lmm/root.go`).
+
+## Design
+
+### 1. Definition files & loading
+
+Custom sources live one-per-file in `~/.config/lmm/sources/*.yaml`.
+
+Common fields:
+
+```yaml
+id: my-repo          # required; [a-z0-9-]+; unique across built-ins and other files
+name: My Mod Repo    # required display name
+type: manifest       # required: manifest | api | directory
+allow_http: false    # optional; permit http:// URLs (default false)
+```
+
+Exactly one type-specific block (`manifest:`, `api:`, or `directory:`) must be
+present and must match `type`.
+
+**Loader:** `internal/storage/config/sources.go` reads the directory, validates
+each file, and returns `([]SourceDefinition, []LoadError)`. Validation covers:
+required fields, ID format, ID collisions (against already-registered sources and
+sibling files), block/type agreement, https-only URLs unless `allow_http: true`.
+
+**Registration:** `registerSources()` in `cmd/lmm/root.go` loads definitions after
+the built-ins, constructs the matching implementation from
+`internal/source/custom`, and registers it. A definition that fails validation
+**warns on stderr and is skipped** — a broken file never bricks the CLI/TUI.
+Load errors are retained for display by `lmm source list`.
+
+**No DB changes.** Definitions are pure config; auth reuses the existing token store.
+
+### 2. `type: directory` — local mod directories
+
+```yaml
+id: donovan-mods
+name: Donovan's 7D2D Modlets
+type: directory
+directory:
+  path: ~/Projects/mods/7dtd/donovan-7d2d-modlets
+```
+
+- **Scanning:** each subdirectory is a mod, and each `.zip`/`.jar` archive is a
+  mod (a source cannot know a game's deploy mode, so it scans both; deploy-mode
+  handling happens at install time). Scans are lazy per operation — local reads
+  are cheap enough that no cache is needed, and edits appear without restarting
+  lmm.
+- **Metadata resolution (priority order):**
+  1. Well-known metadata files, behind a small internal reader interface.
+     v1 ships a `ModInfo.xml` reader (7D2D: name, display name, version,
+     description, author). Future formats (e.g. `fabric.mod.json`) are additive.
+  2. Fallback: directory/file name + the existing version-pattern extraction
+     (promoted from `importer.go` to a shared location).
+- **Mod identity:** the mod ID is the directory name (or archive base name).
+  Stable across versions and human-readable (e.g. mod ID `BiggerBackpack`,
+  installed via the usual `--source donovan-mods`). Renaming a directory creates a
+  new mod identity — accepted trade-off, documented.
+- **Install flow:** `GetModFiles` returns one synthetic `DownloadableFile` per
+  mod whose URL is the local path. The download step recognizes local paths and
+  copies the directory (streaming, reusing importer copy helpers) into the
+  standard cache layout `<game>/<source-id>-<mod-id>/<version>/`. Deploy,
+  enable/disable, uninstall, and profiles use the normal linker flow unchanged.
+- **Updates:** `CheckUpdates` compares the installed version with the current
+  metadata-file version using `domain.IsNewerVersion`. Bumping a modlet's
+  `ModInfo.xml` version makes `lmm update` flag it like a remote update.
+- **Game association:** a directory source has no game-ID namespace; it matches
+  any game whose `sources:` map includes its ID (mapped value accepted, unused).
+- **Auth:** none. `AuthURL` returns `""`; `ExchangeToken` returns `ErrNotSupported`.
+- **Search:** client-side (see §5 semantics shared with manifest type).
+
+### 3. `type: manifest` — published mod-list file
+
+```yaml
+id: my-repo
+name: My Mod Repo
+type: manifest
+manifest:
+  url: https://example.com/mods.yaml   # https URL or local path (~ expanded)
+  refresh: 15m                         # optional cache TTL (default 15m)
+```
+
+The manifest document is an lmm-defined format (JSON or YAML):
+
+```yaml
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    author: someone
+    summary: Makes things cooler
+    game_ids: [skyrimspecialedition]   # matched against the game's mapped value;
+                                       # empty/omitted = matches all games
+    url: https://example.com/mods/cool-mod   # optional web page
+    updated_at: 2026-07-01T00:00:00Z         # optional, RFC 3339
+    dependencies: [other-mod]                # optional, IDs within this source
+    files:
+      - id: main
+        name: Main File
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        size: 123456
+        url: https://example.com/files/cool-mod-1.2.0.zip
+        sha256: <hex digest>           # optional; verified on download if present
+        primary: true
+```
+
+- Fetched on demand; in-memory cache with TTL; local paths read directly each
+  time (cheap).
+- All `ModSource` operations are implemented client-side over the manifest:
+  search (see §5), `GetMod` by ID, `GetModFiles`/`GetDownloadURL` straight from
+  the document, dependencies resolve to `ModReference{SourceID: <this source>}`,
+  `CheckUpdates` compares versions via `domain.IsNewerVersion`.
+- `sha256` plugs into the existing checksum verification (P1 feature).
+- Manifest parse errors fail the operation with a clear error naming the
+  manifest URL; they are not load-time errors (the definition itself is valid).
+- Optional API-key auth (§6) applies to both the manifest fetch and file
+  downloads (same header/query on both).
+
+### 4. `type: api` — declarative REST description
+
+```yaml
+id: esoui
+name: ESOUI
+type: api
+api:
+  base_url: https://api.example.com
+  page_start: 1                  # first page number the API expects (default 1)
+  auth:                          # optional
+    api_key:
+      in: header                 # header | query
+      name: X-API-Key
+  endpoints:                     # each endpoint is optional; absence = capability gap
+    search:
+      path: /mods?game={game_id}&q={query}&page={page}&limit={page_size}
+      list: results              # dot-path to results array
+      total: pagination.total    # optional dot-path to total count
+    get_mod:
+      path: /mods/{mod_id}
+    mod_files:
+      path: /mods/{mod_id}/files
+      list: files
+    download_url:
+      path: /files/{file_id}/download
+      field: url                 # dot-path to the URL string in the response
+  mappings:
+    mod:                         # JSON dot-paths -> domain.Mod fields
+      id: id
+      name: name
+      version: latest_version
+      author: author.name
+      summary: description
+      downloads: download_count
+      updated_at: updated        # RFC 3339 expected; unparseable -> zero value
+      url: web_url
+    file:                        # JSON dot-paths -> domain.DownloadableFile
+      id: id
+      name: title
+      filename: file_name
+      version: version
+      size: size_bytes
+```
+
+Rules and guardrails (v1):
+
+- GET requests returning JSON only.
+- Placeholders: `{game_id}` (from `Game.SourceIDs[source]`), `{query}`, `{page}`
+  (internal 0-based page + `page_start`), `{page_size}`, `{offset}` (internal
+  0-based page × page_size, independent of `page_start`, for offset-based APIs),
+  `{mod_id}`, `{file_id}`. All values URL-escaped on substitution.
+- Dot-paths traverse JSON objects; numbers/strings coerced to the target field
+  type; missing paths yield zero values (except `mod.id`, `mod.name`, and
+  `file.id`, which are required — a response missing them is an error).
+- `mappings.mod.id` etc. are validated at load time for required keys.
+- Undefined endpoint ⇒ that capability is unsupported (§7). A definition with
+  only `get_mod` + `mod_files` + `download_url` is a valid install-by-ID source.
+- `GetDependencies` always returns `ErrNotSupported` in v1.
+- `CheckUpdates` is implemented generically via `get_mod` + version comparison
+  (shared helper with the other types); without `get_mod` it is unsupported.
+
+### 5. Aggregate search
+
+`Service.SearchMods` gains an all-sources mode:
+
+- No `--source` given ⇒ query every source in the game's `sources:` map
+  **concurrently** (errgroup, shared context/timeout).
+- Results are merged and tagged by source; sort = name-match relevance first,
+  then downloads (same heuristic as today).
+- Per-source failures become warnings in the result (one flaky API must not
+  hide local modlets); only all-sources-failed is an error.
+- Pagination is per-source: "page 2" requests page 2 from each source and
+  merges. No global re-ranking in v1.
+- Sources without search capability are skipped silently in aggregate mode.
+- CLI: results gain a source column; `--source` still narrows to one source.
+- TUI: search rows get a source badge; the source picker gains an
+  "All sources" option, which becomes the default.
+
+Client-side search semantics (directory + manifest types): case-insensitive
+substring match on name and summary, game filtering (per-type rules above),
+name-matches ranked before summary-matches, then alphabetical; paginated
+locally honoring `SearchQuery.Page`/`PageSize`.
+
+### 6. Authentication
+
+- Custom sources support **API key or none**. OAuth is out of scope.
+- Key resolution order (matches existing pattern): `LMM_<ID>_API_KEY` env var
+  (ID uppercased, dashes → underscores), then the DB token store.
+- `lmm auth login <source-id>` is extended to prompt for and store an API key
+  for any custom source that declares `auth`.
+- Keys are attached per the definition (`header` or `query`) and never logged.
+- `lmm source list` shows auth state (not needed / configured / missing).
+
+### 7. Capabilities & graceful degradation
+
+New sentinel in `internal/source`:
+
+```go
+var ErrNotSupported = errors.New("operation not supported by this source")
+```
+
+Optional interface:
+
+```go
+type Capabilities struct {
+    Search, Dependencies, Updates, Auth bool
+}
+
+type CapabilityReporter interface {
+    Capabilities() Capabilities
+}
+```
+
+- Sources not implementing `CapabilityReporter` are assumed fully capable
+  (built-ins unchanged).
+- Custom sources return `ErrNotSupported` (wrapped, with source ID) from
+  operations they cannot perform.
+- CLI: `errors.Is(err, source.ErrNotSupported)` ⇒ clean one-line notice, not a
+  stack of wrapped errors.
+- TUI: unsupported actions are hidden or disabled for the selected mod's source.
+- Core: auto-dependency resolution and update checking treat "not supported" as
+  an empty result plus a notice; never a hard failure.
+
+### 8. Management commands
+
+- **`lmm source list`** — every registered source plus failed definitions:
+  ID, name, type (built-in/manifest/api/directory), auth state, capabilities,
+  load error if any.
+- **`lmm source validate <file>`** — full validation with actionable messages;
+  `--probe` additionally performs a live smoke test (manifest fetch+parse, or a
+  search/get_mod call for api types).
+- **TUI:** read-only Sources screen mirroring `source list` (fits the existing
+  views pattern; mutations remain CLI-side in v1, consistent with the Phase 5
+  TUI roadmap).
+
+### 9. Error handling & security
+
+- Definition errors: warn-and-skip at startup; full detail via
+  `source list` / `source validate`.
+- Operational errors: fail fast, wrapped with source ID and action context
+  per GO.md (`fmt.Errorf("source %q: searching: %w", id, err)`).
+- HTTPS enforced for `api.base_url`, remote manifest URLs, and manifest file
+  URLs; per-definition `allow_http: true` opt-out; local paths exempt.
+- All placeholder substitutions URL-escaped; API keys never logged.
+- Manifest `sha256` feeds existing checksum verification; directory-source
+  copies are local and skip it.
+- Directory source: configured path must exist and be a directory; symlinked
+  mod directories are followed; scan results never traverse upward out of the
+  configured path.
+
+### 10. Package layout
+
+```
+internal/source/
+├── source.go            # + ErrNotSupported, Capabilities, CapabilityReporter
+├── custom/
+│   ├── definition.go    # SourceDefinition types + validation
+│   ├── directory.go     # directory source
+│   ├── manifest.go      # manifest source + manifest document types
+│   ├── api.go           # declarative REST source
+│   ├── mapping.go       # dot-path resolution, template substitution
+│   └── metadata/        # well-known metadata readers
+│       ├── reader.go    # reader interface + registry
+│       └── modinfo.go   # 7D2D ModInfo.xml
+internal/storage/config/
+└── sources.go           # loading ~/.config/lmm/sources/*.yaml
+cmd/lmm/
+└── source.go            # `lmm source list|validate`
+```
+
+(Exact file split may flex during implementation; package boundaries hold.)
+
+### 11. Testing strategy
+
+TDD throughout, per repo convention:
+
+| Area | Approach |
+| ---- | -------- |
+| Definition loader/validator | Table-driven tests with bad-YAML fixtures (missing fields, bad IDs, collisions, http URLs) |
+| Directory source | `t.TempDir()` fixture trees; `ModInfo.xml` parsing cases; copy-mode vs extract-mode scans |
+| Manifest source | `httptest` server + local-file manifests; TTL cache behavior; checksum propagation |
+| API source | `httptest` servers per endpoint shape: pagination variants (page_start 0/1, offset), auth header/query, malformed JSON, missing required fields |
+| Aggregate search | Mock sources: merging, ordering, per-source failure isolation, unsupported-search skipping |
+| End-to-end | Install from a directory source through real cache + linker in temp dirs |
+| CLI | `source list` / `source validate` output including error display |
+
+### 12. Delivery
+
+- MINOR version bump → **v1.6.0**; README and CHANGELOG updated (three source
+  types, manifest format spec, new commands, aggregate search).
+- Work tracked under a GitHub issue (to be created/linked before implementation).
+- Implementation phases:
+  1. **Foundation** — `ErrNotSupported` + capabilities, definition
+     loader/validator, `lmm source list|validate`
+  2. **Directory source** — modlets use case end-to-end
+     (scan → metadata → install → update)
+  3. **Manifest source** — format spec, client-side ops, checksum wiring
+  4. **API source** — templates, mappings, pagination, auth
+  5. **Aggregate search** — core + CLI + TUI badge/picker
+
+Each phase lands independently valuable and releasable.

--- a/docs/plans/archive/2026-07-13-custom-sources-p1-p2-impl.md
+++ b/docs/plans/archive/2026-07-13-custom-sources-p1-p2-impl.md
@@ -1,0 +1,2299 @@
+# Custom Sources — Phases 1 & 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Users can define custom mod sources in `~/.config/lmm/sources/*.yaml`; the `directory` type turns a local folder of mods (e.g. 7D2D modlets) into a first-class source — searchable, installable, and update-checked.
+
+**Architecture:** New `internal/source/custom` package implements `ModSource` from declarative YAML definitions loaded by `internal/storage/config`. A `Capabilities`/`ErrNotSupported` mechanism lets partial sources degrade gracefully. Local installs reuse the existing staging cache flow via a `file://` hook in `Service.DownloadModToCache`.
+
+**Tech Stack:** Go, gopkg.in/yaml.v3 (existing dep), encoding/xml (stdlib), testify.
+
+**Spec:** `docs/plans/2026-07-13-custom-sources-design.md` (Phases 3–5 — manifest, api, aggregate search — are separate plans/issues.)
+
+## Global Constraints
+
+- TDD: every task starts with a failing test (`~/.claude/DEV.md`, repo CLAUDE.md).
+- Error wrapping with context: `fmt.Errorf("doing X: %w", err)` (GO.md).
+- `ctx context.Context` first param for I/O paths; no ctx in structs (GO.MD).
+- No new dependencies.
+- `go fmt ./...` and `go vet ./...` clean before every commit.
+- Custom source definition IDs: `^[a-z0-9-]+$`; a broken definition file must never break lmm startup (warn + skip).
+- Definitions live in `<configDir>/sources/*.yaml` (default `~/.config/lmm/sources/`).
+- Commit after each task; conventional commit messages.
+
+---
+
+## Phase 1 — Foundation
+
+### Task 1: Capabilities & ErrNotSupported
+
+**Files:**
+- Modify: `internal/source/source.go`
+- Test: `internal/source/source_test.go` (create)
+
+**Interfaces:**
+- Consumes: existing `ModSource` interface.
+- Produces: `source.ErrNotSupported` (sentinel error), `source.Capabilities{Search, Dependencies, Updates, Auth bool}`, `source.CapabilityReporter` interface, `source.CapabilitiesOf(src ModSource) Capabilities`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/source/source_test.go`:
+
+```go
+package source
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+// fullSource implements ModSource but not CapabilityReporter.
+type fullSource struct{}
+
+func (fullSource) ID() string      { return "full" }
+func (fullSource) Name() string    { return "Full" }
+func (fullSource) AuthURL() string { return "" }
+func (fullSource) ExchangeToken(context.Context, string) (*Token, error) { return nil, nil }
+func (fullSource) Search(context.Context, SearchQuery) (SearchResult, error) {
+	return SearchResult{}, nil
+}
+func (fullSource) GetMod(context.Context, string, string) (*domain.Mod, error) { return nil, nil }
+func (fullSource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) {
+	return nil, nil
+}
+func (fullSource) GetModFiles(context.Context, *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, nil
+}
+func (fullSource) GetDownloadURL(context.Context, *domain.Mod, string) (string, error) {
+	return "", nil
+}
+func (fullSource) CheckUpdates(context.Context, []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, nil
+}
+
+// partialSource additionally reports limited capabilities.
+type partialSource struct{ fullSource }
+
+func (partialSource) Capabilities() Capabilities {
+	return Capabilities{Search: true, Updates: true}
+}
+
+func TestCapabilitiesOf(t *testing.T) {
+	t.Run("defaults to fully capable", func(t *testing.T) {
+		caps := CapabilitiesOf(fullSource{})
+		assert.Equal(t, Capabilities{Search: true, Dependencies: true, Updates: true, Auth: true}, caps)
+	})
+
+	t.Run("uses CapabilityReporter when implemented", func(t *testing.T) {
+		caps := CapabilitiesOf(partialSource{})
+		assert.Equal(t, Capabilities{Search: true, Dependencies: false, Updates: true, Auth: false}, caps)
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/ -run TestCapabilitiesOf -v`
+Expected: FAIL — `undefined: Capabilities`, `undefined: CapabilitiesOf`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/source/source.go` (add `"errors"` to imports):
+
+```go
+// ErrNotSupported indicates a source does not support the requested operation.
+// Callers should branch with errors.Is(err, ErrNotSupported) and degrade
+// gracefully (hide the action, show a notice) rather than treat it as a failure.
+var ErrNotSupported = errors.New("operation not supported by this source")
+
+// Capabilities reports which optional operations a source supports.
+type Capabilities struct {
+	Search       bool
+	Dependencies bool
+	Updates      bool
+	Auth         bool
+}
+
+// CapabilityReporter is implemented by sources that support only a subset of
+// ModSource operations. Sources that do not implement it are assumed fully
+// capable.
+type CapabilityReporter interface {
+	Capabilities() Capabilities
+}
+
+// CapabilitiesOf returns src's capabilities, assuming full capability for
+// sources that do not implement CapabilityReporter (all built-in sources).
+func CapabilitiesOf(src ModSource) Capabilities {
+	if cr, ok := src.(CapabilityReporter); ok {
+		return cr.Capabilities()
+	}
+	return Capabilities{Search: true, Dependencies: true, Updates: true, Auth: true}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/ -v`
+Expected: PASS (all, including existing registry tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/source.go internal/source/source_test.go
+git commit -m "feat(source): add ErrNotSupported sentinel and Capabilities reporting"
+```
+
+---
+
+### Task 2: SourceDefinition schema + validation
+
+**Files:**
+- Create: `internal/source/custom/definition.go`
+- Test: `internal/source/custom/definition_test.go`
+
+**Interfaces:**
+- Produces:
+  - `custom.SourceDefinition{ID, Name, Type string; AllowHTTP bool; Directory *DirectoryConfig; Manifest *ManifestConfig; API *APIConfig}` with yaml tags
+  - `custom.DirectoryConfig{Path string}`
+  - `custom.ManifestConfig{URL string; Refresh string}` (Refresh parsed/validated as duration; used in Phase 3)
+  - `custom.APIConfig{BaseURL string}` (expanded in Phase 4)
+  - `(d *SourceDefinition) Validate() error`
+  - Type constants: `custom.TypeDirectory = "directory"`, `custom.TypeManifest = "manifest"`, `custom.TypeAPI = "api"`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/source/custom/definition_test.go`:
+
+```go
+package custom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func validDirectoryDef() SourceDefinition {
+	return SourceDefinition{
+		ID:        "my-mods",
+		Name:      "My Mods",
+		Type:      TypeDirectory,
+		Directory: &DirectoryConfig{Path: "~/mods"},
+	}
+}
+
+func TestSourceDefinitionValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*SourceDefinition)
+		wantErr string // empty = valid
+	}{
+		{"valid directory", func(d *SourceDefinition) {}, ""},
+		{"missing id", func(d *SourceDefinition) { d.ID = "" }, "id is required"},
+		{"bad id chars", func(d *SourceDefinition) { d.ID = "My_Mods" }, "must match"},
+		{"missing name", func(d *SourceDefinition) { d.Name = "" }, "name is required"},
+		{"missing type", func(d *SourceDefinition) { d.Type = "" }, "type is required"},
+		{"unknown type", func(d *SourceDefinition) { d.Type = "ftp" }, "unknown type"},
+		{"directory without block", func(d *SourceDefinition) { d.Directory = nil }, `requires a "directory" block`},
+		{"directory with empty path", func(d *SourceDefinition) { d.Directory.Path = "" }, "directory.path is required"},
+		{"two type blocks", func(d *SourceDefinition) {
+			d.Manifest = &ManifestConfig{URL: "https://x.test/m.yaml"}
+		}, "exactly one"},
+		{"valid https manifest", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "https://x.test/m.yaml"}
+		}, ""},
+		{"valid local manifest path", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "~/mods/manifest.yaml"}
+		}, ""},
+		{"http manifest rejected", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "http://x.test/m.yaml"}
+		}, "https"},
+		{"http manifest allowed with allow_http", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.AllowHTTP = true
+			d.Manifest = &ManifestConfig{URL: "http://x.test/m.yaml"}
+		}, ""},
+		{"bad manifest refresh", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "https://x.test/m.yaml", Refresh: "soon"}
+		}, "refresh"},
+		{"valid api", func(d *SourceDefinition) {
+			d.Type = TypeAPI
+			d.Directory = nil
+			d.API = &APIConfig{BaseURL: "https://api.x.test"}
+		}, ""},
+		{"http api rejected", func(d *SourceDefinition) {
+			d.Type = TypeAPI
+			d.Directory = nil
+			d.API = &APIConfig{BaseURL: "http://api.x.test"}
+		}, "https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := validDirectoryDef()
+			tt.mutate(&def)
+			err := def.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: FAIL — package does not exist / undefined types.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/source/custom/definition.go`:
+
+```go
+// Package custom implements user-defined mod sources configured declaratively
+// via YAML files in <configDir>/sources/. See the design doc:
+// docs/plans/2026-07-13-custom-sources-design.md
+package custom
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Source type identifiers for SourceDefinition.Type.
+const (
+	TypeDirectory = "directory"
+	TypeManifest  = "manifest"
+	TypeAPI       = "api"
+)
+
+// SourceDefinition is one user-defined source, parsed from a YAML file in
+// <configDir>/sources/. Exactly one of Directory/Manifest/API must be set,
+// matching Type.
+type SourceDefinition struct {
+	ID        string           `yaml:"id"`
+	Name      string           `yaml:"name"`
+	Type      string           `yaml:"type"`
+	AllowHTTP bool             `yaml:"allow_http"`
+	Directory *DirectoryConfig `yaml:"directory"`
+	Manifest  *ManifestConfig  `yaml:"manifest"`
+	API       *APIConfig       `yaml:"api"`
+}
+
+// DirectoryConfig configures a local-directory source.
+type DirectoryConfig struct {
+	Path string `yaml:"path"`
+}
+
+// ManifestConfig configures a manifest source (Phase 3).
+type ManifestConfig struct {
+	URL     string `yaml:"url"`
+	Refresh string `yaml:"refresh"` // Go duration string, e.g. "15m"; empty = default
+}
+
+// APIConfig configures a declarative REST source (expanded in Phase 4).
+type APIConfig struct {
+	BaseURL string `yaml:"base_url"`
+}
+
+var idPattern = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// Validate checks the definition for structural errors. It does not touch the
+// filesystem or network; existence checks happen when the source is constructed.
+func (d *SourceDefinition) Validate() error {
+	if d.ID == "" {
+		return errors.New("id is required")
+	}
+	if !idPattern.MatchString(d.ID) {
+		return fmt.Errorf("id %q must match ^[a-z0-9-]+$", d.ID)
+	}
+	if d.Name == "" {
+		return errors.New("name is required")
+	}
+	if d.Type == "" {
+		return errors.New("type is required")
+	}
+
+	blocks := 0
+	if d.Directory != nil {
+		blocks++
+	}
+	if d.Manifest != nil {
+		blocks++
+	}
+	if d.API != nil {
+		blocks++
+	}
+	if blocks > 1 {
+		return errors.New("exactly one of directory/manifest/api may be set")
+	}
+
+	switch d.Type {
+	case TypeDirectory:
+		if d.Directory == nil {
+			return fmt.Errorf(`type %q requires a "directory" block`, d.Type)
+		}
+		if d.Directory.Path == "" {
+			return errors.New("directory.path is required")
+		}
+	case TypeManifest:
+		if d.Manifest == nil {
+			return fmt.Errorf(`type %q requires a "manifest" block`, d.Type)
+		}
+		if d.Manifest.URL == "" {
+			return errors.New("manifest.url is required")
+		}
+		if err := d.checkURL(d.Manifest.URL); err != nil {
+			return fmt.Errorf("manifest.url: %w", err)
+		}
+		if d.Manifest.Refresh != "" {
+			if _, err := time.ParseDuration(d.Manifest.Refresh); err != nil {
+				return fmt.Errorf("manifest.refresh: %w", err)
+			}
+		}
+	case TypeAPI:
+		if d.API == nil {
+			return fmt.Errorf(`type %q requires an "api" block`, d.Type)
+		}
+		if d.API.BaseURL == "" {
+			return errors.New("api.base_url is required")
+		}
+		if !strings.HasPrefix(d.API.BaseURL, "https://") && !strings.HasPrefix(d.API.BaseURL, "http://") {
+			return errors.New("api.base_url must be an http(s) URL")
+		}
+		if err := d.checkURL(d.API.BaseURL); err != nil {
+			return fmt.Errorf("api.base_url: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown type %q (expected %s, %s, or %s)", d.Type, TypeDirectory, TypeManifest, TypeAPI)
+	}
+
+	return nil
+}
+
+// checkURL rejects plain-http URLs unless allow_http is set. Non-URL values
+// (local paths) pass through untouched.
+func (d *SourceDefinition) checkURL(u string) error {
+	if strings.HasPrefix(u, "http://") && !d.AllowHTTP {
+		return errors.New("plain http is disabled; use https or set allow_http: true")
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS (all table cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/
+git commit -m "feat(source): add custom source definition schema and validation"
+```
+
+---
+
+### Task 3: Definition loader
+
+**Files:**
+- Create: `internal/storage/config/sources.go`
+- Test: `internal/storage/config/sources_test.go`
+
+**Interfaces:**
+- Consumes: `custom.SourceDefinition`, `(*SourceDefinition).Validate()` from Task 2.
+- Produces:
+  - `config.SourceLoadError{File string; Err error}` with `Error() string`
+  - `config.LoadSourceDefinitions(configDir string) ([]custom.SourceDefinition, []SourceLoadError, error)` — missing dir ⇒ `(nil, nil, nil)`; per-file problems land in `[]SourceLoadError`, only unreadable-directory is a hard error
+  - `config.LoadSourceDefinitionFile(path string) (custom.SourceDefinition, error)` — used by `lmm source validate`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/storage/config/sources_test.go`:
+
+```go
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSourceFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644))
+}
+
+func TestLoadSourceDefinitions(t *testing.T) {
+	t.Run("missing sources dir is not an error", func(t *testing.T) {
+		defs, loadErrs, err := LoadSourceDefinitions(t.TempDir())
+		assert.NoError(t, err)
+		assert.Empty(t, defs)
+		assert.Empty(t, loadErrs)
+	})
+
+	t.Run("loads valid definitions and collects per-file errors", func(t *testing.T) {
+		configDir := t.TempDir()
+		srcDir := filepath.Join(configDir, "sources")
+		writeSourceFile(t, srcDir, "good.yaml", `
+id: my-mods
+name: My Mods
+type: directory
+directory:
+  path: ~/mods
+`)
+		writeSourceFile(t, srcDir, "bad-yaml.yaml", "id: [unclosed")
+		writeSourceFile(t, srcDir, "invalid.yaml", `
+id: BAD_ID
+name: Bad
+type: directory
+directory:
+  path: ~/x
+`)
+		writeSourceFile(t, srcDir, "notes.txt", "not yaml, ignored")
+
+		defs, loadErrs, err := LoadSourceDefinitions(configDir)
+		assert.NoError(t, err)
+		require.Len(t, defs, 1)
+		assert.Equal(t, "my-mods", defs[0].ID)
+		require.Len(t, loadErrs, 2)
+		files := []string{loadErrs[0].File, loadErrs[1].File}
+		assert.Contains(t, files, "bad-yaml.yaml")
+		assert.Contains(t, files, "invalid.yaml")
+	})
+
+	t.Run("duplicate ids across files are rejected", func(t *testing.T) {
+		configDir := t.TempDir()
+		srcDir := filepath.Join(configDir, "sources")
+		def := `
+id: dupe
+name: Dupe
+type: directory
+directory:
+  path: ~/mods
+`
+		writeSourceFile(t, srcDir, "a.yaml", def)
+		writeSourceFile(t, srcDir, "b.yaml", def)
+
+		defs, loadErrs, err := LoadSourceDefinitions(configDir)
+		assert.NoError(t, err)
+		assert.Len(t, defs, 1)
+		require.Len(t, loadErrs, 1)
+		assert.ErrorContains(t, loadErrs[0].Err, "duplicate")
+	})
+}
+
+func TestLoadSourceDefinitionFile(t *testing.T) {
+	dir := t.TempDir()
+	writeSourceFile(t, dir, "s.yaml", `
+id: my-mods
+name: My Mods
+type: directory
+directory:
+  path: ~/mods
+`)
+
+	def, err := LoadSourceDefinitionFile(filepath.Join(dir, "s.yaml"))
+	assert.NoError(t, err)
+	assert.Equal(t, "my-mods", def.ID)
+
+	_, err = LoadSourceDefinitionFile(filepath.Join(dir, "missing.yaml"))
+	assert.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/storage/config/ -run 'TestLoadSourceDefinition' -v`
+Expected: FAIL — `undefined: LoadSourceDefinitions`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/storage/config/sources.go`:
+
+```go
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"gopkg.in/yaml.v3"
+)
+
+// SourceLoadError describes a source definition file that could not be loaded.
+// These are collected rather than returned as hard errors so one broken file
+// never prevents lmm from starting.
+type SourceLoadError struct {
+	File string // base filename within the sources directory
+	Err  error
+}
+
+func (e SourceLoadError) Error() string {
+	return fmt.Sprintf("%s: %v", e.File, e.Err)
+}
+
+// LoadSourceDefinitions reads and validates every *.yaml/*.yml file in
+// <configDir>/sources. A missing directory yields no definitions and no error.
+// Per-file parse/validation failures (including duplicate IDs) are returned as
+// SourceLoadErrors; the hard error is reserved for an unreadable directory.
+func LoadSourceDefinitions(configDir string) ([]custom.SourceDefinition, []SourceLoadError, error) {
+	dir := filepath.Join(configDir, "sources")
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading sources directory %s: %w", dir, err)
+	}
+
+	var defs []custom.SourceDefinition
+	var loadErrs []SourceLoadError
+	seen := make(map[string]string) // id -> filename that claimed it
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || (!strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml")) {
+			continue
+		}
+
+		def, err := LoadSourceDefinitionFile(filepath.Join(dir, name))
+		if err != nil {
+			loadErrs = append(loadErrs, SourceLoadError{File: name, Err: err})
+			continue
+		}
+		if prev, dup := seen[def.ID]; dup {
+			loadErrs = append(loadErrs, SourceLoadError{
+				File: name,
+				Err:  fmt.Errorf("duplicate source id %q (already defined in %s)", def.ID, prev),
+			})
+			continue
+		}
+		seen[def.ID] = name
+		defs = append(defs, def)
+	}
+
+	return defs, loadErrs, nil
+}
+
+// LoadSourceDefinitionFile reads and validates a single source definition file.
+func LoadSourceDefinitionFile(path string) (custom.SourceDefinition, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return custom.SourceDefinition{}, fmt.Errorf("reading definition: %w", err)
+	}
+
+	var def custom.SourceDefinition
+	if err := yaml.Unmarshal(data, &def); err != nil {
+		return custom.SourceDefinition{}, fmt.Errorf("parsing YAML: %w", err)
+	}
+	if err := def.Validate(); err != nil {
+		return custom.SourceDefinition{}, fmt.Errorf("invalid definition: %w", err)
+	}
+
+	return def, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/storage/config/ -v`
+Expected: PASS (new and existing config tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/storage/config/sources.go internal/storage/config/sources_test.go
+git commit -m "feat(config): load custom source definitions from sources directory"
+```
+
+---
+
+### Task 4: Factory + startup registration
+
+**Files:**
+- Create: `internal/source/custom/custom.go`
+- Test: `internal/source/custom/custom_test.go`
+- Modify: `cmd/lmm/root.go` (registerSources + initService call site)
+
+**Interfaces:**
+- Consumes: `config.LoadSourceDefinitions` (Task 3), `svc.RegisterSource`/`svc.GetSource` (existing).
+- Produces: `custom.New(def SourceDefinition) (source.ModSource, error)` — the single construction entry point; Phase 2 adds the directory case, Phases 3–4 add theirs.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/source/custom/custom_test.go`:
+
+```go
+package custom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("unimplemented types return a clear error", func(t *testing.T) {
+		for _, typ := range []string{TypeDirectory, TypeManifest, TypeAPI} {
+			def := SourceDefinition{ID: "x", Name: "X", Type: typ}
+			_, err := New(def)
+			assert.ErrorContains(t, err, "not yet supported", "type %s", typ)
+		}
+	})
+}
+```
+
+(Phase 2 flips the `TypeDirectory` expectation; that change is written into Task 11.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestNew -v`
+Expected: FAIL — `undefined: New`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/source/custom/custom.go`:
+
+```go
+package custom
+
+import (
+	"fmt"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+)
+
+// New constructs a ModSource from a validated definition. It returns an error
+// for definition types whose implementation has not shipped yet, so startup
+// can warn-and-skip instead of failing.
+func New(def SourceDefinition) (source.ModSource, error) {
+	switch def.Type {
+	default:
+		return nil, fmt.Errorf("source type %q is not yet supported", def.Type)
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into startup**
+
+In `cmd/lmm/root.go`:
+
+1. Add imports: `"github.com/DonovanMods/linux-mod-manager/internal/source/custom"` (config is already imported).
+2. In `initService()`, change the call `registerSources(svc)` to `registerSources(svc, cfg.ConfigDir)`.
+3. Replace `registerSources` and add `registerCustomSources`:
+
+```go
+// registerSources registers all available mod sources with the service.
+// Built-ins first, then user-defined sources from <configDir>/sources/.
+func registerSources(svc *core.Service, cfgDir string) {
+	// NexusMods
+	nexusKey := getSourceAPIKey(svc, "nexusmods", "NEXUSMODS_API_KEY")
+	svc.RegisterSource(nexusmods.New(nil, nexusKey))
+
+	// CurseForge
+	curseKey := getSourceAPIKey(svc, "curseforge", "CURSEFORGE_API_KEY")
+	svc.RegisterSource(curseforge.New(nil, curseKey))
+
+	registerCustomSources(svc, cfgDir)
+}
+
+// registerCustomSources loads user-defined source definitions and registers
+// the valid ones. Broken definitions warn on stderr and are skipped — a bad
+// file must never prevent lmm from starting.
+func registerCustomSources(svc *core.Service, cfgDir string) {
+	defs, loadErrs, err := config.LoadSourceDefinitions(cfgDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: loading custom sources: %v\n", err)
+		return
+	}
+	for _, le := range loadErrs {
+		fmt.Fprintf(os.Stderr, "warning: skipping source definition %v\n", le)
+	}
+	for _, def := range defs {
+		if _, err := svc.GetSource(def.ID); err == nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping source %q: id already in use\n", def.ID)
+			continue
+		}
+		src, err := custom.New(def)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping source %q: %v\n", def.ID, err)
+			continue
+		}
+		svc.RegisterSource(src)
+	}
+}
+```
+
+- [ ] **Step 6: Verify build and full test suite**
+
+Run: `go build ./... && go test ./...`
+Expected: build OK, all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/custom.go internal/source/custom/custom_test.go cmd/lmm/root.go
+git commit -m "feat(cli): register user-defined sources at startup with warn-and-skip"
+```
+
+---
+
+### Task 5: `lmm source list` and `lmm source validate`
+
+**Files:**
+- Create: `cmd/lmm/source.go`
+- Test: `cmd/lmm/source_test.go`
+
+**Interfaces:**
+- Consumes: `svc.ListSources()`, `source.CapabilitiesOf`, `config.LoadSourceDefinitions`, `config.LoadSourceDefinitionFile`, `withService`, `getServiceConfig` (all existing/prior tasks).
+- Produces: `lmm source list` (table + `--json`), `lmm source validate <file>`. Exit code 1 when validate fails.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/lmm/source_test.go` (follows the light cmd-test pattern used by `list_test.go` — heavy logic was tested in internal packages):
+
+```go
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceCmd_Structure(t *testing.T) {
+	assert.Equal(t, "source", sourceCmd.Use)
+	assert.NotEmpty(t, sourceCmd.Short)
+
+	names := make([]string, 0)
+	for _, c := range sourceCmd.Commands() {
+		names = append(names, c.Name())
+	}
+	assert.Contains(t, names, "list")
+	assert.Contains(t, names, "validate")
+}
+
+func TestSourceValidateCmd(t *testing.T) {
+	run := func(args ...string) (string, error) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.AddCommand(sourceCmd)
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		return buf.String(), err
+	}
+
+	t.Run("valid file passes", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "good.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+id: my-mods
+name: My Mods
+type: directory
+directory:
+  path: ~/mods
+`), 0644))
+
+		out, err := run("source", "validate", path)
+		assert.NoError(t, err)
+		assert.Contains(t, out, "valid")
+	})
+
+	t.Run("invalid file fails with reason", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bad.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+id: BAD_ID
+name: Bad
+type: directory
+directory:
+  path: ~/x
+`), 0644))
+
+		_, err := run("source", "validate", path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must match")
+	})
+
+	t.Run("missing argument errors", func(t *testing.T) {
+		_, err := run("source", "validate")
+		assert.Error(t, err)
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/lmm/ -run 'TestSource' -v`
+Expected: FAIL — `undefined: sourceCmd`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `cmd/lmm/source.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
+	"github.com/spf13/cobra"
+)
+
+var sourceCmd = &cobra.Command{
+	Use:   "source",
+	Short: "Manage mod sources",
+	Long:  "List registered mod sources and validate user-defined source definitions.",
+}
+
+// sourceInfo is one row of `lmm source list` output.
+type sourceInfo struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Type         string `json:"type"` // "built-in", "directory", "manifest", "api", or "error"
+	Auth         string `json:"auth"` // "yes", "no", "n/a"
+	Capabilities string `json:"capabilities"`
+	Error        string `json:"error,omitempty"`
+}
+
+var sourceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all mod sources",
+	Long:  "List built-in and user-defined mod sources, including definitions that failed to load.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return withService(cmd, func(ctx context.Context, svc *core.Service) error {
+			cfg, err := getServiceConfig()
+			if err != nil {
+				return err
+			}
+			defs, loadErrs, err := config.LoadSourceDefinitions(cfg.ConfigDir)
+			if err != nil {
+				return fmt.Errorf("loading source definitions: %w", err)
+			}
+
+			defTypes := make(map[string]string, len(defs))
+			for _, d := range defs {
+				defTypes[d.ID] = d.Type
+			}
+
+			var rows []sourceInfo
+			for _, src := range svc.ListSources() {
+				typ, isCustom := defTypes[src.ID()]
+				if !isCustom {
+					typ = "built-in"
+				}
+				rows = append(rows, sourceInfo{
+					ID:           src.ID(),
+					Name:         src.Name(),
+					Type:         typ,
+					Auth:         authState(src),
+					Capabilities: capabilitySummary(source.CapabilitiesOf(src)),
+				})
+			}
+			for _, le := range loadErrs {
+				rows = append(rows, sourceInfo{
+					ID:    le.File,
+					Type:  "error",
+					Error: le.Err.Error(),
+				})
+			}
+
+			if jsonOutput {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(rows)
+			}
+
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tNAME\tTYPE\tAUTH\tCAPABILITIES\tERROR")
+			for _, r := range rows {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", r.ID, r.Name, r.Type, r.Auth, r.Capabilities, r.Error)
+			}
+			return w.Flush()
+		})
+	},
+}
+
+var sourceValidateCmd = &cobra.Command{
+	Use:   "validate <file>",
+	Short: "Validate a source definition file",
+	Long:  "Parse and validate a user-defined source definition YAML file, reporting any problems.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		def, err := config.LoadSourceDefinitionFile(args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s: valid (%s source %q)\n", args[0], def.Type, def.ID)
+		return nil
+	},
+}
+
+// authState reports a source's authentication status for display.
+func authState(src source.ModSource) string {
+	if !source.CapabilitiesOf(src).Auth {
+		return "n/a"
+	}
+	if a, ok := src.(interface{ IsAuthenticated() bool }); ok {
+		if a.IsAuthenticated() {
+			return "yes"
+		}
+		return "no"
+	}
+	return "yes"
+}
+
+// capabilitySummary renders capabilities as a compact list, e.g. "search,updates".
+func capabilitySummary(c source.Capabilities) string {
+	out := ""
+	add := func(enabled bool, name string) {
+		if !enabled {
+			return
+		}
+		if out != "" {
+			out += ","
+		}
+		out += name
+	}
+	add(c.Search, "search")
+	add(c.Dependencies, "deps")
+	add(c.Updates, "updates")
+	add(c.Auth, "auth")
+	return out
+}
+
+func init() {
+	sourceCmd.AddCommand(sourceListCmd)
+	sourceCmd.AddCommand(sourceValidateCmd)
+	rootCmd.AddCommand(sourceCmd)
+}
+```
+
+- [ ] **Step 4: Run tests, then verify manually**
+
+Run: `go test ./cmd/lmm/ -v`
+Expected: PASS.
+
+Run: `go build -o lmm ./cmd/lmm && ./lmm source list`
+Expected: table showing `nexusmods` and `curseforge` as `built-in` with full capabilities.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add cmd/lmm/source.go cmd/lmm/source_test.go
+git commit -m "feat(cli): add 'lmm source list' and 'lmm source validate' commands"
+```
+
+---
+
+### Task 6: Phase 1 documentation
+
+**Files:**
+- Modify: `README.md` (commands section), `CHANGELOG.md` (`[Unreleased]`)
+
+- [ ] **Step 1: Update docs**
+
+`CHANGELOG.md` — add under `[Unreleased]` → `### Added`:
+
+```markdown
+- `lmm source list` — list built-in and user-defined mod sources
+- `lmm source validate <file>` — validate a user-defined source definition
+- User-defined source definitions loaded from `~/.config/lmm/sources/*.yaml`
+```
+
+`README.md` — add a "Custom Sources" section documenting: the `sources/` directory location, the common definition fields (`id`, `name`, `type`, `allow_http`), warn-and-skip behavior, and both new commands with example output. Copy the YAML example from the design doc §1.
+
+- [ ] **Step 2: Verify and commit**
+
+Run: `go test ./...`
+Expected: PASS.
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "docs: document custom source definitions and source commands"
+```
+
+---
+
+## Phase 2 — Directory Source
+
+### Task 7: Shared version extraction in domain
+
+**Files:**
+- Modify: `internal/domain/mod.go`, `internal/core/importer.go`
+- Test: `internal/domain/mod_test.go` (append)
+
+**Interfaces:**
+- Produces: `domain.ExtractVersionFromName(name string) string` — returns the **last** version-like pattern (e.g. `"jei-1.20.1-15.3.0"` → `"15.3.0"`), or `""`.
+- Consumes/refactors: `extractVersionFromFilename` + `versionRegexImporter` in `internal/core/importer.go` are deleted; call sites switch to the domain function.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/domain/mod_test.go`:
+
+```go
+func TestExtractVersionFromName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"simple", "BiggerBackpack-1.2.0", "1.2.0"},
+		{"v prefix", "cool-mod-v2.1", "2.1"},
+		{"last version wins", "jei-1.20.1-15.3.0", "15.3.0"},
+		{"prerelease suffix", "mod-1.0.0-beta2", "1.0.0-beta2"},
+		{"no version", "JustAName", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ExtractVersionFromName(tt.in))
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/domain/ -run TestExtractVersionFromName -v`
+Expected: FAIL — `undefined: ExtractVersionFromName`.
+
+- [ ] **Step 3: Implement and refactor**
+
+Append to `internal/domain/mod.go` (add `"regexp"` to imports):
+
+```go
+// versionPattern matches version-like strings such as 1.2.3, v1.2.3, or
+// 1.0.0-beta2. The optional suffix must start with a letter so compound
+// strings like "1.20.1-15.3.0" parse as two versions, not one.
+var versionPattern = regexp.MustCompile(`[vV]?(\d+\.\d+(?:\.\d+)?(?:\.\d+)?(?:[-+][a-zA-Z][\w.]*)?)`)
+
+// ExtractVersionFromName extracts the last version-like pattern from a file or
+// directory name (mod version typically follows the game version in names like
+// "jei-1.20.1-15.3.0"). Returns "" when no version is present.
+func ExtractVersionFromName(name string) string {
+	matches := versionPattern.FindAllStringSubmatch(name, -1)
+	if len(matches) > 0 {
+		return matches[len(matches)-1][1]
+	}
+	return ""
+}
+```
+
+In `internal/core/importer.go`: delete `versionRegexImporter` and `extractVersionFromFilename`, and replace every call `extractVersionFromFilename(x)` with `domain.ExtractVersionFromName(x)` (call sites: `Import`, `detectModFromFilename` — find them all with `grep -n extractVersionFromFilename internal/core/`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/domain/ ./internal/core/ -v`
+Expected: PASS (domain new test + all existing importer tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/domain/mod.go internal/domain/mod_test.go internal/core/importer.go
+git commit -m "refactor(domain): promote filename version extraction to domain"
+```
+
+---
+
+### Task 8: Metadata readers (ModInfo.xml)
+
+**Files:**
+- Create: `internal/source/custom/metadata/reader.go`, `internal/source/custom/metadata/modinfo.go`
+- Test: `internal/source/custom/metadata/metadata_test.go`
+
+**Interfaces:**
+- Produces:
+  - `metadata.Info{Name, DisplayName, Version, Summary, Author string}`
+  - `metadata.Reader` interface: `Detect(modDir string) string` (path or `""`), `Read(path string) (*Info, error)`
+  - `metadata.Resolve(modDir string) *Info` — tries readers in order; `nil` when none match or reading fails
+- Consumed by: Task 9 (directory scan).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/source/custom/metadata/metadata_test.go`:
+
+```go
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 7D2D "V2" layout: fields directly under <xml>.
+const modInfoV2 = `<?xml version="1.0" encoding="UTF-8" ?>
+<xml>
+	<Name value="BiggerBackpack"/>
+	<DisplayName value="Bigger Backpack"/>
+	<Version value="1.2.0"/>
+	<Description value="Carry more stuff"/>
+	<Author value="Donovan"/>
+</xml>`
+
+// 7D2D "V1" layout: fields nested in <ModInfo>.
+const modInfoV1 = `<?xml version="1.0" encoding="UTF-8" ?>
+<xml>
+	<ModInfo>
+		<Name value="OldMod"/>
+		<Version value="0.9"/>
+		<Description value="Legacy layout"/>
+		<Author value="Someone"/>
+	</ModInfo>
+</xml>`
+
+func writeModDir(t *testing.T, xml string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ModInfo.xml"), []byte(xml), 0644))
+	return dir
+}
+
+func TestResolveModInfoV2(t *testing.T) {
+	info := Resolve(writeModDir(t, modInfoV2))
+	require.NotNil(t, info)
+	assert.Equal(t, "BiggerBackpack", info.Name)
+	assert.Equal(t, "Bigger Backpack", info.DisplayName)
+	assert.Equal(t, "1.2.0", info.Version)
+	assert.Equal(t, "Carry more stuff", info.Summary)
+	assert.Equal(t, "Donovan", info.Author)
+}
+
+func TestResolveModInfoV1(t *testing.T) {
+	info := Resolve(writeModDir(t, modInfoV1))
+	require.NotNil(t, info)
+	assert.Equal(t, "OldMod", info.Name)
+	assert.Equal(t, "0.9", info.Version)
+}
+
+func TestResolveNoMetadata(t *testing.T) {
+	assert.Nil(t, Resolve(t.TempDir()))
+}
+
+func TestResolveMalformedXML(t *testing.T) {
+	assert.Nil(t, Resolve(writeModDir(t, "<xml><unclosed")))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/metadata/ -v`
+Expected: FAIL — package does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/source/custom/metadata/reader.go`:
+
+```go
+// Package metadata extracts mod metadata from well-known files inside a mod
+// directory (e.g. 7 Days to Die's ModInfo.xml). Adding a format means adding
+// one Reader implementation and listing it in readers.
+package metadata
+
+// Info is metadata extracted from a well-known mod metadata file. Zero-value
+// fields mean the file did not provide them.
+type Info struct {
+	Name        string
+	DisplayName string
+	Version     string
+	Summary     string
+	Author      string
+}
+
+// Reader parses one well-known metadata file format.
+type Reader interface {
+	// Detect returns the metadata file path within modDir, or "" if absent.
+	Detect(modDir string) string
+	// Read parses the metadata file at path.
+	Read(path string) (*Info, error)
+}
+
+// readers lists all known formats in priority order.
+var readers = []Reader{ModInfoXML{}}
+
+// Resolve extracts metadata from modDir using the first matching reader.
+// Returns nil when no known metadata file exists or it cannot be parsed;
+// callers fall back to name-based detection.
+func Resolve(modDir string) *Info {
+	for _, r := range readers {
+		path := r.Detect(modDir)
+		if path == "" {
+			continue
+		}
+		info, err := r.Read(path)
+		if err != nil {
+			continue // malformed metadata falls back, it doesn't fail the scan
+		}
+		return info
+	}
+	return nil
+}
+```
+
+Create `internal/source/custom/metadata/modinfo.go`:
+
+```go
+package metadata
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ModInfoXML reads 7 Days to Die ModInfo.xml files. Two layouts exist:
+// V2 puts fields directly under <xml>; V1 nests them in <ModInfo>.
+type ModInfoXML struct{}
+
+// Detect implements Reader.
+func (ModInfoXML) Detect(modDir string) string {
+	path := filepath.Join(modDir, "ModInfo.xml")
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
+}
+
+type modInfoFields struct {
+	Name        attrValue `xml:"Name"`
+	DisplayName attrValue `xml:"DisplayName"`
+	Version     attrValue `xml:"Version"`
+	Description attrValue `xml:"Description"`
+	Author      attrValue `xml:"Author"`
+}
+
+type modInfoDoc struct {
+	modInfoFields
+	ModInfo *modInfoFields `xml:"ModInfo"`
+}
+
+type attrValue struct {
+	Value string `xml:"value,attr"`
+}
+
+// Read implements Reader.
+func (ModInfoXML) Read(path string) (*Info, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading ModInfo.xml: %w", err)
+	}
+
+	var doc modInfoDoc
+	if err := xml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing ModInfo.xml: %w", err)
+	}
+
+	fields := doc.modInfoFields
+	if doc.ModInfo != nil && doc.ModInfo.Name.Value != "" {
+		fields = *doc.ModInfo // V1 layout
+	}
+	if fields.Name.Value == "" {
+		return nil, fmt.Errorf("ModInfo.xml has no Name element")
+	}
+
+	return &Info{
+		Name:        fields.Name.Value,
+		DisplayName: fields.DisplayName.Value,
+		Version:     fields.Version.Value,
+		Summary:     fields.Description.Value,
+		Author:      fields.Author.Value,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/metadata/ -v`
+Expected: PASS (all four tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/metadata/
+git commit -m "feat(source): add well-known metadata readers with 7D2D ModInfo.xml support"
+```
+
+---
+
+### Task 9: Directory source — construction, scan, and read operations
+
+**Files:**
+- Create: `internal/source/custom/directory.go`
+- Test: `internal/source/custom/directory_test.go`
+
+**Interfaces:**
+- Consumes: `metadata.Resolve` (Task 8), `domain.ExtractVersionFromName` (Task 7), `source.ErrNotSupported`/`Capabilities` (Task 1).
+- Produces:
+  - `custom.NewDirectory(def SourceDefinition) (*Directory, error)` — expands `~`, requires existing directory
+  - `*Directory` implements `source.ModSource` + `source.CapabilityReporter`
+  - Semantics later tasks rely on: mod ID = subdirectory name (or archive base name); `GetModFiles` returns exactly one file with `ID: "main"`; `GetDownloadURL` returns `"file://" + <absolute path>`; `GetDependencies`/`ExchangeToken` return `ErrNotSupported`; `Capabilities() = {Search: true, Updates: true}`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/source/custom/directory_test.go`:
+
+```go
+package custom
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testModInfo = `<?xml version="1.0" encoding="UTF-8" ?>
+<xml>
+	<Name value="BiggerBackpack"/>
+	<DisplayName value="Bigger Backpack"/>
+	<Version value="1.2.0"/>
+	<Description value="Carry more stuff"/>
+	<Author value="Donovan"/>
+</xml>`
+
+// newTestDirectory builds a source over a temp dir containing:
+//   BiggerBackpack/        (with ModInfo.xml)
+//   PlainMod-0.5/          (no metadata; version from dirname)
+//   archived-mod-2.0.zip   (archive mod)
+//   README.md              (ignored: not a dir or archive)
+func newTestDirectory(t *testing.T) *Directory {
+	t.Helper()
+	root := t.TempDir()
+
+	bb := filepath.Join(root, "BiggerBackpack")
+	require.NoError(t, os.MkdirAll(bb, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(bb, "ModInfo.xml"), []byte(testModInfo), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(bb, "readme.txt"), []byte("hi"), 0644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "PlainMod-0.5"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "archived-mod-2.0.zip"), []byte("zipbytes"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("ignored"), 0644))
+
+	def := SourceDefinition{
+		ID:        "my-mods",
+		Name:      "My Mods",
+		Type:      TypeDirectory,
+		Directory: &DirectoryConfig{Path: root},
+	}
+	d, err := NewDirectory(def)
+	require.NoError(t, err)
+	return d
+}
+
+func TestNewDirectoryValidation(t *testing.T) {
+	def := SourceDefinition{
+		ID:        "x",
+		Name:      "X",
+		Type:      TypeDirectory,
+		Directory: &DirectoryConfig{Path: filepath.Join(t.TempDir(), "missing")},
+	}
+	_, err := NewDirectory(def)
+	assert.ErrorContains(t, err, "missing")
+}
+
+func TestDirectoryIdentityAndCapabilities(t *testing.T) {
+	d := newTestDirectory(t)
+	assert.Equal(t, "my-mods", d.ID())
+	assert.Equal(t, "My Mods", d.Name())
+	assert.Equal(t, source.Capabilities{Search: true, Updates: true}, d.Capabilities())
+	assert.Empty(t, d.AuthURL())
+
+	_, err := d.ExchangeToken(context.Background(), "code")
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+
+	_, err = d.GetDependencies(context.Background(), nil)
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+}
+
+func TestDirectorySearch(t *testing.T) {
+	d := newTestDirectory(t)
+	ctx := context.Background()
+
+	t.Run("empty query returns all mods", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{GameID: "anything"})
+		require.NoError(t, err)
+		assert.Equal(t, 3, res.TotalCount)
+		require.Len(t, res.Mods, 3)
+	})
+
+	t.Run("metadata takes priority over dirname", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Query: "backpack"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		m := res.Mods[0]
+		assert.Equal(t, "BiggerBackpack", m.ID)
+		assert.Equal(t, "Bigger Backpack", m.Name)
+		assert.Equal(t, "1.2.0", m.Version)
+		assert.Equal(t, "Carry more stuff", m.Summary)
+		assert.Equal(t, "Donovan", m.Author)
+		assert.Equal(t, "my-mods", m.SourceID)
+	})
+
+	t.Run("fallback parses version from name", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Query: "plainmod"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		assert.Equal(t, "PlainMod-0.5", res.Mods[0].ID)
+		assert.Equal(t, "PlainMod", res.Mods[0].Name)
+		assert.Equal(t, "0.5", res.Mods[0].Version)
+	})
+
+	t.Run("summary matches rank after name matches", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Query: "stuff"}) // only in summary
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		assert.Equal(t, "BiggerBackpack", res.Mods[0].ID)
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Page: 0, PageSize: 2})
+		require.NoError(t, err)
+		assert.Len(t, res.Mods, 2)
+		assert.Equal(t, 3, res.TotalCount)
+
+		res, err = d.Search(ctx, source.SearchQuery{Page: 1, PageSize: 2})
+		require.NoError(t, err)
+		assert.Len(t, res.Mods, 1)
+	})
+}
+
+func TestDirectoryGetMod(t *testing.T) {
+	d := newTestDirectory(t)
+
+	mod, err := d.GetMod(context.Background(), "ignored", "BiggerBackpack")
+	require.NoError(t, err)
+	assert.Equal(t, "Bigger Backpack", mod.Name)
+
+	_, err = d.GetMod(context.Background(), "ignored", "nope")
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestDirectoryFilesAndDownloadURL(t *testing.T) {
+	d := newTestDirectory(t)
+	ctx := context.Background()
+
+	mod, err := d.GetMod(ctx, "", "BiggerBackpack")
+	require.NoError(t, err)
+
+	files, err := d.GetModFiles(ctx, mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "main", files[0].ID)
+	assert.Equal(t, "BiggerBackpack", files[0].FileName)
+	assert.True(t, files[0].IsPrimary)
+
+	url, err := d.GetDownloadURL(ctx, mod, files[0].ID)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(url, "file://"))
+	assert.True(t, strings.HasSuffix(url, "/BiggerBackpack"))
+
+	// Archive mods point at the archive file.
+	zipMod, err := d.GetMod(ctx, "", "archived-mod-2.0")
+	require.NoError(t, err)
+	zipFiles, err := d.GetModFiles(ctx, zipMod)
+	require.NoError(t, err)
+	require.Len(t, zipFiles, 1)
+	assert.Equal(t, "archived-mod-2.0.zip", zipFiles[0].FileName)
+	assert.Equal(t, int64(8), zipFiles[0].Size) // len("zipbytes")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestDirectory -v`
+Expected: FAIL — `undefined: NewDirectory`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/source/custom/directory.go`:
+
+```go
+package custom
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom/metadata"
+)
+
+// Directory is a ModSource backed by a local directory: each subdirectory (or
+// .zip/.jar archive) is one mod. The directory is rescanned on each operation
+// so edits show up without restarting lmm; scans are local and cheap.
+type Directory struct {
+	id   string
+	name string
+	path string // absolute, verified at construction
+}
+
+// NewDirectory constructs a directory source from a validated definition.
+// The configured path must exist and be a directory.
+func NewDirectory(def SourceDefinition) (*Directory, error) {
+	path := def.Directory.Path
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("expanding %q: %w", path, err)
+		}
+		path = filepath.Join(home, path[2:])
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %q: %w", path, err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("directory source path: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("directory source path %s is not a directory", abs)
+	}
+
+	return &Directory{id: def.ID, name: def.Name, path: abs}, nil
+}
+
+// ID implements source.ModSource.
+func (d *Directory) ID() string { return d.id }
+
+// Name implements source.ModSource.
+func (d *Directory) Name() string { return d.name }
+
+// AuthURL implements source.ModSource; directory sources need no auth.
+func (d *Directory) AuthURL() string { return "" }
+
+// ExchangeToken implements source.ModSource.
+func (d *Directory) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
+	return nil, fmt.Errorf("source %q: authentication: %w", d.id, source.ErrNotSupported)
+}
+
+// Capabilities implements source.CapabilityReporter.
+func (d *Directory) Capabilities() source.Capabilities {
+	return source.Capabilities{Search: true, Updates: true}
+}
+
+// dirMod pairs a scanned mod with its filesystem location.
+type dirMod struct {
+	mod       domain.Mod
+	path      string // absolute path to the mod directory or archive
+	isArchive bool
+	size      int64 // archive size in bytes; 0 for directories
+}
+
+// scan reads the source directory. Subdirectories are directory mods;
+// .zip/.jar files are archive mods; everything else is ignored.
+func (d *Directory) scan() ([]dirMod, error) {
+	entries, err := os.ReadDir(d.path)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: scanning %s: %w", d.id, d.path, err)
+	}
+
+	var mods []dirMod
+	for _, entry := range entries {
+		entryPath := filepath.Join(d.path, entry.Name())
+
+		if entry.IsDir() {
+			mods = append(mods, d.scanDir(entry.Name(), entryPath))
+			continue
+		}
+
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if ext != ".zip" && ext != ".jar" {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("source %q: stat %s: %w", d.id, entryPath, err)
+		}
+		base := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+		name, version := nameAndVersionFrom(base)
+		mods = append(mods, dirMod{
+			mod: domain.Mod{
+				ID:       base,
+				SourceID: d.id,
+				Name:     name,
+				Version:  version,
+			},
+			path:      entryPath,
+			isArchive: true,
+			size:      info.Size(),
+		})
+	}
+
+	return mods, nil
+}
+
+// scanDir builds a dirMod for a mod directory, preferring well-known metadata
+// files over dirname parsing.
+func (d *Directory) scanDir(dirName, dirPath string) dirMod {
+	mod := domain.Mod{ID: dirName, SourceID: d.id}
+
+	if info := metadata.Resolve(dirPath); info != nil {
+		mod.Name = info.DisplayName
+		if mod.Name == "" {
+			mod.Name = info.Name
+		}
+		mod.Version = info.Version
+		mod.Summary = info.Summary
+		mod.Description = info.Summary
+		mod.Author = info.Author
+	} else {
+		mod.Name, mod.Version = nameAndVersionFrom(dirName)
+	}
+
+	return dirMod{mod: mod, path: dirPath}
+}
+
+// nameAndVersionFrom splits a directory/file base name into a display name and
+// version ("PlainMod-0.5" -> "PlainMod", "0.5").
+func nameAndVersionFrom(base string) (string, string) {
+	version := domain.ExtractVersionFromName(base)
+	name := base
+	if version != "" {
+		if idx := strings.LastIndex(base, version); idx > 0 {
+			name = strings.TrimRight(base[:idx], "-_ vV")
+		}
+	}
+	return name, version
+}
+
+// Search implements source.ModSource with client-side matching: case-insensitive
+// substring on name and summary; name matches rank first, then alphabetical.
+// GameID is ignored — a directory source applies to any game that maps it.
+func (d *Directory) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	scanned, err := d.scan()
+	if err != nil {
+		return source.SearchResult{}, err
+	}
+
+	q := strings.ToLower(query.Query)
+	type ranked struct {
+		mod       domain.Mod
+		nameMatch bool
+	}
+	var matches []ranked
+	for _, dm := range scanned {
+		nameMatch := q == "" || strings.Contains(strings.ToLower(dm.mod.Name), q) || strings.Contains(strings.ToLower(dm.mod.ID), q)
+		summaryMatch := strings.Contains(strings.ToLower(dm.mod.Summary), q)
+		if !nameMatch && !summaryMatch {
+			continue
+		}
+		matches = append(matches, ranked{mod: dm.mod, nameMatch: nameMatch})
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].nameMatch != matches[j].nameMatch {
+			return matches[i].nameMatch
+		}
+		return matches[i].mod.Name < matches[j].mod.Name
+	})
+
+	pageSize := query.PageSize
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	start := query.Page * pageSize
+	end := min(start+pageSize, len(matches))
+	if start > len(matches) {
+		start = len(matches)
+	}
+
+	mods := make([]domain.Mod, 0, end-start)
+	for _, m := range matches[start:end] {
+		mods = append(mods, m.mod)
+	}
+
+	return source.SearchResult{
+		Mods:       mods,
+		TotalCount: len(matches),
+		Page:       query.Page,
+		PageSize:   pageSize,
+	}, nil
+}
+
+// GetMod implements source.ModSource. gameID is ignored (see Search).
+func (d *Directory) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	dm, err := d.find(modID)
+	if err != nil {
+		return nil, err
+	}
+	mod := dm.mod
+	return &mod, nil
+}
+
+// GetDependencies implements source.ModSource; directory mods declare none.
+func (d *Directory) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	return nil, fmt.Errorf("source %q: dependencies: %w", d.id, source.ErrNotSupported)
+}
+
+// GetModFiles implements source.ModSource: every mod has exactly one synthetic
+// file ("main") representing its directory or archive.
+func (d *Directory) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	dm, err := d.find(mod.ID)
+	if err != nil {
+		return nil, err
+	}
+	return []domain.DownloadableFile{{
+		ID:        "main",
+		Name:      dm.mod.Name,
+		FileName:  filepath.Base(dm.path),
+		Version:   dm.mod.Version,
+		Size:      dm.size,
+		IsPrimary: true,
+	}}, nil
+}
+
+// GetDownloadURL implements source.ModSource, returning a file:// URL that
+// Service.DownloadModToCache ingests by local copy instead of HTTP download.
+func (d *Directory) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	dm, err := d.find(mod.ID)
+	if err != nil {
+		return "", err
+	}
+	return "file://" + dm.path, nil
+}
+
+// CheckUpdates implements source.ModSource by comparing installed versions to
+// the current scan.
+func (d *Directory) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	scanned, err := d.scan()
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]domain.Mod, len(scanned))
+	for _, dm := range scanned {
+		byID[dm.mod.ID] = dm.mod
+	}
+
+	var updates []domain.Update
+	for _, inst := range installed {
+		select {
+		case <-ctx.Done():
+			return updates, ctx.Err()
+		default:
+		}
+		current, ok := byID[inst.ID]
+		if !ok {
+			continue // mod removed from the directory; nothing to offer
+		}
+		if domain.IsNewerVersion(inst.Version, current.Version) {
+			updates = append(updates, domain.Update{
+				InstalledMod: inst,
+				NewVersion:   current.Version,
+			})
+		}
+	}
+	return updates, nil
+}
+
+// find scans and returns the mod with the given ID.
+func (d *Directory) find(modID string) (dirMod, error) {
+	scanned, err := d.scan()
+	if err != nil {
+		return dirMod{}, err
+	}
+	for _, dm := range scanned {
+		if dm.mod.ID == modID {
+			return dm, nil
+		}
+	}
+	return dirMod{}, fmt.Errorf("source %q: mod not found: %s", d.id, modID)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/directory.go internal/source/custom/directory_test.go
+git commit -m "feat(source): add directory source type for local mod folders"
+```
+
+---
+
+### Task 10: Directory CheckUpdates behavior test
+
+**Files:**
+- Test: `internal/source/custom/directory_test.go` (append)
+
+(The implementation shipped in Task 9; this task pins the update semantics with focused tests before wiring — reject-able independently if the semantics are wrong.)
+
+- [ ] **Step 1: Write the test**
+
+Append to `internal/source/custom/directory_test.go`:
+
+```go
+func TestDirectoryCheckUpdates(t *testing.T) {
+	d := newTestDirectory(t) // BiggerBackpack is at 1.2.0
+
+	installed := []domain.InstalledMod{
+		{Mod: domain.Mod{ID: "BiggerBackpack", SourceID: "my-mods", Name: "Bigger Backpack", Version: "1.0.0"}},
+		{Mod: domain.Mod{ID: "PlainMod-0.5", SourceID: "my-mods", Name: "PlainMod", Version: "0.5"}},
+		{Mod: domain.Mod{ID: "Removed", SourceID: "my-mods", Name: "Removed", Version: "1.0"}},
+	}
+
+	updates, err := d.CheckUpdates(context.Background(), installed)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "BiggerBackpack", updates[0].InstalledMod.ID)
+	assert.Equal(t, "1.2.0", updates[0].NewVersion)
+}
+```
+
+Add `"github.com/DonovanMods/linux-mod-manager/internal/domain"` to the test file's imports.
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -run TestDirectoryCheckUpdates -v`
+Expected: PASS (up-to-date mods and removed mods produce no update; outdated mod produces one).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/source/custom/directory_test.go
+git commit -m "test(source): pin directory source update-check semantics"
+```
+
+---
+
+### Task 11: Enable directory type in the factory
+
+**Files:**
+- Modify: `internal/source/custom/custom.go`, `internal/source/custom/custom_test.go`
+
+**Interfaces:**
+- Produces: `custom.New` returns a working `*Directory` for `type: directory` definitions.
+
+- [ ] **Step 1: Update the test**
+
+Replace the body of `TestNew` in `internal/source/custom/custom_test.go`:
+
+```go
+func TestNew(t *testing.T) {
+	t.Run("directory type constructs a source", func(t *testing.T) {
+		def := SourceDefinition{
+			ID:        "my-mods",
+			Name:      "My Mods",
+			Type:      TypeDirectory,
+			Directory: &DirectoryConfig{Path: t.TempDir()},
+		}
+		src, err := New(def)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-mods", src.ID())
+	})
+
+	t.Run("unimplemented types return a clear error", func(t *testing.T) {
+		for _, typ := range []string{TypeManifest, TypeAPI} {
+			def := SourceDefinition{ID: "x", Name: "X", Type: typ}
+			_, err := New(def)
+			assert.ErrorContains(t, err, "not yet supported", "type %s", typ)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestNew -v`
+Expected: FAIL — directory case returns "not yet supported".
+
+- [ ] **Step 3: Implement**
+
+In `internal/source/custom/custom.go`, add the case:
+
+```go
+func New(def SourceDefinition) (source.ModSource, error) {
+	switch def.Type {
+	case TypeDirectory:
+		return NewDirectory(def)
+	default:
+		return nil, fmt.Errorf("source type %q is not yet supported", def.Type)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/custom.go internal/source/custom/custom_test.go
+git commit -m "feat(source): construct directory sources from definitions"
+```
+
+---
+
+### Task 12: Local-path ingest in Service.DownloadModToCache
+
+**Files:**
+- Modify: `internal/core/service.go` (`DownloadModToCache`, new `ingestLocalToCache`)
+- Test: `internal/core/service_download_local_test.go` (create)
+
+**Interfaces:**
+- Consumes: existing `copyDir`, `copyFileStreaming`, `commitStagedCache`, `s.extractor` in package `core`; `file://` URLs from `Directory.GetDownloadURL` (Task 9).
+- Produces: `DownloadModToCache` transparently ingests `file://` URLs — directories are copied recursively; archive files honor the existing DeployCopy/extract split. `DownloadModResult.Checksum` is empty for local ingests.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/core/service_download_local_test.go`:
+
+```go
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newLocalIngestService(t *testing.T) (*Service, *cache.Cache) {
+	t.Helper()
+	svc := &Service{extractor: NewExtractor()}
+	return svc, cache.New(t.TempDir())
+}
+
+func TestIngestLocalToCacheDirectory(t *testing.T) {
+	svc, gameCache := newLocalIngestService(t)
+
+	modDir := filepath.Join(t.TempDir(), "BiggerBackpack")
+	require.NoError(t, os.MkdirAll(filepath.Join(modDir, "Config"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "ModInfo.xml"), []byte("<xml/>"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "Config", "items.xml"), []byte("<items/>"), 0644))
+
+	game := &domain.Game{ID: "7dtd", DeployMode: domain.DeployExtract}
+	mod := &domain.Mod{ID: "BiggerBackpack", SourceID: "my-mods", Version: "1.2.0"}
+	file := &domain.DownloadableFile{ID: "main", FileName: "BiggerBackpack"}
+
+	result, err := svc.ingestLocalToCache(gameCache, game, mod, file, modDir)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.FilesExtracted)
+	assert.Empty(t, result.Checksum)
+
+	files, err := gameCache.ListFiles("7dtd", "my-mods", "BiggerBackpack", "1.2.0")
+	require.NoError(t, err)
+	assert.Len(t, files, 2)
+}
+
+func TestIngestLocalToCacheArchiveCopyMode(t *testing.T) {
+	svc, gameCache := newLocalIngestService(t)
+
+	archive := filepath.Join(t.TempDir(), "coolmod-2.0.zip")
+	require.NoError(t, os.WriteFile(archive, []byte("zipbytes"), 0644))
+
+	game := &domain.Game{ID: "hytale", DeployMode: domain.DeployCopy}
+	mod := &domain.Mod{ID: "coolmod-2.0", SourceID: "my-mods", Version: "2.0"}
+	file := &domain.DownloadableFile{ID: "main", FileName: "coolmod-2.0.zip"}
+
+	result, err := svc.ingestLocalToCache(gameCache, game, mod, file, archive)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesExtracted)
+
+	cached := gameCache.GetFilePath("hytale", "my-mods", "coolmod-2.0", "2.0", "coolmod-2.0.zip")
+	_, err = os.Stat(cached)
+	assert.NoError(t, err)
+}
+
+func TestIngestLocalToCacheMissingPath(t *testing.T) {
+	svc, gameCache := newLocalIngestService(t)
+
+	game := &domain.Game{ID: "7dtd"}
+	mod := &domain.Mod{ID: "x", SourceID: "my-mods", Version: "1.0"}
+	file := &domain.DownloadableFile{ID: "main", FileName: "x"}
+
+	_, err := svc.ingestLocalToCache(gameCache, game, mod, file, filepath.Join(t.TempDir(), "gone"))
+	assert.Error(t, err)
+}
+```
+
+Note: if `Service{extractor: ...}` literal construction fails because of unexported invariants, use the package's existing test helper for building a Service (check `service_test.go`) — the assertions stay the same.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/core/ -run TestIngestLocal -v`
+Expected: FAIL — `undefined: svc.ingestLocalToCache`.
+
+- [ ] **Step 3: Implement**
+
+In `internal/core/service.go` (add `"strings"` to imports if absent):
+
+1. At the top of `DownloadModToCache`, right after the `GetDownloadURL` call and its error check, add:
+
+```go
+	if localPath, ok := strings.CutPrefix(url, "file://"); ok {
+		return s.ingestLocalToCache(gameCache, game, mod, file, localPath)
+	}
+```
+
+2. Add the new method after `DownloadModToCache`:
+
+```go
+// ingestLocalToCache copies a local mod (directory or archive) into the cache
+// using the same staging/commit flow as downloaded mods. Local ingests have no
+// download checksum, so DownloadModResult.Checksum is empty.
+func (s *Service) ingestLocalToCache(gameCache *cache.Cache, game *domain.Game, mod *domain.Mod, file *domain.DownloadableFile, localPath string) (*DownloadModResult, error) {
+	info, err := os.Stat(localPath)
+	if err != nil {
+		return nil, fmt.Errorf("local mod path: %w", err)
+	}
+
+	cachePath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
+	stagePath := cachePath + ".staging"
+	if err := os.RemoveAll(stagePath); err != nil {
+		return nil, fmt.Errorf("clearing staging cache: %w", err)
+	}
+	defer os.RemoveAll(stagePath) //nolint:errcheck
+	if gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version) {
+		if err := copyDir(cachePath, stagePath); err != nil {
+			return nil, fmt.Errorf("staging existing cache: %w", err)
+		}
+	}
+
+	switch {
+	case info.IsDir():
+		if err := copyDir(localPath, stagePath); err != nil {
+			return nil, fmt.Errorf("copying mod directory: %w", err)
+		}
+	case game.DeployMode == domain.DeployCopy || !s.extractor.CanExtract(localPath):
+		if err := os.MkdirAll(stagePath, 0755); err != nil {
+			return nil, fmt.Errorf("creating cache directory: %w", err)
+		}
+		if err := copyFileStreaming(localPath, filepath.Join(stagePath, filepath.Base(localPath))); err != nil {
+			return nil, fmt.Errorf("copying to cache: %w", err)
+		}
+	default:
+		if err := s.extractor.Extract(localPath, stagePath); err != nil {
+			return nil, fmt.Errorf("extracting mod: %w", err)
+		}
+	}
+
+	if err := commitStagedCache(cachePath, stagePath); err != nil {
+		return nil, err
+	}
+
+	files, err := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	if err != nil {
+		return nil, err
+	}
+	return &DownloadModResult{FilesExtracted: len(files)}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -v`
+Expected: PASS (new tests + all existing service/installer tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/core/service.go internal/core/service_download_local_test.go
+git commit -m "feat(core): ingest file:// download URLs by local copy"
+```
+
+---
+
+### Task 13: End-to-end verification, docs, and version bump
+
+**Files:**
+- Test: `internal/core/service_directory_source_test.go` (create)
+- Modify: `README.md`, `CHANGELOG.md`, `cmd/lmm/root.go` (version)
+
+- [ ] **Step 1: Write the end-to-end test**
+
+Create `internal/core/service_directory_source_test.go` — the full loop: definition → source → search → files → download URL → cache ingest:
+
+```go
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectorySourceEndToEnd(t *testing.T) {
+	// A modlets directory with one mod.
+	root := t.TempDir()
+	modDir := filepath.Join(root, "BiggerBackpack")
+	require.NoError(t, os.MkdirAll(modDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "ModInfo.xml"), []byte(
+		`<?xml version="1.0"?><xml><Name value="BiggerBackpack"/><Version value="1.2.0"/></xml>`), 0644))
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "my-mods",
+		Name:      "My Mods",
+		Type:      custom.TypeDirectory,
+		Directory: &custom.DirectoryConfig{Path: root},
+	})
+	require.NoError(t, err)
+
+	svc := &Service{extractor: NewExtractor()}
+	gameCache := cache.New(t.TempDir())
+	game := &domain.Game{ID: "7dtd", DeployMode: domain.DeployExtract}
+	ctx := context.Background()
+
+	// Search finds the mod.
+	res, err := src.Search(ctx, sourceSearchQuery("backpack"))
+	require.NoError(t, err)
+	require.Len(t, res.Mods, 1)
+	mod := res.Mods[0]
+
+	// Files + download URL + local ingest land it in the cache.
+	files, err := src.GetModFiles(ctx, &mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	url, err := src.GetDownloadURL(ctx, &mod, files[0].ID)
+	require.NoError(t, err)
+
+	result, err := svc.ingestLocalToCache(gameCache, game, &mod, &files[0], url[len("file://"):])
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesExtracted)
+	assert.True(t, gameCache.Exists("7dtd", "my-mods", "BiggerBackpack", "1.2.0"))
+}
+```
+
+Add this helper to the same file (keeps the test readable):
+
+```go
+func sourceSearchQuery(q string) source.SearchQuery {
+	return source.SearchQuery{Query: q, PageSize: 20}
+}
+```
+
+with import `"github.com/DonovanMods/linux-mod-manager/internal/source"`.
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `go test ./...`
+Expected: PASS everywhere.
+
+- [ ] **Step 3: Manual smoke test against the real modlets directory**
+
+```bash
+go build -o lmm ./cmd/lmm
+mkdir -p ~/.config/lmm/sources
+cat > ~/.config/lmm/sources/donovan-mods.yaml <<'EOF'
+id: donovan-mods
+name: Donovan's 7D2D Modlets
+type: directory
+directory:
+  path: ~/Projects/mods/7dtd/donovan-7d2d-modlets
+EOF
+./lmm source list                    # expect donovan-mods, type=directory, auth=n/a
+./lmm search backpack -g 7dtd --source donovan-mods   # expect modlet hits (game must exist in games.yaml)
+```
+
+Expected: the custom source lists and searches. (Remove the test definition afterward if undesired.)
+
+- [ ] **Step 4: Update docs and bump version**
+
+- `CHANGELOG.md`: move `[Unreleased]` items to a new `## [1.6.0] - <today>` section; add the directory-source feature line: `- Directory source type: use a local folder of mods as a first-class source`; update comparison links at the bottom.
+- `README.md`: extend the Custom Sources section with the `type: directory` example, metadata resolution rules (ModInfo.xml → dirname fallback), and the mod-ID-is-directory-name note.
+- `cmd/lmm/root.go`: `version = "1.6.0"`.
+
+- [ ] **Step 5: Final verification and commits**
+
+```bash
+go fmt ./... && go vet ./... && go test ./...
+git add internal/core/service_directory_source_test.go README.md CHANGELOG.md
+git commit -m "feat(source): directory source end-to-end test and docs"
+git add cmd/lmm/root.go CHANGELOG.md
+git commit -m "chore: bump version to 1.6.0"
+```
+
+---
+
+## Out of Scope (tracked separately)
+
+- **Phase 3** — manifest source type (issue + plan of its own)
+- **Phase 4** — declarative REST `api` type, custom-source auth via `lmm auth login <id>` / `LMM_<ID>_API_KEY` (issue + plan of its own)
+- **Phase 5** — aggregate search (core + CLI + TUI), TUI Sources screen, `source validate --probe` (issue + plan of its own)

--- a/docs/plans/archive/2026-07-13-tui-phase2-close-and-phase3.md
+++ b/docs/plans/archive/2026-07-13-tui-phase2-close-and-phase3.md
@@ -1,0 +1,1926 @@
+# TUI Phase 2 Close-out and Phase 3 (Service-Backed Read-Only TUI) Implementation Plan
+
+> **EXECUTED — 2026-07-13.** All 11 tasks completed via subagent-driven development
+> and shipped as **v1.4.0** (PRs #34, #36; promotion PR #38; issues #32, #35 closed;
+> tag `v1.4.0` on `main`). A final whole-branch review added one fix commit
+> (prototype-chrome removal) beyond the tasks below. Deviations from this plan as
+> written: the TUI stacked on integration branch `feat/tui` (now deleted), not `main`;
+> commit references use `Refs #35`; a CLI-parity gap audit was appended to
+> `docs/plans/2026-04-28-tui-implementation.md` post-execution. Session ledger:
+> `.superpowers/sdd/progress.md`. **Do not re-execute.** Next work: TUI Phase 4
+> (see the 2026-04-28 plan's status block and issue #37).
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the in-flight Phase 2 visual-iteration PR, harden the prototype TUI's internals, and wire `lmm tui` to real read-only app data through a narrow `DataProvider` boundary.
+
+**Architecture:** The TUI stays thin: Bubble Tea `Model` in `internal/tui` renders view-model types (`Summary`, `ModItem`, `ProfileItem`) that it receives from a `DataProvider` interface. Two providers implement it — a static prototype provider (existing fake data) and a `CoreProvider` adapter over `*core.Service`. `cmd/lmm/tui.go` picks the provider based on `--prototype`, reusing the existing `withGameService` lifecycle helper.
+
+**Tech Stack:** Go 1.25, Bubble Tea + Bubbles + Lip Gloss (already in go.mod), testify, Cobra, `modernc.org/sqlite` via `core.Service`.
+
+## Global Constraints
+
+- Go 1.25.6 (`go.mod`); use builtin `min`/`max`, no hand-rolled versions.
+- No new dependencies — Charmbracelet stack, testify, Cobra are already present.
+- TDD for every behavioral change: failing test → implement → pass (per `~/.claude/CLAUDE.md`). Trivial non-behavioral refactors (deleting a shadowed helper) need only a green test run.
+- All code `gofmt`-formatted; `go vet ./...` clean; `go test ./...` green after every task.
+- Commits are atomic, conventional-commit style, and reference GitHub issues (`Refs #NN`). Work is tracked via GitHub issues (project `CLAUDE.md`).
+- Prototype mode must remain side-effect-free: no DB, API, file, or network access.
+- TUI business logic stays in `internal/core`; `internal/tui` only adapts and presents.
+- CHANGELOG entries go under `[Unreleased]` per task; the version bump (1.4.0) happens once at the end as its own commit.
+- The TUI must stay usable at 80x24.
+
+**Baseline facts (verified 2026-07-13):**
+
+- PR **#31** (prototype shell) is merged. PR **#33** (`feat/tui-visual-iteration`, "stretch prototype panels to available space") is **open**; all 5 Copilot review comments were addressed by follow-up commits (`962be5fc`…`7f4df610`) and all review threads are outdated. `go test ./...` and `go vet ./...` pass on its head.
+- Issue **#32** (TUI Phase 2) is open; PR #33 satisfies everything except "capture/review the theme layouts". Default theme (`wizardry`) is already documented in the plan doc by PR #33.
+- The local checkout sits on stale branch `feat/tui-prototype` (already merged as #31); local `main` is behind `origin/main`.
+- `internal/tui/app.go` on PR #33's head still has: raw-string key handling that ignores `KeyMap`, a hand-rolled `max`, ad-hoc `statusValue` styling, a hard-coded dashboard `itemCount` of 4, and duplicated menu labels across four layout functions.
+- Missing planned test files: `cmd/lmm/tui_test.go`, `internal/tui/navigation_test.go`, `internal/tui/prototype/data_test.go`.
+
+---
+
+### Task 1: Sync workspace and merge PR #33
+
+**Files:** none created/modified (git/GitHub operations only).
+
+**Interfaces:**
+- Consumes: open PR #33 on `feat/tui-visual-iteration`.
+- Produces: `main` containing all Phase 2 layout work; local checkout on fresh `main`.
+
+- [ ] **Step 1: Fetch and inspect the PR one last time**
+
+```bash
+git fetch origin
+gh pr view 33
+gh pr diff 33 --name-only
+```
+
+Expected files: `CHANGELOG.md`, `docs/plans/2026-04-28-tui-implementation.md`, `internal/tui/app.go`, `internal/tui/app_test.go`, `internal/tui/theme/theme.go`, `internal/tui/theme/theme_test.go`.
+
+- [ ] **Step 2: Verify the PR head is green locally**
+
+```bash
+git worktree add /tmp/pr33-check origin/feat/tui-visual-iteration
+cd /tmp/pr33-check && go test ./... && go vet ./...
+cd - && git worktree remove /tmp/pr33-check
+```
+
+Expected: all packages `ok`, vet silent.
+
+- [ ] **Step 3: Merge PR #33**
+
+```bash
+gh pr merge 33 --squash --delete-branch
+```
+
+(Repo history shows squash-style merges for feature PRs; if the merge button offers only merge-commit, use `--merge` to match PR #29/#31 style — check `gh pr view 31 --json mergeCommit` first if unsure.)
+
+- [ ] **Step 4: Reset local workspace onto fresh main**
+
+```bash
+git checkout main
+git pull
+git branch -d feat/tui-prototype 2>/dev/null || git branch -D feat/tui-prototype
+git log --oneline -3   # confirm the PR #33 squash commit is present
+```
+
+- [ ] **Step 5: Confirm baseline**
+
+```bash
+go test ./... && go vet ./...
+```
+
+Expected: green. Do NOT close issue #32 yet — the capture/review criterion lands in Task 2.
+
+---
+
+### Task 2: Phase 2 close-out — theme snapshot captures
+
+Issue #32's remaining acceptance criterion is "Capture/review the existing `amber`, `wizardry`, `dos`, and `green` layouts." `Model.View()` is pure (no TTY needed), so snapshots can be generated deterministically by a regeneration-gated test and committed for review.
+
+**Files:**
+- Create: `internal/tui/snapshot_test.go`
+- Create: `docs/assets/tui/` (generated `*.ansi` files, one per theme × size)
+- Modify: `CHANGELOG.md` (under `[Unreleased]` → `Added`)
+
+**Interfaces:**
+- Consumes: `NewPrototypeModel(Options{Theme: string}) (Model, error)`, `Model.Update(tea.WindowSizeMsg)`, `Model.View() string` (all existing).
+- Produces: committed snapshot files reviewable with `cat docs/assets/tui/<theme>-<WxH>.ansi`.
+
+- [ ] **Step 1: Start the close-out branch**
+
+```bash
+git checkout -b chore/tui-phase2-closeout main
+```
+
+- [ ] **Step 2: Write the snapshot generator test**
+
+Create `internal/tui/snapshot_test.go`:
+
+```go
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateThemeSnapshots regenerates the committed theme captures under
+// docs/assets/tui. It only runs when UPDATE_TUI_SNAPSHOTS=1 so normal test
+// runs never write into the repo.
+//
+//	UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui -run TestGenerateThemeSnapshots
+func TestGenerateThemeSnapshots(t *testing.T) {
+	if os.Getenv("UPDATE_TUI_SNAPSHOTS") != "1" {
+		t.Skip("set UPDATE_TUI_SNAPSHOTS=1 to regenerate theme snapshots")
+	}
+
+	outDir := filepath.Join("..", "..", "docs", "assets", "tui")
+	require.NoError(t, os.MkdirAll(outDir, 0o755))
+
+	sizes := []struct{ width, height int }{{80, 24}, {120, 36}}
+	for _, themeName := range []string{"wizardry", "amber", "dos", "green"} {
+		for _, size := range sizes {
+			model, err := NewPrototypeModel(Options{Theme: themeName})
+			require.NoError(t, err)
+
+			// Run the init command if the model has one, so snapshots keep
+			// capturing loaded data once async loading lands (Phase 3).
+			if cmd := model.Init(); cmd != nil {
+				loaded, _ := model.Update(cmd())
+				model = loaded.(Model)
+			}
+
+			updated, _ := model.Update(tea.WindowSizeMsg{Width: size.width, Height: size.height})
+			view := updated.(Model).View()
+
+			name := fmt.Sprintf("%s-%dx%d.ansi", themeName, size.width, size.height)
+			require.NoError(t, os.WriteFile(filepath.Join(outDir, name), []byte(view+"\n"), 0o644))
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run it in skip mode, then in generate mode**
+
+```bash
+go test ./internal/tui -run TestGenerateThemeSnapshots -v
+```
+
+Expected: `SKIP`.
+
+```bash
+UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui -run TestGenerateThemeSnapshots -v
+ls docs/assets/tui
+```
+
+Expected: PASS; 8 files (`wizardry-80x24.ansi`, `wizardry-120x36.ansi`, `amber-…`, `dos-…`, `green-…`).
+
+- [ ] **Step 4: Review the captures against the design checklist**
+
+```bash
+for f in docs/assets/tui/*-80x24.ansi; do echo "== $f =="; cat "$f"; done
+```
+
+Check (from the plan doc's design review checklist): selected item identifiable, warnings visible, readable at 80x24, dense mod list readable. If any layout is broken at 80x24, file it as a follow-up comment on issue #32 rather than expanding this task.
+
+- [ ] **Step 5: Update CHANGELOG and commit**
+
+Add under `## [Unreleased]` → `### Added`:
+
+```markdown
+- **TUI theme snapshots**: Committed ANSI captures of all four prototype themes at 80x24 and 120x36 under `docs/assets/tui/`, regenerable via `UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui -run TestGenerateThemeSnapshots`.
+```
+
+```bash
+go test ./... && go vet ./...
+git add internal/tui/snapshot_test.go docs/assets/tui CHANGELOG.md
+git commit -m "test(tui): add regeneration-gated theme snapshot captures
+
+Refs #32"
+```
+
+---
+
+### Task 3: Route key handling through KeyMap
+
+`internal/tui/keys.go` defines a `KeyMap` (used only by tests), while `Model.updateKey` matches raw strings — two sources of truth that can drift. Wire `updateKey` through `key.Matches` and give `Model` a `keys` field. Add explicit jump bindings for screens 1/2/4 (search already owns `/` and `3`).
+
+**Files:**
+- Modify: `internal/tui/keys.go`
+- Modify: `internal/tui/app.go` (Model struct, `NewPrototypeModel`, `updateKey`)
+- Test: `internal/tui/app_test.go`, `internal/tui/keys_test.go`
+
+**Interfaces:**
+- Consumes: `github.com/charmbracelet/bubbles/key` (`key.Binding`, `key.Matches`).
+- Produces: `Model.keys KeyMap` field; `KeyMap` gains `Dashboard`, `InstalledMods`, `Profiles key.Binding`. Task 5 adds `Select` to this same struct.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/tui/app_test.go` (add `"github.com/charmbracelet/bubbles/key"` to imports):
+
+```go
+// TestUpdateKeyConsultsKeyMap proves key handling reads the KeyMap rather
+// than hard-coded strings: rebinding NextScreen must change which key cycles.
+func TestUpdateKeyConsultsKeyMap(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	model.keys.NextScreen = key.NewBinding(key.WithKeys("n"))
+
+	moved := updateWithRunes(t, model, "n")
+	require.Equal(t, ScreenInstalledMods, moved.CurrentScreen())
+
+	// The old default must no longer cycle once rebound away.
+	stay := updateWithRunes(t, model, "l")
+	require.Equal(t, ScreenDashboard, stay.CurrentScreen())
+}
+
+func TestNumberKeysJumpToScreens(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	for keyPress, want := range map[string]Screen{
+		"1": ScreenDashboard,
+		"2": ScreenInstalledMods,
+		"3": ScreenSearch,
+		"4": ScreenProfiles,
+	} {
+		require.Equal(t, want, updateWithRunes(t, model, keyPress).CurrentScreen(), "key %q", keyPress)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+go test ./internal/tui -run 'TestUpdateKeyConsultsKeyMap|TestNumberKeysJumpToScreens' -v
+```
+
+Expected: compile FAIL — `model.keys undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `internal/tui/keys.go`, add the jump bindings to `KeyMap` and `DefaultKeyMap`:
+
+```go
+type KeyMap struct {
+	Quit          key.Binding
+	Help          key.Binding
+	NextScreen    key.Binding
+	PrevScreen    key.Binding
+	Up            key.Binding
+	Down          key.Binding
+	Search        key.Binding
+	Dashboard     key.Binding
+	InstalledMods key.Binding
+	Profiles      key.Binding
+}
+```
+
+In `DefaultKeyMap()`, append:
+
+```go
+		Dashboard: key.NewBinding(
+			key.WithKeys("1"),
+			key.WithHelp("1", "dashboard"),
+		),
+		InstalledMods: key.NewBinding(
+			key.WithKeys("2"),
+			key.WithHelp("2", "installed mods"),
+		),
+		Profiles: key.NewBinding(
+			key.WithKeys("4"),
+			key.WithHelp("4", "profiles"),
+		),
+```
+
+In `internal/tui/app.go`: add `keys KeyMap` to `Model`; set `keys: DefaultKeyMap()` in `NewPrototypeModel`; replace `updateKey` (add `"github.com/charmbracelet/bubbles/key"` import):
+
+```go
+func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, m.keys.Quit):
+		return m, tea.Quit
+	case key.Matches(msg, m.keys.Help):
+		m.showHelp = !m.showHelp
+		return m, nil
+	case key.Matches(msg, m.keys.NextScreen):
+		m.screen = screenAt((m.screenIndex() + 1) % len(screens))
+		return m, nil
+	case key.Matches(msg, m.keys.PrevScreen):
+		m.screen = screenAt((m.screenIndex() - 1 + len(screens)) % len(screens))
+		return m, nil
+	case key.Matches(msg, m.keys.Dashboard):
+		m.screen = ScreenDashboard
+		return m, nil
+	case key.Matches(msg, m.keys.InstalledMods):
+		m.screen = ScreenInstalledMods
+		return m, nil
+	case key.Matches(msg, m.keys.Search):
+		m.screen = ScreenSearch
+		return m, nil
+	case key.Matches(msg, m.keys.Profiles):
+		m.screen = ScreenProfiles
+		return m, nil
+	case key.Matches(msg, m.keys.Up):
+		m.moveSelection(-1)
+		return m, nil
+	case key.Matches(msg, m.keys.Down):
+		m.moveSelection(1)
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+```
+
+Behavior note: `Search` keeps keys `/` and `3` (already in `DefaultKeyMap`), so `3` still reaches the search screen exactly as before.
+
+- [ ] **Step 4: Run the full package tests**
+
+```bash
+go test ./internal/tui/... -v
+```
+
+Expected: all PASS, including the pre-existing navigation tests (proving no regression).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go vet ./... && gofmt -l internal/tui
+git add internal/tui/keys.go internal/tui/app.go internal/tui/app_test.go
+git commit -m "refactor(tui): route key handling through KeyMap
+
+updateKey now uses key.Matches against Model.keys instead of raw strings,
+making KeyMap the single source of truth for bindings.
+
+Refs #32"
+```
+
+---
+
+### Task 4: Theme-owned status styles; delete hand-rolled max
+
+`statusValue` in `app.go` builds an ad-hoc `lipgloss.NewStyle()` per call, violating the plan's "theme, do not sprinkle styles" principle — and it drops the theme background (the PR #33 follow-ups specifically fixed default-background bleed). Move the styles into `theme.Theme`. Also delete the hand-rolled `max` (Go 1.25 builtin).
+
+**Files:**
+- Modify: `internal/tui/theme/theme.go`
+- Modify: `internal/tui/app.go`
+- Test: `internal/tui/theme/theme_test.go`
+
+**Interfaces:**
+- Produces: `theme.Theme.WarningText`, `theme.Theme.DangerText lipgloss.Style` — bold, foregrounded with `Warning`/`Danger`, backgrounded with the theme background. Later tasks may use them for any warning/danger copy.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/tui/theme/theme_test.go`:
+
+```go
+func TestStatusTextStylesMatchStatusColors(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"wizardry", "amber", "dos", "green"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			th, err := ByName(name)
+			require.NoError(t, err)
+
+			require.Equal(t, th.Warning, th.WarningText.GetForeground(), "WarningText foreground")
+			require.Equal(t, th.Danger, th.DangerText.GetForeground(), "DangerText foreground")
+			require.Equal(t, th.Background, th.WarningText.GetBackground(), "WarningText background")
+			require.Equal(t, th.Background, th.DangerText.GetBackground(), "DangerText background")
+			require.True(t, th.WarningText.GetBold())
+			require.True(t, th.DangerText.GetBold())
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/tui/theme -run TestStatusTextStylesMatchStatusColors -v
+```
+
+Expected: compile FAIL — `th.WarningText undefined`.
+
+Note: `wizardry` overrides `Warning` *after* `base()` returns, so a naive "set the style inside base()" implementation passes for amber/dos/green but fails for wizardry. The builder below exists precisely for that case.
+
+- [ ] **Step 3: Implement**
+
+In `internal/tui/theme/theme.go`, add fields to `Theme`:
+
+```go
+	WarningText lipgloss.Style
+	DangerText  lipgloss.Style
+```
+
+Add a builder next to `withMuted` and use it everywhere status colors are set:
+
+```go
+// withStatusColors sets the status palette and the derived text styles
+// together so they can never drift apart.
+func (t Theme) withStatusColors(warning, danger, success lipgloss.Color) Theme {
+	t.Warning = warning
+	t.Danger = danger
+	t.Success = success
+	t.WarningText = lipgloss.NewStyle().Foreground(warning).Background(t.Background).Bold(true)
+	t.DangerText = lipgloss.NewStyle().Foreground(danger).Background(t.Background).Bold(true)
+	return t
+}
+```
+
+In `base()`, replace the direct `Warning`/`Danger`/`Success` struct-field assignments with a final `return t.withMuted(muted).withStatusColors(warning, danger, success)` (keep the local color variables). In `Wizardry()`, replace:
+
+```go
+	t.Warning = lipgloss.Color("215")
+	t.Success = lipgloss.Color("150")
+```
+
+with:
+
+```go
+	t = t.withStatusColors(lipgloss.Color("215"), t.Danger, lipgloss.Color("150"))
+```
+
+In `internal/tui/app.go`:
+1. Delete `statusValue` and the `func max(a, b int) int { … }` at the bottom of the file (the Go builtin takes over — no call-site changes needed).
+2. Replace the two `statusValue` call sites in `partyDashboardView`:
+
+```go
+		fmt.Sprintf("%s updates available", m.theme.WarningText.Render(fmt.Sprintf("%d", m.data.Stats.Updates))),
+		fmt.Sprintf("%s file conflict", m.theme.DangerText.Render(fmt.Sprintf("%d", m.data.Stats.Conflicts))),
+```
+
+and the one in `terminalDashboardView`:
+
+```go
+		fmt.Sprintf("> ALERTS   %s UPDATES // %s CONFLICT", m.theme.WarningText.Render(fmt.Sprintf("%d", m.data.Stats.Updates)), m.theme.DangerText.Render(fmt.Sprintf("%d", m.data.Stats.Conflicts))),
+```
+
+(If Task 8 has already renamed `m.data.Stats` fields when you execute this out of order, use the summary fields instead — the render calls are what matter.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/tui/... -v && go vet ./...
+```
+
+Expected: PASS (including layout/height tests — the rendered rune widths are unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/theme/theme.go internal/tui/theme/theme_test.go internal/tui/app.go
+git commit -m "refactor(tui): move status text styles into theme; drop hand-rolled max
+
+Themes now own WarningText/DangerText styles (with correct backgrounds)
+instead of app.go building ad-hoc lipgloss styles per render. The custom
+max helper is deleted in favor of the Go builtin.
+
+Refs #32"
+```
+
+---
+
+### Task 5: Single-source dashboard menu with Enter activation
+
+The four dashboard layouts each hard-code the same four menu entries, and `itemCount` separately hard-codes `4`. Pressing Enter on a menu item does nothing. Define the menu once (per layout flavor), derive the count from it, and make Enter navigate.
+
+**Files:**
+- Modify: `internal/tui/app.go`
+- Modify: `internal/tui/keys.go`
+- Test: `internal/tui/app_test.go`
+
+**Interfaces:**
+- Consumes: `KeyMap` from Task 3.
+- Produces: `KeyMap.Select key.Binding` ("enter"); unexported `menuItem{label string; target Screen; hasTarget bool}` and `Model.dashboardMenu() []menuItem`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/tui/app_test.go`:
+
+```go
+func TestDashboardEnterOpensSelectedMenuEntry(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	// Initial selection is the first menu entry: Installed Mods.
+	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ScreenInstalledMods, opened.(Model).CurrentScreen())
+
+	// Second entry opens Search.
+	moved := updateWithRunes(t, model, "j")
+	opened, _ = moved.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ScreenSearch, opened.(Model).CurrentScreen())
+}
+
+func TestDashboardEnterOnOracleEntryStaysPut(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	// Move to the last entry (Conflict Oracle) — no screen exists for it yet.
+	for range 3 {
+		model = updateWithRunes(t, model, "j")
+	}
+	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ScreenDashboard, opened.(Model).CurrentScreen())
+}
+
+func TestEnterOutsideDashboardIsANoop(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+	model = updateWithRunes(t, model, "2")
+
+	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ScreenInstalledMods, opened.(Model).CurrentScreen())
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+go test ./internal/tui -run 'TestDashboardEnter|TestEnterOutside' -v
+```
+
+Expected: FAIL — Enter currently falls through `updateKey`'s default case, so `CurrentScreen()` stays `ScreenDashboard` in the first test.
+
+- [ ] **Step 3: Implement**
+
+`internal/tui/keys.go` — add to `KeyMap`:
+
+```go
+	Select key.Binding
+```
+
+and to `DefaultKeyMap()`:
+
+```go
+		Select: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "open"),
+		),
+```
+
+`internal/tui/app.go` — add the menu model:
+
+```go
+// menuItem is one dashboard menu entry. hasTarget is false for flavor-only
+// entries (like the Conflict Oracle) that have no screen yet.
+type menuItem struct {
+	label     string
+	target    Screen
+	hasTarget bool
+}
+
+func (m Model) dashboardMenu() []menuItem {
+	if m.layout == LayoutMonochromeTerminal {
+		return []menuItem{
+			{label: "RUN SPELLBOOK SCAN", target: ScreenInstalledMods, hasTarget: true},
+			{label: "QUERY ARCHIVE INDEX", target: ScreenSearch, hasTarget: true},
+			{label: "LOAD PROFILE ROSTER", target: ScreenProfiles, hasTarget: true},
+			{label: "ASK CONFLICT ORACLE"},
+		}
+	}
+	return []menuItem{
+		{label: "Installed Mods", target: ScreenInstalledMods, hasTarget: true},
+		{label: "Search Archives", target: ScreenSearch, hasTarget: true},
+		{label: "Profiles", target: ScreenProfiles, hasTarget: true},
+		{label: "Consult Conflict Oracle"},
+	}
+}
+
+func (m Model) dashboardMenuRows() []string {
+	items := m.dashboardMenu()
+	rows := make([]string, 0, len(items))
+	for i, item := range items {
+		rows = append(rows, m.row(i, item.label))
+	}
+	return rows
+}
+
+func (m Model) openSelectedMenuEntry() Model {
+	if m.screen != ScreenDashboard {
+		return m
+	}
+	items := m.dashboardMenu()
+	selected := m.selected[ScreenDashboard]
+	if selected >= len(items) || !items[selected].hasTarget {
+		return m
+	}
+	m.screen = items[selected].target
+	return m
+}
+```
+
+Notes for the existing view functions:
+- `partyDashboardView`, `commanderDashboardView`, `crtDashboardView`: replace their four `m.row(0, …)`…`m.row(3, …)` menu lines with `m.dashboardMenuRows()...` appended to the surrounding `[]string` (e.g. `append([]string{m.theme.PanelTitle.Render("COMMANDS")}, m.dashboardMenuRows()...)`). The commander layout's old label "Conflict Oracle" becomes "Consult Conflict Oracle" — acceptable copy unification; the layout tests compare layouts, not exact strings.
+- `terminalDashboardView`: same replacement for its four `m.row` lines (it hits the `LayoutMonochromeTerminal` branch so labels are unchanged).
+- `itemCount`: change the `default:` branch from `return 4` to `return len(m.dashboardMenu())`.
+- `updateKey`: add a case (before `default`):
+
+```go
+	case key.Matches(msg, m.keys.Select):
+		return m.openSelectedMenuEntry(), nil
+```
+
+- [ ] **Step 4: Run the full package tests**
+
+```bash
+go test ./internal/tui/... -v && go vet ./...
+```
+
+Expected: PASS, including the width/height layout tests.
+
+- [ ] **Step 5: Regenerate snapshots (labels changed for dos layout) and commit**
+
+```bash
+UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui -run TestGenerateThemeSnapshots
+git add internal/tui/app.go internal/tui/keys.go internal/tui/app_test.go docs/assets/tui
+git commit -m "feat(tui): single-source dashboard menu with enter-to-open
+
+The four layouts now share one menu definition, itemCount derives from it,
+and Enter opens the selected entry's screen.
+
+Refs #32"
+```
+
+---
+
+### Task 6: Fill test gaps — cmd, navigation, prototype data
+
+The implementation plan called for `cmd/lmm/tui_test.go`, `internal/tui/navigation_test.go`, and `internal/tui/prototype/data_test.go`; none exist. These are tests-only additions (no production code should need to change — if a test exposes a bug, stop and fix it test-first within this task).
+
+**Files:**
+- Create: `cmd/lmm/tui_test.go`
+- Create: `internal/tui/navigation_test.go`
+- Create: `internal/tui/prototype/data_test.go`
+
+**Interfaces:**
+- Consumes: `runTUI` (unexported, same package), `screenAt`, `Screen.String`, `prototype.Load`.
+
+- [ ] **Step 1: Write the cmd tests**
+
+Create `cmd/lmm/tui_test.go`:
+
+```go
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunTUIRejectsRealModeUntilImplemented(t *testing.T) {
+	tuiOptions.prototype = false
+	t.Cleanup(func() { tuiOptions.prototype = false })
+
+	err := runTUI(tuiCmd, nil)
+	require.ErrorContains(t, err, "use --prototype")
+}
+
+func TestRunTUIRejectsUnknownTheme(t *testing.T) {
+	tuiOptions.prototype = true
+	tuiOptions.theme = "vaporwave"
+	t.Cleanup(func() {
+		tuiOptions.prototype = false
+		tuiOptions.theme = "wizardry"
+	})
+
+	err := runTUI(tuiCmd, nil)
+	require.ErrorContains(t, err, `unknown TUI theme "vaporwave"`)
+}
+```
+
+(These never start the Bubble Tea program: both paths error before `tea.NewProgram`. Task 10 rewrites the first test when real mode exists.)
+
+- [ ] **Step 2: Write the navigation tests**
+
+Create `internal/tui/navigation_test.go`:
+
+```go
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScreenAtClampsOutOfRangeIndexes(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, ScreenDashboard, screenAt(-1))
+	require.Equal(t, ScreenProfiles, screenAt(len(screens)))
+	require.Equal(t, ScreenInstalledMods, screenAt(1))
+}
+
+func TestScreenStringNamesEveryScreen(t *testing.T) {
+	t.Parallel()
+
+	for _, s := range screens {
+		require.NotContains(t, s.String(), "Screen(", "screen %d needs a display name", int(s))
+	}
+	require.Equal(t, "Screen(99)", Screen(99).String())
+}
+```
+
+- [ ] **Step 3: Write the prototype data tests**
+
+Create `internal/tui/prototype/data_test.go`:
+
+```go
+package prototype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadProvidesConsistentDemoData(t *testing.T) {
+	t.Parallel()
+
+	data := Load()
+
+	require.NotEmpty(t, data.InstalledMods)
+	require.NotEmpty(t, data.SearchResults)
+	require.NotEmpty(t, data.Profiles)
+
+	active := 0
+	for _, p := range data.Profiles {
+		if p.Active {
+			active++
+			require.Equal(t, data.Profile.Name, p.Name, "active roster entry must match the current profile")
+		}
+	}
+	require.Equal(t, 1, active, "exactly one profile should be active")
+
+	require.Equal(t, data.Stats.Installed, data.Profile.ModCount, "dashboard stats should agree with the profile mod count")
+}
+```
+
+- [ ] **Step 4: Run everything**
+
+```bash
+go test ./cmd/... ./internal/tui/... -v && go vet ./...
+```
+
+Expected: PASS. (If `TestLoadProvidesConsistentDemoData` fails on the invariants, fix `prototype.Load`'s data — not the test — so the demo data is self-consistent.)
+
+- [ ] **Step 5: Commit and open the close-out PR**
+
+```bash
+git add cmd/lmm/tui_test.go internal/tui/navigation_test.go internal/tui/prototype/data_test.go
+git commit -m "test(tui): cover cmd flags, navigation clamping, and prototype data
+
+Refs #32"
+git push -u origin chore/tui-phase2-closeout
+gh pr create --title "chore(tui): Phase 2 close-out — snapshots, keymap wiring, menu single-sourcing" \
+  --body "$(cat <<'EOF'
+## Summary
+- Committed ANSI captures of all four themes (80x24 and 120x36) with a regeneration-gated test — the last open acceptance criterion of #32.
+- Key handling now flows through KeyMap (single source of truth); dashboard menu is defined once with Enter-to-open.
+- Status text styles moved into the theme; hand-rolled max deleted.
+- Added the test files the TUI plan called for: cmd/lmm/tui_test.go, navigation_test.go, prototype/data_test.go.
+
+Closes #32
+
+## Test Plan
+- [x] go test ./...
+- [x] go vet ./...
+- [x] Manual: ./lmm tui --prototype --theme wizardry (navigate, enter on menu, ?, q)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+After review, merge and pull main (same flow as Task 1 steps 3–5). Issue #32 closes automatically.
+
+---
+
+### Task 7: Phase 3a — view models, DataProvider interface, prototype provider
+
+Start of Phase 3 (read-only service-backed TUI). Create a GitHub issue first, then define the narrow boundary: view-model types the views render, a `DataProvider` interface, and the prototype implementation over the existing fake data.
+
+**Files:**
+- Create: `internal/tui/service.go`
+- Test: `internal/tui/service_test.go`
+
+**Interfaces:**
+- Consumes: `prototype.Load() prototype.Data` (existing).
+- Produces (used by Tasks 8–10):
+
+```go
+type Summary struct {
+	GameName    string
+	ProfileName string
+	Installed   int
+	Enabled     int
+	Updates     int // -1 = unknown (no update check has run)
+	Conflicts   int // -1 = unknown
+}
+type ModItem struct{ Name, Author, Version, Source, Status string }
+type ProfileItem struct {
+	Name     string
+	Active   bool
+	ModCount int
+}
+type DataProvider interface {
+	Summary(ctx context.Context) (Summary, error)
+	InstalledMods(ctx context.Context) ([]ModItem, error)
+	SearchResults(ctx context.Context) ([]ModItem, error)
+	Profiles(ctx context.Context) ([]ProfileItem, error)
+}
+func NewPrototypeProvider() DataProvider
+```
+
+- [ ] **Step 1: Create the Phase 3 issue and branch**
+
+```bash
+gh issue create --title "TUI Phase 3: read-only service-backed TUI" --body "$(cat <<'EOF'
+Replace prototype fake data with real app data for safe, read-only screens, per docs/plans/2026-04-28-tui-implementation.md Phase 3 and docs/plans/2026-07-13-tui-phase2-close-and-phase3.md Tasks 7-11.
+
+Acceptance criteria:
+- A narrow DataProvider interface in internal/tui/service.go with prototype and core.Service-backed implementations.
+- `lmm tui` (without --prototype) initializes config/service like existing CLI commands and shows real Dashboard, Installed Mods, and Profiles data.
+- Search view shows an honest placeholder until Phase 4.
+- Loading and error states render without crashing; --prototype remains side-effect-free.
+- Existing CLI behavior unchanged; go test ./... and go vet ./... pass.
+EOF
+)"
+git checkout -b feat/tui-service-backed main
+```
+
+Note the issue number printed by `gh issue create` — commits below use `Refs #<phase3-issue>`; substitute the real number.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `internal/tui/service_test.go`:
+
+```go
+package tui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
+)
+
+func TestPrototypeProviderMirrorsFakeData(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	provider := NewPrototypeProvider()
+	data := prototype.Load()
+
+	summary, err := provider.Summary(ctx)
+	require.NoError(t, err)
+	require.Equal(t, data.Game.Name, summary.GameName)
+	require.Equal(t, data.Profile.Name, summary.ProfileName)
+	require.Equal(t, data.Stats.Installed, summary.Installed)
+	require.Equal(t, data.Stats.Enabled, summary.Enabled)
+	require.Equal(t, data.Stats.Updates, summary.Updates)
+	require.Equal(t, data.Stats.Conflicts, summary.Conflicts)
+
+	mods, err := provider.InstalledMods(ctx)
+	require.NoError(t, err)
+	require.Len(t, mods, len(data.InstalledMods))
+	require.Equal(t, data.InstalledMods[0].Name, mods[0].Name)
+	require.Equal(t, data.InstalledMods[0].Status, mods[0].Status)
+
+	results, err := provider.SearchResults(ctx)
+	require.NoError(t, err)
+	require.Len(t, results, len(data.SearchResults))
+
+	profiles, err := provider.Profiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, profiles, len(data.Profiles))
+	require.Equal(t, data.Profiles[0].Name, profiles[0].Name)
+	require.True(t, profiles[0].Active)
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+go test ./internal/tui -run TestPrototypeProviderMirrorsFakeData -v
+```
+
+Expected: compile FAIL — `NewPrototypeProvider` undefined.
+
+- [ ] **Step 4: Implement**
+
+Create `internal/tui/service.go`:
+
+```go
+package tui
+
+import (
+	"context"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
+)
+
+// Summary is the dashboard header data.
+type Summary struct {
+	GameName    string
+	ProfileName string
+	Installed   int
+	Enabled     int
+	Updates     int // -1 = unknown (no update check has run)
+	Conflicts   int // -1 = unknown
+}
+
+// ModItem is one renderable mod row.
+type ModItem struct {
+	Name    string
+	Author  string
+	Version string
+	Source  string
+	Status  string
+}
+
+// ProfileItem is one renderable profile row.
+type ProfileItem struct {
+	Name     string
+	Active   bool
+	ModCount int
+}
+
+// DataProvider is the narrow, read-only boundary between the TUI and app
+// data. Implementations must be safe to call from a Bubble Tea command
+// goroutine.
+type DataProvider interface {
+	Summary(ctx context.Context) (Summary, error)
+	InstalledMods(ctx context.Context) ([]ModItem, error)
+	SearchResults(ctx context.Context) ([]ModItem, error)
+	Profiles(ctx context.Context) ([]ProfileItem, error)
+}
+
+// prototypeProvider serves the static demo data set. It must never touch
+// disk, network, DB, or APIs.
+type prototypeProvider struct {
+	data prototype.Data
+}
+
+// NewPrototypeProvider returns the side-effect-free demo DataProvider used
+// by --prototype mode and tests.
+func NewPrototypeProvider() DataProvider {
+	return prototypeProvider{data: prototype.Load()}
+}
+
+func (p prototypeProvider) Summary(_ context.Context) (Summary, error) {
+	return Summary{
+		GameName:    p.data.Game.Name,
+		ProfileName: p.data.Profile.Name,
+		Installed:   p.data.Stats.Installed,
+		Enabled:     p.data.Stats.Enabled,
+		Updates:     p.data.Stats.Updates,
+		Conflicts:   p.data.Stats.Conflicts,
+	}, nil
+}
+
+func (p prototypeProvider) InstalledMods(_ context.Context) ([]ModItem, error) {
+	return modItems(p.data.InstalledMods), nil
+}
+
+func (p prototypeProvider) SearchResults(_ context.Context) ([]ModItem, error) {
+	return modItems(p.data.SearchResults), nil
+}
+
+func (p prototypeProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
+	items := make([]ProfileItem, 0, len(p.data.Profiles))
+	for _, profile := range p.data.Profiles {
+		items = append(items, ProfileItem{
+			Name:     profile.Name,
+			Active:   profile.Active,
+			ModCount: profile.ModCount,
+		})
+	}
+	return items, nil
+}
+
+func modItems(mods []prototype.Mod) []ModItem {
+	items := make([]ModItem, 0, len(mods))
+	for _, mod := range mods {
+		items = append(items, ModItem{
+			Name:    mod.Name,
+			Author:  mod.Author,
+			Version: mod.Version,
+			Source:  mod.Source,
+			Status:  mod.Status,
+		})
+	}
+	return items
+}
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+go test ./internal/tui/... -v && go vet ./...
+git add internal/tui/service.go internal/tui/service_test.go
+git commit -m "feat(tui): add DataProvider boundary with prototype implementation
+
+Refs #<phase3-issue>"
+```
+
+---
+
+### Task 8: Phase 3b — async load lifecycle in the Model
+
+Make the `Model` load its data through `DataProvider` via a Bubble Tea command, with explicit loading / ready / failed states. The prototype provider stays synchronous, so prototype behavior is unchanged apart from one `Init` message cycle.
+
+**Files:**
+- Modify: `internal/tui/app.go` (Model fields, `NewPrototypeModel`, new `NewModel`, `Init`, `Update`, views)
+- Test: `internal/tui/app_test.go`
+
+**Interfaces:**
+- Consumes: `DataProvider`, `Summary`, `ModItem`, `ProfileItem` (Task 7).
+- Produces: `NewModel(options Options) (Model, error)` where `Options` gains `Provider DataProvider`; unexported `dataLoadedMsg`, `loadFailedMsg`; `Model.state` (`loadState` enum). `NewPrototypeModel` stays as a convenience wrapper (used by existing tests and `--prototype`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/tui/app_test.go`:
+
+```go
+type failingProvider struct{ err error }
+
+func (f failingProvider) Summary(context.Context) (Summary, error)        { return Summary{}, f.err }
+func (f failingProvider) InstalledMods(context.Context) ([]ModItem, error) { return nil, f.err }
+func (f failingProvider) SearchResults(context.Context) ([]ModItem, error) { return nil, f.err }
+func (f failingProvider) Profiles(context.Context) ([]ProfileItem, error)  { return nil, f.err }
+
+func TestModelShowsLoadingBeforeDataArrives(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(Options{Theme: "wizardry", Provider: NewPrototypeProvider()})
+	require.NoError(t, err)
+
+	require.Contains(t, model.View(), "Consulting the archives")
+}
+
+func TestInitLoadsDataThroughProvider(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(Options{Theme: "wizardry", Provider: NewPrototypeProvider()})
+	require.NoError(t, err)
+
+	msg := model.Init()()
+	updated, _ := model.Update(msg)
+	view := updated.(Model).View()
+
+	require.Contains(t, view, "Skyrim Special Edition")
+	require.NotContains(t, view, "Consulting the archives")
+}
+
+func TestLoadFailureRendersErrorState(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(Options{Theme: "wizardry", Provider: failingProvider{err: errors.New("the archive door is sealed")}})
+	require.NoError(t, err)
+
+	msg := model.Init()()
+	updated, _ := model.Update(msg)
+	view := updated.(Model).View()
+
+	require.Contains(t, view, "the archive door is sealed")
+	require.Contains(t, view, "q: quit")
+}
+
+func TestNewModelRequiresProvider(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewModel(Options{Theme: "wizardry"})
+	require.ErrorContains(t, err, "provider")
+}
+```
+
+Add `"context"` and `"errors"` to the test file imports.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+go test ./internal/tui -run 'TestModelShowsLoading|TestInitLoadsData|TestLoadFailure|TestNewModelRequiresProvider' -v
+```
+
+Expected: compile FAIL — `NewModel` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `internal/tui/app.go`:
+
+1. `Options` becomes:
+
+```go
+// Options configures the TUI app.
+type Options struct {
+	Theme    string
+	Provider DataProvider
+}
+```
+
+2. Replace `data prototype.Data` in `Model` with loaded state (drop the `prototype` import from this file when nothing else uses it):
+
+```go
+type Model struct {
+	theme    theme.Theme
+	layout   Layout
+	keys     KeyMap
+	provider DataProvider
+
+	state   loadState
+	loadErr error
+
+	summary       Summary
+	mods          []ModItem
+	searchResults []ModItem
+	profiles      []ProfileItem
+
+	screen   Screen
+	selected map[Screen]int
+	showHelp bool
+	width    int
+	height   int
+}
+
+type loadState int
+
+const (
+	stateLoading loadState = iota
+	stateReady
+	stateFailed
+)
+```
+
+3. Constructors:
+
+```go
+// NewModel creates the TUI model backed by the given DataProvider.
+func NewModel(options Options) (Model, error) {
+	if options.Provider == nil {
+		return Model{}, fmt.Errorf("TUI options: provider is required")
+	}
+	t, err := theme.ByName(options.Theme)
+	if err != nil {
+		return Model{}, err
+	}
+
+	return Model{
+		theme:    t,
+		layout:   layoutForTheme(t.Name),
+		keys:     DefaultKeyMap(),
+		provider: options.Provider,
+		state:    stateLoading,
+		screen:   ScreenDashboard,
+		selected: map[Screen]int{
+			ScreenDashboard:     0,
+			ScreenInstalledMods: 0,
+			ScreenSearch:        0,
+			ScreenProfiles:      0,
+		},
+	}, nil
+}
+
+// NewPrototypeModel creates a side-effect-free TUI model backed by fake data.
+func NewPrototypeModel(options Options) (Model, error) {
+	options.Provider = NewPrototypeProvider()
+	return NewModel(options)
+}
+```
+
+4. Load command and messages:
+
+```go
+type dataLoadedMsg struct {
+	summary       Summary
+	mods          []ModItem
+	searchResults []ModItem
+	profiles      []ProfileItem
+}
+
+type loadFailedMsg struct{ err error }
+
+func (m Model) Init() tea.Cmd {
+	return m.loadData
+}
+
+func (m Model) loadData() tea.Msg {
+	ctx := context.Background()
+
+	summary, err := m.provider.Summary(ctx)
+	if err != nil {
+		return loadFailedMsg{err: err}
+	}
+	mods, err := m.provider.InstalledMods(ctx)
+	if err != nil {
+		return loadFailedMsg{err: err}
+	}
+	results, err := m.provider.SearchResults(ctx)
+	if err != nil {
+		return loadFailedMsg{err: err}
+	}
+	profiles, err := m.provider.Profiles(ctx)
+	if err != nil {
+		return loadFailedMsg{err: err}
+	}
+
+	return dataLoadedMsg{summary: summary, mods: mods, searchResults: results, profiles: profiles}
+}
+```
+
+(Add `"context"` to the imports. `context.Background()` is acceptable here for now: `tea.WithContext` in cmd already bounds the program's lifetime, and per-request cancellation arrives with Phase 4's in-flight searches.)
+
+5. Handle the messages in `Update` (new cases before `tea.KeyMsg`):
+
+```go
+	case dataLoadedMsg:
+		m.state = stateReady
+		m.summary = msg.summary
+		m.mods = msg.mods
+		m.searchResults = msg.searchResults
+		m.profiles = msg.profiles
+		return m, nil
+	case loadFailedMsg:
+		m.state = stateFailed
+		m.loadErr = msg.err
+		return m, nil
+```
+
+6. Gate `screenView` on state:
+
+```go
+func (m Model) screenView() string {
+	switch m.state {
+	case stateLoading:
+		return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).
+			Render(m.theme.PanelTitle.Render("Consulting the archives..."))
+	case stateFailed:
+		return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).
+			Render(strings.Join([]string{
+				m.theme.PanelTitle.Render("THE RITUAL FAILED"),
+				m.theme.DangerText.Render(m.loadErr.Error()),
+				"",
+				m.theme.MutedText.Render("q: quit"),
+			}, "\n"))
+	}
+
+	switch m.screen {
+	// ... existing screen switch unchanged ...
+	}
+}
+```
+
+7. Mechanical data renames throughout the view functions: `m.data.Game.Name` → `m.summary.GameName`, `m.data.Profile.Name` → `m.summary.ProfileName`, `m.data.Stats.X` → `m.summary.X`, `m.data.InstalledMods` → `m.mods`, `m.data.SearchResults` → `m.searchResults`, `m.data.Profiles` → `m.profiles` (its element type becomes `ProfileItem` — field names `Name`/`Active`/`ModCount` are identical). `modRow`'s parameter type changes `prototype.Mod` → `ModItem`. Where the summary can be unknown (`Updates`/`Conflicts` == -1), render `?` instead of a number:
+
+```go
+func countLabel(n int) string {
+	if n < 0 {
+		return "?"
+	}
+	return fmt.Sprintf("%d", n)
+}
+```
+
+and use `m.theme.WarningText.Render(countLabel(m.summary.Updates))` / `m.theme.DangerText.Render(countLabel(m.summary.Conflicts))` at the three status call sites from Task 4.
+
+8. Update the existing test helper so all visual tests exercise the loaded state — in `app_test.go`, `sizedPrototypeModel` runs the init cycle:
+
+```go
+func sizedPrototypeModel(t *testing.T, themeName string, width, height int) Model {
+	t.Helper()
+
+	model, err := NewPrototypeModel(Options{Theme: themeName})
+	require.NoError(t, err)
+
+	loaded, _ := model.Update(model.Init()())
+	updated, _ := loaded.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	updatedModel, ok := updated.(Model)
+	require.True(t, ok)
+	return updatedModel
+}
+```
+
+Any other test that renders data (not just navigation) should be routed through this helper or given the same two-line load cycle. Tests passing `Options{…, Prototype: true}` lose that field — delete the field usage (the `Prototype` field is removed from `Options`; `--prototype` is now expressed by choosing the provider).
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+go test ./... && go vet ./...
+```
+
+Expected: PASS. Then a manual smoke test:
+
+```bash
+go build -o /tmp/lmm-dev ./cmd/lmm && /tmp/lmm-dev tui --prototype --theme wizardry
+```
+
+Expected: identical prototype behavior (data appears immediately; navigate, `?`, `q`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/app.go internal/tui/app_test.go cmd/lmm/tui.go
+git commit -m "feat(tui): async data loading with loading/error states
+
+Model now loads through DataProvider via a Bubble Tea command and renders
+explicit loading, ready, and failed states. Prototype mode is a provider
+choice instead of an Options flag.
+
+Refs #<phase3-issue>"
+```
+
+(`cmd/lmm/tui.go` needs its `tui.Options{…, Prototype: true}` call updated to `tui.NewPrototypeModel(tui.Options{Theme: tuiOptions.theme})` for the build to stay green — include it here.)
+
+---
+
+### Task 9: Phase 3c — CoreProvider adapter over core.Service
+
+The real read-only adapter. `Updates`/`Conflicts` are reported as `-1` (rendered `?`) in Phase 3: an update check is a network operation and conflict detection (`Installer.GetConflicts`) is per-mod and filesystem-heavy — both belong to later phases; the TUI must stay honest rather than guess.
+
+**Files:**
+- Create: `internal/tui/service_core.go`
+- Test: `internal/tui/service_core_test.go`
+
+**Interfaces:**
+- Consumes: `core.Service.GetInstalledMods(gameID, profileName string) ([]domain.InstalledMod, error)`, `core.Service.NewProfileManager() *core.ProfileManager`, `ProfileManager.List(gameID string) ([]*domain.Profile, error)`, `domain.InstalledMod{Mod domain.Mod; Enabled, Deployed bool; …}`, `domain.Profile{Name string; Mods []domain.ModReference; IsDefault bool}`.
+- Deliberate choice: use `GetInstalledMods` (DB order, shows everything), NOT `GetInstalledModsInProfileOrder` — the latter **omits mods missing from the profile YAML** (`internal/core/service.go:319-320`), and `lmm list` uses `GetInstalledMods` (`cmd/lmm/list.go:69`); the TUI must agree with the CLI. Profile load-order display arrives with the Phase 6 load-order workflows.
+- Produces: `NewCoreProvider(svc *core.Service, game *domain.Game, profileName string) DataProvider` (used by Task 10).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/tui/service_core_test.go`:
+
+```go
+package tui_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/tui"
+)
+
+func newCoreProviderFixture(t *testing.T) (tui.DataProvider, *core.Service, *domain.Game) {
+	t.Helper()
+
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{
+		ID:          "test-game",
+		Name:        "Test Game",
+		InstallPath: t.TempDir(),
+		ModPath:     t.TempDir(),
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "101",
+			SourceID: "nexusmods",
+			GameID:   game.ID,
+			Name:     "SkyUI",
+			Author:   "schlangster",
+			Version:  "5.2",
+		},
+		ProfileName: "default",
+		Enabled:     true,
+		Deployed:    true,
+	}))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "102",
+			SourceID: "nexusmods",
+			GameID:   game.ID,
+			Name:     "USSEP",
+			Author:   "Arthmoor",
+			Version:  "4.3",
+		},
+		ProfileName: "default",
+		Enabled:     false,
+	}))
+
+	return tui.NewCoreProvider(svc, game, "default"), svc, game
+}
+
+func TestCoreProviderSummary(t *testing.T) {
+	provider, _, _ := newCoreProviderFixture(t)
+
+	summary, err := provider.Summary(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Test Game", summary.GameName)
+	require.Equal(t, "default", summary.ProfileName)
+	require.Equal(t, 2, summary.Installed)
+	require.Equal(t, 1, summary.Enabled)
+	require.Equal(t, -1, summary.Updates, "updates are unknown until an update check runs")
+	require.Equal(t, -1, summary.Conflicts, "conflicts are unknown in the read-only phase")
+}
+
+func TestCoreProviderInstalledMods(t *testing.T) {
+	provider, _, _ := newCoreProviderFixture(t)
+
+	mods, err := provider.InstalledMods(context.Background())
+	require.NoError(t, err)
+	require.Len(t, mods, 2)
+
+	byName := map[string]tui.ModItem{}
+	for _, m := range mods {
+		byName[m.Name] = m
+	}
+	require.Equal(t, "deployed", byName["SkyUI"].Status)
+	require.Equal(t, "nexusmods", byName["SkyUI"].Source)
+	require.Equal(t, "5.2", byName["SkyUI"].Version)
+	require.Equal(t, "disabled", byName["USSEP"].Status)
+}
+
+func TestCoreProviderSearchResultsAreEmptyUntilPhase4(t *testing.T) {
+	provider, _, _ := newCoreProviderFixture(t)
+
+	results, err := provider.SearchResults(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, results)
+}
+
+func TestCoreProviderProfiles(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+
+	_, err := svc.NewProfileManager().Create(game.ID, "hardcore")
+	require.NoError(t, err)
+
+	profiles, err := provider.Profiles(context.Background())
+	require.NoError(t, err)
+	require.Len(t, profiles, 2)
+
+	byName := map[string]tui.ProfileItem{}
+	for _, p := range profiles {
+		byName[p.Name] = p
+	}
+	require.True(t, byName["default"].Active)
+	require.False(t, byName["hardcore"].Active)
+}
+```
+
+(Note the `tui_test` external test package: the fixture exercises only exported API, and it avoids an import cycle with `core` in-package.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/tui -run TestCoreProvider -v
+```
+
+Expected: compile FAIL — `tui.NewCoreProvider` undefined. (If the fixture itself errors — e.g. `pm.Create` already creates a default differently, or `AddGame` validates paths — adjust the fixture to the actual core API before writing the implementation; the assertions are the contract, the fixture is plumbing.)
+
+- [ ] **Step 3: Implement**
+
+Create `internal/tui/service_core.go`:
+
+```go
+package tui
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// coreProvider adapts *core.Service to the read-only DataProvider boundary.
+type coreProvider struct {
+	svc     *core.Service
+	game    *domain.Game
+	profile string
+}
+
+// NewCoreProvider returns a DataProvider backed by the real app service for
+// one game/profile pair.
+func NewCoreProvider(svc *core.Service, game *domain.Game, profileName string) DataProvider {
+	return &coreProvider{svc: svc, game: game, profile: profileName}
+}
+
+func (p *coreProvider) Summary(_ context.Context) (Summary, error) {
+	mods, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
+	if err != nil {
+		return Summary{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
+	}
+
+	enabled := 0
+	for _, mod := range mods {
+		if mod.Enabled {
+			enabled++
+		}
+	}
+
+	return Summary{
+		GameName:    p.game.Name,
+		ProfileName: p.profile,
+		Installed:   len(mods),
+		Enabled:     enabled,
+		Updates:     -1, // unknown: update checks are a Phase 6 workflow
+		Conflicts:   -1, // unknown: conflict detection is a Phase 6 workflow
+	}, nil
+}
+
+func (p *coreProvider) InstalledMods(_ context.Context) ([]ModItem, error) {
+	mods, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
+	if err != nil {
+		return nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
+	}
+
+	items := make([]ModItem, 0, len(mods))
+	for _, mod := range mods {
+		items = append(items, ModItem{
+			Name:    mod.Name,
+			Author:  mod.Author,
+			Version: mod.Version,
+			Source:  mod.SourceID,
+			Status:  installedModStatus(mod),
+		})
+	}
+	return items, nil
+}
+
+// SearchResults is an honest placeholder until Phase 4 wires real source
+// search into the TUI.
+func (p *coreProvider) SearchResults(_ context.Context) ([]ModItem, error) {
+	return nil, nil
+}
+
+func (p *coreProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
+	profiles, err := p.svc.NewProfileManager().List(p.game.ID)
+	if err != nil {
+		return nil, fmt.Errorf("listing profiles for %s: %w", p.game.ID, err)
+	}
+
+	items := make([]ProfileItem, 0, len(profiles))
+	for _, profile := range profiles {
+		items = append(items, ProfileItem{
+			Name:     profile.Name,
+			Active:   profile.Name == p.profile,
+			ModCount: len(profile.Mods),
+		})
+	}
+	return items, nil
+}
+
+func installedModStatus(mod domain.InstalledMod) string {
+	switch {
+	case mod.Enabled && mod.Deployed:
+		return "deployed"
+	case mod.Enabled:
+		return "enabled"
+	default:
+		return "disabled"
+	}
+}
+```
+
+Also give the search view an empty-state line so real mode is honest — in `app.go` `searchView`, after the query line:
+
+```go
+	if len(m.searchResults) == 0 {
+		rows = append(rows, m.theme.MutedText.Render("The archive index opens in a later chapter. (Search arrives in Phase 4.)"))
+	}
+```
+
+and the mods view an empty state after its header rows:
+
+```go
+	if len(m.mods) == 0 {
+		rows = append(rows, m.theme.MutedText.Render("No mods installed yet. 'lmm install <mod>' begins the quest."))
+	}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/tui/... -v && go vet ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/service_core.go internal/tui/service_core_test.go internal/tui/app.go
+git commit -m "feat(tui): add core.Service-backed DataProvider
+
+Read-only adapter mapping installed mods, profiles, and summary counts to
+TUI view models. Updates/conflicts report unknown (-1 -> '?') until the
+Phase 6 workflows land. Empty states added for mods and search views.
+
+Refs #<phase3-issue>"
+```
+
+---
+
+### Task 10: Phase 3d — wire `lmm tui` real mode
+
+`lmm tui` without `--prototype` initializes config and service exactly like other CLI commands (via `withGameService`), resolves the default profile, and runs the model with `CoreProvider`. Missing game/config errors surface through the existing helper error paths before the TUI starts (matching CLI behavior); provider errors after startup render in the TUI's failed state.
+
+**Files:**
+- Modify: `cmd/lmm/tui.go`
+- Test: `cmd/lmm/tui_test.go`
+
+**Interfaces:**
+- Consumes: `withGameService(cmd, fn)` (`cmd/lmm/helpers.go:35`), `core.Service.NewProfileManager().GetDefault(gameID string) (*domain.Profile, error)`, `tui.NewModel`, `tui.NewCoreProvider`, `tui.NewPrototypeProvider`.
+- Produces: user-facing `lmm tui [--theme X]` real mode; `lmm tui --prototype` unchanged.
+
+- [ ] **Step 1: Rewrite the failing cmd test**
+
+In `cmd/lmm/tui_test.go`, replace `TestRunTUIRejectsRealModeUntilImplemented` with a test that real mode goes through the game-resolution path (no TTY needed — it fails before the program starts):
+
+```go
+func TestRunTUIRealModeRequiresAGame(t *testing.T) {
+	tuiOptions.prototype = false
+	tuiOptions.theme = "wizardry"
+	configDir = t.TempDir()
+	dataDir = t.TempDir()
+	gameID = ""
+	t.Cleanup(func() {
+		configDir = ""
+		dataDir = ""
+		gameID = ""
+	})
+
+	err := runTUI(tuiCmd, nil)
+	require.ErrorContains(t, err, "no game specified")
+}
+```
+
+(Match the variable names used by other `_NoGame` cmd tests — see `TestSearchCmd_NoGame` in `cmd/lmm/search_test.go` for the exact globals to set; reuse its setup pattern verbatim if it differs from the above.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./cmd/lmm -run TestRunTUIRealModeRequiresAGame -v
+```
+
+Expected: FAIL — current `runTUI` returns "real TUI mode is not implemented yet; use --prototype".
+
+- [ ] **Step 3: Implement**
+
+Rewrite `cmd/lmm/tui.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/tui"
+)
+
+var tuiOptions struct {
+	prototype bool
+	theme     string
+}
+
+var tuiCmd = &cobra.Command{
+	Use:   "tui",
+	Short: "Launch the interactive terminal UI",
+	Long: `Launch the interactive terminal UI.
+
+Shows the configured game's installed mods, profiles, and status using the
+same config, database, and game resolution as the CLI commands. Read-only:
+browsing never installs, updates, deploys, or deletes anything.
+
+Use --prototype for a demo mode backed by static fake data:
+
+  lmm tui --prototype --theme amber`,
+	RunE: runTUI,
+}
+
+func init() {
+	tuiCmd.Flags().BoolVar(&tuiOptions.prototype, "prototype", false, "run the side-effect-free fake-data TUI prototype")
+	tuiCmd.Flags().StringVar(&tuiOptions.theme, "theme", "wizardry", "TUI theme (wizardry, amber, dos, green)")
+	rootCmd.AddCommand(tuiCmd)
+}
+
+func runTUI(cmd *cobra.Command, args []string) error {
+	if tuiOptions.prototype {
+		model, err := tui.NewModel(tui.Options{Theme: tuiOptions.theme, Provider: tui.NewPrototypeProvider()})
+		if err != nil {
+			return err
+		}
+		return runTUIProgram(cmd.Context(), model)
+	}
+
+	return withGameService(cmd, func(ctx context.Context, svc *core.Service, game *domain.Game) error {
+		// Match the CLI's behavior (profileOrDefault): fall back to the
+		// literal "default" profile when none exists yet, so a fresh setup
+		// opens an empty TUI instead of erroring.
+		profileName := "default"
+		if profile, err := svc.NewProfileManager().GetDefault(game.ID); err == nil {
+			profileName = profile.Name
+		} else if !errors.Is(err, domain.ErrProfileNotFound) {
+			return fmt.Errorf("resolving default profile for %s: %w", game.ID, err)
+		}
+
+		model, err := tui.NewModel(tui.Options{
+			Theme:    tuiOptions.theme,
+			Provider: tui.NewCoreProvider(svc, game, profileName),
+		})
+		if err != nil {
+			return err
+		}
+		return runTUIProgram(ctx, model)
+	})
+}
+
+func runTUIProgram(ctx context.Context, model tui.Model) error {
+	if _, err := tea.NewProgram(model, tea.WithContext(ctx), tea.WithAltScreen()).Run(); err != nil {
+		return fmt.Errorf("running TUI: %w", err)
+	}
+	return nil
+}
+```
+
+Note `tea.WithAltScreen()`: the app now fills the terminal and restores the shell on exit — appropriate once real data is shown. It applies to prototype mode too; if the snapshot review in Task 2 found reasons to keep inline rendering, drop the option and note why in the commit body.
+
+- [ ] **Step 4: Run tests, then verify end-to-end**
+
+```bash
+go test ./... && go vet ./...
+go build -o /tmp/lmm-dev ./cmd/lmm
+/tmp/lmm-dev tui --prototype                 # demo mode still works
+/tmp/lmm-dev tui                             # real mode with your local config
+/tmp/lmm-dev tui --theme amber               # theme flag in real mode
+```
+
+Expected: real mode shows your actual configured game, installed mods, and profiles; `?` renders for updates/conflicts; navigation and `q` work; the shell restores cleanly. If no local game is configured, expect the CLI error `no game specified; use --game or -g flag…` before the TUI starts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/lmm/tui.go cmd/lmm/tui_test.go
+git commit -m "feat(tui): wire lmm tui to real read-only app data
+
+lmm tui without --prototype now initializes the service via
+withGameService, resolves the default profile, and browses real installed
+mods and profiles through CoreProvider. Prototype mode is unchanged.
+
+Refs #<phase3-issue>"
+```
+
+---
+
+### Task 11: Docs, changelog, version 1.4.0, and PR
+
+**Files:**
+- Modify: `README.md` (usage section — add `lmm tui`)
+- Modify: `BACKLOG.md` (TUI section is stale: says "Code removed, to be reimplemented")
+- Modify: `CHANGELOG.md`
+- Modify: `cmd/lmm/root.go:25` (`version = "1.3.10"` → `"1.4.0"`)
+
+**Interfaces:**
+- Consumes: completed Tasks 7–10.
+- Produces: shippable, documented `lmm tui`.
+
+- [ ] **Step 1: Update README**
+
+Add a `### Terminal UI` subsection to README's usage docs (place it alongside the other command sections):
+
+```markdown
+### Terminal UI
+
+Browse your configured game, installed mods, and profiles interactively:
+
+​```bash
+lmm tui                     # real data, read-only
+lmm tui --theme amber       # themes: wizardry (default), amber, dos, green
+lmm tui --prototype         # demo mode with static fake data
+​```
+
+Keys: `tab`/`h`/`l` cycle screens, `1`–`4` jump, `↑↓`/`j`/`k` move, `enter` open,
+`/` search screen, `?` help, `q` quit. Browsing is read-only — install/update/deploy
+actions from the TUI arrive in a later release.
+```
+
+(Remove the zero-width characters around the inner code fence when pasting — they exist only to nest the fence in this plan.)
+
+- [ ] **Step 2: Update BACKLOG.md**
+
+Replace the stale "Terminal UI (TUI)" deferred section's **Status** line with:
+
+```markdown
+**Status:** Reimplemented. Prototype shell (v1.3.x, #31/#32) and read-only
+service-backed TUI (v1.4.0) are done; search, mutations, and workflows are
+tracked by the Phase 4-6 sections of docs/plans/2026-04-28-tui-implementation.md.
+```
+
+- [ ] **Step 3: Update CHANGELOG and bump version**
+
+In `CHANGELOG.md`, ensure `[Unreleased]` contains the accumulated TUI entries, then move them to a new section:
+
+```markdown
+## [1.4.0] - <today's date>
+
+### Added
+
+- **`lmm tui` (read-only)**: The TUI now runs against real app data — Dashboard, Installed Mods, and Profiles views load the configured game, default profile, and installed mods through a narrow read-only provider. Search shows an honest placeholder until source search is wired in. `--prototype` remains as a side-effect-free demo mode.
+- **TUI theme snapshots**: Committed ANSI captures of all four themes at 80x24 and 120x36 under `docs/assets/tui/`, regenerable with `UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui -run TestGenerateThemeSnapshots`.
+- **Dashboard enter-to-open**: The dashboard menu is defined once, and Enter opens the selected entry's screen.
+
+### Changed
+
+- **TUI internals**: Key handling flows through the shared KeyMap; status text styles live in the theme; the TUI uses the terminal's alternate screen.
+```
+
+Add the comparison link at the bottom of the file following the existing pattern, and update `cmd/lmm/root.go` `version = "1.4.0"`.
+
+- [ ] **Step 4: Final verification**
+
+```bash
+go fmt ./... && go vet ./... && go test ./... -v | tail -25
+go build -o /tmp/lmm-dev ./cmd/lmm && /tmp/lmm-dev --version && /tmp/lmm-dev tui --help
+```
+
+Expected: everything green; `--version` prints 1.4.0; help shows the updated long description.
+
+- [ ] **Step 5: Commit the version bump separately, push, open PR**
+
+```bash
+git add README.md BACKLOG.md CHANGELOG.md
+git commit -m "docs: document lmm tui usage and refresh backlog status
+
+Refs #<phase3-issue>"
+git add cmd/lmm/root.go CHANGELOG.md
+git commit -m "chore: bump version to 1.4.0"
+git push -u origin feat/tui-service-backed
+gh pr create --title "feat(tui): read-only service-backed TUI (Phase 3)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Narrow read-only DataProvider boundary between the TUI and core.Service, with prototype and real implementations.
+- `lmm tui` initializes config/service via withGameService, resolves the default profile, and browses real installed mods and profiles.
+- Async load with explicit loading/error states; honest placeholders for search (Phase 4) and update/conflict counts (Phase 6).
+- Docs, changelog, and version 1.4.0.
+
+Closes #<phase3-issue>
+
+## Test Plan
+- [x] go test ./... / go vet ./... / go fmt ./...
+- [x] Manual: lmm tui with a real configured game; lmm tui --prototype; all four themes; 80x24 terminal
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Follow-ups deliberately NOT in this plan
+
+Each of these is its own plan when its phase begins (per the phased TUI plan doc):
+
+- **Phase 4** — search input (`bubbles/textinput`), real source search with cancellation, detail panel, auth-required messaging.
+- **Phase 5** — mutating actions behind confirmations (enable/disable, switch profile, deploy, install, update).
+- **Phase 6** — conflict/update/load-order workflows (this is when `Summary.Updates`/`Conflicts` stop being `-1`).
+- **Structural split** of `internal/tui/app.go` into `views/` + `widgets/` packages: deferred until Phase 4 adds stateful sub-models (text input, spinners) that justify the package boundary; splitting a ~500-line file of pure render funcs earlier adds churn without payoff.
+- `TODO.local.md` "Schedule" items (encrypted tokens, download history, profile-level link_method, etc.) — unrelated to the TUI track.

--- a/docs/plans/archive/2026-07-13-tui-phase4-search-impl.md
+++ b/docs/plans/archive/2026-07-13-tui-phase4-search-impl.md
@@ -1,0 +1,872 @@
+# TUI Phase 4: Search and Detail Browsing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the TUI useful for browsing mod-source search results — text input, real source search with cancellation, installed markers, detail panel, pagination — without installing anything (issue #40).
+
+**Architecture:** The `DataProvider` boundary evolves: `Summary`+`InstalledMods` merge into a single-fetch `Overview`, the `SearchResults` placeholder becomes `Search(ctx, source, query, page)`, and `Sources()` exposes the game's configured sources. The Bubble Tea `Model` gains the program context (`Options.Ctx`) and a search sub-model (`internal/tui/search.go`) owning a Bubbles `textinput`, focus state, and a generation-tagged async search command (cancel context + discard stale results). Focus-aware key routing suspends the global KeyMap while the input is focused.
+
+**Tech Stack:** Go 1.25, Bubble Tea + Bubbles (`textinput`) + Lip Gloss (all present), testify, existing `core.Service.SearchMods`.
+
+## Global Constraints
+
+- **`main` is branch-protected — all changes land via PR** (merge-commit style). Work on branch `feat/tui-phase4-search` off `main`. PRs get an automatic Copilot review within minutes; triage its comments before merging.
+- Commits reference **`Refs #40`**; the PR body says `Closes #40` (main IS the default branch now, so it auto-closes).
+- **Pre-made design decisions (from the blindspot pass — binding):**
+  - **Enter-to-search only.** No debounced live search: `internal/source/httpclient` has no 429/backoff handling.
+  - **Single source per search.** Default = first configured source, sorted alphabetically (mirrors `resolveSource`/`getConfiguredSources` in `cmd/lmm/helpers.go:86`); the active source is displayed and cycleable with `s`.
+  - **Results mark already-installed mods** (Status "installed"), like `lmm search` does.
+  - **Detail panel renders search-result fields only** — no follow-up `GetMod` call.
+  - **No category/tag filters** this phase.
+  - **`views/` split scoped to the search sub-model only** — one new file `internal/tui/search.go` in package `tui`; no new package (a package split would force exporting theme/model internals for zero Phase 4 benefit — revisit in Phase 5).
+- Pagination mirrors the CLI picker (`cmd/lmm/install.go:198-286`): **page size 10, 0-based pages, re-query per page, `n`/`p` keys**, TotalCount-driven "more" hint with a full-page fallback when TotalCount is 0.
+- Generation-tagged search results: a result/error message whose `gen` doesn't match the model's current generation is **discarded**. Each new search cancels the previous context AND bumps the generation.
+- `domain.ErrAuthRequired` renders as a first-class search state with the exact remedy text `run 'lmm auth login <source>'`.
+- Unknown values render `?` (existing `countLabel` convention); never fake data. Prototype mode stays side-effect-free.
+- TDD per task (compile failure counts as RED); `go test ./...`, `go vet ./...` green; `gofmt -l cmd internal/tui` prints nothing (known pre-existing offender `internal/storage/cache/cache.go` is out of scope — never touch it).
+- **Snapshot regeneration is required in any task that changes view output**: `UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui -run TestGenerateThemeSnapshots`, commit the changed `.ansi` files, and state in the report which files changed and why.
+- MINOR version bump to **1.5.0** at the end (new feature), CHANGELOG + README updates, separate `chore:` version commit.
+
+**Baseline (verified):** `main` at the PR #39 merge; only `main` exists locally/remotely; suite green. Current TUI: `Model` in `internal/tui/app.go` with `provider DataProvider`, `keys KeyMap`, async `loadData` (`dataLoadedMsg`/`loadFailedMsg`), `m.selected map[Screen]int`, `screenView()` state gating, `searchView()` rendering a static empty-state line. `DataProvider` (internal/tui/service.go) currently has `Summary`, `InstalledMods`, `SearchResults` (placeholder), `Profiles`. `KeyMap` (internal/tui/keys.go) routes everything via `key.Matches` in `updateKey`; `Search` binding is `/`+`3`.
+
+---
+
+### Task 1: DataProvider v2 — Overview, Sources, Search; prototype provider
+
+**Files:**
+- Modify: `internal/tui/service.go`
+- Modify: `internal/tui/prototype/data.go` (add Summary/Downloads demo fields)
+- Test: `internal/tui/service_test.go`, `internal/tui/prototype/data_test.go`
+
+**Interfaces:**
+- Produces (consumed by Tasks 2–5):
+
+```go
+const SearchPageSize = 10 // mirrors the CLI picker's displayPageSize
+
+type ModItem struct {
+	Name            string
+	Author          string
+	Version         string
+	Source          string
+	Status          string
+	Summary         string
+	Downloads       int64
+	Endorsements    int64
+	HasEndorsements bool
+}
+
+// SearchPage is one page of search results for one source/query.
+type SearchPage struct {
+	Results    []ModItem
+	Query      string
+	Source     string
+	Page       int // 0-based
+	PageSize   int
+	TotalCount int // 0 if the source doesn't report totals
+}
+
+type DataProvider interface {
+	// Overview returns the dashboard summary and installed-mod rows from a
+	// single underlying fetch.
+	Overview(ctx context.Context) (Summary, []ModItem, error)
+	Profiles(ctx context.Context) ([]ProfileItem, error)
+	// Sources lists the game's configured source IDs, sorted; index 0 is the
+	// default (mirrors the CLI's resolveSource).
+	Sources() []string
+	Search(ctx context.Context, source, query string, page int) (SearchPage, error)
+}
+```
+
+- `Summary`, `ProfileItem` unchanged. The old `Summary(ctx)`, `InstalledMods(ctx)`, `SearchResults(ctx)` methods are **removed** from the interface and both implementations.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace `TestPrototypeProviderMirrorsFakeData`'s method calls in `internal/tui/service_test.go` with the v2 interface and add search behavior tests:
+
+```go
+func TestPrototypeProviderOverviewMirrorsFakeData(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	provider := NewPrototypeProvider()
+	data := prototype.Load()
+
+	summary, mods, err := provider.Overview(ctx)
+	require.NoError(t, err)
+	require.Equal(t, data.Game.Name, summary.GameName)
+	require.Equal(t, data.Stats.Installed, summary.Installed)
+	require.Len(t, mods, len(data.InstalledMods))
+	require.Equal(t, data.InstalledMods[0].Name, mods[0].Name)
+}
+
+func TestPrototypeProviderSources(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"nexusmods"}, NewPrototypeProvider().Sources())
+}
+
+func TestPrototypeProviderSearchFiltersCannedResults(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	provider := NewPrototypeProvider()
+
+	page, err := provider.Search(ctx, "nexusmods", "frost", 0)
+	require.NoError(t, err)
+	require.Equal(t, "frost", page.Query)
+	require.Equal(t, "nexusmods", page.Source)
+	require.Len(t, page.Results, 1)
+	require.Equal(t, "Frostfall", page.Results[0].Name)
+	require.Equal(t, 1, page.TotalCount)
+
+	all, err := provider.Search(ctx, "nexusmods", "", 0)
+	require.NoError(t, err)
+	require.Len(t, all.Results, len(prototype.Load().SearchResults), "empty query returns everything")
+}
+```
+
+Keep the `Profiles` assertions from the old test (unchanged method).
+
+- [ ] **Step 2: Run to verify RED**
+
+`go test ./internal/tui -run TestPrototypeProvider -v` — compile FAIL (`provider.Overview` undefined).
+
+- [ ] **Step 3: Implement**
+
+In `internal/tui/service.go`: add the constants/types/interface above; rewrite the prototype provider:
+
+```go
+func (p prototypeProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
+	return Summary{
+		GameName:    p.data.Game.Name,
+		ProfileName: p.data.Profile.Name,
+		Installed:   p.data.Stats.Installed,
+		Enabled:     p.data.Stats.Enabled,
+		Updates:     p.data.Stats.Updates,
+		Conflicts:   p.data.Stats.Conflicts,
+	}, modItems(p.data.InstalledMods), nil
+}
+
+func (p prototypeProvider) Sources() []string {
+	return []string{"nexusmods"}
+}
+
+func (p prototypeProvider) Search(_ context.Context, source, query string, _ int) (SearchPage, error) {
+	all := modItems(p.data.SearchResults)
+	matched := make([]ModItem, 0, len(all))
+	for _, item := range all {
+		if strings.Contains(strings.ToLower(item.Name), strings.ToLower(query)) {
+			matched = append(matched, item)
+		}
+	}
+	return SearchPage{
+		Results:    matched,
+		Query:      query,
+		Source:     source,
+		Page:       0,
+		PageSize:   SearchPageSize,
+		TotalCount: len(matched),
+	}, nil
+}
+```
+
+Extend `modItems` to copy the new fields, and add `Summary string` + `Downloads int64` to `prototype.Mod` with short demo values in `Load()` (e.g. Campfire: "Camping and survival skill system.", 4_200_000). Update `prototype/data_test.go` only if its invariants break (they shouldn't — it checks counts and the active profile).
+
+Delete the now-unimplemented old methods from the prototype provider. **`app.go` will not compile after this task alone** — that is expected; Task 3 rewires the Model. To keep the branch bisectable, apply the minimal mechanical shim in this task: change `loadData` to call `Overview`/`Profiles` and delete its `SearchResults` call plus the `searchResults` payload from `dataLoadedMsg` (the field `m.searchResults` and `searchView`'s use of it become an empty-slice render until Task 4 replaces the view). Adjust `failingProvider`/`emptyProvider` in `app_test.go` to the v2 interface.
+
+- [ ] **Step 4: Run the full suite** — `go test ./... && go vet ./...`; `gofmt -l internal/tui` silent. Snapshot check: regenerate; the search view now renders its empty state unconditionally — if captures change, include them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/service.go internal/tui/prototype/data.go internal/tui/service_test.go internal/tui/prototype/data_test.go internal/tui/app.go internal/tui/app_test.go docs/assets/tui
+git commit -m "feat(tui): evolve DataProvider — Overview single-fetch, Sources, Search
+
+Refs #40"
+```
+
+---
+
+### Task 2: CoreProvider v2 — single fetch, Sources, Search with installed markers
+
+**Files:**
+- Modify: `internal/tui/service_core.go`
+- Test: `internal/tui/service_core_test.go`
+
+**Interfaces:**
+- Consumes: `core.Service.SearchMods(ctx, sourceID, gameID, query, category string, tags []string, page, pageSize int) (source.SearchResult, error)` (service.go:107 — already maps `game.SourceIDs`), `source.SearchResult{Mods []domain.Mod; TotalCount, Page, PageSize int}`, `core.Service.RegisterSource(source.ModSource)`, `domain.ModKey(sourceID, modID) string`, `source.ModSource` interface (internal/source/source.go:36).
+- Produces: `NewCoreProvider` unchanged signature; v2 methods.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `internal/tui/service_core_test.go` (external `tui_test` package): update the fixture's assertions to `Overview`, and add a stub source so `Search` can be tested against the real service path:
+
+```go
+// stubSource implements source.ModSource with canned search results.
+// Only Search and identity methods matter; the rest are unreachable in these tests.
+type stubSource struct {
+	result source.SearchResult
+	err    error
+}
+
+func (s *stubSource) ID() string      { return "stub" }
+func (s *stubSource) Name() string    { return "Stub Source" }
+func (s *stubSource) AuthURL() string { return "" }
+func (s *stubSource) ExchangeToken(context.Context, string) (*source.Token, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubSource) Search(context.Context, source.SearchQuery) (source.SearchResult, error) {
+	return s.result, s.err
+}
+func (s *stubSource) GetMod(context.Context, string, string) (*domain.Mod, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubSource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubSource) GetModFiles(context.Context, *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, errors.New("not implemented")
+}
+```
+
+If `source.ModSource` has methods beyond these (check `internal/source/source.go` — e.g. `GetDownloadURL`), stub them the same way: the compiler is the checklist.
+
+```go
+func TestCoreProviderOverviewSingleFetch(t *testing.T) {
+	provider, _, _ := newCoreProviderFixture(t)
+
+	summary, mods, err := provider.Overview(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 2, summary.Installed)
+	require.Equal(t, 1, summary.Enabled)
+	require.Equal(t, -1, summary.Updates)
+	require.Len(t, mods, 2)
+}
+
+func TestCoreProviderSources(t *testing.T) {
+	provider, _, game := newCoreProviderFixture(t)
+	game.SourceIDs = map[string]string{"nexusmods": "testgame", "stub": "testgame"}
+
+	require.Equal(t, []string{"nexusmods", "stub"}, provider.Sources())
+}
+
+func TestCoreProviderSearchMarksInstalled(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+	game.SourceIDs = map[string]string{"stub": "testgame"}
+	svc.RegisterSource(&stubSource{result: source.SearchResult{
+		Mods: []domain.Mod{
+			{ID: "101", SourceID: "stub", Name: "SkyUI-Stub", Author: "a", Version: "5.2"},
+			{ID: "999", SourceID: "stub", Name: "NewMod", Author: "b", Version: "1.0"},
+		},
+		TotalCount: 2, Page: 0, PageSize: 10,
+	}})
+	// Fixture installed mod 101 under sourceID "nexusmods"; install one under "stub" too:
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:         domain.Mod{ID: "101", SourceID: "stub", GameID: game.ID, Name: "SkyUI-Stub", Version: "5.2"},
+		ProfileName: "default", Enabled: true,
+	}))
+
+	page, err := provider.Search(context.Background(), "stub", "sky", 0)
+	require.NoError(t, err)
+	require.Equal(t, "sky", page.Query)
+	require.Equal(t, "stub", page.Source)
+	require.Equal(t, 2, page.TotalCount)
+	require.Len(t, page.Results, 2)
+
+	byName := map[string]tui.ModItem{}
+	for _, r := range page.Results {
+		byName[r.Name] = r
+	}
+	require.Equal(t, "installed", byName["SkyUI-Stub"].Status)
+	require.Equal(t, "available", byName["NewMod"].Status)
+}
+
+func TestCoreProviderSearchPropagatesAuthRequired(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+	game.SourceIDs = map[string]string{"stub": "testgame"}
+	svc.RegisterSource(&stubSource{err: fmt.Errorf("%w: key required", domain.ErrAuthRequired)})
+
+	_, err := provider.Search(context.Background(), "stub", "x", 0)
+	require.ErrorIs(t, err, domain.ErrAuthRequired)
+}
+```
+
+(Add `"errors"`, `"fmt"`, and the `source` package to the test imports. Update the two old `TestCoreProviderSummary`/`TestCoreProviderInstalledMods` tests to go through `Overview`; delete `TestCoreProviderSearchResultsAreEmptyUntilPhase4`.)
+
+- [ ] **Step 2: Verify RED** — compile FAIL (`provider.Overview`, `Sources`, new `Search` undefined).
+
+- [ ] **Step 3: Implement** in `internal/tui/service_core.go`:
+
+```go
+func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
+	mods, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
+	if err != nil {
+		return Summary{}, nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
+	}
+
+	enabled := 0
+	items := make([]ModItem, 0, len(mods))
+	for _, mod := range mods {
+		if mod.Enabled {
+			enabled++
+		}
+		items = append(items, ModItem{
+			Name:    mod.Name,
+			Author:  mod.Author,
+			Version: mod.Version,
+			Source:  mod.SourceID,
+			Status:  installedModStatus(mod),
+		})
+	}
+
+	summary := Summary{
+		GameName:    p.game.Name,
+		ProfileName: p.profile,
+		Installed:   len(mods),
+		Enabled:     enabled,
+		Updates:     -1,
+		Conflicts:   -1,
+	}
+	return summary, items, nil
+}
+
+func (p *coreProvider) Sources() []string {
+	sources := make([]string, 0, len(p.game.SourceIDs))
+	for id := range p.game.SourceIDs {
+		sources = append(sources, id)
+	}
+	sort.Strings(sources)
+	return sources
+}
+
+func (p *coreProvider) Search(ctx context.Context, sourceID, query string, page int) (SearchPage, error) {
+	result, err := p.svc.SearchMods(ctx, sourceID, p.game.ID, query, "", nil, page, SearchPageSize)
+	if err != nil {
+		return SearchPage{}, fmt.Errorf("searching %s for %q: %w", sourceID, query, err)
+	}
+
+	installed, err := p.svc.GetInstalledMods(p.game.ID, p.profile)
+	if err != nil {
+		return SearchPage{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, p.profile, err)
+	}
+	installedKeys := make(map[string]bool, len(installed))
+	for _, mod := range installed {
+		installedKeys[domain.ModKey(mod.SourceID, mod.ID)] = true
+	}
+
+	items := make([]ModItem, 0, len(result.Mods))
+	for _, mod := range result.Mods {
+		status := "available"
+		if installedKeys[domain.ModKey(mod.SourceID, mod.ID)] {
+			status = "installed"
+		}
+		item := ModItem{
+			Name:    mod.Name,
+			Author:  mod.Author,
+			Version: mod.Version,
+			Source:  mod.SourceID,
+			Status:  status,
+			Summary: mod.Summary,
+			Downloads: mod.Downloads,
+		}
+		if mod.Endorsements != nil {
+			item.Endorsements = *mod.Endorsements
+			item.HasEndorsements = true
+		}
+		items = append(items, item)
+	}
+
+	return SearchPage{
+		Results:    items,
+		Query:      query,
+		Source:     sourceID,
+		Page:       page,
+		PageSize:   SearchPageSize,
+		TotalCount: result.TotalCount,
+	}, nil
+}
+```
+
+Delete the old `Summary`/`InstalledMods`/`SearchResults` methods (fold the status-mapping loop into `Overview` as above; keep `installedModStatus`). Add `"sort"` import. Note the `%w` wrap preserves `errors.Is(err, domain.ErrAuthRequired)`.
+
+- [ ] **Step 4: Full suite** — `go test ./... && go vet ./...`, gofmt silent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/service_core.go internal/tui/service_core_test.go
+git commit -m "feat(tui): CoreProvider v2 — Overview, Sources, real Search with installed markers
+
+Refs #40"
+```
+
+---
+
+### Task 3: Program-context threading (Options.Ctx)
+
+**Files:**
+- Modify: `internal/tui/app.go`, `cmd/lmm/tui.go`
+- Test: `internal/tui/app_test.go`
+
+**Interfaces:**
+- Produces: `Options{Theme string; Provider DataProvider; Ctx context.Context}`; `Model.ctx context.Context` (Background fallback when nil). Task 4's search commands derive per-search contexts from `m.ctx`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestModelUsesProvidedContext(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+
+	var seen context.Context
+	provider := recordingProvider{onOverview: func(c context.Context) { seen = c }}
+	model, err := NewModel(Options{Theme: "wizardry", Provider: provider, Ctx: ctx})
+	require.NoError(t, err)
+
+	model.Init()()
+	require.Equal(t, "marker", seen.Value(ctxKey{}))
+}
+```
+
+with a small `recordingProvider` in `app_test.go` that wraps `NewPrototypeProvider()` and calls `onOverview(ctx)` before delegating `Overview`; other methods delegate directly.
+
+- [ ] **Step 2: Verify RED** — compile FAIL (`Options.Ctx` undefined).
+
+- [ ] **Step 3: Implement** — add `Ctx` to `Options`; in `NewModel`, `if options.Ctx == nil { options.Ctx = context.Background() }`, store `ctx: options.Ctx` on `Model`; `loadData` uses `m.ctx` instead of `context.Background()`. In `cmd/lmm/tui.go`, pass `Ctx: cmd.Context()` (prototype path) and `Ctx: ctx` (real path inside `withGameService`).
+
+- [ ] **Step 4: Full suite**; no view changes → assert snapshots unchanged after regeneration.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/app.go internal/tui/app_test.go cmd/lmm/tui.go
+git commit -m "feat(tui): thread program context into the model and data loads
+
+Refs #40"
+```
+
+---
+
+### Task 4: Search sub-model — focus routing, generation-tagged async search
+
+**Files:**
+- Create: `internal/tui/search.go`
+- Modify: `internal/tui/app.go` (Model wiring, updateKey routing, itemCount), `internal/tui/keys.go`
+- Test: `internal/tui/search_test.go` (new), `internal/tui/app_test.go`
+
+**Interfaces:**
+- Consumes: `DataProvider.Search`/`Sources` (Tasks 1–2), `m.ctx` (Task 3), `github.com/charmbracelet/bubbles/textinput`, `domain.ErrAuthRequired`.
+- Produces (consumed by Task 5's rendering):
+
+```go
+type searchState int
+
+const (
+	searchIdle searchState = iota
+	searchLoading
+	searchReady
+	searchFailed
+	searchAuthRequired
+)
+
+type searchModel struct {
+	input      textinput.Model
+	sources    []string
+	sourceIdx  int
+	state      searchState
+	page       SearchPage
+	err        error
+	authSource string
+	gen        int
+	cancel     context.CancelFunc
+}
+
+type searchResultMsg struct {
+	gen  int
+	page SearchPage
+}
+
+type searchFailedMsg struct {
+	gen    int
+	err    error
+	source string
+}
+```
+
+KeyMap additions: `Submit` (enter), `Blur` (esc), `NextPage` (n), `PrevPage` (p), `CycleSource` (s).
+
+- [ ] **Step 1: Write the failing tests** (`internal/tui/search_test.go`, package `tui`)
+
+```go
+func searchScreenModel(t *testing.T) Model {
+	t.Helper()
+	model := sizedPrototypeModel(t, "wizardry", 100, 30)
+	return updateWithRunes(t, model, "3") // jump to search screen (blurred)
+}
+
+func TestSlashFocusesSearchInputOnSearchScreen(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model = updateWithRunes(t, model, "/")
+	require.True(t, model.search.input.Focused())
+}
+
+func TestTypingWhileFocusedDoesNotTriggerGlobalKeys(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model = updateWithRunes(t, model, "/")
+	for _, r := range "quest124" { // q would quit; 1/2/4 would jump screens
+		model = updateWithRunes(t, model, string(r))
+	}
+	require.Equal(t, ScreenSearch, model.CurrentScreen())
+	require.Equal(t, "quest124", model.search.input.Value())
+}
+
+func TestEscBlursSearchInput(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model = updateWithRunes(t, model, "/")
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.False(t, updated.(Model).search.input.Focused())
+}
+
+func TestEnterSubmitsSearchAndRendersResults(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model = updateWithRunes(t, model, "/")
+	for _, r := range "frost" {
+		model = updateWithRunes(t, model, string(r))
+	}
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.Equal(t, searchLoading, model.search.state)
+	require.NotNil(t, cmd)
+
+	result, _ := model.Update(cmd())
+	model = result.(Model)
+	require.Equal(t, searchReady, model.search.state)
+	require.Len(t, model.search.page.Results, 1)
+	require.Equal(t, "Frostfall", model.search.page.Results[0].Name)
+}
+
+func TestStaleSearchResultsAreDiscarded(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.gen = 5
+	model.search.state = searchLoading
+
+	updated, _ := model.Update(searchResultMsg{gen: 4, page: SearchPage{Query: "stale"}})
+	require.Equal(t, searchLoading, updated.(Model).search.state, "stale gen must be ignored")
+}
+
+func TestAuthRequiredBecomesFirstClassState(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.gen = 1
+	updated, _ := model.Update(searchFailedMsg{
+		gen:    1,
+		err:    fmt.Errorf("%w: key required", domain.ErrAuthRequired),
+		source: "nexusmods",
+	})
+	m := updated.(Model)
+	require.Equal(t, searchAuthRequired, m.search.state)
+	require.Equal(t, "nexusmods", m.search.authSource)
+}
+
+func TestCycleSourceKey(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.sources = []string{"curseforge", "nexusmods"}
+	model = updateWithRunes(t, model, "s")
+	require.Equal(t, 1, model.search.sourceIdx)
+	model = updateWithRunes(t, model, "s")
+	require.Equal(t, 0, model.search.sourceIdx, "cycling wraps")
+}
+
+func TestPaginationKeysRequeryWithinBounds(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+	model.search.state = searchReady
+	model.search.page = SearchPage{Query: "q", Source: "nexusmods", Page: 0, PageSize: 10, TotalCount: 25}
+
+	updated, cmd := model.Update(keyRunes("n"))
+	require.NotNil(t, cmd, "next page issues a search command")
+	_ = updated
+
+	model.search.page.Page = 0
+	_, cmd = model.Update(keyRunes("p"))
+	require.Nil(t, cmd, "prev on page 0 is a no-op")
+}
+```
+
+Add tiny helper `keyRunes(s string) tea.KeyMsg` (or reuse `updateWithRunes`'s construction) and imports (`fmt`, `domain`, `tea`). Note `moveSelection`'s `itemCount(ScreenSearch)` must become `len(m.search.page.Results)` — update `TestSelectionMovementIsClamped` if it exercises the search screen.
+
+- [ ] **Step 2: Verify RED** — compile FAIL (`model.search` undefined).
+
+- [ ] **Step 3: Implement**
+
+`internal/tui/search.go` — the sub-model plus command constructor:
+
+```go
+func newSearchModel(provider DataProvider) searchModel {
+	input := textinput.New()
+	input.Placeholder = "search the archives"
+	input.CharLimit = 120
+	return searchModel{input: input, sources: provider.Sources()}
+}
+
+func (s searchModel) source() string {
+	if len(s.sources) == 0 {
+		return ""
+	}
+	return s.sources[s.sourceIdx]
+}
+```
+
+On `Model`: add `search searchModel` (init in `NewModel` via `newSearchModel(options.Provider)`). Search command (method on `Model` so it reaches provider/ctx):
+
+```go
+// startSearch cancels any in-flight search, bumps the generation, and returns
+// the model plus a command executing the new query.
+func (m Model) startSearch(query string, page int) (Model, tea.Cmd) {
+	if m.search.cancel != nil {
+		m.search.cancel()
+	}
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.search.cancel = cancel
+	m.search.gen++
+	m.search.state = searchLoading
+
+	gen := m.search.gen
+	provider := m.provider
+	source := m.search.source()
+	return m, func() tea.Msg {
+		result, err := provider.Search(ctx, source, query, page)
+		if err != nil {
+			return searchFailedMsg{gen: gen, err: err, source: source}
+		}
+		return searchResultMsg{gen: gen, page: result}
+	}
+}
+```
+
+Message handling in `Update` (new cases; both discard stale generations):
+
+```go
+	case searchResultMsg:
+		if msg.gen != m.search.gen {
+			return m, nil
+		}
+		m.search.state = searchReady
+		m.search.page = msg.page
+		m.selected[ScreenSearch] = 0
+		return m, nil
+	case searchFailedMsg:
+		if msg.gen != m.search.gen {
+			return m, nil
+		}
+		if errors.Is(msg.err, domain.ErrAuthRequired) {
+			m.search.state = searchAuthRequired
+			m.search.authSource = msg.source
+			return m, nil
+		}
+		m.search.state = searchFailed
+		m.search.err = msg.err
+		return m, nil
+```
+
+Focus routing at the TOP of `updateKey` (before the global switch):
+
+```go
+	if m.screen == ScreenSearch && m.search.input.Focused() {
+		switch {
+		case key.Matches(msg, m.keys.Quit) && msg.String() == "ctrl+c":
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.Blur):
+			m.search.input.Blur()
+			return m, nil
+		case key.Matches(msg, m.keys.Submit):
+			m.search.input.Blur()
+			return m.startSearch(m.search.input.Value(), 0)
+		default:
+			var cmd tea.Cmd
+			m.search.input, cmd = m.search.input.Update(msg)
+			return m, cmd
+		}
+	}
+```
+
+(`q` must type a letter while focused — hence the explicit `ctrl+c`-only quit check.) Blurred-on-search-screen keys, added to the global switch **before** the `Search` jump case:
+
+```go
+	case key.Matches(msg, m.keys.Search):
+		if m.screen == ScreenSearch {
+			m.search.input.Focus()
+			return m, textinput.Blink
+		}
+		m.screen = ScreenSearch
+		return m, nil
+	case key.Matches(msg, m.keys.NextPage):
+		if m.screen == ScreenSearch && m.search.state == searchReady && m.search.hasNextPage() {
+			return m.startSearch(m.search.page.Query, m.search.page.Page+1)
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.PrevPage):
+		if m.screen == ScreenSearch && m.search.state == searchReady && m.search.page.Page > 0 {
+			return m.startSearch(m.search.page.Query, m.search.page.Page-1)
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.CycleSource):
+		if m.screen == ScreenSearch && len(m.search.sources) > 1 {
+			m.search.sourceIdx = (m.search.sourceIdx + 1) % len(m.search.sources)
+		}
+		return m, nil
+```
+
+with `hasNextPage` on `searchModel` mirroring the CLI picker's logic (install.go:244-251):
+
+```go
+func (s searchModel) hasNextPage() bool {
+	if s.page.TotalCount > 0 {
+		return (s.page.Page+1)*s.page.PageSize < s.page.TotalCount
+	}
+	return len(s.page.Results) == s.page.PageSize // full page ⇒ maybe more
+}
+```
+
+`keys.go`: add `Submit` ("enter", help "search"), `Blur` ("esc", help "cancel input"), `NextPage` ("n"), `PrevPage` ("p"), `CycleSource` ("s") to `KeyMap`+`DefaultKeyMap`. **Conflict check:** `Select` also binds "enter" — the focused branch consumes enter before the global switch, and the global `Select` case only acts on `ScreenDashboard`, so no shadowing; note this in the commit body. `itemCount(ScreenSearch)` returns `len(m.search.page.Results)`; delete the `m.searchResults` Model field and its remaining uses (Task 1's shim).
+
+- [ ] **Step 4: Full suite + snapshot regeneration** (search view content changes: idle state now shows the input — Task 5 rewrites rendering, but the placeholder line changes now if `searchView` renders the input; keep `searchView` minimally rendering `m.search.input.View()` above the existing empty-state so tests/captures stay honest).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/search.go internal/tui/search_test.go internal/tui/app.go internal/tui/app_test.go internal/tui/keys.go docs/assets/tui
+git commit -m "feat(tui): search sub-model with focus routing and cancellable queries
+
+Focused input suspends the global keymap (ctrl+c still quits, esc blurs,
+enter submits). Searches carry a generation tag: new queries cancel the
+in-flight context and stale results/errors are discarded. n/p paginate
+per the CLI picker contract; s cycles the game's configured sources.
+
+Refs #40"
+```
+
+---
+
+### Task 5: Search view rendering — results, installed markers, detail panel, states
+
+**Files:**
+- Modify: `internal/tui/app.go` (`searchView`, `helpView`)
+- Test: `internal/tui/app_test.go` or `internal/tui/search_test.go`
+
+**Interfaces:** Consumes Task 4's `searchModel` states and Task 1's `SearchPage`/`ModItem`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestSearchViewRendersStates(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t)
+
+	require.Contains(t, model.View(), "search the archives", "idle shows the input placeholder")
+
+	model.search.state = searchAuthRequired
+	model.search.authSource = "nexusmods"
+	view := model.View()
+	require.Contains(t, view, "lmm auth login nexusmods")
+
+	model.search.state = searchFailed
+	model.search.err = errors.New("the aether is down")
+	require.Contains(t, model.View(), "the aether is down")
+
+	model.search.state = searchReady
+	model.search.page = SearchPage{
+		Query: "sky", Source: "nexusmods", Page: 0, PageSize: 10, TotalCount: 12,
+		Results: []ModItem{
+			{Name: "SkyUI", Author: "schlangster", Version: "5.2", Status: "installed", Summary: "UI overhaul.", Downloads: 1000, Endorsements: 50, HasEndorsements: true},
+			{Name: "SkyFresh", Author: "someone", Version: "1.0", Status: "available"},
+		},
+	}
+	view = model.View()
+	require.Contains(t, view, "SkyUI")
+	require.Contains(t, view, "installed")
+	require.Contains(t, view, "Page 1/2")
+	require.Contains(t, view, "UI overhaul.", "detail panel shows the selected result's summary")
+}
+
+func TestSearchViewStaysWithinBounds(t *testing.T) {
+	t.Parallel()
+
+	model := searchScreenModel(t) // 100x30
+	model.search.state = searchReady
+	model.search.page = SearchPage{Query: "q", Source: "nexusmods", PageSize: 10, TotalCount: 10,
+		Results: []ModItem{{Name: "A", Status: "available"}}}
+	require.Equal(t, model.availableWidth(), lipgloss.Width(model.screenView()))
+	require.Equal(t, model.availableContentHeight(), lipgloss.Height(model.screenView()))
+}
+```
+
+- [ ] **Step 2: Verify RED** — the idle assertion may pass (input renders from Task 4); the ready/auth/detail assertions FAIL against the current placeholder view.
+
+- [ ] **Step 3: Implement** — rewrite `searchView()`:
+
+- Header line: `ARCHIVE SEARCH  [source: <s.source()>  (s cycles)]` (theme `PanelTitle` + `MutedText`), then `m.search.input.View()`.
+- `searchIdle`: muted hint `"/ focus · enter search · s source"` — no fake data.
+- `searchLoading`: `"Consulting the archive index..."`.
+- `searchAuthRequired`: `DangerText` line `Authentication required for <authSource>.` + plain line `Run 'lmm auth login <authSource>' in a shell, then search again.`
+- `searchFailed`: `DangerText` with `m.search.err.Error()`.
+- `searchReady`: two-pane layout like `commanderDashboardView` (reuse `panelWithHeight` + `lipgloss.JoinHorizontal`): left pane = result rows via `m.row(i, ...)` with columns `name / version / status` (status styled `WarningText` when "installed" so it pops); right pane = detail of `m.selected[ScreenSearch]`: Name, Author, Version, Source, Status, Downloads (`fmt` with thousands via plain %d — no new deps), Endorsements (`?` unless `HasEndorsements`), and Summary wrapped with `lipgloss.NewStyle().Width(...)` — width-constrained rendering only; get the style from the theme (`MutedText.Width(w)`), never a bare `NewStyle` (theme principle).
+- Footer: `Page X/Y (N results) · n next · p prev` — Y from TotalCount when known, else `Page X` + `n next` only when `hasNextPage()`.
+- Empty results (`searchReady`, zero rows): `No archives matched "<query>" on <source>.`
+- `helpView()` gains the search keys (`/ focus · enter search · esc cancel · n/p pages · s source`).
+
+The whole view must fill `availableWidth()`/`availableContentHeight()` exactly (the existing screen-size tests iterate all screens — they will enforce this).
+
+- [ ] **Step 4: Full suite + regenerate snapshots** (search captures change: input + hint replace the old placeholder).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/app.go internal/tui/app_test.go internal/tui/search_test.go docs/assets/tui
+git commit -m "feat(tui): render search results, detail panel, and search states
+
+Refs #40"
+```
+
+---
+
+### Task 6: Docs, changelog, version 1.5.0, final review, PR
+
+**Files:**
+- Modify: `README.md` (Terminal UI section: search usage + new keys), `CHANGELOG.md`, `cmd/lmm/root.go` (version → "1.5.0"), `cmd/lmm/tui.go` (Long help text mentions search)
+
+**Steps:**
+
+- [ ] README Terminal UI section: add search usage (`/` to focus, enter to search, `n`/`p` pages, `s` source cycle, `esc` cancel; results mark installed mods; auth-required shows the login command). Update the key list.
+- [ ] `cmd/lmm/tui.go` Long description: replace "Search shows an honest placeholder" phrasing (if present) with the real capability; keep the read-only caveat (browsing/searching never installs).
+- [ ] CHANGELOG: new `## [1.5.0] - <date>` section under the emptied `[Unreleased]`: Added — **TUI search** (real source search with cancellation, installed markers, detail panel, pagination, source cycling, auth-required guidance); Changed — DataProvider boundary v2 (single-fetch Overview; program-context threading). Update comparison links (`v1.4.0...v1.5.0`, Unreleased from v1.5.0) matching the existing v-prefixed pattern.
+- [ ] Version bump: `cmd/lmm/root.go` → `"1.5.0"` as its own `chore: bump version to 1.5.0` commit.
+- [ ] Verification: `go fmt ./... && go vet ./... && go test ./...`; build; `--version` prints 1.5.0; `tui --help` reflects search. (If `go fmt` touches `internal/storage/cache/cache.go`, check it out — out of scope.)
+- [ ] Final whole-branch review (controller dispatches per SDD skill), fix wave if needed, then push and open PR to `main`: title `feat(tui): search and detail browsing (Phase 4)`, body summarizing the above + `Closes #40`, note the interactive smoke test (`lmm tui`, `/`, query, pagination, `s`, auth-required path with a logged-out source) is deferred to the user. Triage the auto-Copilot review before merging.
+
+---
+
+## Deliberately NOT in this plan
+
+- Category/tag filters, live/debounced search, `GetMod` detail fetch, image thumbnails (pre-made decisions / roadmap deferrals).
+- Install-from-search (Phase 5), update/conflict workflows (Phase 6) — issue #37.
+- 429/backoff handling in httpclient — prerequisite if live search is ever wanted; separate issue.
+- The `views/` package split beyond the search sub-model file; cmd test-globals helper chore (#37).

--- a/docs/plans/archive/2026-07-14-custom-sources-p3-manifest-impl.md
+++ b/docs/plans/archive/2026-07-14-custom-sources-p3-manifest-impl.md
@@ -1,0 +1,2041 @@
+# Custom Sources — Phase 3 (Manifest Source) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `type: manifest` custom sources — a published JSON/YAML mod list (https URL or local path) becomes a full ModSource: search, install (with sha256 verification), within-source dependencies, and update checks.
+
+**Architecture:** A `Manifest` type in `internal/source/custom` fetches the manifest document on demand (in-memory TTL cache for remote URLs; local paths read each time) and implements every ModSource operation client-side over the parsed document. Optional API-key auth (header or query) applies to both the manifest fetch and file downloads. Declared `sha256` values ride on a new `domain.DownloadableFile.SHA256` field and are verified in `Service.DownloadModToCache` before the archive is committed to cache.
+
+**Tech Stack:** Go stdlib (net/http, crypto/sha256, net/url), gopkg.in/yaml.v3 (existing dep — YAML 1.2 is a JSON superset, so one parser covers both formats), testify, httptest.
+
+**Spec:** `docs/plans/2026-07-13-custom-sources-design.md` §3 (manifest), §5 (search semantics), §6 (auth), §9 (security). Issue: #48 (epic #45).
+
+## Global Constraints
+
+- TDD: every task starts with a failing test (`~/.claude/DEV.md`, repo CLAUDE.md).
+- Error wrapping with context: `fmt.Errorf("doing X: %w", err)` (GO.md).
+- `ctx context.Context` first param for I/O paths; no ctx stored in structs (GO.md).
+- No new dependencies.
+- `go fmt ./...` and `go vet ./...` clean before every commit.
+- Manifest fetch/parse errors must name the manifest URL and fail only the operation — never source registration (a valid definition always registers).
+- HTTPS enforced for remote manifest URLs and manifest file URLs unless the definition sets `allow_http: true`; local paths exempt.
+- API keys are never logged. Key resolution order: `LMM_<ID>_API_KEY` env var (ID uppercased, `-` → `_`), then DB token store.
+- Bounded reads on untrusted remote data (10 MiB manifest cap — same defense class as the P2 zip-bomb cap).
+- Commit after each task; conventional commit messages.
+
+---
+
+## Task 1: Auth config block in the definition schema
+
+**Files:**
+- Modify: `internal/source/custom/definition.go`
+- Test: `internal/source/custom/definition_test.go` (append cases)
+
+**Interfaces:**
+- Produces: `custom.AuthConfig{APIKey *APIKeyConfig}`, `custom.APIKeyConfig{In, Name string}`, `ManifestConfig.Auth *AuthConfig`, `(d *SourceDefinition) validateAuth(a *AuthConfig) error`. Phase 4 (`api` type) will reuse `AuthConfig` unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` table in `TestSourceDefinitionValidate` (`internal/source/custom/definition_test.go`):
+
+```go
+		{"valid manifest auth header", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{
+				URL:  "https://x.test/m.yaml",
+				Auth: &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}},
+			}
+		}, ""},
+		{"valid manifest auth query", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{
+				URL:  "https://x.test/m.yaml",
+				Auth: &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}},
+			}
+		}, ""},
+		{"auth without api_key block", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{URL: "https://x.test/m.yaml", Auth: &AuthConfig{}}
+		}, "auth.api_key is required"},
+		{"auth bad in", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{
+				URL:  "https://x.test/m.yaml",
+				Auth: &AuthConfig{APIKey: &APIKeyConfig{In: "body", Name: "k"}},
+			}
+		}, `auth.api_key.in must be "header" or "query"`},
+		{"auth missing name", func(d *SourceDefinition) {
+			d.Type = TypeManifest
+			d.Directory = nil
+			d.Manifest = &ManifestConfig{
+				URL:  "https://x.test/m.yaml",
+				Auth: &AuthConfig{APIKey: &APIKeyConfig{In: "header"}},
+			}
+		}, "auth.api_key.name is required"},
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestSourceDefinitionValidate -v`
+Expected: FAIL — `undefined: AuthConfig`, `unknown field Auth`.
+
+- [ ] **Step 3: Implement**
+
+In `internal/source/custom/definition.go`, extend `ManifestConfig` and add the auth types + validation:
+
+```go
+// ManifestConfig configures a manifest source.
+type ManifestConfig struct {
+	URL     string      `yaml:"url"`
+	Refresh string      `yaml:"refresh"` // Go duration string, e.g. "15m"; empty = default
+	Auth    *AuthConfig `yaml:"auth"`
+}
+
+// AuthConfig configures optional API-key authentication for a custom source.
+// The key itself is never stored in the definition; it comes from the
+// LMM_<ID>_API_KEY env var or the DB token store at startup.
+type AuthConfig struct {
+	APIKey *APIKeyConfig `yaml:"api_key"`
+}
+
+// APIKeyConfig says where the API key is attached on requests.
+type APIKeyConfig struct {
+	In   string `yaml:"in"`   // "header" or "query"
+	Name string `yaml:"name"` // header name or query parameter name
+}
+
+// validateAuth checks an optional auth block. Shared by manifest (Phase 3)
+// and api (Phase 4) validation.
+func validateAuth(a *AuthConfig) error {
+	if a == nil {
+		return nil
+	}
+	if a.APIKey == nil {
+		return errors.New("auth.api_key is required when auth is set")
+	}
+	if a.APIKey.In != "header" && a.APIKey.In != "query" {
+		return fmt.Errorf(`auth.api_key.in must be "header" or "query", got %q`, a.APIKey.In)
+	}
+	if a.APIKey.Name == "" {
+		return errors.New("auth.api_key.name is required")
+	}
+	return nil
+}
+```
+
+In `Validate()`'s `case TypeManifest:` branch, after the existing Refresh check, add:
+
+```go
+		if err := validateAuth(d.Manifest.Auth); err != nil {
+			return fmt.Errorf("manifest: %w", err)
+		}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS (new cases + all existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/definition.go internal/source/custom/definition_test.go
+git commit -m "feat(source): add auth config to custom source definitions"
+```
+
+---
+
+## Task 2: Declared-checksum verification on download
+
+**Files:**
+- Modify: `internal/domain/mod.go` (`DownloadableFile`), `internal/core/service.go` (`DownloadModToCache` + new helper)
+- Test: `internal/core/service_sha256_test.go` (create)
+
+**Interfaces:**
+- Produces: `domain.DownloadableFile.SHA256 string` (optional expected hash, hex; empty = no verification — all built-in sources leave it empty, zero behavior change for them); `core.verifyFileSHA256(path, expectedHex string) error` (unexported). `DownloadModToCache` fails with a "sha256 mismatch" error and does NOT commit to cache when the downloaded bytes don't match a declared hash.
+- Consumed by: Task 6 (`GetModFiles` maps manifest `sha256` onto the field), Task 10 (e2e).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/core/service_sha256_test.go`. It is `package core_test` and reuses the existing mock-source pattern from `service_test.go` (`newMockSource`, `mockSourceWithDownloads` with `AddDownload`/`Close`, `core.NewService`, `svc.DownloadMod`) — read those helpers first and match their construction exactly:
+
+```go
+package core_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// downloadWithSHA256 runs one DownloadMod through a mock source serving
+// content, with expectedSHA declared on the file. Returns the error.
+func downloadWithSHA256(t *testing.T, content []byte, expectedSHA string) (error, *domain.Game, *domain.Mod, func() bool) {
+	t.Helper()
+
+	cfg := coreServiceConfig(t) // see note below
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	mock := newMockSourceWithDownloads("test")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: filepath.Join(t.TempDir(), "mods"), DeployMode: domain.DeployCopy}
+	require.NoError(t, svc.AddGame(game))
+
+	mod := &domain.Mod{ID: "m1", SourceID: "test", Name: "Mod", Version: "1.0.0", GameID: "testgame"}
+	file := &domain.DownloadableFile{ID: "file1", Name: "File", FileName: "m1.zip", SHA256: expectedSHA}
+
+	mock.AddDownload(file.ID, content)
+
+	_, err = svc.DownloadMod(context.Background(), "test", game, mod, file, nil)
+	gameCache := svc.GetGameCache(game)
+	cached := func() bool { return gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version) }
+	return err, game, mod, cached
+}
+
+func TestDownloadModVerifiesDeclaredSHA256(t *testing.T) {
+	content := []byte("mod archive bytes")
+	sum := sha256.Sum256(content)
+	good := hex.EncodeToString(sum[:])
+
+	t.Run("matching hash passes", func(t *testing.T) {
+		err, _, _, cached := downloadWithSHA256(t, content, good)
+		require.NoError(t, err)
+		assert.True(t, cached())
+	})
+
+	t.Run("uppercase hash passes (case-insensitive)", func(t *testing.T) {
+		err, _, _, cached := downloadWithSHA256(t, content, strings.ToUpper(good))
+		require.NoError(t, err)
+		assert.True(t, cached())
+	})
+
+	t.Run("mismatched hash fails and nothing is cached", func(t *testing.T) {
+		err, _, _, cached := downloadWithSHA256(t, content, strings.Repeat("ab", 32))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sha256 mismatch")
+		assert.False(t, cached())
+	})
+
+	t.Run("empty hash skips verification", func(t *testing.T) {
+		err, _, _, cached := downloadWithSHA256(t, content, "")
+		require.NoError(t, err)
+		assert.True(t, cached())
+	})
+}
+```
+
+Adaptation notes for the implementer (the assertions stay the same):
+- If there is no `coreServiceConfig(t)` helper, inline `core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}` (the pattern used by `TestService_DownloadMod_RejectsFileURLFromNonDirectorySource`).
+- Match the real constructor/name of the downloads mock (`mockSourceWithDownloads` and its `AddDownload`); if its constructor differs, adapt the call, not the behavior.
+- Add `"strings"` to imports.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/core/ -run TestDownloadModVerifiesDeclaredSHA256 -v`
+Expected: FAIL — `unknown field SHA256 in struct literal`.
+
+- [ ] **Step 3: Implement**
+
+`internal/domain/mod.go` — add to `DownloadableFile`:
+
+```go
+	SHA256 string // Expected SHA-256 of the download (hex); empty = source declares no checksum
+```
+
+`internal/core/service.go` — in `DownloadModToCache`, immediately after the `s.downloader.Download(...)` call and its error check, add:
+
+```go
+	if file.SHA256 != "" {
+		if err := verifyFileSHA256(archivePath, file.SHA256); err != nil {
+			return nil, fmt.Errorf("verifying download of %s: %w", file.FileName, err)
+		}
+	}
+```
+
+Add the helper after `DownloadModToCache` (imports: `crypto/sha256`, `encoding/hex`; `io`, `os`, `strings` are already imported):
+
+```go
+// verifyFileSHA256 streams path and compares its SHA-256 against expectedHex
+// (case-insensitive). Sources that publish expected checksums (manifest
+// sha256) set DownloadableFile.SHA256; built-in sources leave it empty and
+// skip this entirely.
+func verifyFileSHA256(path, expectedHex string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening downloaded file: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hashing downloaded file: %w", err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, expectedHex) {
+		return fmt.Errorf("sha256 mismatch: source declares %s, downloaded file is %s", expectedHex, got)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -v`
+Expected: PASS (new tests + no regressions — built-ins have empty SHA256).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/domain/mod.go internal/core/service.go internal/core/service_sha256_test.go
+git commit -m "feat(core): verify source-declared sha256 checksums on download"
+```
+
+---
+
+## Task 3: Manifest document parsing
+
+**Files:**
+- Create: `internal/source/custom/manifestdoc.go`
+- Test: `internal/source/custom/manifestdoc_test.go`
+
+**Interfaces:**
+- Produces (all unexported, used by Tasks 4–7):
+  - `manifestDoc{Version int; Mods []manifestMod}`
+  - `manifestMod{ID, Name, Version, Author, Summary string; GameIDs []string; URL string; UpdatedAt string; Dependencies []string; Files []manifestFile}`
+  - `manifestFile{ID, Name, Filename, Version string; Size int64; URL, SHA256 string; Primary bool}`
+  - `parseManifest(data []byte, allowHTTP bool) (*manifestDoc, error)` — one parser for YAML and JSON (yaml.v3 handles both).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/source/custom/manifestdoc_test.go`:
+
+```go
+package custom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validManifestYAML = `
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    author: someone
+    summary: Makes things cooler
+    game_ids: [skyrimspecialedition]
+    url: https://example.com/mods/cool-mod
+    updated_at: 2026-07-01T00:00:00Z
+    dependencies: [other-mod]
+    files:
+      - id: main
+        name: Main File
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        size: 123456
+        url: https://example.com/files/cool-mod-1.2.0.zip
+        sha256: aabbcc
+        primary: true
+  - id: other-mod
+    name: Other Mod
+    version: 0.9.0
+    files:
+      - id: main
+        filename: other-mod.zip
+        url: https://example.com/files/other-mod.zip
+`
+
+func TestParseManifestYAML(t *testing.T) {
+	doc, err := parseManifest([]byte(validManifestYAML), false)
+	require.NoError(t, err)
+	require.Len(t, doc.Mods, 2)
+	m := doc.Mods[0]
+	assert.Equal(t, "cool-mod", m.ID)
+	assert.Equal(t, "Cool Mod", m.Name)
+	assert.Equal(t, []string{"skyrimspecialedition"}, m.GameIDs)
+	assert.Equal(t, []string{"other-mod"}, m.Dependencies)
+	require.Len(t, m.Files, 1)
+	assert.Equal(t, "main", m.Files[0].ID)
+	assert.Equal(t, "cool-mod-1.2.0.zip", m.Files[0].Filename)
+	assert.Equal(t, int64(123456), m.Files[0].Size)
+	assert.Equal(t, "aabbcc", m.Files[0].SHA256)
+	assert.True(t, m.Files[0].Primary)
+}
+
+func TestParseManifestJSON(t *testing.T) {
+	doc, err := parseManifest([]byte(`{"version":1,"mods":[{"id":"j","name":"J","files":[{"id":"main","filename":"j.zip","url":"https://x.test/j.zip"}]}]}`), false)
+	require.NoError(t, err)
+	require.Len(t, doc.Mods, 1)
+	assert.Equal(t, "j", doc.Mods[0].ID)
+}
+
+func TestParseManifestErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     string
+		wantErr string
+	}{
+		{"bad syntax", "version: [unclosed", "parsing manifest"},
+		{"wrong version", "version: 2\nmods: []", "unsupported manifest version 2"},
+		{"missing version", "mods: []", "unsupported manifest version 0"},
+		{"mod missing id", "version: 1\nmods:\n  - name: X\n    files: [{id: main, filename: x.zip, url: https://x.test/x.zip}]", "mods[0]: id is required"},
+		{"mod missing name", "version: 1\nmods:\n  - id: x\n    files: [{id: main, filename: x.zip, url: https://x.test/x.zip}]", `mod "x": name is required`},
+		{"duplicate mod ids", "version: 1\nmods:\n  - {id: x, name: X}\n  - {id: x, name: X2}", `duplicate mod id "x"`},
+		{"file missing id", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{filename: x.zip, url: https://x.test/x.zip}]", `mod "x": files[0]: id is required`},
+		{"file missing filename", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, url: https://x.test/x.zip}]", `file "main": filename is required`},
+		{"file missing url", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip}]", `file "main": url is required`},
+		{"http file url rejected", "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip, url: http://x.test/x.zip}]", "plain http"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseManifest([]byte(tt.doc), false)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestParseManifestAllowHTTP(t *testing.T) {
+	doc := "version: 1\nmods:\n  - id: x\n    name: X\n    files: [{id: main, filename: x.zip, url: http://x.test/x.zip}]"
+	_, err := parseManifest([]byte(doc), true)
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestParseManifest -v`
+Expected: FAIL — `undefined: parseManifest`.
+
+- [ ] **Step 3: Implement**
+
+Create `internal/source/custom/manifestdoc.go`:
+
+```go
+package custom
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// manifestDoc is the lmm-defined manifest format (design §3), version 1.
+// YAML 1.2 is a superset of JSON, so yaml.v3 parses both encodings.
+type manifestDoc struct {
+	Version int           `yaml:"version"`
+	Mods    []manifestMod `yaml:"mods"`
+}
+
+type manifestMod struct {
+	ID           string         `yaml:"id"`
+	Name         string         `yaml:"name"`
+	Version      string         `yaml:"version"`
+	Author       string         `yaml:"author"`
+	Summary      string         `yaml:"summary"`
+	GameIDs      []string       `yaml:"game_ids"` // matched against the game's mapped value; empty = all games
+	URL          string         `yaml:"url"`
+	UpdatedAt    string         `yaml:"updated_at"` // RFC 3339; unparseable -> zero value (design §4 rule)
+	Dependencies []string       `yaml:"dependencies"`
+	Files        []manifestFile `yaml:"files"`
+}
+
+type manifestFile struct {
+	ID       string `yaml:"id"`
+	Name     string `yaml:"name"`
+	Filename string `yaml:"filename"`
+	Version  string `yaml:"version"`
+	Size     int64  `yaml:"size"`
+	URL      string `yaml:"url"`
+	SHA256   string `yaml:"sha256"` // optional; verified on download when present
+	Primary  bool   `yaml:"primary"`
+}
+
+// parseManifest decodes and validates a manifest document. allowHTTP mirrors
+// the definition's allow_http flag: file URLs must be https unless it is set.
+// Local file paths never appear here — manifest files reference downloads by
+// URL only.
+func parseManifest(data []byte, allowHTTP bool) (*manifestDoc, error) {
+	var doc manifestDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing manifest: %w", err)
+	}
+	if doc.Version != 1 {
+		return nil, fmt.Errorf("unsupported manifest version %d (expected 1)", doc.Version)
+	}
+
+	seen := make(map[string]bool, len(doc.Mods))
+	for i, m := range doc.Mods {
+		if m.ID == "" {
+			return nil, fmt.Errorf("mods[%d]: id is required", i)
+		}
+		if seen[m.ID] {
+			return nil, fmt.Errorf("duplicate mod id %q", m.ID)
+		}
+		seen[m.ID] = true
+		if m.Name == "" {
+			return nil, fmt.Errorf("mod %q: name is required", m.ID)
+		}
+		for j, f := range m.Files {
+			if f.ID == "" {
+				return nil, fmt.Errorf("mod %q: files[%d]: id is required", m.ID, j)
+			}
+			if f.Filename == "" {
+				return nil, fmt.Errorf("mod %q: file %q: filename is required", m.ID, f.ID)
+			}
+			if f.URL == "" {
+				return nil, fmt.Errorf("mod %q: file %q: url is required", m.ID, f.ID)
+			}
+			if strings.HasPrefix(f.URL, "http://") && !allowHTTP {
+				return nil, fmt.Errorf("mod %q: file %q: plain http is disabled; use https or set allow_http: true", m.ID, f.ID)
+			}
+		}
+	}
+
+	return &doc, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -run TestParseManifest -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/manifestdoc.go internal/source/custom/manifestdoc_test.go
+git commit -m "feat(source): parse lmm manifest documents"
+```
+
+---
+
+## Task 4: Manifest source construction and fetching (TTL cache + auth)
+
+**Files:**
+- Create: `internal/source/custom/manifest.go`
+- Test: `internal/source/custom/manifest_test.go`
+
+**Interfaces:**
+- Consumes: `parseManifest` (Task 3), `AuthConfig` (Task 1).
+- Produces: `custom.NewManifest(def SourceDefinition) (*Manifest, error)` — pure construction, never touches network/filesystem (a valid definition must always register; fetch errors are operation-time). `(m *Manifest) SetAPIKey(key string)`, `(m *Manifest) IsAuthenticated() bool`, and the unexported `(m *Manifest) fetch(ctx) (*manifestDoc, error)` used by Tasks 6–7. Test hooks: unexported `httpClient *http.Client` and `now func() time.Time` fields.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/source/custom/manifest_test.go`:
+
+```go
+package custom
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testManifest = `
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    author: someone
+    summary: Makes things cooler
+    game_ids: [skyrim]
+    dependencies: [other-mod]
+    files:
+      - id: main
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        size: 4
+        url: https://files.test/cool-mod-1.2.0.zip
+        sha256: aabbcc
+        primary: true
+  - id: other-mod
+    name: Other Mod
+    version: 0.9.0
+    summary: A dependency
+    files:
+      - id: main
+        filename: other-mod.zip
+        url: https://files.test/other-mod.zip
+`
+
+func manifestDef(url string) SourceDefinition {
+	return SourceDefinition{
+		ID:       "my-repo",
+		Name:     "My Repo",
+		Type:     TypeManifest,
+		Manifest: &ManifestConfig{URL: url},
+	}
+}
+
+// newLocalManifest writes testManifest to a temp file and builds a source over it.
+func newLocalManifest(t *testing.T) *Manifest {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "mods.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(testManifest), 0644))
+	m, err := NewManifest(manifestDef(path))
+	require.NoError(t, err)
+	return m
+}
+
+func TestNewManifestIsPure(t *testing.T) {
+	// Construction must succeed even when the manifest is unreachable —
+	// fetch errors are operation-time, not registration-time.
+	m, err := NewManifest(manifestDef("https://unreachable.invalid/mods.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "my-repo", m.ID())
+	assert.Equal(t, "My Repo", m.Name())
+}
+
+func TestManifestFetchLocal(t *testing.T) {
+	m := newLocalManifest(t)
+	doc, err := m.fetch(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, doc.Mods, 2)
+}
+
+func TestManifestFetchLocalMissingFileNamesPath(t *testing.T) {
+	def := manifestDef(filepath.Join(t.TempDir(), "gone.yaml"))
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+	_, err = m.fetch(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gone.yaml")
+	assert.Contains(t, err.Error(), "my-repo")
+}
+
+func TestManifestFetchRemoteTTL(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = w.Write([]byte(testManifest))
+	}))
+	defer srv.Close()
+
+	def := manifestDef(srv.URL + "/mods.yaml")
+	def.AllowHTTP = true // httptest is plain http
+	def.Manifest.Refresh = "15m"
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+
+	current := time.Unix(1_800_000_000, 0)
+	m.now = func() time.Time { return current }
+
+	ctx := context.Background()
+	_, err = m.fetch(ctx)
+	require.NoError(t, err)
+	_, err = m.fetch(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, hits, "second fetch within TTL must hit the cache")
+
+	current = current.Add(16 * time.Minute)
+	_, err = m.fetch(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, hits, "fetch after TTL expiry must re-download")
+}
+
+func TestManifestFetchAttachesAuth(t *testing.T) {
+	t.Run("header", func(t *testing.T) {
+		var gotHeader string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotHeader = r.Header.Get("X-API-Key")
+			_, _ = w.Write([]byte(testManifest))
+		}))
+		defer srv.Close()
+
+		def := manifestDef(srv.URL + "/mods.yaml")
+		def.AllowHTTP = true
+		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+
+		_, err = m.fetch(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "sekrit", gotHeader)
+	})
+
+	t.Run("query", func(t *testing.T) {
+		var gotQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query().Get("api_key")
+			_, _ = w.Write([]byte(testManifest))
+		}))
+		defer srv.Close()
+
+		def := manifestDef(srv.URL + "/mods.yaml")
+		def.AllowHTTP = true
+		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+
+		_, err = m.fetch(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "sekrit", gotQuery)
+	})
+}
+
+func TestManifestFetchRemoteErrorNamesURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	def := manifestDef(srv.URL + "/mods.yaml")
+	def.AllowHTTP = true
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+
+	_, err = m.fetch(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), srv.URL)
+	assert.Contains(t, err.Error(), "my-repo")
+}
+
+func TestManifestIsAuthenticated(t *testing.T) {
+	def := manifestDef("https://x.test/mods.yaml")
+	def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+	assert.False(t, m.IsAuthenticated())
+	m.SetAPIKey("k")
+	assert.True(t, m.IsAuthenticated())
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestManifest -v`
+Expected: FAIL — `undefined: NewManifest`.
+
+- [ ] **Step 3: Implement**
+
+Create `internal/source/custom/manifest.go`:
+
+```go
+package custom
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultManifestRefresh is the remote-manifest cache TTL when the definition
+// does not set manifest.refresh.
+const defaultManifestRefresh = 15 * time.Minute
+
+// maxManifestSize bounds how much of a remote manifest we read into memory.
+// Real manifests are KBs; 10 MiB is generous and prevents a hostile or broken
+// server from exhausting memory.
+const maxManifestSize = 10 << 20 // 10 MiB
+
+// Manifest is a ModSource backed by a published mod-list document (design §3).
+// Remote manifests are fetched on demand and cached in memory for the
+// configured TTL; local paths are read on every operation (cheap).
+// Construction is pure: a valid definition always registers, and fetch/parse
+// problems surface as operation errors naming the manifest URL.
+type Manifest struct {
+	id        string
+	name      string
+	url       string // https URL, or absolute local path (~ expanded)
+	isRemote  bool
+	refresh   time.Duration
+	allowHTTP bool
+	auth      *AuthConfig
+
+	apiKey     string
+	httpClient *http.Client
+	now        func() time.Time // injectable for TTL tests
+
+	mu        sync.Mutex
+	cached    *manifestDoc
+	fetchedAt time.Time
+}
+
+// NewManifest constructs a manifest source from a validated definition. It
+// performs no I/O — the manifest is first fetched when an operation needs it.
+func NewManifest(def SourceDefinition) (*Manifest, error) {
+	cfg := def.Manifest
+
+	refresh := defaultManifestRefresh
+	if cfg.Refresh != "" {
+		d, err := time.ParseDuration(cfg.Refresh)
+		if err != nil {
+			return nil, fmt.Errorf("manifest.refresh: %w", err) // unreachable after Validate, kept for safety
+		}
+		refresh = d
+	}
+
+	u := cfg.URL
+	isRemote := strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")
+	if !isRemote {
+		if strings.HasPrefix(u, "~/") {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil, fmt.Errorf("expanding %q: %w", u, err)
+			}
+			u = filepath.Join(home, u[2:])
+		}
+		abs, err := filepath.Abs(u)
+		if err != nil {
+			return nil, fmt.Errorf("resolving %q: %w", u, err)
+		}
+		u = abs
+	}
+
+	return &Manifest{
+		id:         def.ID,
+		name:       def.Name,
+		url:        u,
+		isRemote:   isRemote,
+		refresh:    refresh,
+		allowHTTP:  def.AllowHTTP,
+		auth:       cfg.Auth,
+		httpClient: http.DefaultClient,
+		now:        time.Now,
+	}, nil
+}
+
+// SetAPIKey provides the API key resolved at startup (env var or token store).
+func (m *Manifest) SetAPIKey(key string) { m.apiKey = key }
+
+// IsAuthenticated reports whether an API key is configured. Only meaningful
+// when the definition declares auth (Capabilities().Auth).
+func (m *Manifest) IsAuthenticated() bool { return m.apiKey != "" }
+
+// fetch returns the parsed manifest, honoring the TTL cache for remote URLs.
+// Errors name the source and manifest URL so users can act on them.
+func (m *Manifest) fetch(ctx context.Context) (*manifestDoc, error) {
+	if !m.isRemote {
+		data, err := os.ReadFile(m.url)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: reading manifest %s: %w", m.id, m.url, err)
+		}
+		doc, err := parseManifest(data, m.allowHTTP)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: manifest %s: %w", m.id, m.url, err)
+		}
+		return doc, nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.cached != nil && m.now().Sub(m.fetchedAt) < m.refresh {
+		return m.cached, nil
+	}
+
+	doc, err := m.fetchRemote(ctx)
+	if err != nil {
+		return nil, err
+	}
+	m.cached = doc
+	m.fetchedAt = m.now()
+	return doc, nil
+}
+
+// fetchRemote downloads and parses the manifest document. Callers hold m.mu.
+func (m *Manifest) fetchRemote(ctx context.Context) (*manifestDoc, error) {
+	reqURL := m.url
+	if m.auth != nil && m.auth.APIKey.In == "query" && m.apiKey != "" {
+		u, err := addQueryParam(reqURL, m.auth.APIKey.Name, m.apiKey)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: manifest %s: %w", m.id, m.url, err)
+		}
+		reqURL = u
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: manifest %s: %w", m.id, m.url, err)
+	}
+	if m.auth != nil && m.auth.APIKey.In == "header" && m.apiKey != "" {
+		req.Header.Set(m.auth.APIKey.Name, m.apiKey)
+	}
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: fetching manifest %s: %w", m.id, m.url, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("source %q: fetching manifest %s: HTTP %d", m.id, m.url, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("source %q: reading manifest %s: %w", m.id, m.url, err)
+	}
+	if len(data) > maxManifestSize {
+		return nil, fmt.Errorf("source %q: manifest %s exceeds %d bytes", m.id, m.url, maxManifestSize)
+	}
+
+	doc, err := parseManifest(data, m.allowHTTP)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: manifest %s: %w", m.id, m.url, err)
+	}
+	return doc, nil
+}
+```
+
+Add the `addQueryParam` helper to the same file (also used by Task 6's `GetDownloadURL`):
+
+```go
+// addQueryParam returns rawURL with name=value appended to its query string,
+// preserving existing parameters. Values are URL-escaped.
+func addQueryParam(rawURL, name, value string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing URL: %w", err)
+	}
+	q := u.Query()
+	q.Set(name, value)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+```
+
+(Add `"net/url"` to imports.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -run TestManifest -v` then `go test ./internal/source/custom/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/manifest.go internal/source/custom/manifest_test.go
+git commit -m "feat(source): fetch manifest documents with TTL cache and API-key auth"
+```
+
+---
+
+## Task 5: Shared client-side search helper
+
+**Files:**
+- Create: `internal/source/custom/search.go`
+- Modify: `internal/source/custom/directory.go` (`Search` body only)
+
+**Interfaces:**
+- Produces: `searchMods(mods []domain.Mod, query source.SearchQuery) source.SearchResult` (unexported) — the exact semantics currently inside `Directory.Search` (design §5): case-insensitive substring on Name/ID/Summary, empty query matches all, name-matches rank before summary-only matches, then alphabetical by Name; PageSize default 20; negative page clamped; `GameID` stamped onto every returned mod.
+- Consumed by: `Directory.Search` (refactor, this task) and `Manifest.Search` (Task 6).
+
+This is a behavior-preserving refactor: the existing `TestDirectorySearch` suite is the safety net — no new tests, no test edits.
+
+- [ ] **Step 1: Extract the helper**
+
+Create `internal/source/custom/search.go` by lifting the body of `Directory.Search` after the scan (everything from `q := strings.ToLower(query.Query)` down) **verbatim**:
+
+```go
+package custom
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+)
+
+// searchMods implements the client-side search semantics shared by directory
+// and manifest sources (design §5): case-insensitive substring match on
+// name/ID/summary, name matches ranked before summary-only matches, then
+// alphabetical; local pagination with default page size 20. GameID is stamped
+// onto every returned mod so downstream installs are attributed correctly.
+func searchMods(mods []domain.Mod, query source.SearchQuery) source.SearchResult {
+	q := strings.ToLower(query.Query)
+	type ranked struct {
+		mod       domain.Mod
+		nameMatch bool
+	}
+	var matches []ranked
+	for _, m := range mods {
+		nameMatch := q == "" || strings.Contains(strings.ToLower(m.Name), q) || strings.Contains(strings.ToLower(m.ID), q)
+		summaryMatch := strings.Contains(strings.ToLower(m.Summary), q)
+		if !nameMatch && !summaryMatch {
+			continue
+		}
+		matches = append(matches, ranked{mod: m, nameMatch: nameMatch})
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].nameMatch != matches[j].nameMatch {
+			return matches[i].nameMatch
+		}
+		return matches[i].mod.Name < matches[j].mod.Name
+	})
+
+	pageSize := query.PageSize
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	start := query.Page * pageSize
+	if start < 0 {
+		start = 0
+	}
+	end := min(start+pageSize, len(matches))
+	if start > len(matches) {
+		start = len(matches)
+	}
+
+	out := make([]domain.Mod, 0, end-start)
+	for _, m := range matches[start:end] {
+		mod := m.mod
+		mod.GameID = query.GameID
+		out = append(out, mod)
+	}
+
+	return source.SearchResult{
+		Mods:       out,
+		TotalCount: len(matches),
+		Page:       query.Page,
+		PageSize:   pageSize,
+	}
+}
+```
+
+Replace `Directory.Search`'s body with:
+
+```go
+func (d *Directory) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	scanned, err := d.scan()
+	if err != nil {
+		return source.SearchResult{}, err
+	}
+	mods := make([]domain.Mod, 0, len(scanned))
+	for _, dm := range scanned {
+		mods = append(mods, dm.mod)
+	}
+	return searchMods(mods, query), nil
+}
+```
+
+(Keep `Directory.Search`'s doc comment; remove the now-unused `"sort"` import from directory.go if nothing else uses it.)
+
+- [ ] **Step 2: Verify no behavior change**
+
+Run: `go test ./internal/source/custom/ -v && go build ./...`
+Expected: PASS — every existing `TestDirectorySearch` case green, untouched.
+
+- [ ] **Step 3: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/search.go internal/source/custom/directory.go
+git commit -m "refactor(source): share client-side search across custom source types"
+```
+
+---
+
+## Task 6: Manifest read operations
+
+**Files:**
+- Modify: `internal/source/custom/manifest.go`
+- Test: `internal/source/custom/manifest_test.go` (append)
+
+**Interfaces:**
+- Consumes: `m.fetch` (Task 4), `searchMods` (Task 5), `domain.DownloadableFile.SHA256` (Task 2), `source.ErrNotSupported`/`Capabilities` (Phase 1).
+- Produces: `*Manifest` implements `source.ModSource` (Search, GetMod, GetModFiles, GetDownloadURL; GetDependencies/CheckUpdates land in Task 7 — stub them here returning `ErrNotSupported` so the interface compiles, Task 7 replaces the stubs) + `source.CapabilityReporter`. Semantics later tasks rely on: `GetModFiles` maps manifest `sha256` → `DownloadableFile.SHA256`; `GetDownloadURL` appends the query-auth parameter when configured; game filtering matches `game_ids` against `query.GameID` (empty `game_ids` or empty `query.GameID` ⇒ match).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/source/custom/manifest_test.go`:
+
+```go
+func TestManifestIdentityAndCapabilities(t *testing.T) {
+	m := newLocalManifest(t)
+	assert.Equal(t, source.Capabilities{Search: true, Dependencies: true, Updates: true, Auth: false}, m.Capabilities())
+	assert.Empty(t, m.AuthURL())
+
+	_, err := m.ExchangeToken(context.Background(), "code")
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+
+	def := manifestDef("https://x.test/mods.yaml")
+	def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+	authed, err := NewManifest(def)
+	require.NoError(t, err)
+	assert.True(t, authed.Capabilities().Auth)
+}
+
+func TestManifestSearch(t *testing.T) {
+	m := newLocalManifest(t)
+	ctx := context.Background()
+
+	t.Run("empty query returns all mods for a matching game", func(t *testing.T) {
+		res, err := m.Search(ctx, source.SearchQuery{GameID: "skyrim"})
+		require.NoError(t, err)
+		assert.Equal(t, 2, res.TotalCount) // cool-mod matches game_ids; other-mod has no game_ids (all games)
+	})
+
+	t.Run("game_ids filters non-matching games", func(t *testing.T) {
+		res, err := m.Search(ctx, source.SearchQuery{GameID: "othergame"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1) // only other-mod (no game_ids = all games)
+		assert.Equal(t, "other-mod", res.Mods[0].ID)
+	})
+
+	t.Run("empty GameID matches everything", func(t *testing.T) {
+		res, err := m.Search(ctx, source.SearchQuery{})
+		require.NoError(t, err)
+		assert.Equal(t, 2, res.TotalCount)
+	})
+
+	t.Run("query matches and mod fields map", func(t *testing.T) {
+		res, err := m.Search(ctx, source.SearchQuery{Query: "cool", GameID: "skyrim"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		mod := res.Mods[0]
+		assert.Equal(t, "cool-mod", mod.ID)
+		assert.Equal(t, "my-repo", mod.SourceID)
+		assert.Equal(t, "Cool Mod", mod.Name)
+		assert.Equal(t, "1.2.0", mod.Version)
+		assert.Equal(t, "someone", mod.Author)
+		assert.Equal(t, "Makes things cooler", mod.Summary)
+		assert.Equal(t, "skyrim", mod.GameID)
+	})
+}
+
+func TestManifestGetMod(t *testing.T) {
+	m := newLocalManifest(t)
+	mod, err := m.GetMod(context.Background(), "skyrim", "cool-mod")
+	require.NoError(t, err)
+	assert.Equal(t, "Cool Mod", mod.Name)
+	assert.Equal(t, "skyrim", mod.GameID)
+
+	_, err = m.GetMod(context.Background(), "skyrim", "nope")
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestManifestFilesAndDownloadURL(t *testing.T) {
+	m := newLocalManifest(t)
+	ctx := context.Background()
+
+	mod, err := m.GetMod(ctx, "skyrim", "cool-mod")
+	require.NoError(t, err)
+
+	files, err := m.GetModFiles(ctx, mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	f := files[0]
+	assert.Equal(t, "main", f.ID)
+	assert.Equal(t, "cool-mod-1.2.0.zip", f.FileName)
+	assert.Equal(t, "1.2.0", f.Version)
+	assert.Equal(t, int64(4), f.Size)
+	assert.Equal(t, "aabbcc", f.SHA256)
+	assert.True(t, f.IsPrimary)
+
+	u, err := m.GetDownloadURL(ctx, mod, "main")
+	require.NoError(t, err)
+	assert.Equal(t, "https://files.test/cool-mod-1.2.0.zip", u)
+
+	_, err = m.GetDownloadURL(ctx, mod, "nope")
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestManifestDownloadURLQueryAuth(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mods.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(testManifest), 0644))
+	def := manifestDef(path)
+	def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+	m.SetAPIKey("sekrit")
+
+	mod, err := m.GetMod(context.Background(), "skyrim", "cool-mod")
+	require.NoError(t, err)
+	u, err := m.GetDownloadURL(context.Background(), mod, "main")
+	require.NoError(t, err)
+	assert.Equal(t, "https://files.test/cool-mod-1.2.0.zip?api_key=sekrit", u)
+}
+```
+
+Add `"errors"` and `"github.com/DonovanMods/linux-mod-manager/internal/source"` to the test file's imports.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run 'TestManifestIdentity|TestManifestSearch|TestManifestGetMod|TestManifestFiles|TestManifestDownloadURL' -v`
+Expected: FAIL — `m.Capabilities undefined`, etc.
+
+- [ ] **Step 3: Implement**
+
+Append to `internal/source/custom/manifest.go` (add `"time"` usage for UpdatedAt parsing; `domain` and `source` imports):
+
+```go
+// ID implements source.ModSource.
+func (m *Manifest) ID() string { return m.id }
+
+// Name implements source.ModSource.
+func (m *Manifest) Name() string { return m.name }
+
+// AuthURL implements source.ModSource; manifest sources use API keys, not OAuth.
+func (m *Manifest) AuthURL() string { return "" }
+
+// ExchangeToken implements source.ModSource.
+func (m *Manifest) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
+	return nil, fmt.Errorf("source %q: authentication: %w", m.id, source.ErrNotSupported)
+}
+
+// Capabilities implements source.CapabilityReporter. Auth reflects whether the
+// definition declares an auth block.
+func (m *Manifest) Capabilities() source.Capabilities {
+	return source.Capabilities{Search: true, Dependencies: true, Updates: true, Auth: m.auth != nil}
+}
+
+// toMod converts a manifest entry to a domain.Mod. GameID is stamped by
+// searchMods / the callers, not here.
+func (m *Manifest) toMod(mm manifestMod) domain.Mod {
+	mod := domain.Mod{
+		ID:        mm.ID,
+		SourceID:  m.id,
+		Name:      mm.Name,
+		Version:   mm.Version,
+		Author:    mm.Author,
+		Summary:   mm.Summary,
+		Description: mm.Summary,
+		SourceURL: mm.URL,
+	}
+	if mm.UpdatedAt != "" {
+		if ts, err := time.Parse(time.RFC3339, mm.UpdatedAt); err == nil {
+			mod.UpdatedAt = ts // unparseable -> zero value, by design
+		}
+	}
+	for _, dep := range mm.Dependencies {
+		mod.Dependencies = append(mod.Dependencies, domain.ModReference{SourceID: m.id, ModID: dep})
+	}
+	return mod
+}
+
+// gameMatches reports whether a manifest entry applies to gameID: an empty
+// game_ids list matches every game, and an empty gameID matches every entry.
+func gameMatches(mm manifestMod, gameID string) bool {
+	if len(mm.GameIDs) == 0 || gameID == "" {
+		return true
+	}
+	for _, g := range mm.GameIDs {
+		if g == gameID {
+			return true
+		}
+	}
+	return false
+}
+
+// Search implements source.ModSource with the shared client-side semantics
+// (design §5), filtered by the manifest's per-mod game_ids.
+func (m *Manifest) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	doc, err := m.fetch(ctx)
+	if err != nil {
+		return source.SearchResult{}, err
+	}
+	mods := make([]domain.Mod, 0, len(doc.Mods))
+	for _, mm := range doc.Mods {
+		if !gameMatches(mm, query.GameID) {
+			continue
+		}
+		mods = append(mods, m.toMod(mm))
+	}
+	return searchMods(mods, query), nil
+}
+
+// GetMod implements source.ModSource. gameID does not filter (install-by-ID
+// works from any game); it is echoed onto the returned mod for attribution.
+func (m *Manifest) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	mm, err := m.findMod(ctx, modID)
+	if err != nil {
+		return nil, err
+	}
+	mod := m.toMod(*mm)
+	mod.GameID = gameID
+	return &mod, nil
+}
+
+// GetModFiles implements source.ModSource, mapping manifest file entries —
+// including declared sha256 checksums — onto DownloadableFiles.
+func (m *Manifest) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	mm, err := m.findMod(ctx, mod.ID)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]domain.DownloadableFile, 0, len(mm.Files))
+	for _, f := range mm.Files {
+		files = append(files, domain.DownloadableFile{
+			ID:        f.ID,
+			Name:      f.Name,
+			FileName:  f.Filename,
+			Version:   f.Version,
+			Size:      f.Size,
+			IsPrimary: f.Primary,
+			SHA256:    f.SHA256,
+		})
+	}
+	return files, nil
+}
+
+// GetDownloadURL implements source.ModSource. Query-mode auth is appended
+// here; header-mode auth rides via DownloadHeaders (see DownloadHeaderProvider).
+func (m *Manifest) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	mm, err := m.findMod(ctx, mod.ID)
+	if err != nil {
+		return "", err
+	}
+	for _, f := range mm.Files {
+		if f.ID != fileID {
+			continue
+		}
+		u := f.URL
+		if m.auth != nil && m.auth.APIKey.In == "query" && m.apiKey != "" {
+			withKey, err := addQueryParam(u, m.auth.APIKey.Name, m.apiKey)
+			if err != nil {
+				return "", fmt.Errorf("source %q: file %q: %w", m.id, fileID, err)
+			}
+			u = withKey
+		}
+		return u, nil
+	}
+	return "", fmt.Errorf("source %q: mod %q: file not found: %s", m.id, mod.ID, fileID)
+}
+
+// findMod fetches the manifest and returns the entry with the given ID.
+func (m *Manifest) findMod(ctx context.Context, modID string) (*manifestMod, error) {
+	doc, err := m.fetch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range doc.Mods {
+		if doc.Mods[i].ID == modID {
+			return &doc.Mods[i], nil
+		}
+	}
+	return nil, fmt.Errorf("source %q: mod not found: %s", m.id, modID)
+}
+```
+
+Also add temporary stubs so `*Manifest` satisfies `source.ModSource` until Task 7 replaces them:
+
+```go
+// GetDependencies is implemented in the dependencies task (replaces this stub).
+func (m *Manifest) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	return nil, fmt.Errorf("source %q: dependencies: %w", m.id, source.ErrNotSupported)
+}
+
+// CheckUpdates is implemented in the update-check task (replaces this stub).
+func (m *Manifest) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, fmt.Errorf("source %q: update checks: %w", m.id, source.ErrNotSupported)
+}
+```
+
+And a compile-time interface assertion at the bottom of manifest.go:
+
+```go
+var _ source.ModSource = (*Manifest)(nil)
+var _ source.CapabilityReporter = (*Manifest)(nil)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v && go build ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/manifest.go internal/source/custom/manifest_test.go
+git commit -m "feat(source): manifest source read operations"
+```
+
+---
+
+## Task 7: Manifest dependencies and update checks
+
+**Files:**
+- Modify: `internal/source/custom/manifest.go` (replace the two stubs)
+- Test: `internal/source/custom/manifest_test.go` (append)
+
+**Interfaces:**
+- Produces: real `GetDependencies` (within-source `ModReference`s) and `CheckUpdates` (via `domain.IsNewerVersion`, removed mods skipped, ctx cancellation respected — same semantics as `Directory.CheckUpdates`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/source/custom/manifest_test.go` (add `domain` import):
+
+```go
+func TestManifestGetDependencies(t *testing.T) {
+	m := newLocalManifest(t)
+
+	mod, err := m.GetMod(context.Background(), "skyrim", "cool-mod")
+	require.NoError(t, err)
+	deps, err := m.GetDependencies(context.Background(), mod)
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, domain.ModReference{SourceID: "my-repo", ModID: "other-mod"}, deps[0])
+
+	other, err := m.GetMod(context.Background(), "skyrim", "other-mod")
+	require.NoError(t, err)
+	deps, err = m.GetDependencies(context.Background(), other)
+	require.NoError(t, err)
+	assert.Empty(t, deps)
+}
+
+func TestManifestCheckUpdates(t *testing.T) {
+	m := newLocalManifest(t) // cool-mod is at 1.2.0
+
+	installed := []domain.InstalledMod{
+		{Mod: domain.Mod{ID: "cool-mod", SourceID: "my-repo", Version: "1.0.0"}},
+		{Mod: domain.Mod{ID: "other-mod", SourceID: "my-repo", Version: "0.9.0"}},
+		{Mod: domain.Mod{ID: "removed", SourceID: "my-repo", Version: "1.0"}},
+	}
+
+	updates, err := m.CheckUpdates(context.Background(), installed)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "cool-mod", updates[0].InstalledMod.ID)
+	assert.Equal(t, "1.2.0", updates[0].NewVersion)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run 'TestManifestGetDependencies|TestManifestCheckUpdates' -v`
+Expected: FAIL — both currently return `ErrNotSupported`.
+
+- [ ] **Step 3: Implement (replace the stubs)**
+
+```go
+// GetDependencies implements source.ModSource: manifest dependencies are IDs
+// within this source, returned as ModReferences for the resolver.
+func (m *Manifest) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	mm, err := m.findMod(ctx, mod.ID)
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]domain.ModReference, 0, len(mm.Dependencies))
+	for _, dep := range mm.Dependencies {
+		refs = append(refs, domain.ModReference{SourceID: m.id, ModID: dep})
+	}
+	return refs, nil
+}
+
+// CheckUpdates implements source.ModSource by comparing installed versions to
+// the current manifest.
+func (m *Manifest) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	doc, err := m.fetch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]manifestMod, len(doc.Mods))
+	for _, mm := range doc.Mods {
+		byID[mm.ID] = mm
+	}
+
+	var updates []domain.Update
+	for _, inst := range installed {
+		select {
+		case <-ctx.Done():
+			return updates, ctx.Err()
+		default:
+		}
+		current, ok := byID[inst.ID]
+		if !ok {
+			continue // mod removed from the manifest; nothing to offer
+		}
+		if domain.IsNewerVersion(inst.Version, current.Version) {
+			updates = append(updates, domain.Update{
+				InstalledMod: inst,
+				NewVersion:   current.Version,
+			})
+		}
+	}
+	return updates, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/manifest.go internal/source/custom/manifest_test.go
+git commit -m "feat(source): manifest dependencies and update checks"
+```
+
+---
+
+## Task 8: Header auth on file downloads
+
+**Files:**
+- Modify: `internal/source/source.go` (new optional interface), `internal/core/downloader.go` (headers support), `internal/core/service.go` (wiring), `internal/source/custom/manifest.go` (implement provider)
+- Test: `internal/core/downloader_test.go` (append), `internal/source/custom/manifest_test.go` (append)
+
+**Interfaces:**
+- Produces:
+  - `source.DownloadHeaderProvider interface { DownloadHeaders() map[string]string }` — consulted by `DownloadModToCache` before downloading; nil/absent map = no extra headers.
+  - `(d *Downloader) DownloadWithHeaders(ctx context.Context, url, destPath string, headers map[string]string, progressFn ProgressFunc) (*DownloadResult, error)`; existing `Download` delegates with nil headers (no caller changes).
+  - `(m *Manifest) DownloadHeaders() map[string]string` — non-nil only for header-mode auth with a configured key.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/core/downloader_test.go` (match the file's existing package and helper style — read it first):
+
+```go
+func TestDownloadWithHeadersSetsHeaders(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-API-Key")
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer srv.Close()
+
+	d := NewDownloader(nil)
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	_, err := d.DownloadWithHeaders(context.Background(), srv.URL, dest, map[string]string{"X-API-Key": "sekrit"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "sekrit", got)
+}
+```
+
+Append to `internal/source/custom/manifest_test.go`:
+
+```go
+func TestManifestDownloadHeaders(t *testing.T) {
+	t.Run("header auth with key", func(t *testing.T) {
+		def := manifestDef("https://x.test/mods.yaml")
+		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, m.DownloadHeaders())
+	})
+
+	t.Run("query auth or no key yields nil", func(t *testing.T) {
+		def := manifestDef("https://x.test/mods.yaml")
+		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Nil(t, m.DownloadHeaders())
+
+		noKey, err := NewManifest(manifestDef("https://x.test/mods.yaml"))
+		require.NoError(t, err)
+		assert.Nil(t, noKey.DownloadHeaders())
+	})
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/ -run TestDownloadWithHeaders -v; go test ./internal/source/custom/ -run TestManifestDownloadHeaders -v`
+Expected: FAIL — `undefined: DownloadWithHeaders` / `m.DownloadHeaders undefined`.
+
+- [ ] **Step 3: Implement**
+
+`internal/source/source.go` — append:
+
+```go
+// DownloadHeaderProvider is implemented by sources whose file downloads need
+// extra HTTP headers (e.g. header-mode API-key auth on a manifest source).
+// Service.DownloadModToCache consults it before downloading. A nil map means
+// no extra headers.
+type DownloadHeaderProvider interface {
+	DownloadHeaders() map[string]string
+}
+```
+
+`internal/core/downloader.go`:
+1. Rename the guts: `Download` becomes a delegator, `downloadOnce` gains a `headers map[string]string` param.
+
+```go
+// Download fetches a file from the URL and saves it to destPath, with retries
+// on transient failures (exponential backoff). Progress updates are sent to
+// the optional progressFn callback.
+func (d *Downloader) Download(ctx context.Context, url, destPath string, progressFn ProgressFunc) (*DownloadResult, error) {
+	return d.DownloadWithHeaders(ctx, url, destPath, nil, progressFn)
+}
+
+// DownloadWithHeaders is Download with extra request headers applied to every
+// attempt — used for authenticated file downloads from custom sources.
+func (d *Downloader) DownloadWithHeaders(ctx context.Context, url, destPath string, headers map[string]string, progressFn ProgressFunc) (*DownloadResult, error) {
+```
+
+(The retry loop body moves into `DownloadWithHeaders` unchanged, with the inner call becoming `d.downloadOnce(ctx, url, destPath, headers, progressFn)`.)
+
+2. In `downloadOnce`, after `http.NewRequestWithContext` succeeds:
+
+```go
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
+```
+
+`internal/core/service.go` — in `DownloadModToCache`, replace the `s.downloader.Download(...)` call with:
+
+```go
+	var headers map[string]string
+	if hp, ok := src.(source.DownloadHeaderProvider); ok {
+		headers = hp.DownloadHeaders()
+	}
+	downloadResult, err := s.downloader.DownloadWithHeaders(ctx, url, archivePath, headers, progressFn)
+```
+
+(`src` is already in scope from the file:// gating; check the `source` package import exists.)
+
+`internal/source/custom/manifest.go` — append:
+
+```go
+// DownloadHeaders implements source.DownloadHeaderProvider: header-mode auth
+// applies the same key to file downloads as to manifest fetches (design §6).
+func (m *Manifest) DownloadHeaders() map[string]string {
+	if m.auth == nil || m.auth.APIKey.In != "header" || m.apiKey == "" {
+		return nil
+	}
+	return map[string]string{m.auth.APIKey.Name: m.apiKey}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ ./internal/source/custom/ -v && go build ./...`
+Expected: PASS, no regressions (all existing Download callers unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/source.go internal/core/downloader.go internal/core/downloader_test.go internal/core/service.go internal/source/custom/manifest.go internal/source/custom/manifest_test.go
+git commit -m "feat(core): support authenticated file downloads via source-provided headers"
+```
+
+---
+
+## Task 9: Factory, startup key attachment, and auth commands for custom sources
+
+**Files:**
+- Modify: `internal/source/custom/custom.go` + `custom_test.go` (factory case), `cmd/lmm/root.go` (key attachment), `cmd/lmm/auth.go` (login/logout for custom sources), `cmd/lmm/source.go` (`isCustomSource` gains `*custom.Manifest`)
+- Test: `cmd/lmm/auth_test.go` (append or create, following the light cmd-test pattern), `internal/source/custom/custom_test.go`
+
+**Interfaces:**
+- Consumes: `NewManifest` (Task 4), `getSourceAPIKey` (existing), `svc.ListSources`/`source.CapabilitiesOf` (existing).
+- Produces: `custom.New` handles `TypeManifest`; `envKeyForSourceID(id string) string` in cmd/lmm (`"LMM_" + upper(id, -→_) + "_API_KEY"`); `lmm auth login/logout <custom-id>` accepted for registered custom sources whose `Capabilities().Auth` is true.
+
+- [ ] **Step 1: Write the failing tests**
+
+`internal/source/custom/custom_test.go` — update `TestNew`: move `TypeManifest` from the "unimplemented" loop into its own passing case:
+
+```go
+	t.Run("manifest type constructs a source", func(t *testing.T) {
+		def := SourceDefinition{
+			ID:       "my-repo",
+			Name:     "My Repo",
+			Type:     TypeManifest,
+			Manifest: &ManifestConfig{URL: "https://x.test/mods.yaml"},
+		}
+		src, err := New(def)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-repo", src.ID())
+	})
+
+	t.Run("unimplemented types return a clear error", func(t *testing.T) {
+		def := SourceDefinition{ID: "x", Name: "X", Type: TypeAPI}
+		_, err := New(def)
+		assert.ErrorContains(t, err, "not yet supported")
+	})
+```
+
+`cmd/lmm/auth_test.go` — append (create the file with the standard cmd package header if absent):
+
+```go
+func TestEnvKeyForSourceID(t *testing.T) {
+	assert.Equal(t, "LMM_DONOVAN_MODS_API_KEY", envKeyForSourceID("donovan-mods"))
+	assert.Equal(t, "LMM_MY_REPO_API_KEY", envKeyForSourceID("my-repo"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/source/custom/ -run TestNew -v; go test ./cmd/lmm/ -run TestEnvKeyForSourceID -v`
+Expected: FAIL — manifest case errors "not yet supported"; `undefined: envKeyForSourceID`.
+
+- [ ] **Step 3: Implement**
+
+`internal/source/custom/custom.go`:
+
+```go
+func New(def SourceDefinition) (source.ModSource, error) {
+	switch def.Type {
+	case TypeDirectory:
+		return NewDirectory(def)
+	case TypeManifest:
+		return NewManifest(def)
+	default:
+		return nil, fmt.Errorf("source type %q is not yet supported", def.Type)
+	}
+}
+```
+
+`cmd/lmm/root.go` — in `registerCustomSources`, after `custom.New(def)` succeeds and before `svc.RegisterSource(src)`:
+
+```go
+		if a, ok := src.(interface{ SetAPIKey(string) }); ok {
+			if key := getSourceAPIKey(svc, def.ID, envKeyForSourceID(def.ID)); key != "" {
+				a.SetAPIKey(key)
+			}
+		}
+```
+
+`cmd/lmm/auth.go`:
+
+1. Add the env-key helper (design §6 naming rule):
+
+```go
+// envKeyForSourceID derives the env var that can supply a custom source's API
+// key: LMM_<ID>_API_KEY with the ID uppercased and dashes as underscores.
+func envKeyForSourceID(sourceID string) string {
+	return "LMM_" + strings.ReplaceAll(strings.ToUpper(sourceID), "-", "_") + "_API_KEY"
+}
+```
+
+2. `getEnvKeyForSource`: change the `default:` branch to `return envKeyForSourceID(sourceID)`.
+3. Custom-source acceptance: the login/logout paths currently gate on the hardcoded `supportedSources` list. Rework the gate to also accept any *registered* source whose capabilities report auth. `runAuthLogin`/`runAuthLogout` already run inside `withService`, so thread the service into the check:
+
+```go
+// isAuthCapableSource reports whether sourceID can hold an API key: either a
+// built-in from supportedSources, or a registered custom source whose
+// definition declares auth.
+func isAuthCapableSource(service *core.Service, sourceID string) bool {
+	if isSupportedSource(sourceID) {
+		return true
+	}
+	src, err := service.GetSource(sourceID)
+	if err != nil {
+		return false
+	}
+	return source.CapabilitiesOf(src).Auth
+}
+```
+
+Update `selectAuthSource` to take the service (`selectAuthSource(service, args)`) and use `isAuthCapableSource` for the args path; update both call sites (`runAuthLogin`, `runAuthLogout` — check how logout validates and apply the same gate). The interactive `promptForSource()` path keeps offering built-ins only (custom sources are named explicitly).
+4. `validateAPIKey`: built-ins keep their live validation; for custom sources there is no generic validation endpoint — add a `default:` that prints nothing and returns nil (the key is exercised on first fetch). Check the switch already has a default; adjust it to return nil for registered custom sources.
+5. `printAuthInstructions`: add a default case that prints the env var alternative:
+
+```go
+	default:
+		fmt.Printf("Enter the API key for %s.\n", sourceID)
+		fmt.Printf("(Alternatively, set the %s environment variable.)\n", envKeyForSourceID(sourceID))
+```
+
+`cmd/lmm/source.go` — extend `isCustomSource` (the type-switch/assertion added in the P2 fix wave) to also recognize `*custom.Manifest`.
+
+- [ ] **Step 4: Verify build and full suite**
+
+Run: `go build ./... && go test ./...`
+Expected: PASS.
+
+Manual check:
+
+```bash
+go build -o lmm ./cmd/lmm
+mkdir -p /tmp/lmm-p3-smoke && cat > /tmp/lmm-p3-smoke/repo.yaml <<'EOF'
+id: smoke-repo
+name: Smoke Repo
+type: manifest
+manifest:
+  url: /tmp/lmm-p3-smoke/mods.yaml
+EOF
+cat > /tmp/lmm-p3-smoke/mods.yaml <<'EOF'
+version: 1
+mods:
+  - id: hello
+    name: Hello Mod
+    version: 1.0.0
+    files:
+      - id: main
+        filename: hello.zip
+        url: https://example.test/hello.zip
+EOF
+./lmm source validate /tmp/lmm-p3-smoke/repo.yaml   # expect: valid (manifest source "smoke-repo")
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/custom.go internal/source/custom/custom_test.go cmd/lmm/root.go cmd/lmm/auth.go cmd/lmm/auth_test.go cmd/lmm/source.go
+git commit -m "feat(cli): register manifest sources and extend auth commands to custom sources"
+```
+
+---
+
+## Task 10: End-to-end test — static file server as a full source
+
+**Files:**
+- Test: `internal/core/service_manifest_source_test.go` (create)
+
+Acceptance criterion #48-1: "A static file server (or local file) publishing one manifest works as a full source, including dependency resolution and update checks."
+
+- [ ] **Step 1: Write the test**
+
+Create `internal/core/service_manifest_source_test.go` (`package core_test`; reuse `core.NewService` construction from `service_test.go`):
+
+```go
+package core_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManifestSourceEndToEnd drives the full loop against a static file
+// server: manifest fetch -> search -> files (sha256) -> download+verify ->
+// cache, plus dependency resolution and update checks (issue #48 acceptance).
+func TestManifestSourceEndToEnd(t *testing.T) {
+	archive := []byte("mod payload bytes")
+	sum := sha256.Sum256(archive)
+	archiveSHA := hex.EncodeToString(sum[:])
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    summary: Makes things cooler
+    dependencies: [dep-mod]
+    files:
+      - id: main
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        url: %s/files/cool-mod-1.2.0.zip
+        sha256: %s
+        primary: true
+  - id: dep-mod
+    name: Dep Mod
+    version: 0.5.0
+    files:
+      - id: main
+        filename: dep-mod.zip
+        url: %s/files/dep-mod.zip
+`, srv.URL, archiveSHA, srv.URL)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	mux.HandleFunc("/files/", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(archive) })
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "e2e-repo",
+		Name:      "E2E Repo",
+		Type:      custom.TypeManifest,
+		AllowHTTP: true, // httptest serves plain http
+		Manifest:  &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(src)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), DeployMode: domain.DeployCopy}
+	require.NoError(t, svc.AddGame(game))
+	ctx := context.Background()
+
+	// Search finds the mod and stamps identity.
+	res, err := src.Search(ctx, source.SearchQuery{Query: "cool", GameID: "testgame", PageSize: 20})
+	require.NoError(t, err)
+	require.Len(t, res.Mods, 1)
+	mod := res.Mods[0]
+	assert.Equal(t, "e2e-repo", mod.SourceID)
+	assert.Equal(t, "testgame", mod.GameID)
+
+	// Dependencies resolve within the source.
+	deps, err := src.GetDependencies(ctx, &mod)
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, domain.ModReference{SourceID: "e2e-repo", ModID: "dep-mod"}, deps[0])
+
+	// Files carry the declared sha256; download verifies it and lands in cache.
+	files, err := src.GetModFiles(ctx, &mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, archiveSHA, files[0].SHA256)
+
+	result, err := svc.DownloadMod(ctx, "e2e-repo", game, &mod, &files[0], nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesExtracted)
+	gameCache := svc.GetGameCache(game)
+	assert.True(t, gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version))
+
+	// Update checks: installed 1.0.0 -> manifest 1.2.0 offers an update.
+	installed := []domain.InstalledMod{{Mod: domain.Mod{ID: "cool-mod", SourceID: "e2e-repo", Version: "1.0.0"}}}
+	updates, err := src.CheckUpdates(ctx, installed)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "1.2.0", updates[0].NewVersion)
+}
+
+// TestManifestSourceEndToEndCorruptDownload pins acceptance criterion 2 of
+// the sha256 wiring: a server whose file bytes don't match the declared hash
+// must fail the install and leave the cache empty.
+func TestManifestSourceEndToEndCorruptDownload(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	wrongSHA := strings.Repeat("de", 32) // 64 hex chars that won't match the served bytes
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: bad-mod
+    name: Bad Mod
+    version: 1.0.0
+    files:
+      - id: main
+        filename: bad-mod.zip
+        url: %s/files/bad-mod.zip
+        sha256: %s
+`, srv.URL, wrongSHA)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	mux.HandleFunc("/files/", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("tampered content")) })
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID: "bad-repo", Name: "Bad Repo", Type: custom.TypeManifest, AllowHTTP: true,
+		Manifest: &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(src)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), DeployMode: domain.DeployCopy}
+	require.NoError(t, svc.AddGame(game))
+	ctx := context.Background()
+
+	mod, err := src.GetMod(ctx, "testgame", "bad-mod")
+	require.NoError(t, err)
+	files, err := src.GetModFiles(ctx, mod)
+	require.NoError(t, err)
+
+	_, err = svc.DownloadMod(ctx, "bad-repo", game, mod, &files[0], nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sha256 mismatch")
+	gameCache := svc.GetGameCache(game)
+	assert.False(t, gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version))
+}
+```
+
+- [ ] **Step 2: Run the test and the full suite**
+
+Run: `go test ./internal/core/ -run TestManifestSourceEndToEnd -v && go test ./...`
+Expected: PASS everywhere.
+
+- [ ] **Step 3: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/core/service_manifest_source_test.go
+git commit -m "test(core): manifest source end-to-end coverage"
+```
+
+---
+
+## Task 11: Documentation and version bump
+
+**Files:**
+- Modify: `README.md`, `CHANGELOG.md`, `cmd/lmm/root.go` (version)
+
+- [ ] **Step 1: Update docs**
+
+`README.md` — in the Custom Sources section:
+- New "Manifest Sources" subsection: the definition YAML (design §3 example), the manifest document format — a fields table for `mods[]` (id, name, version, author, summary, game_ids, url, updated_at, dependencies, files) and `files[]` (id, name, filename, version, size, url, sha256, primary) with required fields marked — plus the semantics: remote manifests cached for `refresh` (default 15m), local paths read live; `game_ids` matched against the game's mapped `sources:` value (empty = all games); `sha256` verified on download; dependencies resolve within the source.
+- New "Authentication" subsection: `auth.api_key` block (`in: header|query`, `name`), key resolution (`LMM_<ID>_API_KEY` env var → `lmm auth login <id>` stored token), key applies to both manifest fetch and file downloads.
+- Update the Common Fields `type` row: `directory` and `manifest` are supported; `api` is planned.
+
+`CHANGELOG.md` — under `[Unreleased]` → `### Added`:
+
+```markdown
+- Manifest source type: publish a JSON/YAML mod list (https URL or local file) and use it as a full source — search, install, within-source dependencies, and update checks
+- Declared `sha256` checksums in manifests are verified on download
+- API-key authentication for custom sources (`auth.api_key` in the definition; `LMM_<ID>_API_KEY` env var or `lmm auth login <id>`)
+```
+
+- [ ] **Step 2: Version bump and final verification**
+
+- `CHANGELOG.md`: move `[Unreleased]` items to `## [1.7.0] - <today>`; update comparison links.
+- `cmd/lmm/root.go`: `version = "1.7.0"`.
+
+```bash
+go fmt ./... && go vet ./... && go test ./...
+git add README.md CHANGELOG.md
+git commit -m "docs: document manifest sources and custom-source authentication"
+git add cmd/lmm/root.go CHANGELOG.md
+git commit -m "chore: bump version to 1.7.0"
+```
+
+---
+
+## Out of Scope (tracked separately)
+
+- **Phase 4** — declarative REST `api` type (#49) — reuses `AuthConfig`, `DownloadHeaderProvider`, and `searchMods` from this phase
+- **Phase 5** — aggregate search, TUI Sources screen, `source validate --probe` (#50)
+- Deferred polish items — issue #52

--- a/docs/plans/archive/2026-07-15-custom-sources-p4-api-impl.md
+++ b/docs/plans/archive/2026-07-15-custom-sources-p4-api-impl.md
@@ -1,0 +1,1993 @@
+# Custom Sources — Phase 4 (Declarative REST API Source) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `type: api` custom sources — a GET+JSON REST API described declaratively (endpoint URL templates + dot-path mappings) becomes a ModSource, including install-by-ID-only definitions with clean capability gaps, plus `lmm source validate --probe` live smoke tests for all custom source types.
+
+**Architecture:** A new `API` type in `internal/source/custom` executes per-operation endpoint templates (`search`, `get_mod`, `mod_files`, `download_url`) with URL-escaped placeholder substitution, decodes JSON, and maps responses onto `domain.Mod`/`domain.DownloadableFile` via configurable dot-paths (engine in `mapping.go`). Undefined endpoints surface as `ErrNotSupported` capability gaps. Auth reuses Phase 3's `AuthConfig` end to end: same-origin credential scoping (vs `base_url`), URL-aware `DownloadHeaders`, startup key attachment, and `auth login/status/logout` all work unchanged via the interfaces that already exist.
+
+**Tech Stack:** Go stdlib (net/http, net/url, encoding/json, strconv), testify, httptest. No new dependencies.
+
+**Spec:** `docs/plans/2026-07-13-custom-sources-design.md` §4 (api type), §6 (auth), §8 (`--probe`), §9 (security). Issue: #49 (epic #45). Note: #49's "extend `lmm auth login` to custom sources" item already shipped in Phase 3 — nothing to do beyond the `API` type implementing `SetAPIKey`/`IsAuthenticated`.
+
+## Global Constraints
+
+- TDD: every task starts with a failing test.
+- Error wrapping with context: `fmt.Errorf("doing X: %w", err)` (GO.md); operational errors name the source ID and action (`source %q: searching: %w`).
+- `ctx context.Context` first param for I/O paths; no ctx in structs (GO.md).
+- No new dependencies.
+- `go fmt ./...` and `go vet ./...` clean before every commit.
+- GET requests returning JSON only; https enforced for `base_url` unless `allow_http: true`.
+- All placeholder substitutions URL-escaped; API keys never appear in logs or error text (the Phase 3 redaction/origin-scoping invariants carry over — reuse, don't reinvent).
+- Bounded reads on remote responses (10 MiB, same defense class as manifests).
+- Placeholder semantics (design §4, binding): `{page}` = internal 0-based page + `page_start` (default 1); `{offset}` = 0-based page × page_size, independent of `page_start`; `{game_id}` from the query/installed mod (the Service/Updater already pass source-mapped values); required mapping keys are `mod.id`, `mod.name`, and `file.id` — a response missing them is an error; other missing paths yield zero values.
+- `GetDependencies` always returns `ErrNotSupported` in v1.
+- Commit after each task; conventional commit messages.
+
+---
+
+## Task 1: APIConfig schema and validation
+
+**Files:**
+- Modify: `internal/source/custom/definition.go` (replace the stub `APIConfig`)
+- Test: `internal/source/custom/definition_test.go` (append)
+
+**Interfaces:**
+- Produces (consumed by every later task):
+
+```go
+type APIConfig struct {
+	BaseURL   string          `yaml:"base_url"`
+	PageStart *int            `yaml:"page_start"` // nil = default 1; explicit 0 respected
+	Auth      *AuthConfig     `yaml:"auth"`
+	Endpoints APIEndpoints    `yaml:"endpoints"`
+	Mappings  APIMappings     `yaml:"mappings"`
+}
+
+type APIEndpoints struct {
+	Search      *EndpointConfig `yaml:"search"`
+	GetMod      *EndpointConfig `yaml:"get_mod"`
+	ModFiles    *EndpointConfig `yaml:"mod_files"`
+	DownloadURL *EndpointConfig `yaml:"download_url"`
+}
+
+type EndpointConfig struct {
+	Path  string `yaml:"path"`  // required; may contain {placeholders}
+	List  string `yaml:"list"`  // dot-path to results array (required for search & mod_files)
+	Total string `yaml:"total"` // optional dot-path to total count (search only)
+	Field string `yaml:"field"` // dot-path to a scalar (required for download_url)
+}
+
+type APIMappings struct {
+	Mod  map[string]string `yaml:"mod"`  // domain field key -> JSON dot-path
+	File map[string]string `yaml:"file"`
+}
+```
+
+- Validation rules (in `Validate()`'s `case TypeAPI:`, replacing the current minimal checks; keep the existing base_url http(s)+checkURL logic):
+  - `auth` via existing `validateAuth`
+  - at least one endpoint defined
+  - every defined endpoint: `path` required
+  - `search` defined ⇒ `list` required on it; `mod_files` defined ⇒ `list` required on it; `download_url` defined ⇒ `field` required on it
+  - `mappings.mod` must contain keys `id` and `name`; `mod_files` defined ⇒ `mappings.file` must contain key `id`
+  - unknown mapping keys are errors (typo detection): mod keys ⊆ {`id`,`name`,`version`,`author`,`summary`,`description`,`downloads`,`updated_at`,`url`,`picture_url`}; file keys ⊆ {`id`,`name`,`filename`,`version`,`size`}
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` table in `TestSourceDefinitionValidate` (`internal/source/custom/definition_test.go`). First add a helper near `validDirectoryDef`:
+
+```go
+func validAPIDef() SourceDefinition {
+	return SourceDefinition{
+		ID:   "my-api",
+		Name: "My API",
+		Type: TypeAPI,
+		API: &APIConfig{
+			BaseURL: "https://api.x.test",
+			Endpoints: APIEndpoints{
+				Search:      &EndpointConfig{Path: "/mods?q={query}&page={page}", List: "results", Total: "total"},
+				GetMod:      &EndpointConfig{Path: "/mods/{mod_id}"},
+				ModFiles:    &EndpointConfig{Path: "/mods/{mod_id}/files", List: "files"},
+				DownloadURL: &EndpointConfig{Path: "/files/{file_id}/download", Field: "url"},
+			},
+			Mappings: APIMappings{
+				Mod:  map[string]string{"id": "id", "name": "name", "version": "latest_version"},
+				File: map[string]string{"id": "id", "filename": "file_name"},
+			},
+		},
+	}
+}
+```
+
+Then the table cases (the existing `"valid api"` and `"http api rejected"` cases construct a minimal `&APIConfig{BaseURL: ...}` — UPDATE them to use `validAPIDef()`'s API block with the base_url swapped, since a bare BaseURL is no longer valid):
+
+```go
+		{"valid full api", func(d *SourceDefinition) {
+			*d = validAPIDef()
+		}, ""},
+		{"api no endpoints", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints = APIEndpoints{}
+		}, "at least one endpoint"},
+		{"api endpoint missing path", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints.GetMod = &EndpointConfig{}
+		}, "get_mod: path is required"},
+		{"api search missing list", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints.Search.List = ""
+		}, "search: list is required"},
+		{"api mod_files missing list", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints.ModFiles.List = ""
+		}, "mod_files: list is required"},
+		{"api download_url missing field", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints.DownloadURL.Field = ""
+		}, "download_url: field is required"},
+		{"api mappings missing mod id", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			delete(d.API.Mappings.Mod, "id")
+		}, `mappings.mod: "id" is required`},
+		{"api mappings missing mod name", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			delete(d.API.Mappings.Mod, "name")
+		}, `mappings.mod: "name" is required`},
+		{"api mod_files without file id mapping", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			delete(d.API.Mappings.File, "id")
+		}, `mappings.file: "id" is required`},
+		{"api unknown mod mapping key", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Mappings.Mod["fancyness"] = "x"
+		}, `mappings.mod: unknown key "fancyness"`},
+		{"api unknown file mapping key", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Mappings.File["sha512"] = "x"
+		}, `mappings.file: unknown key "sha512"`},
+		{"api with auth", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+		}, ""},
+		{"api bad auth", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "body", Name: "k"}}
+		}, `auth.api_key.in must be "header" or "query"`},
+		{"api install-by-id only is valid", func(d *SourceDefinition) {
+			*d = validAPIDef()
+			d.API.Endpoints.Search = nil
+		}, ""},
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestSourceDefinitionValidate -v`
+Expected: FAIL — `unknown field Endpoints`, etc.
+
+- [ ] **Step 3: Implement**
+
+In `internal/source/custom/definition.go`, replace the stub `APIConfig` with the types from the Interfaces block above, then replace the body of `case TypeAPI:` in `Validate()`:
+
+```go
+	case TypeAPI:
+		if d.API == nil {
+			return fmt.Errorf(`type %q requires an "api" block`, d.Type)
+		}
+		if d.API.BaseURL == "" {
+			return errors.New("api.base_url is required")
+		}
+		if !strings.HasPrefix(d.API.BaseURL, "https://") && !strings.HasPrefix(d.API.BaseURL, "http://") {
+			return errors.New("api.base_url must be an http(s) URL")
+		}
+		if err := d.checkURL(d.API.BaseURL); err != nil {
+			return fmt.Errorf("api.base_url: %w", err)
+		}
+		if err := validateAuth(d.API.Auth); err != nil {
+			return fmt.Errorf("api: %w", err)
+		}
+		if err := d.API.validateEndpointsAndMappings(); err != nil {
+			return fmt.Errorf("api: %w", err)
+		}
+```
+
+Add to definition.go:
+
+```go
+// knownModMappingKeys / knownFileMappingKeys are the domain fields a mapping
+// may target. Unknown keys are validation errors so typos surface at load
+// time instead of silently producing empty fields.
+var knownModMappingKeys = map[string]bool{
+	"id": true, "name": true, "version": true, "author": true, "summary": true,
+	"description": true, "downloads": true, "updated_at": true, "url": true, "picture_url": true,
+}
+
+var knownFileMappingKeys = map[string]bool{
+	"id": true, "name": true, "filename": true, "version": true, "size": true,
+}
+
+// validateEndpointsAndMappings checks the api block's endpoint/mapping rules
+// (design §4): at least one endpoint, per-endpoint required fields, required
+// mapping keys, and no unknown mapping keys.
+func (c *APIConfig) validateEndpointsAndMappings() error {
+	eps := []struct {
+		name string
+		ep   *EndpointConfig
+	}{
+		{"search", c.Endpoints.Search},
+		{"get_mod", c.Endpoints.GetMod},
+		{"mod_files", c.Endpoints.ModFiles},
+		{"download_url", c.Endpoints.DownloadURL},
+	}
+
+	defined := false
+	for _, e := range eps {
+		if e.ep == nil {
+			continue
+		}
+		defined = true
+		if e.ep.Path == "" {
+			return fmt.Errorf("endpoints.%s: path is required", e.name)
+		}
+	}
+	if !defined {
+		return errors.New("endpoints: at least one endpoint must be defined")
+	}
+	if c.Endpoints.Search != nil && c.Endpoints.Search.List == "" {
+		return errors.New("endpoints.search: list is required")
+	}
+	if c.Endpoints.ModFiles != nil && c.Endpoints.ModFiles.List == "" {
+		return errors.New("endpoints.mod_files: list is required")
+	}
+	if c.Endpoints.DownloadURL != nil && c.Endpoints.DownloadURL.Field == "" {
+		return errors.New("endpoints.download_url: field is required")
+	}
+
+	if c.Mappings.Mod["id"] == "" {
+		return errors.New(`mappings.mod: "id" is required`)
+	}
+	if c.Mappings.Mod["name"] == "" {
+		return errors.New(`mappings.mod: "name" is required`)
+	}
+	if c.Endpoints.ModFiles != nil && c.Mappings.File["id"] == "" {
+		return errors.New(`mappings.file: "id" is required when mod_files is defined`)
+	}
+	for k := range c.Mappings.Mod {
+		if !knownModMappingKeys[k] {
+			return fmt.Errorf("mappings.mod: unknown key %q", k)
+		}
+	}
+	for k := range c.Mappings.File {
+		if !knownFileMappingKeys[k] {
+			return fmt.Errorf("mappings.file: unknown key %q", k)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS (new cases + all existing; the two updated legacy api cases too).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/definition.go internal/source/custom/definition_test.go
+git commit -m "feat(source): expand api source definition schema and validation"
+```
+
+---
+
+## Task 2: Dot-path mapping engine
+
+**Files:**
+- Create: `internal/source/custom/mapping.go`
+- Test: `internal/source/custom/mapping_test.go`
+
+**Interfaces:**
+- Produces (unexported, consumed by Tasks 5–7):
+  - `lookupPath(doc any, path string) (any, bool)` — traverses `map[string]any` by dot-separated keys; false when any segment is missing or a non-map is traversed into
+  - `coerceString(v any) string` — string as-is; float64 via `strconv.FormatFloat(f, 'f', -1, 64)` (JSON numbers arrive as float64; integer ids must render without ".0"); bool/nil/other → ""
+  - `coerceInt64(v any) int64` — float64 truncated; string parsed (best effort, 0 on failure); other → 0
+  - `mapMod(doc any, mapping map[string]string, sourceID string) (domain.Mod, error)` — error when `id` or `name` resolve empty; `updated_at` parsed RFC3339, unparseable → zero; `url` → `SourceURL`, `picture_url` → `PictureURL`
+  - `mapFile(doc any, mapping map[string]string) (domain.DownloadableFile, error)` — error when `id` resolves empty; `filename` → `FileName`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/source/custom/mapping_test.go`:
+
+```go
+package custom
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// jsonDoc decodes a JSON literal the way the API source does (numbers become
+// float64), so tests exercise the real coercion paths.
+func jsonDoc(t *testing.T, s string) any {
+	t.Helper()
+	var doc any
+	require.NoError(t, json.Unmarshal([]byte(s), &doc))
+	return doc
+}
+
+func TestLookupPath(t *testing.T) {
+	doc := jsonDoc(t, `{"a": {"b": {"c": 42}}, "top": "x", "arr": [1,2]}`)
+
+	v, ok := lookupPath(doc, "a.b.c")
+	require.True(t, ok)
+	assert.Equal(t, float64(42), v)
+
+	v, ok = lookupPath(doc, "top")
+	require.True(t, ok)
+	assert.Equal(t, "x", v)
+
+	_, ok = lookupPath(doc, "a.missing")
+	assert.False(t, ok)
+
+	_, ok = lookupPath(doc, "top.deeper") // traversing into a non-map
+	assert.False(t, ok)
+
+	_, ok = lookupPath(doc, "arr.0") // array indexing unsupported in v1
+	assert.False(t, ok)
+}
+
+func TestCoercions(t *testing.T) {
+	assert.Equal(t, "hello", coerceString("hello"))
+	assert.Equal(t, "123", coerceString(float64(123)))     // integer id, no ".0"
+	assert.Equal(t, "1.5", coerceString(float64(1.5)))
+	assert.Equal(t, "", coerceString(nil))
+	assert.Equal(t, "", coerceString(true))
+
+	assert.Equal(t, int64(42), coerceInt64(float64(42)))
+	assert.Equal(t, int64(42), coerceInt64("42"))
+	assert.Equal(t, int64(0), coerceInt64("not a number"))
+	assert.Equal(t, int64(0), coerceInt64(nil))
+}
+
+func TestMapMod(t *testing.T) {
+	doc := jsonDoc(t, `{
+		"id": 77, "name": "Cool Mod", "latest_version": "1.2.0",
+		"author": {"name": "someone"}, "description": "Makes things cooler",
+		"download_count": 12345, "updated": "2026-07-01T00:00:00Z",
+		"web_url": "https://x.test/mods/77"
+	}`)
+	mapping := map[string]string{
+		"id": "id", "name": "name", "version": "latest_version",
+		"author": "author.name", "summary": "description",
+		"downloads": "download_count", "updated_at": "updated", "url": "web_url",
+	}
+
+	mod, err := mapMod(doc, mapping, "my-api")
+	require.NoError(t, err)
+	assert.Equal(t, "77", mod.ID) // numeric id coerced without ".0"
+	assert.Equal(t, "my-api", mod.SourceID)
+	assert.Equal(t, "Cool Mod", mod.Name)
+	assert.Equal(t, "1.2.0", mod.Version)
+	assert.Equal(t, "someone", mod.Author)
+	assert.Equal(t, "Makes things cooler", mod.Summary)
+	assert.Equal(t, int64(12345), mod.Downloads)
+	assert.Equal(t, 2026, mod.UpdatedAt.Year())
+	assert.Equal(t, "https://x.test/mods/77", mod.SourceURL)
+}
+
+func TestMapModRequiredFields(t *testing.T) {
+	mapping := map[string]string{"id": "id", "name": "name"}
+
+	_, err := mapMod(jsonDoc(t, `{"name": "NoID"}`), mapping, "s")
+	assert.ErrorContains(t, err, `required field "id"`)
+
+	_, err = mapMod(jsonDoc(t, `{"id": 1}`), mapping, "s")
+	assert.ErrorContains(t, err, `required field "name"`)
+}
+
+func TestMapModOptionalMissingYieldsZero(t *testing.T) {
+	mapping := map[string]string{"id": "id", "name": "name", "version": "nope.nothere", "updated_at": "bad_time"}
+	mod, err := mapMod(jsonDoc(t, `{"id": "x", "name": "X", "bad_time": "yesterday-ish"}`), mapping, "s")
+	require.NoError(t, err)
+	assert.Empty(t, mod.Version)
+	assert.True(t, mod.UpdatedAt.IsZero())
+}
+
+func TestMapFile(t *testing.T) {
+	doc := jsonDoc(t, `{"id": 900, "title": "Main File", "file_name": "cool-1.2.0.zip", "version": "1.2.0", "size_bytes": 123456}`)
+	mapping := map[string]string{"id": "id", "name": "title", "filename": "file_name", "version": "version", "size": "size_bytes"}
+
+	f, err := mapFile(doc, mapping)
+	require.NoError(t, err)
+	assert.Equal(t, "900", f.ID)
+	assert.Equal(t, "Main File", f.Name)
+	assert.Equal(t, "cool-1.2.0.zip", f.FileName)
+	assert.Equal(t, "1.2.0", f.Version)
+	assert.Equal(t, int64(123456), f.Size)
+
+	_, err = mapFile(jsonDoc(t, `{"title": "no id"}`), mapping)
+	assert.ErrorContains(t, err, `required field "id"`)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run 'TestLookupPath|TestCoercions|TestMapMod|TestMapFile' -v`
+Expected: FAIL — `undefined: lookupPath` etc.
+
+- [ ] **Step 3: Implement**
+
+Create `internal/source/custom/mapping.go`:
+
+```go
+package custom
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// lookupPath traverses a decoded JSON document (map[string]any tree) by a
+// dot-separated path. Returns (value, true) when every segment resolves;
+// (nil, false) when any segment is missing or a non-object is traversed
+// into. Array indexing is not supported in v1 (design §4).
+func lookupPath(doc any, path string) (any, bool) {
+	cur := doc
+	for _, seg := range strings.Split(path, ".") {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = m[seg]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// coerceString renders a JSON scalar as a string. JSON numbers decode as
+// float64, so integer ids must format without a trailing ".0".
+func coerceString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	default:
+		return ""
+	}
+}
+
+// coerceInt64 renders a JSON scalar as an int64, best effort (0 on failure).
+func coerceInt64(v any) int64 {
+	switch t := v.(type) {
+	case float64:
+		return int64(t)
+	case string:
+		n, err := strconv.ParseInt(t, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return n
+	default:
+		return 0
+	}
+}
+
+// pathString resolves a mapping path to a string; "" when the mapping key or
+// the path is absent.
+func pathString(doc any, mapping map[string]string, key string) string {
+	path, ok := mapping[key]
+	if !ok {
+		return ""
+	}
+	v, ok := lookupPath(doc, path)
+	if !ok {
+		return ""
+	}
+	return coerceString(v)
+}
+
+// mapMod builds a domain.Mod from a decoded JSON object using the definition's
+// mod mappings. id and name are required (design §4); everything else is a
+// zero value when missing or unmapped.
+func mapMod(doc any, mapping map[string]string, sourceID string) (domain.Mod, error) {
+	mod := domain.Mod{SourceID: sourceID}
+
+	mod.ID = pathString(doc, mapping, "id")
+	if mod.ID == "" {
+		return domain.Mod{}, fmt.Errorf(`response is missing required field "id" (mapped from %q)`, mapping["id"])
+	}
+	mod.Name = pathString(doc, mapping, "name")
+	if mod.Name == "" {
+		return domain.Mod{}, fmt.Errorf(`response is missing required field "name" (mapped from %q)`, mapping["name"])
+	}
+
+	mod.Version = pathString(doc, mapping, "version")
+	mod.Author = pathString(doc, mapping, "author")
+	mod.Summary = pathString(doc, mapping, "summary")
+	mod.Description = pathString(doc, mapping, "description")
+	if mod.Description == "" {
+		mod.Description = mod.Summary
+	}
+	mod.SourceURL = pathString(doc, mapping, "url")
+	mod.PictureURL = pathString(doc, mapping, "picture_url")
+
+	if path, ok := mapping["downloads"]; ok {
+		if v, found := lookupPath(doc, path); found {
+			mod.Downloads = coerceInt64(v)
+		}
+	}
+	if ts := pathString(doc, mapping, "updated_at"); ts != "" {
+		if parsed, err := time.Parse(time.RFC3339, ts); err == nil {
+			mod.UpdatedAt = parsed // unparseable -> zero value, by design
+		}
+	}
+
+	return mod, nil
+}
+
+// mapFile builds a domain.DownloadableFile from a decoded JSON object using
+// the definition's file mappings. id is required (design §4).
+func mapFile(doc any, mapping map[string]string) (domain.DownloadableFile, error) {
+	f := domain.DownloadableFile{}
+
+	f.ID = pathString(doc, mapping, "id")
+	if f.ID == "" {
+		return domain.DownloadableFile{}, fmt.Errorf(`response is missing required field "id" (mapped from %q)`, mapping["id"])
+	}
+	f.Name = pathString(doc, mapping, "name")
+	f.FileName = pathString(doc, mapping, "filename")
+	f.Version = pathString(doc, mapping, "version")
+	if path, ok := mapping["size"]; ok {
+		if v, found := lookupPath(doc, path); found {
+			f.Size = coerceInt64(v)
+		}
+	}
+	return f, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/mapping.go internal/source/custom/mapping_test.go
+git commit -m "feat(source): add JSON dot-path mapping engine for api sources"
+```
+
+---
+
+## Task 3: Shared origin helper (behavior-preserving refactor)
+
+**Files:**
+- Create: `internal/source/custom/origin.go`
+- Modify: `internal/source/custom/manifest.go` (`sameOrigin` delegates; `normalizedHost` moves)
+
+**Interfaces:**
+- Produces: `sameOriginURLs(a, b string) bool` (package-level) — scheme equality + default-port-normalized host equality; false when either URL fails to parse. `Manifest.sameOrigin(fileURL)` becomes `return sameOriginURLs(fileURL, m.url)`. Task 4's `API` uses `sameOriginURLs(fileURL, a.baseURL)`.
+- No new tests: the existing `TestManifestDownloadHeaders`, `TestManifestSameOriginNormalizesDefaultPorts`, and query-auth tests are the safety net and must pass untouched.
+
+- [ ] **Step 1: Extract**
+
+Create `internal/source/custom/origin.go` by MOVING (verbatim, adjusting only the receiver-based wrapper) `normalizedHost` out of manifest.go and adding:
+
+```go
+package custom
+
+import "net/url"
+
+// sameOriginURLs reports whether two URLs share scheme and host. Ports are
+// normalized before comparing: an explicit default port (:443 on https, :80
+// on http) matches a URL with no port at all; any other explicit port must
+// match exactly. Either URL failing to parse is not same-origin (fail closed).
+// Used to scope custom-source API keys to their own origin (design §9).
+func sameOriginURLs(a, b string) bool {
+	au, err := url.Parse(a)
+	if err != nil {
+		return false
+	}
+	bu, err := url.Parse(b)
+	if err != nil {
+		return false
+	}
+	return au.Scheme == bu.Scheme && normalizedHost(au) == normalizedHost(bu)
+}
+```
+
+(Move `normalizedHost` into origin.go unchanged, with its doc comment.) In manifest.go, replace `sameOrigin`'s body with `return sameOriginURLs(fileURL, m.url)` — keep its doc comment, trimmed of the mechanics now documented on `sameOriginURLs`. Remove `net/url` from manifest.go imports ONLY if nothing else there uses it (check: `addQueryParam` uses it — it stays).
+
+- [ ] **Step 2: Verify no behavior change**
+
+Run: `go test ./internal/source/custom/ -race -v && go build ./...`
+Expected: PASS, zero test-file changes (`git status` shows only origin.go + manifest.go).
+
+- [ ] **Step 3: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/origin.go internal/source/custom/manifest.go
+git commit -m "refactor(source): extract shared same-origin helper"
+```
+
+---
+
+## Task 4: API source construction, request layer, identity, capabilities
+
+**Files:**
+- Create: `internal/source/custom/api.go`
+- Test: `internal/source/custom/api_test.go`
+
+**Interfaces:**
+- Consumes: `APIConfig` (Task 1), `sameOriginURLs` (Task 3), `AuthConfig`, `addQueryParam`, `source.ErrNotSupported`/`Capabilities`, `domain.ErrAuthRequired`.
+- Produces:
+  - `custom.NewAPI(def SourceDefinition) (*API, error)` — pure construction (no I/O); dedicated `&http.Client{Timeout: apiRequestTimeout}` (new const, 30s); `pageStart` resolved (nil → 1)
+  - `(a *API) SetAPIKey(key string)`, `IsAuthenticated() bool`, `DownloadHeaders(fileURL string) map[string]string` (header-mode + key + `sameOriginURLs(fileURL, a.baseURL)` only)
+  - `ID/Name/AuthURL/ExchangeToken/GetDependencies` (the latter two `ErrNotSupported`); `Capabilities()` = `{Search: eps.Search != nil, Dependencies: false, Updates: eps.GetMod != nil, Auth: auth != nil}`
+  - unexported request layer used by Tasks 5–7: `buildEndpointURL(pathTemplate string, vals map[string]string) string` (every `{placeholder}` in vals replaced with its URL-escaped value; unknown placeholders left intact) and `getJSON(ctx context.Context, rawURL string) (any, error)` (GET; auth attach header/query — query via `addQueryParam`; 401 → wraps `domain.ErrAuthRequired`; non-200 → error with status; 10 MiB `maxAPIResponseSize` cap; `*url.Error` unwrapped before wrapping so keys never leak — mirror `fetchRemote`'s redaction exactly)
+  - Temporary stubs so the interface compiles: `Search`, `GetMod`, `GetModFiles`, `GetDownloadURL`, `CheckUpdates` all return `ErrNotSupported` (Tasks 5–7 replace them); compile-time assertions `var _ source.ModSource = (*API)(nil)`, `var _ source.CapabilityReporter = (*API)(nil)`, `var _ source.DownloadHeaderProvider = (*API)(nil)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/source/custom/api_test.go`:
+
+```go
+package custom
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func apiDef(baseURL string) SourceDefinition {
+	def := validAPIDef()
+	def.API.BaseURL = baseURL
+	def.AllowHTTP = true // httptest serves plain http
+	return def
+}
+
+func TestNewAPIIsPure(t *testing.T) {
+	a, err := NewAPI(apiDef("https://unreachable.invalid"))
+	require.NoError(t, err)
+	assert.Equal(t, "my-api", a.ID())
+	assert.Equal(t, "My API", a.Name())
+	assert.Equal(t, apiRequestTimeout, a.httpClient.Timeout)
+	assert.Equal(t, 1, a.pageStart) // default when page_start omitted
+}
+
+func TestNewAPIExplicitPageStartZero(t *testing.T) {
+	def := apiDef("https://x.test")
+	zero := 0
+	def.API.PageStart = &zero
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+	assert.Equal(t, 0, a.pageStart)
+}
+
+func TestAPIIdentityAndCapabilities(t *testing.T) {
+	a, err := NewAPI(apiDef("https://x.test"))
+	require.NoError(t, err)
+	assert.Equal(t, source.Capabilities{Search: true, Dependencies: false, Updates: true, Auth: false}, a.Capabilities())
+	assert.Empty(t, a.AuthURL())
+
+	_, err = a.ExchangeToken(context.Background(), "code")
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+	_, err = a.GetDependencies(context.Background(), &domain.Mod{ID: "x"})
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+
+	def := apiDef("https://x.test")
+	def.API.Endpoints.Search = nil
+	def.API.Endpoints.GetMod = nil
+	limited, err := NewAPI(def)
+	require.NoError(t, err)
+	assert.Equal(t, source.Capabilities{Search: false, Dependencies: false, Updates: false, Auth: false}, limited.Capabilities())
+}
+
+func TestBuildEndpointURL(t *testing.T) {
+	got := buildEndpointURL("/mods?q={query}&page={page}&x={unknown}", map[string]string{
+		"query": "cool mod & more", "page": "2",
+	})
+	assert.Equal(t, "/mods?q=cool+mod+%26+more&page=2&x={unknown}", got)
+}
+
+func TestGetJSONAuthAndErrors(t *testing.T) {
+	t.Run("header auth attached and 401 maps to ErrAuthRequired", func(t *testing.T) {
+		var gotKey string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotKey = r.Header.Get("X-API-Key")
+			if gotKey == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte(`{"ok": true}`))
+		}))
+		defer srv.Close()
+
+		def := apiDef(srv.URL)
+		def.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+		a, err := NewAPI(def)
+		require.NoError(t, err)
+
+		_, err = a.getJSON(context.Background(), srv.URL+"/mods/1")
+		assert.True(t, errors.Is(err, domain.ErrAuthRequired))
+
+		a.SetAPIKey("sekrit")
+		doc, err := a.getJSON(context.Background(), srv.URL+"/mods/1")
+		require.NoError(t, err)
+		assert.Equal(t, "sekrit", gotKey)
+		assert.Equal(t, map[string]any{"ok": true}, doc)
+	})
+
+	t.Run("query auth attached", func(t *testing.T) {
+		var gotQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query().Get("api_key")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer srv.Close()
+
+		def := apiDef(srv.URL)
+		def.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+		a, err := NewAPI(def)
+		require.NoError(t, err)
+		a.SetAPIKey("sekrit")
+
+		_, err = a.getJSON(context.Background(), srv.URL+"/mods/1")
+		require.NoError(t, err)
+		assert.Equal(t, "sekrit", gotQuery)
+	})
+
+	t.Run("network error does not leak query key", func(t *testing.T) {
+		def := apiDef("http://127.0.0.1:1")
+		def.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+		a, err := NewAPI(def)
+		require.NoError(t, err)
+		a.SetAPIKey("LEAKME")
+
+		_, err = a.getJSON(context.Background(), "http://127.0.0.1:1/mods/1")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "LEAKME")
+		assert.Contains(t, err.Error(), "my-api")
+	})
+
+	t.Run("non-200 surfaces status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		a, err := NewAPI(apiDef(srv.URL))
+		require.NoError(t, err)
+		_, err = a.getJSON(context.Background(), srv.URL+"/x")
+		assert.ErrorContains(t, err, "HTTP 500")
+	})
+}
+
+func TestAPIDownloadHeaders(t *testing.T) {
+	def := apiDef("https://api.x.test")
+	def.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+	a.SetAPIKey("sekrit")
+
+	assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, a.DownloadHeaders("https://api.x.test/dl/1.zip"))
+	assert.Nil(t, a.DownloadHeaders("https://cdn.elsewhere.test/dl/1.zip"), "cross-origin downloads must not receive the key")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run 'TestNewAPI|TestAPIIdentity|TestBuildEndpointURL|TestGetJSON|TestAPIDownloadHeaders' -v`
+Expected: FAIL — `undefined: NewAPI`.
+
+- [ ] **Step 3: Implement**
+
+Create `internal/source/custom/api.go`:
+
+```go
+package custom
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+)
+
+// apiRequestTimeout bounds every request to a declarative REST source.
+const apiRequestTimeout = 30 * time.Second
+
+// maxAPIResponseSize bounds how much of an API response we read into memory
+// (same defense class as maxManifestSize).
+const maxAPIResponseSize = 10 << 20 // 10 MiB
+
+// API is a ModSource backed by a declaratively-described GET+JSON REST API
+// (design §4). Endpoints that the definition omits surface as ErrNotSupported
+// capability gaps rather than errors at load time.
+type API struct {
+	id        string
+	name      string
+	baseURL   string
+	pageStart int
+	auth      *AuthConfig
+	endpoints APIEndpoints
+	mappings  APIMappings
+
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewAPI constructs an api source from a validated definition. It performs
+// no I/O — a valid definition always registers; request problems surface as
+// operation errors.
+func NewAPI(def SourceDefinition) (*API, error) {
+	cfg := def.API
+	pageStart := 1
+	if cfg.PageStart != nil {
+		pageStart = *cfg.PageStart
+	}
+	return &API{
+		id:         def.ID,
+		name:       def.Name,
+		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+		pageStart:  pageStart,
+		auth:       cfg.Auth,
+		endpoints:  cfg.Endpoints,
+		mappings:   cfg.Mappings,
+		httpClient: &http.Client{Timeout: apiRequestTimeout},
+	}, nil
+}
+
+// ID implements source.ModSource.
+func (a *API) ID() string { return a.id }
+
+// Name implements source.ModSource.
+func (a *API) Name() string { return a.name }
+
+// AuthURL implements source.ModSource; api sources use API keys, not OAuth.
+func (a *API) AuthURL() string { return "" }
+
+// ExchangeToken implements source.ModSource.
+func (a *API) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
+	return nil, fmt.Errorf("source %q: authentication: %w", a.id, source.ErrNotSupported)
+}
+
+// GetDependencies implements source.ModSource; always unsupported in v1
+// (design §4).
+func (a *API) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	return nil, fmt.Errorf("source %q: dependencies: %w", a.id, source.ErrNotSupported)
+}
+
+// SetAPIKey provides the API key resolved at startup (env var or token store).
+func (a *API) SetAPIKey(key string) { a.apiKey = key }
+
+// IsAuthenticated reports whether an API key is configured.
+func (a *API) IsAuthenticated() bool { return a.apiKey != "" }
+
+// Capabilities implements source.CapabilityReporter: an undefined endpoint is
+// an unsupported capability (design §4/§7).
+func (a *API) Capabilities() source.Capabilities {
+	return source.Capabilities{
+		Search:       a.endpoints.Search != nil,
+		Dependencies: false,
+		Updates:      a.endpoints.GetMod != nil,
+		Auth:         a.auth != nil,
+	}
+}
+
+// DownloadHeaders implements source.DownloadHeaderProvider: header-mode keys
+// go only to downloads on the API's own origin (design §9).
+func (a *API) DownloadHeaders(fileURL string) map[string]string {
+	if a.auth == nil || a.auth.APIKey.In != "header" || a.apiKey == "" {
+		return nil
+	}
+	if !sameOriginURLs(fileURL, a.baseURL) {
+		return nil
+	}
+	return map[string]string{a.auth.APIKey.Name: a.apiKey}
+}
+
+// buildEndpointURL substitutes {placeholder} tokens in an endpoint path
+// template with URL-escaped values. Placeholders without a value are left
+// intact (they will typically 404 loudly rather than silently matching).
+func buildEndpointURL(pathTemplate string, vals map[string]string) string {
+	out := pathTemplate
+	for name, value := range vals {
+		out = strings.ReplaceAll(out, "{"+name+"}", url.QueryEscape(value))
+	}
+	return out
+}
+
+// getJSON performs an authenticated GET against rawURL and decodes the JSON
+// response. 401 maps to domain.ErrAuthRequired; other non-200s surface the
+// status. Errors never contain the request URL's query string (keys ride
+// there in query mode) — the inner *url.Error is unwrapped, mirroring the
+// manifest fetcher's redaction.
+func (a *API) getJSON(ctx context.Context, rawURL string) (any, error) {
+	reqURL := rawURL
+	if a.auth != nil && a.auth.APIKey.In == "query" && a.apiKey != "" {
+		u, err := addQueryParam(reqURL, a.auth.APIKey.Name, a.apiKey)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: %w", a.id, err)
+		}
+		reqURL = u
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: building request: %w", a.id, err)
+	}
+	if a.auth != nil && a.auth.APIKey.In == "header" && a.apiKey != "" {
+		req.Header.Set(a.auth.APIKey.Name, a.apiKey)
+	}
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		var uerr *url.Error
+		if errors.As(err, &uerr) {
+			err = uerr.Err // strip the URL (and any query-mode key) from the message
+		}
+		return nil, fmt.Errorf("source %q: requesting %s: %w", a.id, redactedURL(rawURL), err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("source %q: %w", a.id, domain.ErrAuthRequired)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("source %q: requesting %s: HTTP %d", a.id, redactedURL(rawURL), resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("source %q: reading response: %w", a.id, err)
+	}
+	if len(data) > maxAPIResponseSize {
+		return nil, fmt.Errorf("source %q: response from %s exceeds %d bytes", a.id, redactedURL(rawURL), maxAPIResponseSize)
+	}
+
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("source %q: parsing response from %s: %w", a.id, redactedURL(rawURL), err)
+	}
+	return doc, nil
+}
+
+// redactedURL strips the query string from a URL for error messages.
+func redactedURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "(unparseable URL)"
+	}
+	u.RawQuery = ""
+	return u.String()
+}
+
+var (
+	_ source.ModSource              = (*API)(nil)
+	_ source.CapabilityReporter     = (*API)(nil)
+	_ source.DownloadHeaderProvider = (*API)(nil)
+)
+```
+
+Add temporary stubs at the bottom (Tasks 5–7 replace them):
+
+```go
+// Search is implemented in the search task (replaces this stub).
+func (a *API) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	return source.SearchResult{}, fmt.Errorf("source %q: searching: %w", a.id, source.ErrNotSupported)
+}
+
+// GetMod is implemented in the read-ops task (replaces this stub).
+func (a *API) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	return nil, fmt.Errorf("source %q: fetching mod: %w", a.id, source.ErrNotSupported)
+}
+
+// GetModFiles is implemented in the read-ops task (replaces this stub).
+func (a *API) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, fmt.Errorf("source %q: listing files: %w", a.id, source.ErrNotSupported)
+}
+
+// GetDownloadURL is implemented in the read-ops task (replaces this stub).
+func (a *API) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	return "", fmt.Errorf("source %q: download URL: %w", a.id, source.ErrNotSupported)
+}
+
+// CheckUpdates is implemented in the update-check task (replaces this stub).
+func (a *API) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, fmt.Errorf("source %q: update checks: %w", a.id, source.ErrNotSupported)
+}
+```
+
+Note on `buildEndpointURL` escaping: `url.QueryEscape` is correct for the query-string placeholders this design targets (design §4's examples put placeholders in query strings and simple path segments; QueryEscape's `+` for spaces is acceptable in both for v1).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v && go build ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/api.go internal/source/custom/api_test.go
+git commit -m "feat(source): api source construction, request layer, and capabilities"
+```
+
+---
+
+## Task 5: API search
+
+**Files:**
+- Modify: `internal/source/custom/api.go` (replace the Search stub)
+- Test: `internal/source/custom/api_test.go` (append)
+
+**Interfaces:**
+- Consumes: `buildEndpointURL`, `getJSON`, `lookupPath`, `coerceInt64`, `mapMod`.
+- Produces: real `Search` — placeholder values `{game_id}`=query.GameID, `{query}`=query.Query, `{page}`=strconv(query.Page+a.pageStart), `{page_size}`=strconv(pageSize), `{offset}`=strconv(query.Page×pageSize); pageSize default 20 when ≤0; list dot-path → array → `mapMod` per element (a mapping error on one element fails the operation with the element index); `TotalCount` from the total dot-path (0 when absent/unmapped); missing search endpoint → `ErrNotSupported`; every returned mod gets `GameID = query.GameID`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/source/custom/api_test.go`:
+
+```go
+const apiSearchResponse = `{
+	"results": [
+		{"id": 1, "name": "Alpha Mod", "latest_version": "1.0.0"},
+		{"id": 2, "name": "Beta Mod", "latest_version": "2.0.0"}
+	],
+	"pagination": {"total": 41}
+}`
+
+func TestAPISearch(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.String()
+		_, _ = w.Write([]byte(apiSearchResponse))
+	}))
+	defer srv.Close()
+
+	def := apiDef(srv.URL)
+	def.API.Endpoints.Search = &EndpointConfig{
+		Path:  "/mods?game={game_id}&q={query}&page={page}&limit={page_size}&skip={offset}",
+		List:  "results",
+		Total: "pagination.total",
+	}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+
+	res, err := a.Search(context.Background(), source.SearchQuery{
+		GameID: "skyrim", Query: "cool mod", Page: 2, PageSize: 10,
+	})
+	require.NoError(t, err)
+
+	// {page} = 0-based page + page_start(1) = 3; {offset} = 2*10 = 20.
+	assert.Equal(t, "/mods?game=skyrim&q=cool+mod&page=3&limit=10&skip=20", gotPath)
+	require.Len(t, res.Mods, 2)
+	assert.Equal(t, "1", res.Mods[0].ID)
+	assert.Equal(t, "Alpha Mod", res.Mods[0].Name)
+	assert.Equal(t, "my-api", res.Mods[0].SourceID)
+	assert.Equal(t, "skyrim", res.Mods[0].GameID)
+	assert.Equal(t, 41, res.TotalCount)
+	assert.Equal(t, 2, res.Page)
+	assert.Equal(t, 10, res.PageSize)
+}
+
+func TestAPISearchNoEndpoint(t *testing.T) {
+	def := apiDef("https://x.test")
+	def.API.Endpoints.Search = nil
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+
+	_, err = a.Search(context.Background(), source.SearchQuery{Query: "x"})
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+}
+
+func TestAPISearchMissingListPathFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"unexpected": {}}`))
+	}))
+	defer srv.Close()
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+	_, err = a.Search(context.Background(), source.SearchQuery{Query: "x"})
+	assert.ErrorContains(t, err, "results")
+}
+
+func TestAPISearchTotalAbsentIsZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer srv.Close()
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+	res, err := a.Search(context.Background(), source.SearchQuery{Query: "x"})
+	require.NoError(t, err)
+	assert.Zero(t, res.TotalCount)
+	assert.Empty(t, res.Mods)
+}
+```
+
+(Note `apiDef`'s `validAPIDef` search endpoint already uses `List: "results"`, `Total: "total"` — the absent-total test relies on `pagination.total`… no: `validAPIDef` sets `Total: "total"`, and the response has no `total` key, so TotalCount is 0. Correct as written.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestAPISearch -v`
+Expected: FAIL — stub returns ErrNotSupported for every case.
+
+- [ ] **Step 3: Implement (replace the Search stub)**
+
+```go
+// Search implements source.ModSource by executing the search endpoint
+// template and mapping the results (design §4). An undefined search endpoint
+// is an unsupported capability.
+func (a *API) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	ep := a.endpoints.Search
+	if ep == nil {
+		return source.SearchResult{}, fmt.Errorf("source %q: searching: %w", a.id, source.ErrNotSupported)
+	}
+
+	pageSize := query.PageSize
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	vals := map[string]string{
+		"game_id":   query.GameID,
+		"query":     query.Query,
+		"page":      strconv.Itoa(query.Page + a.pageStart),
+		"page_size": strconv.Itoa(pageSize),
+		"offset":    strconv.Itoa(query.Page * pageSize),
+	}
+
+	doc, err := a.getJSON(ctx, a.baseURL+buildEndpointURL(ep.Path, vals))
+	if err != nil {
+		return source.SearchResult{}, fmt.Errorf("searching: %w", err)
+	}
+
+	listVal, ok := lookupPath(doc, ep.List)
+	if !ok {
+		return source.SearchResult{}, fmt.Errorf("source %q: searching: response has no %q array", a.id, ep.List)
+	}
+	items, ok := listVal.([]any)
+	if !ok {
+		return source.SearchResult{}, fmt.Errorf("source %q: searching: %q is not an array", a.id, ep.List)
+	}
+
+	mods := make([]domain.Mod, 0, len(items))
+	for i, item := range items {
+		mod, err := mapMod(item, a.mappings.Mod, a.id)
+		if err != nil {
+			return source.SearchResult{}, fmt.Errorf("source %q: searching: %s[%d]: %w", a.id, ep.List, i, err)
+		}
+		mod.GameID = query.GameID
+		mods = append(mods, mod)
+	}
+
+	total := 0
+	if ep.Total != "" {
+		if v, found := lookupPath(doc, ep.Total); found {
+			total = int(coerceInt64(v))
+		}
+	}
+
+	return source.SearchResult{Mods: mods, TotalCount: total, Page: query.Page, PageSize: pageSize}, nil
+}
+```
+
+(Add `"strconv"` to api.go imports.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/api.go internal/source/custom/api_test.go
+git commit -m "feat(source): api source search with template placeholders and pagination"
+```
+
+---
+
+## Task 6: API GetMod, GetModFiles, GetDownloadURL
+
+**Files:**
+- Modify: `internal/source/custom/api.go` (replace three stubs)
+- Test: `internal/source/custom/api_test.go` (append)
+
+**Interfaces:**
+- Produces: real `GetMod` (get_mod endpoint; `{mod_id}` + `{game_id}`; response root mapped via `mapMod`; `GameID` echoed from the param), `GetModFiles` (mod_files endpoint; list path; `mapFile` per element; `{mod_id}`/`{game_id}` from the mod), `GetDownloadURL` (download_url endpoint; `{file_id}`/`{mod_id}`/`{game_id}`; `field` dot-path → string; query-mode key appended ONLY when `sameOriginURLs(downloadURL, a.baseURL)`). Missing endpoints → `ErrNotSupported`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/source/custom/api_test.go`:
+
+```go
+// newTestAPIServer wires a minimal fake REST API for the read ops.
+func newTestAPIServer(t *testing.T) (*httptest.Server, *API) {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/mods/77", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id": 77, "name": "Cool Mod", "latest_version": "1.2.0"}`))
+	})
+	mux.HandleFunc("/mods/77/files", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"files": [{"id": 900, "file_name": "cool-1.2.0.zip", "version": "1.2.0", "size_bytes": 4}]}`))
+	})
+	mux.HandleFunc("/files/900/download", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"url": "` + srv.URL + `/dl/cool-1.2.0.zip"}`))
+	})
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+	return srv, a
+}
+
+func TestAPIGetMod(t *testing.T) {
+	_, a := newTestAPIServer(t)
+
+	mod, err := a.GetMod(context.Background(), "skyrim", "77")
+	require.NoError(t, err)
+	assert.Equal(t, "77", mod.ID)
+	assert.Equal(t, "Cool Mod", mod.Name)
+	assert.Equal(t, "1.2.0", mod.Version)
+	assert.Equal(t, "skyrim", mod.GameID)
+	assert.Equal(t, "my-api", mod.SourceID)
+}
+
+func TestAPIGetModFiles(t *testing.T) {
+	_, a := newTestAPIServer(t)
+
+	files, err := a.GetModFiles(context.Background(), &domain.Mod{ID: "77", GameID: "skyrim"})
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "900", files[0].ID)
+	assert.Equal(t, "cool-1.2.0.zip", files[0].FileName)
+	assert.Equal(t, int64(4), files[0].Size)
+}
+
+func TestAPIGetDownloadURL(t *testing.T) {
+	srv, a := newTestAPIServer(t)
+
+	u, err := a.GetDownloadURL(context.Background(), &domain.Mod{ID: "77", GameID: "skyrim"}, "900")
+	require.NoError(t, err)
+	assert.Equal(t, srv.URL+"/dl/cool-1.2.0.zip", u)
+}
+
+func TestAPIGetDownloadURLQueryAuthSameOriginOnly(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	sameOrigin := srv.URL + "/dl/a.zip"
+	mux.HandleFunc("/files/1/download", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"url": "` + sameOrigin + `"}`))
+	})
+	mux.HandleFunc("/files/2/download", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"url": "https://cdn.elsewhere.test/b.zip"}`))
+	})
+
+	def := apiDef(srv.URL)
+	def.API.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+	a.SetAPIKey("sekrit")
+
+	u, err := a.GetDownloadURL(context.Background(), &domain.Mod{ID: "x"}, "1")
+	require.NoError(t, err)
+	assert.Contains(t, u, "api_key=sekrit", "same-origin download URL gets the query key")
+
+	u, err = a.GetDownloadURL(context.Background(), &domain.Mod{ID: "x"}, "2")
+	require.NoError(t, err)
+	assert.NotContains(t, u, "sekrit", "cross-origin download URL must not carry the key")
+}
+
+func TestAPIReadOpsMissingEndpoints(t *testing.T) {
+	def := apiDef("https://x.test")
+	def.API.Endpoints = APIEndpoints{GetMod: &EndpointConfig{Path: "/mods/{mod_id}"}}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+
+	_, err = a.GetModFiles(context.Background(), &domain.Mod{ID: "1"})
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+	_, err = a.GetDownloadURL(context.Background(), &domain.Mod{ID: "1"}, "f")
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run 'TestAPIGet|TestAPIReadOps' -v`
+Expected: FAIL — stubs return ErrNotSupported.
+
+- [ ] **Step 3: Implement (replace the three stubs)**
+
+```go
+// GetMod implements source.ModSource via the get_mod endpoint. gameID feeds
+// the {game_id} placeholder and is echoed onto the returned mod for
+// downstream attribution (the persisted row is normalized by the installer).
+func (a *API) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	ep := a.endpoints.GetMod
+	if ep == nil {
+		return nil, fmt.Errorf("source %q: fetching mod: %w", a.id, source.ErrNotSupported)
+	}
+
+	vals := map[string]string{"mod_id": modID, "game_id": gameID}
+	doc, err := a.getJSON(ctx, a.baseURL+buildEndpointURL(ep.Path, vals))
+	if err != nil {
+		return nil, fmt.Errorf("fetching mod %s: %w", modID, err)
+	}
+
+	mod, err := mapMod(doc, a.mappings.Mod, a.id)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: mod %s: %w", a.id, modID, err)
+	}
+	mod.GameID = gameID
+	return &mod, nil
+}
+
+// GetModFiles implements source.ModSource via the mod_files endpoint.
+func (a *API) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	ep := a.endpoints.ModFiles
+	if ep == nil {
+		return nil, fmt.Errorf("source %q: listing files: %w", a.id, source.ErrNotSupported)
+	}
+
+	vals := map[string]string{"mod_id": mod.ID, "game_id": mod.GameID}
+	doc, err := a.getJSON(ctx, a.baseURL+buildEndpointURL(ep.Path, vals))
+	if err != nil {
+		return nil, fmt.Errorf("listing files for %s: %w", mod.ID, err)
+	}
+
+	listVal, ok := lookupPath(doc, ep.List)
+	if !ok {
+		return nil, fmt.Errorf("source %q: mod %s: response has no %q array", a.id, mod.ID, ep.List)
+	}
+	items, ok := listVal.([]any)
+	if !ok {
+		return nil, fmt.Errorf("source %q: mod %s: %q is not an array", a.id, mod.ID, ep.List)
+	}
+
+	files := make([]domain.DownloadableFile, 0, len(items))
+	for i, item := range items {
+		f, err := mapFile(item, a.mappings.File)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: mod %s: %s[%d]: %w", a.id, mod.ID, ep.List, i, err)
+		}
+		files = append(files, f)
+	}
+	if len(files) == 1 {
+		files[0].IsPrimary = true // a single file is trivially the primary one
+	}
+	return files, nil
+}
+
+// GetDownloadURL implements source.ModSource via the download_url endpoint.
+// Query-mode keys are appended only for same-origin download URLs (design §9).
+func (a *API) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	ep := a.endpoints.DownloadURL
+	if ep == nil {
+		return "", fmt.Errorf("source %q: download URL: %w", a.id, source.ErrNotSupported)
+	}
+
+	vals := map[string]string{"file_id": fileID, "mod_id": mod.ID, "game_id": mod.GameID}
+	doc, err := a.getJSON(ctx, a.baseURL+buildEndpointURL(ep.Path, vals))
+	if err != nil {
+		return "", fmt.Errorf("download URL for file %s: %w", fileID, err)
+	}
+
+	v, ok := lookupPath(doc, ep.Field)
+	if !ok {
+		return "", fmt.Errorf("source %q: file %s: response has no %q field", a.id, fileID, ep.Field)
+	}
+	dlURL := coerceString(v)
+	if dlURL == "" {
+		return "", fmt.Errorf("source %q: file %s: %q is not a URL string", a.id, fileID, ep.Field)
+	}
+
+	if a.auth != nil && a.auth.APIKey.In == "query" && a.apiKey != "" && sameOriginURLs(dlURL, a.baseURL) {
+		withKey, err := addQueryParam(dlURL, a.auth.APIKey.Name, a.apiKey)
+		if err != nil {
+			return "", fmt.Errorf("source %q: file %s: %w", a.id, fileID, err)
+		}
+		dlURL = withKey
+	}
+	return dlURL, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/api.go internal/source/custom/api_test.go
+git commit -m "feat(source): api source read operations with same-origin key scoping"
+```
+
+---
+
+## Task 7: API update checks
+
+**Files:**
+- Modify: `internal/source/custom/api.go` (replace the CheckUpdates stub)
+- Test: `internal/source/custom/api_test.go` (append)
+
+**Interfaces:**
+- Produces: real `CheckUpdates` — per installed mod: ctx-cancellation check, `GetMod(ctx, inst.GameID, inst.ID)` (the Updater already passes source-mapped GameIDs), `domain.IsNewerVersion` comparison. Per-mod fetch errors are collected (`errors.Join`) and returned alongside partial results — never a silent skip. Missing get_mod endpoint → `ErrNotSupported`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/source/custom/api_test.go`:
+
+```go
+func TestAPICheckUpdates(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/mods/77", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id": 77, "name": "Cool Mod", "latest_version": "1.2.0"}`))
+	})
+	mux.HandleFunc("/mods/88", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id": 88, "name": "Fresh Mod", "latest_version": "0.9.0"}`))
+	})
+	mux.HandleFunc("/mods/99", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "gone", http.StatusInternalServerError)
+	})
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+
+	installed := []domain.InstalledMod{
+		{Mod: domain.Mod{ID: "77", SourceID: "my-api", Version: "1.0.0", GameID: "skyrim"}},
+		{Mod: domain.Mod{ID: "88", SourceID: "my-api", Version: "0.9.0", GameID: "skyrim"}},
+		{Mod: domain.Mod{ID: "99", SourceID: "my-api", Version: "1.0", GameID: "skyrim"}},
+	}
+
+	updates, err := a.CheckUpdates(context.Background(), installed)
+	require.Error(t, err, "the failing mod must surface, not vanish")
+	assert.Contains(t, err.Error(), "99")
+	require.Len(t, updates, 1, "partial results returned alongside the error")
+	assert.Equal(t, "77", updates[0].InstalledMod.ID)
+	assert.Equal(t, "1.2.0", updates[0].NewVersion)
+}
+
+func TestAPICheckUpdatesNoEndpoint(t *testing.T) {
+	def := apiDef("https://x.test")
+	def.API.Endpoints = APIEndpoints{Search: &EndpointConfig{Path: "/mods", List: "results"}}
+	a, err := NewAPI(def)
+	require.NoError(t, err)
+
+	_, err = a.CheckUpdates(context.Background(), []domain.InstalledMod{{Mod: domain.Mod{ID: "1"}}})
+	assert.True(t, errors.Is(err, source.ErrNotSupported))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestAPICheckUpdates -v`
+Expected: FAIL — stub returns ErrNotSupported for both.
+
+- [ ] **Step 3: Implement (replace the stub)**
+
+```go
+// CheckUpdates implements source.ModSource generically via get_mod + version
+// comparison (design §4). Per-mod fetch failures are collected and returned
+// alongside partial results so a single flaky mod page doesn't hide the rest
+// — and doesn't get silently skipped either.
+func (a *API) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	if a.endpoints.GetMod == nil {
+		return nil, fmt.Errorf("source %q: update checks: %w", a.id, source.ErrNotSupported)
+	}
+
+	var updates []domain.Update
+	var errs []error
+	for _, inst := range installed {
+		select {
+		case <-ctx.Done():
+			return updates, ctx.Err()
+		default:
+		}
+		current, err := a.GetMod(ctx, inst.GameID, inst.ID)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if domain.IsNewerVersion(inst.Version, current.Version) {
+			updates = append(updates, domain.Update{
+				InstalledMod: inst,
+				NewVersion:   current.Version,
+			})
+		}
+	}
+	return updates, errors.Join(errs...)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/api.go internal/source/custom/api_test.go
+git commit -m "feat(source): api source update checks via get_mod"
+```
+
+---
+
+## Task 8: Factory, cmd wiring, and `source validate --probe`
+
+**Files:**
+- Modify: `internal/source/custom/custom.go` + `custom_test.go` (factory), `cmd/lmm/source.go` (`isCustomSource`, probe flag + logic)
+- Test: `cmd/lmm/source_test.go` (append)
+
+**Interfaces:**
+- Produces: `custom.New` handles `TypeAPI` (the "not yet supported" default now only catches unknown strings, which `Validate` already rejects — keep it as defense); `isCustomSource` recognizes `*custom.API`; `lmm source validate <file> --probe [--id <mod-id>]` — after static validation, constructs the source and performs a live smoke test:
+  - directory → scan via `Search(ctx, {})`, report mod count
+  - manifest → `Search(ctx, {})` (fetch+parse), report mod count
+  - api → `Search(ctx, {PageSize: 1})` when the search endpoint exists; else `GetMod(ctx, "", <--id>)` when `--id` given; else a clear error saying this definition needs `--id` for probing
+  - probe resolves the API key like startup does: `LMM_<ID>_API_KEY` env var, then the token store (probe runs inside `withService`)
+  - probe failure → non-zero exit with the operation's error (which names the source and URL)
+
+- [ ] **Step 1: Write the failing tests**
+
+`internal/source/custom/custom_test.go` — move `TypeAPI` out of the unimplemented loop:
+
+```go
+	t.Run("api type constructs a source", func(t *testing.T) {
+		def := validAPIDef()
+		src, err := New(def)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-api", src.ID())
+	})
+
+	t.Run("unknown type is rejected", func(t *testing.T) {
+		def := SourceDefinition{ID: "x", Name: "X", Type: "ftp"}
+		_, err := New(def)
+		assert.ErrorContains(t, err, "not yet supported")
+	})
+```
+
+`cmd/lmm/source_test.go` — append (reuse the file's existing `run` helper pattern from `TestSourceValidateCmd`; read it first):
+
+```go
+func TestSourceValidateProbe(t *testing.T) {
+	t.Run("probe directory source reports mod count", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "SomeMod"), 0755))
+		path := filepath.Join(t.TempDir(), "dir.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+id: probe-dir
+name: Probe Dir
+type: directory
+directory:
+  path: `+root+`
+`), 0644))
+
+		out, err := runSourceCmd(t, "source", "validate", path, "--probe")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "probe: ok")
+		assert.Contains(t, out, "1 mod(s)")
+	})
+
+	t.Run("probe api without search requires --id", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "api.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+id: probe-api
+name: Probe API
+type: api
+api:
+  base_url: https://api.x.test
+  endpoints:
+    get_mod:
+      path: /mods/{mod_id}
+  mappings:
+    mod:
+      id: id
+      name: name
+`), 0644))
+
+		_, err := runSourceCmd(t, "source", "validate", path, "--probe")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--id")
+	})
+
+	t.Run("probe failure exits non-zero", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bad.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+id: probe-bad
+name: Probe Bad
+type: manifest
+manifest:
+  url: `+filepath.Join(t.TempDir(), "missing.yaml")+`
+`), 0644))
+
+		_, err := runSourceCmd(t, "source", "validate", path, "--probe")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "probe-bad")
+	})
+}
+```
+
+Adaptation note: `runSourceCmd` is whatever helper shape the existing `TestSourceValidateCmd` uses to execute the command tree with args and capture output — reuse/extend it rather than duplicating; if the existing helper doesn't reset the `--probe` flag between runs, reset it explicitly (package-level cobra flags persist across tests). The probe path runs `withService` — the existing cmd tests already run against a real temp-config service via the global flag setup; mirror how other service-backed cmd tests arrange that (check `list_test.go`); if arranging a service in this test file is disproportionate, mark the directory-probe subtest to configure `cfgFile`/data dirs the way those tests do.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/source/custom/ -run TestNew -v; go test ./cmd/lmm/ -run TestSourceValidateProbe -v`
+Expected: FAIL — api case errors "not yet supported"; `unknown flag: --probe`.
+
+- [ ] **Step 3: Implement**
+
+`internal/source/custom/custom.go`:
+
+```go
+func New(def SourceDefinition) (source.ModSource, error) {
+	switch def.Type {
+	case TypeDirectory:
+		return NewDirectory(def)
+	case TypeManifest:
+		return NewManifest(def)
+	case TypeAPI:
+		return NewAPI(def)
+	default:
+		return nil, fmt.Errorf("source type %q is not yet supported", def.Type)
+	}
+}
+```
+
+`cmd/lmm/source.go`:
+1. `isCustomSource`: add `*custom.API` to the type switch.
+2. Add flags + probe logic to `sourceValidateCmd`:
+
+```go
+var (
+	sourceProbe   bool
+	sourceProbeID string
+)
+
+var sourceValidateCmd = &cobra.Command{
+	Use:   "validate <file>",
+	Short: "Validate a source definition file",
+	Long:  "Parse and validate a user-defined source definition YAML file, reporting any problems. With --probe, also perform a live smoke test (directory scan, manifest fetch+parse, or an API call).",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		def, err := config.LoadSourceDefinitionFile(args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s: valid (%s source %q)\n", args[0], def.Type, def.ID)
+		if !sourceProbe {
+			return nil
+		}
+		return withService(cmd, func(ctx context.Context, svc *core.Service) error {
+			return probeSource(ctx, cmd, svc, def)
+		})
+	},
+}
+
+// probeSource constructs the definition's source and performs one live
+// operation against it, so users can smoke-test a definition before relying
+// on it (design §8).
+func probeSource(ctx context.Context, cmd *cobra.Command, svc *core.Service, def custom.SourceDefinition) error {
+	src, err := custom.New(def)
+	if err != nil {
+		return fmt.Errorf("probe: constructing source: %w", err)
+	}
+	if a, ok := src.(interface{ SetAPIKey(string) }); ok {
+		if key := getSourceAPIKey(svc, def.ID, envKeyForSourceID(def.ID)); key != "" {
+			a.SetAPIKey(key)
+		}
+	}
+
+	switch def.Type {
+	case custom.TypeDirectory, custom.TypeManifest:
+		res, err := src.Search(ctx, source.SearchQuery{PageSize: 1})
+		if err != nil {
+			return fmt.Errorf("probe: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "probe: ok — %d mod(s) visible\n", res.TotalCount)
+	case custom.TypeAPI:
+		if def.API.Endpoints.Search != nil {
+			res, err := src.Search(ctx, source.SearchQuery{PageSize: 1})
+			if err != nil {
+				return fmt.Errorf("probe: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "probe: ok — search responded (%d total reported)\n", res.TotalCount)
+			return nil
+		}
+		if sourceProbeID == "" {
+			return fmt.Errorf("probe: this definition has no search endpoint; provide a known mod id with --id to probe get_mod")
+		}
+		mod, err := src.GetMod(ctx, "", sourceProbeID)
+		if err != nil {
+			return fmt.Errorf("probe: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "probe: ok — get_mod %s returned %q\n", sourceProbeID, mod.Name)
+	}
+	return nil
+}
+```
+
+3. In `init()`: `sourceValidateCmd.Flags().BoolVar(&sourceProbe, "probe", false, "perform a live smoke test after validation")` and `sourceValidateCmd.Flags().StringVar(&sourceProbeID, "id", "", "mod id to probe with (api definitions without a search endpoint)")`.
+4. Note the directory/manifest probe reports `res.TotalCount` — for the directory source, an empty query matches all mods, so TotalCount is the scan size even with PageSize 1. Check imports: `custom`, `source`, `core`, `context` (some already present).
+
+- [ ] **Step 4: Run tests and full build**
+
+Run: `go test ./internal/source/custom/ ./cmd/lmm/ -v && go build ./... && go test ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/custom.go internal/source/custom/custom_test.go cmd/lmm/source.go cmd/lmm/source_test.go
+git commit -m "feat(cli): construct api sources and add 'source validate --probe'"
+```
+
+---
+
+## Task 9: End-to-end test — fake REST API as a full source
+
+**Files:**
+- Test: `internal/core/service_api_source_test.go` (create)
+
+Pins #49's acceptance criteria: (1) an install-by-ID-only definition works with search cleanly unsupported; (2) the auth key is attached per the definition and never logged.
+
+- [ ] **Step 1: Write the test**
+
+Create `internal/core/service_api_source_test.go` (`package core_test`, mirroring `service_manifest_source_test.go`'s construction — read it first):
+
+```go
+package core_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFakeRESTServer serves a minimal authenticated mod API plus the payload.
+func newFakeRESTServer(t *testing.T, requireKey bool) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	auth := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if requireKey && r.Header.Get("X-API-Key") != "e2e-key" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			h(w, r)
+		}
+	}
+
+	mux.HandleFunc("/mods", auth(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"results": [{"id": 77, "name": "Cool Mod", "latest_version": "1.2.0"}], "total": 1}`)
+	}))
+	mux.HandleFunc("/mods/77", auth(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"id": 77, "name": "Cool Mod", "latest_version": "1.2.0"}`)
+	}))
+	mux.HandleFunc("/mods/77/files", auth(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"files": [{"id": 900, "file_name": "cool-1.2.0.zip", "version": "1.2.0", "size_bytes": 11}]}`)
+	}))
+	mux.HandleFunc("/files/900/download", auth(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"url": %q}`, srv.URL+"/dl/cool-1.2.0.zip")
+	}))
+	mux.HandleFunc("/dl/cool-1.2.0.zip", auth(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("mod payload"))
+	}))
+
+	return srv
+}
+
+func apiSourceDef(baseURL string, withSearch bool) custom.SourceDefinition {
+	endpoints := custom.APIEndpoints{
+		GetMod:      &custom.EndpointConfig{Path: "/mods/{mod_id}"},
+		ModFiles:    &custom.EndpointConfig{Path: "/mods/{mod_id}/files", List: "files"},
+		DownloadURL: &custom.EndpointConfig{Path: "/files/{file_id}/download", Field: "url"},
+	}
+	if withSearch {
+		endpoints.Search = &custom.EndpointConfig{Path: "/mods?q={query}&page={page}", List: "results", Total: "total"}
+	}
+	return custom.SourceDefinition{
+		ID: "e2e-api", Name: "E2E API", Type: custom.TypeAPI, AllowHTTP: true,
+		API: &custom.APIConfig{
+			BaseURL:   baseURL,
+			Auth:      &custom.AuthConfig{APIKey: &custom.APIKeyConfig{In: "header", Name: "X-API-Key"}},
+			Endpoints: endpoints,
+			Mappings: custom.APIMappings{
+				Mod:  map[string]string{"id": "id", "name": "name", "version": "latest_version"},
+				File: map[string]string{"id": "id", "filename": "file_name", "version": "version", "size": "size_bytes"},
+			},
+		},
+	}
+}
+
+func TestAPISourceEndToEnd(t *testing.T) {
+	srv := newFakeRESTServer(t, true)
+
+	src, err := custom.New(apiSourceDef(srv.URL, true))
+	require.NoError(t, err)
+	src.(interface{ SetAPIKey(string) }).SetAPIKey("e2e-key")
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(src)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), DeployMode: domain.DeployCopy}
+	require.NoError(t, svc.AddGame(game))
+	ctx := context.Background()
+
+	res, err := src.Search(ctx, source.SearchQuery{Query: "cool", GameID: "testgame", PageSize: 20})
+	require.NoError(t, err)
+	require.Len(t, res.Mods, 1)
+	mod := res.Mods[0]
+	assert.Equal(t, "e2e-api", mod.SourceID)
+	assert.Equal(t, "testgame", mod.GameID)
+
+	files, err := src.GetModFiles(ctx, &mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	result, err := svc.DownloadMod(ctx, "e2e-api", game, &mod, &files[0], nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesExtracted)
+	gameCache := svc.GetGameCache(game)
+	assert.True(t, gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version))
+
+	installed := []domain.InstalledMod{{Mod: domain.Mod{ID: "77", SourceID: "e2e-api", Version: "1.0.0", GameID: "testgame"}}}
+	updates, err := src.CheckUpdates(ctx, installed)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "1.2.0", updates[0].NewVersion)
+}
+
+// TestAPISourceInstallByIDOnly pins #49 acceptance criterion 1: a definition
+// with no search endpoint works for install-by-ID, and search reports
+// unsupported cleanly.
+func TestAPISourceInstallByIDOnly(t *testing.T) {
+	srv := newFakeRESTServer(t, false)
+
+	src, err := custom.New(apiSourceDef(srv.URL, false))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = src.Search(ctx, source.SearchQuery{Query: "cool"})
+	assert.True(t, errors.Is(err, source.ErrNotSupported), "search must be a clean capability gap")
+	assert.False(t, source.CapabilitiesOf(src).Search)
+
+	mod, err := src.GetMod(ctx, "testgame", "77")
+	require.NoError(t, err)
+	files, err := src.GetModFiles(ctx, mod)
+	require.NoError(t, err)
+	u, err := src.GetDownloadURL(ctx, mod, files[0].ID)
+	require.NoError(t, err)
+	assert.Contains(t, u, "/dl/cool-1.2.0.zip")
+}
+
+// TestAPISourceKeyNeverInErrors pins #49 acceptance criterion 2's "never
+// logged" half for the error path.
+func TestAPISourceKeyNeverInErrors(t *testing.T) {
+	def := apiSourceDef("http://127.0.0.1:1", true)
+	def.API.Auth = &custom.AuthConfig{APIKey: &custom.APIKeyConfig{In: "query", Name: "api_key"}}
+	src, err := custom.New(def)
+	require.NoError(t, err)
+	src.(interface{ SetAPIKey(string) }).SetAPIKey("SUPERSECRET")
+
+	_, err = src.Search(context.Background(), source.SearchQuery{Query: "x"})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "SUPERSECRET")
+}
+```
+
+- [ ] **Step 2: Run the tests and the full suite**
+
+Run: `go test ./internal/core/ -run TestAPISource -v && go test ./...`
+Expected: PASS everywhere.
+
+- [ ] **Step 3: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/core/service_api_source_test.go
+git commit -m "test(core): api source end-to-end coverage"
+```
+
+---
+
+## Task 10: Documentation and version bump
+
+**Files:**
+- Modify: `README.md`, `CHANGELOG.md`, `cmd/lmm/root.go` (version)
+
+ACCURACY RULE (two docs tasks in this epic were rejected for unbacked claims): verify every sentence against the code on this branch before writing it.
+
+- [ ] **Step 1: Update docs**
+
+`README.md` — Custom Sources section:
+- New "API Sources" subsection: the definition YAML (design §4's example, adjusted to the shipped schema), a placeholders table (`{game_id}`, `{query}`, `{page}` with the page_start rule, `{page_size}`, `{offset}` with its independence from page_start, `{mod_id}`, `{file_id}` — all URL-escaped), mapping-keys tables for `mod` and `file` (required keys marked: mod id+name, file id), the capability-gap rule (undefined endpoint = unsupported operation; `GetDependencies` always unsupported), GET+JSON-only and https/`allow_http` guardrails, and the credential-scoping note (same-origin scheme+host vs `base_url` for both auth modes; header keys also stripped on off-origin download redirects — this reuses the v1.8.0 machinery).
+- Update the Common Fields `type` row: all three types supported.
+- `source validate` docs: add `--probe` (and `--id` for search-less api definitions) with a real captured output example (build the binary; probe a temp directory definition).
+
+`CHANGELOG.md` — under `[Unreleased]` → `### Added`:
+
+```markdown
+- API source type: describe a GET+JSON REST API declaratively (endpoint templates + dot-path mappings) and use it as a mod source — search, install (including install-by-ID-only definitions), and update checks
+- `lmm source validate --probe` — live smoke test for a definition (directory scan, manifest fetch, or API call; `--id` probes get_mod for search-less API definitions)
+```
+
+Then move `[Unreleased]` to `## [1.9.0] - <today>`, update comparison links per convention, and set `version = "1.9.0"` in cmd/lmm/root.go.
+
+- [ ] **Step 2: Final verification and commits**
+
+```bash
+go fmt ./... && go vet ./... && go test ./... -race
+git add README.md CHANGELOG.md
+git commit -m "docs: document api sources and source validate --probe"
+git add cmd/lmm/root.go CHANGELOG.md
+git commit -m "chore: bump version to 1.9.0"
+```
+
+---
+
+## Out of Scope
+
+- **Phase 5** (#50): aggregate search, TUI Sources screen
+- POST/GraphQL/OAuth/scraping APIs; array indexing in dot-paths; per-endpoint rate limiting (design §4's v1 guardrails)
+- #52 directory-source polish

--- a/docs/plans/archive/2026-07-15-issue-54-hardening-impl.md
+++ b/docs/plans/archive/2026-07-15-issue-54-hardening-impl.md
@@ -1,0 +1,868 @@
+# Issue #54 Hardening (Manifest Sources + Auth) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close every checkbox in issue #54 — the Phase 5 concurrency prerequisite (manifest fetch mutex/timeout/defensive copy), the pre-existing NexusMods update-domain bug, the same-origin download-key guard, auth CLI polish (status for custom sources, logout for unregistered sources, test pin cleanup), and single-pass download hashing.
+
+**Architecture:** The manifest fetcher stops holding its mutex across the network (lock only guards cache state; duplicate concurrent fetches are acceptable), gains a timeout-bounded dedicated HTTP client, and returns deep copies of the cached document. `Updater.CheckUpdates` gains the game so it can translate installed mods' GameIDs to source-mapped values before calling each source. `DownloadHeaderProvider` becomes URL-aware so manifest sources attach header keys only to same-origin file downloads. The downloader computes SHA-256 alongside MD5 in its existing single streaming pass, letting the service drop its second file read.
+
+**Tech Stack:** Go stdlib only (net/http, net/url, crypto/sha256, sync). No new dependencies.
+
+**Spec:** GitHub issue #54 (checkboxes are the requirements). Design context: docs/plans/2026-07-13-custom-sources-design.md §6/§9.
+
+## Global Constraints
+
+- TDD: every task starts with a failing test.
+- Error wrapping with context: `fmt.Errorf("doing X: %w", err)` (GO.md).
+- `ctx context.Context` first param for I/O paths; no ctx in structs (GO.md).
+- No new dependencies (`golang.org/x/sync` is NOT allowed — hand-roll or accept duplicate fetches).
+- `go fmt ./...` and `go vet ./...` clean before every commit.
+- API keys never appear in logs or error text (preserved invariant from Phase 3).
+- Existing error-message contracts that tests pin must keep working — notably `"sha256 mismatch: source declares %s, downloaded file is %s"`.
+- Commit after each task; conventional commit messages.
+
+---
+
+## Task 1: Manifest fetch — timeout, lock-free network, defensive copy
+
+**Files:**
+- Modify: `internal/source/custom/manifest.go`
+- Test: `internal/source/custom/manifest_test.go` (append)
+
+**Interfaces:**
+- Consumes: existing `Manifest` struct fields (`mu`, `cached`, `fetchedAt`, `httpClient`, `now`), `fetchRemote`.
+- Produces: `fetch(ctx)` returns a **deep copy** of the document (callers may mutate freely); `NewManifest` builds a dedicated `&http.Client{Timeout: manifestFetchTimeout}`; the mutex is never held across a network call. `deepCopyManifest(doc *manifestDoc) *manifestDoc` (unexported helper).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/source/custom/manifest_test.go`:
+
+```go
+func TestManifestFetchReturnsDefensiveCopy(t *testing.T) {
+	m := newLocalManifest(t)
+	ctx := context.Background()
+
+	first, err := m.fetch(ctx)
+	require.NoError(t, err)
+	// Mutate everything a caller could plausibly touch.
+	first.Mods[0].Name = "MUTATED"
+	first.Mods[0].GameIDs[0] = "MUTATED"
+	first.Mods[0].Files[0].URL = "MUTATED"
+	first.Mods = nil
+
+	second, err := m.fetch(ctx)
+	require.NoError(t, err)
+	require.Len(t, second.Mods, 2)
+	assert.Equal(t, "Cool Mod", second.Mods[0].Name)
+	assert.Equal(t, "skyrim", second.Mods[0].GameIDs[0])
+	assert.NotEqual(t, "MUTATED", second.Mods[0].Files[0].URL)
+}
+
+func TestManifestFetchConcurrent(t *testing.T) {
+	// Race-detector safety net: concurrent fetches (cache hits and misses)
+	// must be data-race free. Run with -race in CI/the suite.
+	hits := 0
+	var srvMu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srvMu.Lock()
+		hits++
+		srvMu.Unlock()
+		_, _ = w.Write([]byte(testManifest))
+	}))
+	defer srv.Close()
+
+	def := manifestDef(srv.URL + "/mods.yaml")
+	def.AllowHTTP = true
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, ferr := m.fetch(context.Background())
+			assert.NoError(t, ferr)
+		}()
+	}
+	wg.Wait()
+	srvMu.Lock()
+	defer srvMu.Unlock()
+	assert.GreaterOrEqual(t, hits, 1)
+}
+
+func TestManifestFetchDoesNotBlockOnHungServer(t *testing.T) {
+	// A hung server must be bounded by the client timeout, not hang forever.
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // hang until test cleanup
+	}))
+	defer func() { close(release); srv.Close() }()
+
+	def := manifestDef(srv.URL + "/mods.yaml")
+	def.AllowHTTP = true
+	m, err := NewManifest(def)
+	require.NoError(t, err)
+	m.httpClient = &http.Client{Timeout: 200 * time.Millisecond}
+
+	start := time.Now()
+	_, err = m.fetch(context.Background())
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second)
+	assert.NotContains(t, err.Error(), "api_key")
+}
+
+func TestNewManifestClientHasTimeout(t *testing.T) {
+	m, err := NewManifest(manifestDef("https://x.test/mods.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, m.httpClient)
+	assert.Equal(t, manifestFetchTimeout, m.httpClient.Timeout)
+}
+```
+
+Add `"sync"` to the test file's imports (`time`, `net/http`, `httptest` already present).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/source/custom/ -run 'TestManifestFetchReturnsDefensiveCopy|TestManifestFetchConcurrent|TestManifestFetchDoesNotBlockOnHungServer|TestNewManifestClientHasTimeout' -race -v`
+Expected: FAIL — `undefined: manifestFetchTimeout`; the defensive-copy test fails (mutations visible on refetch); the hung-server test hangs briefly then fails on `http.DefaultClient` having no timeout (it will actually hang until test timeout — that IS the failure).
+
+- [ ] **Step 3: Implement**
+
+In `internal/source/custom/manifest.go`:
+
+1. Add the timeout constant next to the existing constants:
+
+```go
+// manifestFetchTimeout bounds a remote manifest fetch. Without it a hung
+// server would block the fetching goroutine indefinitely (and, before the
+// lock rework, every other operation on this source).
+const manifestFetchTimeout = 30 * time.Second
+```
+
+2. In `NewManifest`, replace `httpClient: http.DefaultClient,` with:
+
+```go
+		httpClient: &http.Client{Timeout: manifestFetchTimeout},
+```
+
+3. Replace the remote branch of `fetch` so the lock never spans the network. Current shape (lock → TTL check → fetchRemote → store → unlock) becomes:
+
+```go
+	m.mu.Lock()
+	if m.cached != nil && m.now().Sub(m.fetchedAt) < m.refresh {
+		doc := m.cached
+		m.mu.Unlock()
+		return deepCopyManifest(doc), nil
+	}
+	m.mu.Unlock()
+
+	// Network I/O happens outside the lock. Two goroutines racing past the
+	// TTL check may both fetch — an acceptable, idempotent duplication that
+	// keeps a slow server from blocking readers of the cached copy.
+	doc, err := m.fetchRemote(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	m.cached = doc
+	m.fetchedAt = m.now()
+	m.mu.Unlock()
+	return deepCopyManifest(doc), nil
+```
+
+Also make the local branch return a copy for symmetry — it re-reads the file each time, so it already returns a fresh doc; leave it as-is but add a comment noting parse output is caller-owned. Remove the now-stale doc comment sentence about the lock covering fetchRemote (update the `fetch` doc comment to describe the new semantics).
+
+4. Add the deep copy helper (manifestDoc contains only value types, strings, and slices — copy every slice):
+
+```go
+// deepCopyManifest returns a copy of doc that shares no mutable memory with
+// the cached original, so callers can never corrupt the cache between TTL
+// refreshes.
+func deepCopyManifest(doc *manifestDoc) *manifestDoc {
+	out := &manifestDoc{Version: doc.Version, Mods: make([]manifestMod, len(doc.Mods))}
+	for i, m := range doc.Mods {
+		cm := m // struct copy; now fix up slice fields
+		cm.GameIDs = append([]string(nil), m.GameIDs...)
+		cm.Dependencies = append([]string(nil), m.Dependencies...)
+		cm.Files = append([]manifestFile(nil), m.Files...)
+		out.Mods[i] = cm
+	}
+	return out
+}
+```
+
+Note: `findMod` (used by GetMod/GetModFiles/GetDownloadURL/GetDependencies) calls `fetch` and takes `&doc.Mods[i]` of the returned copy — with copies this is now always safe by construction; no change needed there.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/source/custom/ -race -v`
+Expected: PASS (new tests + entire existing manifest suite under -race).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/custom/manifest.go internal/source/custom/manifest_test.go
+git commit -m "fix(source): bound manifest fetches with a timeout and stop locking across the network"
+```
+
+---
+
+## Task 2: Updater translates installed GameIDs to source-mapped values
+
+**Files:**
+- Modify: `internal/core/updater.go` (`CheckUpdates` signature + translation), `cmd/lmm/update.go:140` and `cmd/lmm/update.go:285` (call sites)
+- Test: `internal/core/updater_test.go` (append; read the file first for its mock conventions)
+
+**Interfaces:**
+- Consumes: `domain.Game.SourceIDs map[string]string`.
+- Produces: `(u *Updater) CheckUpdates(ctx context.Context, game *domain.Game, installed []domain.InstalledMod) ([]domain.Update, error)` — before calling each source, mods in that source's group get `GameID` set to `game.SourceIDs[sourceID]` when that mapping is non-empty (copies only; caller slices untouched). `game == nil` skips translation (defensive; both real call sites pass a game).
+
+Background: installed rows persist the lmm `game.ID` (the Phase 3 fix). NexusMods' `CheckUpdates` uses `inst.GameID` as its API game domain, so a game whose mapping differs (e.g. lmm id `skyrim-se`, nexus domain `skyrimspecialedition`) needs translation at the boundary — exactly mirroring what `Service.SearchMods`/`GetMod` do on the query side.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/core/updater_test.go` (adapt the mock to the file's existing mock-source pattern — read it first; the assertions stay):
+
+```go
+// gameIDCapturingSource records the GameIDs it receives in CheckUpdates.
+type gameIDCapturingSource struct {
+	source.ModSource // embed an existing test mock for the other methods
+	id       string
+	received []string
+}
+
+func (g *gameIDCapturingSource) ID() string { return g.id }
+func (g *gameIDCapturingSource) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	for _, inst := range installed {
+		g.received = append(g.received, inst.GameID)
+	}
+	return nil, nil
+}
+
+func TestCheckUpdatesTranslatesGameIDPerSourceMapping(t *testing.T) {
+	reg := source.NewRegistry()
+	mapped := &gameIDCapturingSource{id: "nexusmods"}
+	unmapped := &gameIDCapturingSource{id: "my-repo"}
+	reg.Register(mapped)
+	reg.Register(unmapped)
+	u := NewUpdater(reg)
+
+	game := &domain.Game{
+		ID: "skyrim-se",
+		SourceIDs: map[string]string{
+			"nexusmods": "skyrimspecialedition",
+			"my-repo":   "", // empty mapping: keep the lmm game id
+		},
+	}
+	installed := []domain.InstalledMod{
+		{Mod: domain.Mod{ID: "a", SourceID: "nexusmods", GameID: "skyrim-se", Version: "1.0"}},
+		{Mod: domain.Mod{ID: "b", SourceID: "my-repo", GameID: "skyrim-se", Version: "1.0"}},
+	}
+
+	_, err := u.CheckUpdates(context.Background(), game, installed)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"skyrimspecialedition"}, mapped.received)
+	assert.Equal(t, []string{"skyrim-se"}, unmapped.received)
+	// Caller's slice must be untouched.
+	assert.Equal(t, "skyrim-se", installed[0].GameID)
+}
+```
+
+Notes for the implementer: check how existing updater tests construct mocks (there is likely a `mockSource` implementing `source.ModSource` — embed or copy its pattern rather than embedding the interface if that reads better in context). If `source.NewRegistry()`/`Register` have different names, match reality.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/core/ -run TestCheckUpdatesTranslatesGameID -v`
+Expected: FAIL — compile error (`CheckUpdates` takes 2 args today).
+
+- [ ] **Step 3: Implement**
+
+In `internal/core/updater.go`, change the signature and add translation inside the per-source loop, right before `src.CheckUpdates(ctx, mods)`:
+
+```go
+// CheckUpdates checks for available updates for installed mods. game supplies
+// the source-ID mapping: installed rows persist the lmm game ID, but sources
+// like NexusMods address games by their own domain, so each source's batch is
+// translated via game.SourceIDs before the call (empty mapping = keep the lmm
+// id, matching the search-side semantics in Service.SearchMods/GetMod).
+func (u *Updater) CheckUpdates(ctx context.Context, game *domain.Game, installed []domain.InstalledMod) ([]domain.Update, error) {
+```
+
+Inside the loop, before `src.CheckUpdates(ctx, mods)`:
+
+```go
+		if game != nil {
+			if mappedID, ok := game.SourceIDs[sourceID]; ok && mappedID != "" {
+				translated := make([]domain.InstalledMod, len(mods))
+				copy(translated, mods)
+				for i := range translated {
+					translated[i].GameID = mappedID
+				}
+				mods = translated
+			}
+		}
+```
+
+Update both call sites in `cmd/lmm/update.go` (`game` is already in scope at both):
+
+```go
+	updates, err := updater.CheckUpdates(ctx, game, installed)
+```
+
+and
+
+```go
+	updates, err := updater.CheckUpdates(ctx, game, []domain.InstalledMod{*mod})
+```
+
+Fix any other compile-breaking callers found by `go build ./...` (tests included — update existing updater tests to pass a game or nil, preserving their assertions).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ ./cmd/lmm/ -v && go build ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/core/updater.go internal/core/updater_test.go cmd/lmm/update.go
+git commit -m "fix(core): translate installed GameIDs to source-mapped values in update checks"
+```
+
+---
+
+## Task 3: Same-origin guard for header-mode download keys
+
+**Files:**
+- Modify: `internal/source/source.go` (`DownloadHeaderProvider`), `internal/source/custom/manifest.go` (`DownloadHeaders`), `internal/core/service.go` (call site)
+- Test: `internal/source/custom/manifest_test.go` (modify `TestManifestDownloadHeaders`)
+
+**Interfaces:**
+- Produces: `DownloadHeaderProvider` becomes `DownloadHeaders(fileURL string) map[string]string`. Manifest semantics: header-mode auth with a key attaches ONLY when the file URL's host equals the manifest URL's host (remote manifests); local-path manifests are user-authored and trusted — headers attach to any host. Query-mode/no-key behavior unchanged (nil).
+
+- [ ] **Step 1: Update the tests (failing first)**
+
+Replace `TestManifestDownloadHeaders` in `internal/source/custom/manifest_test.go`:
+
+```go
+func TestManifestDownloadHeaders(t *testing.T) {
+	headerAuth := &AuthConfig{APIKey: &APIKeyConfig{In: "header", Name: "X-API-Key"}}
+
+	t.Run("remote manifest: same-origin file URL gets the key", func(t *testing.T) {
+		def := manifestDef("https://repo.test/mods.yaml")
+		def.Manifest.Auth = headerAuth
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, m.DownloadHeaders("https://repo.test/files/a.zip"))
+	})
+
+	t.Run("remote manifest: cross-origin file URL gets nothing", func(t *testing.T) {
+		def := manifestDef("https://repo.test/mods.yaml")
+		def.Manifest.Auth = headerAuth
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Nil(t, m.DownloadHeaders("https://cdn.example.com/files/a.zip"),
+			"the repo's API key must not be shipped to third-party hosts")
+	})
+
+	t.Run("local manifest: any host gets the key (user-authored, trusted)", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "mods.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(testManifest), 0644))
+		def := manifestDef(path)
+		def.Manifest.Auth = headerAuth
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Equal(t, map[string]string{"X-API-Key": "sekrit"}, m.DownloadHeaders("https://anywhere.test/a.zip"))
+	})
+
+	t.Run("query auth or no key yields nil", func(t *testing.T) {
+		def := manifestDef("https://repo.test/mods.yaml")
+		def.Manifest.Auth = &AuthConfig{APIKey: &APIKeyConfig{In: "query", Name: "api_key"}}
+		m, err := NewManifest(def)
+		require.NoError(t, err)
+		m.SetAPIKey("sekrit")
+		assert.Nil(t, m.DownloadHeaders("https://repo.test/a.zip"))
+
+		noKey, err := NewManifest(manifestDef("https://repo.test/mods.yaml"))
+		require.NoError(t, err)
+		assert.Nil(t, noKey.DownloadHeaders("https://repo.test/a.zip"))
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestManifestDownloadHeaders -v`
+Expected: FAIL — compile error (DownloadHeaders takes no argument today).
+
+- [ ] **Step 3: Implement**
+
+`internal/source/source.go` — update the interface and doc:
+
+```go
+// DownloadHeaderProvider is implemented by sources whose file downloads need
+// extra HTTP headers (e.g. header-mode API-key auth on a manifest source).
+// Service.DownloadModToCache consults it with the resolved download URL so
+// the source can scope credentials (e.g. same-origin only). A nil map means
+// no extra headers.
+type DownloadHeaderProvider interface {
+	DownloadHeaders(fileURL string) map[string]string
+}
+```
+
+`internal/source/custom/manifest.go` — replace `DownloadHeaders`:
+
+```go
+// DownloadHeaders implements source.DownloadHeaderProvider. Header-mode auth
+// applies the same key to file downloads as to manifest fetches (design §6),
+// but for remote manifests only when the file URL is same-origin with the
+// manifest — a manifest pointing files at a third-party CDN must not ship the
+// repo's key there. Local-path manifests are user-authored and trusted, so
+// their configured key attaches regardless of host.
+func (m *Manifest) DownloadHeaders(fileURL string) map[string]string {
+	if m.auth == nil || m.auth.APIKey.In != "header" || m.apiKey == "" {
+		return nil
+	}
+	if m.isRemote {
+		fu, err := url.Parse(fileURL)
+		if err != nil {
+			return nil
+		}
+		mu, err := url.Parse(m.url)
+		if err != nil {
+			return nil
+		}
+		if fu.Host != mu.Host {
+			return nil
+		}
+	}
+	return map[string]string{m.auth.APIKey.Name: m.apiKey}
+}
+```
+
+`internal/core/service.go` — the call site in `DownloadModToCache` passes the resolved URL:
+
+```go
+	if hp, ok := src.(source.DownloadHeaderProvider); ok {
+		headers = hp.DownloadHeaders(url)
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/source/custom/ ./internal/core/ -v && go build ./...`
+Expected: PASS (the Task-8-era e2e/auth tests still pass — their file URLs are same-origin with their httptest manifests; verify, and if any e2e used a second host, adapt per the new semantics with a comment).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/source/source.go internal/source/custom/manifest.go internal/source/custom/manifest_test.go internal/core/service.go
+git commit -m "fix(security): scope header-mode download keys to same-origin file URLs"
+```
+
+---
+
+## Task 4: Single-pass download hashing
+
+**Files:**
+- Modify: `internal/core/downloader.go` (`DownloadResult`, `downloadOnce`), `internal/core/service.go` (verification uses the result; delete `verifyFileSHA256`)
+- Test: `internal/core/downloader_test.go` (append), `internal/core/service_sha256_test.go` (unchanged — it pins the behavior contract)
+
+**Interfaces:**
+- Produces: `DownloadResult.SHA256 string` (hex, lowercase) computed in the same streaming pass as the existing MD5 `Checksum`. `DownloadModToCache` compares `file.SHA256` against `downloadResult.SHA256` with `strings.EqualFold` and keeps the exact error text `sha256 mismatch: source declares %s, downloaded file is %s`. `verifyFileSHA256` is deleted (no remaining callers).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/core/downloader_test.go`:
+
+```go
+func TestDownloadComputesSHA256(t *testing.T) {
+	content := []byte("payload for hashing")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer srv.Close()
+
+	d := NewDownloader(nil)
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	result, err := d.Download(context.Background(), srv.URL, dest, nil)
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(content)
+	assert.Equal(t, hex.EncodeToString(sum[:]), result.SHA256)
+	assert.NotEmpty(t, result.Checksum) // MD5 still present
+}
+```
+
+Add `"crypto/sha256"` and `"encoding/hex"` to the test imports if absent.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/core/ -run TestDownloadComputesSHA256 -v`
+Expected: FAIL — `result.SHA256 undefined`.
+
+- [ ] **Step 3: Implement**
+
+`internal/core/downloader.go`:
+
+1. Extend the result type:
+
+```go
+// DownloadResult contains the outcome of a download
+type DownloadResult struct {
+	Path     string // Final file path
+	Size     int64  // Bytes downloaded
+	Checksum string // MD5 hash of downloaded file (recorded in the DB)
+	SHA256   string // SHA-256 of downloaded file (compared against source-declared checksums)
+}
+```
+
+2. In `downloadOnce`, hash both digests in the one existing pass (add `"crypto/sha256"` import):
+
+```go
+	md5Hasher := md5.New()
+	shaHasher := sha256.New()
+	reader := &progressReader{
+		reader:     resp.Body,
+		totalBytes: totalBytes,
+		progressFn: progressFn,
+	}
+	teeReader := io.TeeReader(reader, io.MultiWriter(md5Hasher, shaHasher))
+```
+
+and in the return:
+
+```go
+	return &DownloadResult{
+		Path:     destPath,
+		Size:     written,
+		Checksum: hex.EncodeToString(md5Hasher.Sum(nil)),
+		SHA256:   hex.EncodeToString(shaHasher.Sum(nil)),
+	}, nil
+```
+
+(Rename the existing `hasher` variable to `md5Hasher` throughout the function.)
+
+3. `internal/core/service.go` — in `DownloadModToCache`, replace the post-download verification block:
+
+```go
+	if file.SHA256 != "" && !strings.EqualFold(downloadResult.SHA256, file.SHA256) {
+		return nil, fmt.Errorf("verifying download of %s: sha256 mismatch: source declares %s, downloaded file is %s",
+			file.FileName, file.SHA256, downloadResult.SHA256)
+	}
+```
+
+Delete `verifyFileSHA256` and drop now-unused imports (`crypto/sha256`, `encoding/hex` — verify with `go build`; `strings`/`io`/`os` are used elsewhere).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -v`
+Expected: PASS — including the untouched `service_sha256_test.go` (all four subtests: match, uppercase match via EqualFold, mismatch text intact, empty-skip) and the manifest e2e corrupt-download test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/core/downloader.go internal/core/downloader_test.go internal/core/service.go
+git commit -m "perf(core): compute download sha256 in the existing streaming pass"
+```
+
+---
+
+## Task 5: `lmm auth status` covers custom sources
+
+**Files:**
+- Modify: `cmd/lmm/auth.go` (`doAuthStatus`)
+- Test: `cmd/lmm/auth_status_test.go` (create)
+
+**Interfaces:**
+- Consumes: `service.ListSources()`, `source.CapabilitiesOf`, `service.GetSourceToken`, `envKeyForSourceID`, `maskAPIKey`, `isSupportedSource` (all existing).
+- Produces: after the built-ins loop, `doAuthStatus` also reports every registered non-builtin source whose `Capabilities().Auth` is true: `authenticated (key: ab…yz)` from the token store, `authenticated via LMM_<ID>_API_KEY (key: …)` from the env, else `not authenticated (run: lmm auth login <id>)`. Non-auth custom sources (directory, auth-less manifest) are not listed.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/lmm/auth_status_test.go`. `doAuthStatus` prints to stdout via `fmt.Printf` — capture it the way existing cmd tests capture stdout if a helper exists (grep for `os.Pipe` in cmd/lmm tests); otherwise use this pattern:
+
+```go
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	require.NoError(t, fn())
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestDoAuthStatusIncludesCustomSources(t *testing.T) {
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	// Auth-capable manifest source, key provided via env.
+	withAuth, err := custom.NewManifest(custom.SourceDefinition{
+		ID: "my-repo", Name: "My Repo", Type: custom.TypeManifest,
+		Manifest: &custom.ManifestConfig{
+			URL:  "https://repo.test/mods.yaml",
+			Auth: &custom.AuthConfig{APIKey: &custom.APIKeyConfig{In: "header", Name: "X-API-Key"}},
+		},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(withAuth)
+
+	// Auth-capable manifest source with no key anywhere.
+	noKey, err := custom.NewManifest(custom.SourceDefinition{
+		ID: "keyless-repo", Name: "Keyless", Type: custom.TypeManifest,
+		Manifest: &custom.ManifestConfig{
+			URL:  "https://other.test/mods.yaml",
+			Auth: &custom.AuthConfig{APIKey: &custom.APIKeyConfig{In: "header", Name: "X-API-Key"}},
+		},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(noKey)
+
+	// Directory source: no auth capability, must not be listed.
+	dir, err := custom.NewDirectory(custom.SourceDefinition{
+		ID: "local-mods", Name: "Local", Type: custom.TypeDirectory,
+		Directory: &custom.DirectoryConfig{Path: t.TempDir()},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(dir)
+
+	t.Setenv("LMM_MY_REPO_API_KEY", "supersecretkey")
+
+	out := captureStdout(t, func() error { return doAuthStatus(svc) })
+
+	assert.Contains(t, out, "my-repo: authenticated via LMM_MY_REPO_API_KEY")
+	assert.NotContains(t, out, "supersecretkey")
+	assert.Contains(t, out, "keyless-repo: not authenticated")
+	assert.NotContains(t, out, "local-mods")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/lmm/ -run TestDoAuthStatusIncludesCustomSources -v`
+Expected: FAIL — output contains neither custom source.
+
+- [ ] **Step 3: Implement**
+
+In `cmd/lmm/auth.go`, at the end of `doAuthStatus` (after the built-ins loop, before the final `return nil`), append:
+
+```go
+	// Custom sources that declare auth get the same treatment as built-ins.
+	for _, src := range service.ListSources() {
+		id := src.ID()
+		if isSupportedSource(id) {
+			continue // already reported above
+		}
+		if !source.CapabilitiesOf(src).Auth {
+			continue // directory sources, auth-less manifests: nothing to report
+		}
+
+		token, err := service.GetSourceToken(id)
+		if err != nil {
+			return fmt.Errorf("checking %s: %w", id, err)
+		}
+		if token != nil {
+			fmt.Printf("%s: authenticated (key: %s)\n", id, maskAPIKey(token.APIKey))
+			continue
+		}
+		envKey := envKeyForSourceID(id)
+		if apiKey := os.Getenv(envKey); apiKey != "" {
+			fmt.Printf("%s: authenticated via %s (key: %s)\n", id, envKey, maskAPIKey(apiKey))
+			continue
+		}
+		fmt.Printf("%s: not authenticated (run: lmm auth login %s)\n", id, id)
+	}
+```
+
+Check the `source` package import in auth.go (present since the Phase 3 gating work; verify).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/lmm/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add cmd/lmm/auth.go cmd/lmm/auth_status_test.go
+git commit -m "feat(cli): report custom-source auth state in 'lmm auth status'"
+```
+
+---
+
+## Task 6: Logout for unregistered sources + env-key test pin cleanup
+
+**Files:**
+- Modify: `cmd/lmm/auth.go` (`runAuthLogout`), `cmd/lmm/auth_test.go` (env-key test)
+- Test: `cmd/lmm/auth_test.go` (append logout coverage if a service-level test is tractable; otherwise the runAuthLogout unit shape below)
+
+**Interfaces:**
+- Produces: `lmm auth logout <id>` succeeds for ANY source ID that has a stored token — even if the definition file was deleted and the source is no longer registered. An ID with no stored token and no auth capability still errors. `TestGetEnvKeyForSource` no longer pins `LMM__API_KEY` for empty IDs.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/lmm/auth_test.go`:
+
+```go
+func TestResolveLogoutSource(t *testing.T) {
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	// A token stored for a source whose definition file has been deleted:
+	// not registered, but logout must still be able to remove it.
+	require.NoError(t, svc.SaveSourceToken("ghost-repo", "leftover-key"))
+
+	id, err := resolveLogoutSource(svc, []string{"ghost-repo"})
+	require.NoError(t, err)
+	assert.Equal(t, "ghost-repo", id)
+
+	// Unknown ID with no token and no registration still errors.
+	_, err = resolveLogoutSource(svc, []string{"never-existed"})
+	assert.Error(t, err)
+
+	// Built-ins keep working.
+	id, err = resolveLogoutSource(svc, []string{"nexusmods"})
+	require.NoError(t, err)
+	assert.Equal(t, "nexusmods", id)
+}
+```
+
+And replace the empty/unknown-ID expectations in `TestGetEnvKeyForSource` (and the equivalent cases in `TestEnvKeyForSourceID` if present): drop any case asserting `LMM__API_KEY` for `""`; keep/add real-ID cases only (`nexusmods` → `NEXUSMODS_API_KEY`, `curseforge` → `CURSEFORGE_API_KEY`, `my-repo` → `LMM_MY_REPO_API_KEY`). Note: `getEnvKeyForSource("unknown-source")` → `LMM_UNKNOWN_SOURCE_API_KEY` is real derivation behavior for custom sources — keep such a case; only the empty-ID pin goes.
+
+(Check `svc.SaveSourceToken`'s real name/signature — grep `SaveSourceToken` in internal/core; adapt the call, not the behavior.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/lmm/ -run TestResolveLogoutSource -v`
+Expected: FAIL — `undefined: resolveLogoutSource`.
+
+- [ ] **Step 3: Implement**
+
+In `cmd/lmm/auth.go`, add the resolver and use it in `runAuthLogout`:
+
+```go
+// resolveLogoutSource picks the source to log out. Unlike login, logout must
+// also work for sources that are no longer registered (definition file
+// deleted after a key was stored) — otherwise the stored token becomes
+// unremovable via the CLI.
+func resolveLogoutSource(service *core.Service, args []string) (string, error) {
+	if len(args) == 0 {
+		return selectAuthSource(service, args) // interactive prompt path unchanged
+	}
+	sourceID := args[0]
+	if isAuthCapableSource(service, sourceID) {
+		return sourceID, nil
+	}
+	token, err := service.GetSourceToken(sourceID)
+	if err != nil {
+		return "", fmt.Errorf("checking stored credentials for %s: %w", sourceID, err)
+	}
+	if token != nil {
+		return sourceID, nil
+	}
+	return "", fmt.Errorf("no stored credentials for %q and it is not a registered auth-capable source", sourceID)
+}
+```
+
+In `runAuthLogout`, replace `selectAuthSource(service, args)` with `resolveLogoutSource(service, args)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/lmm/ -v`
+Expected: PASS (including the updated env-key expectations).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add cmd/lmm/auth.go cmd/lmm/auth_test.go
+git commit -m "fix(cli): allow auth logout for unregistered sources with stored tokens"
+```
+
+---
+
+## Task 7: Docs, changelog, version 1.8.0
+
+**Files:**
+- Modify: `README.md`, `CHANGELOG.md`, `cmd/lmm/root.go` (version)
+
+- [ ] **Step 1: Update docs (accuracy rule: every claim must match the code on this branch — verify before writing)**
+
+README.md:
+- Authentication subsection (Custom Sources): add the same-origin rule — for remote manifests, header-mode keys are sent only to file URLs on the manifest's own host; local-path manifests attach the key to any host (user-authored). Note `lmm auth status` now lists auth-capable custom sources, and `lmm auth logout <id>` works even after the definition file is removed.
+- Manifest Sources subsection: one sentence noting remote fetches are bounded by a 30s timeout.
+
+CHANGELOG.md — under `[Unreleased]`:
+
+```markdown
+### Added
+- `lmm auth status` reports auth-capable custom sources (stored token or env var, masked)
+
+### Fixed
+- `lmm auth logout` works for sources whose definition file was removed
+- Update checks translate installed mods to each source's mapped game ID (fixes NexusMods update checks for games whose lmm ID differs from the Nexus domain)
+- Remote manifest fetches are bounded by a 30-second timeout and no longer block other operations on the same source
+
+### Security
+- Header-mode API keys are only sent to file downloads on the manifest's own host
+
+### Changed
+- Download checksums (MD5 + SHA-256) are computed in a single streaming pass
+```
+
+Then move `[Unreleased]` content to `## [1.8.0] - <today>`, update comparison links per the file's convention, and set `version = "1.8.0"` in cmd/lmm/root.go.
+
+- [ ] **Step 2: Final verification and commits**
+
+```bash
+go fmt ./... && go vet ./... && go test ./... -race
+git add README.md CHANGELOG.md
+git commit -m "docs: document same-origin download keys, auth status coverage, and fetch timeout"
+git add cmd/lmm/root.go CHANGELOG.md
+git commit -m "chore: bump version to 1.8.0"
+```
+
+(Note the `-race` run here — Task 1's concurrency work makes this the cheap moment to catch races across the whole suite.)
+
+---
+
+## Out of Scope
+
+- `#50` aggregate search itself (this plan clears its prerequisite)
+- `#49` api source type
+- Issue #52 items (directory-source polish from Phase 2)

--- a/docs/plans/archive/2026-07-18-custom-sources-p5-aggregate-impl.md
+++ b/docs/plans/archive/2026-07-18-custom-sources-p5-aggregate-impl.md
@@ -1,0 +1,880 @@
+# Custom Sources — Phase 5 (Aggregate Search + TUI Sources) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One search across all of a game's sources — `lmm search` with no `--source` queries every configured source concurrently, merges labeled results, and degrades per-source failures to warnings; the TUI gets an "All sources" default with per-row source labels and a read-only Sources screen.
+
+**Architecture:** New `Service.SearchAllSources` fans out over the game's `sources:` map with `errgroup` (promoting the already-present indirect `golang.org/x/sync`), skips non-searching sources via `CapabilitiesOf`, collects per-source warnings, and merges with name-match-then-downloads ranking. The CLI defaults to aggregate mode and gains a SOURCE column plus design-§7 clean capability-gap notices. The TUI reuses its `DataProvider` seam: `""` becomes the "All sources" sentinel in `Search`, `SearchPage` carries warnings, and a new `SourceInfos()` method backs the Sources screen (registered via the standard keys.go/app.go pattern).
+
+**Tech Stack:** Go, golang.org/x/sync/errgroup (module already in the dependency graph — promotion, not addition; same precedent as charmbracelet/x/ansi in TUI Phase 4), Bubble Tea (existing), testify.
+
+**Spec:** `docs/plans/2026-07-13-custom-sources-design.md` §5 (aggregate search), §7 (graceful degradation UX), §8 (Sources screen). Issue #50 (epic #45).
+
+**Scope note on acceptance criterion 2** ("unsupported actions hidden/disabled in the TUI"): the TUI is read-only today — no per-mod actions exist to gate (verified; TUI mutations are #37/#42). This criterion is satisfied by (a) the Sources screen displaying per-source capabilities and (b) a recorded requirement on #37 that future mutation UI must consult `CapabilitiesOf`. The final PR must state this explicitly.
+
+## Global Constraints
+
+- TDD: every task starts with a failing test.
+- Error wrapping with context: `fmt.Errorf("doing X: %w", err)` (GO.md); `ctx` first param; no ctx in structs.
+- No NEW module dependencies (`golang.org/x/sync` is already in go.sum via the module graph — adding the import promotes it to direct; anything else is off-limits).
+- `go fmt ./...` and `go vet ./...` clean before every commit; run `-race` on TUI/core concurrency tests.
+- Design §5 semantics (binding): per-source failures are warnings — one flaky API must not hide local modlets; only all-sources-failed is an error; sources without search capability are skipped silently; pagination is per-source (page N = page N from each source, merged; no global re-ranking beyond the sort below); merged sort = name-match relevance first, then Downloads descending, then Name ascending (stable).
+- Design §7 (CLI): `errors.Is(err, source.ErrNotSupported)` ⇒ a clean one-line notice, never a wrapped-error dump.
+- CLI and TUI are equally first-class (repo CLAUDE.md): the aggregate default and source labels ship in both.
+- Commit after each task; conventional commit messages.
+
+---
+
+## Task 1: Core aggregate search (+ the deferred negative-page clamp)
+
+**Files:**
+- Modify: `internal/core/service.go` (new types + `SearchAllSources`), `internal/source/custom/api.go` (negative-page clamp, from the Phase 4 review triage), `go.mod` (x/sync promotion happens automatically via `go mod tidy`)
+- Test: `internal/core/service_aggregate_search_test.go` (create), `internal/source/custom/api_test.go` (append one case)
+
+**Interfaces:**
+- Produces:
+
+```go
+// SourceWarning reports a per-source failure during an aggregate operation.
+type SourceWarning struct {
+	SourceID string
+	Err      error
+}
+
+// AggregateSearchResult is the merged outcome of searching every source
+// configured for a game.
+type AggregateSearchResult struct {
+	Mods       []domain.Mod    // merged, ranked; each Mod carries its SourceID
+	TotalCount int             // sum of per-source totals (sources reporting 0/unknown contribute 0)
+	Warnings   []SourceWarning // per-source failures (design §5: warnings, not errors)
+}
+
+func (s *Service) SearchAllSources(ctx context.Context, gameID, query, category string, tags []string, page, pageSize int) (AggregateSearchResult, error)
+```
+
+- Semantics later tasks rely on: candidate sources = the game's `SourceIDs` keys, sorted; unregistered mapped source → warning; `CapabilitiesOf(src).Search == false` → silent skip; runtime `ErrNotSupported` from Search → silent skip too (belt and suspenders); other error → warning; each candidate queried via the existing `s.SearchMods` (so per-source game-ID mapping applies) concurrently under `errgroup.WithContext`; all-attempted-failed (≥1 attempted, 0 succeeded) → `(partial result with warnings, error)`; zero attemptable sources → empty result, nil error.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/source/custom/api_test.go` (the clamp case):
+
+```go
+func TestAPISearchNegativePageClamped(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.String()
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer srv.Close()
+
+	a, err := NewAPI(apiDef(srv.URL))
+	require.NoError(t, err)
+
+	_, err = a.Search(context.Background(), source.SearchQuery{Query: "x", Page: -3, PageSize: 10})
+	require.NoError(t, err)
+	// Negative pages clamp to page 0: {page} = 0 + pageStart(1) = 1, {offset} = 0.
+	assert.Contains(t, gotPath, "page=1")
+	assert.Contains(t, gotPath, "skip=0")
+}
+```
+
+Create `internal/core/service_aggregate_search_test.go` (`package core_test`; reuse the existing mock-source helpers in service_test.go — read them first; the mock must let each fake source return canned `SearchResult`s or errors. If the existing `mockSource` can't return search results, extend the TEST helpers (test files only) with a small `searchStubSource` implementing `source.ModSource` + optional `source.CapabilityReporter`):
+
+```go
+package core_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// searchStubSource is a minimal ModSource whose Search returns canned data.
+type searchStubSource struct {
+	id      string
+	caps    *source.Capabilities // nil = no CapabilityReporter (assumed fully capable)
+	result  source.SearchResult
+	err     error
+	gotGame string // records the GameID the source was queried with
+}
+
+func (s *searchStubSource) ID() string      { return s.id }
+func (s *searchStubSource) Name() string    { return s.id }
+func (s *searchStubSource) AuthURL() string { return "" }
+func (s *searchStubSource) ExchangeToken(context.Context, string) (*source.Token, error) {
+	return nil, nil
+}
+func (s *searchStubSource) Search(ctx context.Context, q source.SearchQuery) (source.SearchResult, error) {
+	s.gotGame = q.GameID
+	if s.err != nil {
+		return source.SearchResult{}, s.err
+	}
+	return s.result, nil
+}
+func (s *searchStubSource) GetMod(context.Context, string, string) (*domain.Mod, error) {
+	return nil, nil
+}
+func (s *searchStubSource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) {
+	return nil, nil
+}
+func (s *searchStubSource) GetModFiles(context.Context, *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, nil
+}
+func (s *searchStubSource) GetDownloadURL(context.Context, *domain.Mod, string) (string, error) {
+	return "", nil
+}
+func (s *searchStubSource) CheckUpdates(context.Context, []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, nil
+}
+
+// capsStubSource adds a CapabilityReporter to searchStubSource.
+type capsStubSource struct{ *searchStubSource }
+
+func (c *capsStubSource) Capabilities() source.Capabilities { return *c.caps }
+
+func newAggregateTestService(t *testing.T, sources map[string]string, srcs ...source.ModSource) (*core.Service, *domain.Game) {
+	t.Helper()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	for _, s := range srcs {
+		svc.RegisterSource(s)
+	}
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), SourceIDs: sources}
+	require.NoError(t, svc.AddGame(game))
+	return svc, game
+}
+
+func mods(sourceID string, entries ...string) []domain.Mod {
+	out := make([]domain.Mod, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, domain.Mod{ID: e, SourceID: sourceID, Name: e})
+	}
+	return out
+}
+
+func TestSearchAllSourcesMergesAndTags(t *testing.T) {
+	a := &searchStubSource{id: "alpha", result: source.SearchResult{
+		Mods: []domain.Mod{
+			{ID: "cool-a", SourceID: "alpha", Name: "Cool A", Downloads: 5},
+			{ID: "other-a", SourceID: "alpha", Name: "Unrelated", Downloads: 100},
+		},
+		TotalCount: 2,
+	}}
+	b := &searchStubSource{id: "beta", result: source.SearchResult{
+		Mods:       []domain.Mod{{ID: "cool-b", SourceID: "beta", Name: "Cool B", Downloads: 50}},
+		TotalCount: 7,
+	}}
+	svc, game := newAggregateTestService(t, map[string]string{"alpha": "", "beta": "mapped-beta"}, a, b)
+
+	res, err := svc.SearchAllSources(context.Background(), game.ID, "cool", "", nil, 0, 10)
+	require.NoError(t, err)
+	assert.Empty(t, res.Warnings)
+	assert.Equal(t, 9, res.TotalCount)
+
+	// Ranking: name matches ("Cool B" 50 > "Cool A" 5 by downloads) before
+	// non-matches ("Unrelated"), stable and deterministic.
+	require.Len(t, res.Mods, 3)
+	assert.Equal(t, "cool-b", res.Mods[0].ID)
+	assert.Equal(t, "cool-a", res.Mods[1].ID)
+	assert.Equal(t, "other-a", res.Mods[2].ID)
+
+	// Per-source game-ID mapping applied (empty mapping -> lmm game id).
+	assert.Equal(t, "testgame", a.gotGame)
+	assert.Equal(t, "mapped-beta", b.gotGame)
+}
+
+func TestSearchAllSourcesFailureIsWarning(t *testing.T) {
+	ok := &searchStubSource{id: "local", result: source.SearchResult{
+		Mods: mods("local", "modlet"), TotalCount: 1,
+	}}
+	flaky := &searchStubSource{id: "remote", err: fmt.Errorf("dial tcp: connection refused")}
+	svc, game := newAggregateTestService(t, map[string]string{"local": "", "remote": ""}, ok, flaky)
+
+	res, err := svc.SearchAllSources(context.Background(), game.ID, "mod", "", nil, 0, 10)
+	require.NoError(t, err, "one flaky source must not fail the aggregate")
+	require.Len(t, res.Mods, 1)
+	assert.Equal(t, "local", res.Mods[0].SourceID)
+	require.Len(t, res.Warnings, 1)
+	assert.Equal(t, "remote", res.Warnings[0].SourceID)
+}
+
+func TestSearchAllSourcesSkipsNonSearching(t *testing.T) {
+	searcher := &searchStubSource{id: "manifest", result: source.SearchResult{Mods: mods("manifest", "m1"), TotalCount: 1}}
+	caps := source.Capabilities{Search: false, Updates: true}
+	idOnly := &capsStubSource{&searchStubSource{id: "id-only-api", caps: &caps,
+		err: fmt.Errorf("should never be called")}}
+	svc, game := newAggregateTestService(t, map[string]string{"manifest": "", "id-only-api": ""}, searcher, idOnly)
+
+	res, err := svc.SearchAllSources(context.Background(), game.ID, "m", "", nil, 0, 10)
+	require.NoError(t, err)
+	assert.Empty(t, res.Warnings, "non-searching sources are skipped silently, not warned")
+	require.Len(t, res.Mods, 1)
+}
+
+func TestSearchAllSourcesUnregisteredMappedSourceWarns(t *testing.T) {
+	ok := &searchStubSource{id: "real", result: source.SearchResult{Mods: mods("real", "x"), TotalCount: 1}}
+	svc, game := newAggregateTestService(t, map[string]string{"real": "", "ghost": ""}, ok)
+
+	res, err := svc.SearchAllSources(context.Background(), game.ID, "x", "", nil, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, res.Warnings, 1)
+	assert.Equal(t, "ghost", res.Warnings[0].SourceID)
+	require.Len(t, res.Mods, 1)
+}
+
+func TestSearchAllSourcesAllFailedIsError(t *testing.T) {
+	f1 := &searchStubSource{id: "s1", err: errors.New("boom1")}
+	f2 := &searchStubSource{id: "s2", err: errors.New("boom2")}
+	svc, game := newAggregateTestService(t, map[string]string{"s1": "", "s2": ""}, f1, f2)
+
+	res, err := svc.SearchAllSources(context.Background(), game.ID, "x", "", nil, 0, 10)
+	require.Error(t, err)
+	assert.Len(t, res.Warnings, 2)
+	assert.Empty(t, res.Mods)
+}
+
+func TestSearchAllSourcesUnknownGame(t *testing.T) {
+	svc, _ := newAggregateTestService(t, map[string]string{})
+	_, err := svc.SearchAllSources(context.Background(), "nope", "x", "", nil, 0, 10)
+	assert.Error(t, err)
+}
+```
+
+Note for the implementer: `mockSource` helpers already exist in service_test.go — if embedding/reusing them is cleaner than the standalone `searchStubSource` above, adapt the construction; every assertion stays.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/ -run TestSearchAllSources -v; go test ./internal/source/custom/ -run TestAPISearchNegativePageClamped -v`
+Expected: FAIL — `undefined: svc.SearchAllSources`; clamp test gets `page=-2`/`skip=-30`.
+
+- [ ] **Step 3: Implement**
+
+`internal/source/custom/api.go` — at the top of `Search`, right after the endpoint-nil check:
+
+```go
+	page := query.Page
+	if page < 0 {
+		page = 0 // match the shared searchMods clamp; never send negative paging upstream
+	}
+```
+
+and use `page` instead of `query.Page` in the `vals` map and the returned `SearchResult.Page`.
+
+`internal/core/service.go` — add the types from the Interfaces block and:
+
+```go
+// SearchAllSources searches every source configured for a game concurrently
+// and merges the results (design §5). Per-source failures become Warnings —
+// one flaky API must not hide local modlets; only all-sources-failed is an
+// error. Sources without search capability are skipped silently. Pagination
+// is per-source: page N requests page N from each source and merges.
+func (s *Service) SearchAllSources(ctx context.Context, gameID, query, category string, tags []string, page, pageSize int) (AggregateSearchResult, error) {
+	game, ok := s.games[gameID]
+	if !ok {
+		return AggregateSearchResult{}, fmt.Errorf("game not found: %s", gameID)
+	}
+
+	sourceIDs := make([]string, 0, len(game.SourceIDs))
+	for id := range game.SourceIDs {
+		sourceIDs = append(sourceIDs, id)
+	}
+	sort.Strings(sourceIDs)
+
+	var result AggregateSearchResult
+	type slot struct {
+		res source.SearchResult
+		err error
+	}
+	slots := make([]slot, len(sourceIDs))
+	attempted := make([]bool, len(sourceIDs))
+
+	g, gctx := errgroup.WithContext(ctx)
+	for i, sourceID := range sourceIDs {
+		src, err := s.registry.Get(sourceID)
+		if err != nil {
+			slots[i].err = err
+			attempted[i] = true
+			continue
+		}
+		if !source.CapabilitiesOf(src).Search {
+			continue // silent skip (design §5)
+		}
+		attempted[i] = true
+		i, sourceID := i, sourceID
+		g.Go(func() error {
+			res, err := s.SearchMods(gctx, sourceID, gameID, query, category, tags, page, pageSize)
+			if err != nil {
+				if errors.Is(err, source.ErrNotSupported) {
+					attempted[i] = false // runtime capability gap: silent skip, not a warning
+					return nil
+				}
+				slots[i].err = err
+				return nil // never abort the group: siblings keep searching
+			}
+			slots[i].res = res
+			return nil
+		})
+	}
+	_ = g.Wait() // goroutines always return nil; errors live in slots
+
+	succeeded := 0
+	for i, sourceID := range sourceIDs {
+		if !attempted[i] {
+			continue
+		}
+		if slots[i].err != nil {
+			result.Warnings = append(result.Warnings, SourceWarning{SourceID: sourceID, Err: slots[i].err})
+			continue
+		}
+		succeeded++
+		result.Mods = append(result.Mods, slots[i].res.Mods...)
+		result.TotalCount += slots[i].res.TotalCount
+	}
+
+	rankAggregate(result.Mods, query)
+
+	attemptedCount := 0
+	for _, a := range attempted {
+		if a {
+			attemptedCount++
+		}
+	}
+	if attemptedCount > 0 && succeeded == 0 {
+		errs := make([]error, 0, len(result.Warnings))
+		for _, w := range result.Warnings {
+			errs = append(errs, fmt.Errorf("source %s: %w", w.SourceID, w.Err))
+		}
+		return result, fmt.Errorf("all %d source(s) failed: %w", attemptedCount, errors.Join(errs...))
+	}
+	return result, nil
+}
+
+// rankAggregate orders merged results: query-name matches first, then by
+// Downloads descending, then Name ascending — deterministic regardless of
+// which source responded first (design §5: no global re-ranking beyond this).
+func rankAggregate(mods []domain.Mod, query string) {
+	q := strings.ToLower(query)
+	nameMatch := func(m domain.Mod) bool {
+		return q != "" && (strings.Contains(strings.ToLower(m.Name), q) || strings.Contains(strings.ToLower(m.ID), q))
+	}
+	sort.SliceStable(mods, func(i, j int) bool {
+		mi, mj := nameMatch(mods[i]), nameMatch(mods[j])
+		if mi != mj {
+			return mi
+		}
+		if mods[i].Downloads != mods[j].Downloads {
+			return mods[i].Downloads > mods[j].Downloads
+		}
+		return mods[i].Name < mods[j].Name
+	})
+}
+```
+
+Imports for service.go: add `"sort"`, `"errors"`, `"golang.org/x/sync/errgroup"` (verify which are already present). Run `go mod tidy` — x/sync moves to the direct require block; commit go.mod/go.sum with this task.
+
+Note the `attempted[i] = false` write inside the goroutine: it's only read after `g.Wait()`, and each goroutine touches only its own index — race-free by construction; the `-race` run in Step 4 is the proof.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -run TestSearchAllSources -race -v && go test ./internal/source/custom/ -v && go test ./... && go build ./...`
+Expected: PASS everywhere, `-race` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/core/service.go internal/core/service_aggregate_search_test.go internal/source/custom/api.go internal/source/custom/api_test.go go.mod go.sum
+git commit -m "feat(core): aggregate search across all of a game's sources"
+```
+
+---
+
+## Task 2: CLI aggregate default, source column, and §7 notices
+
+**Files:**
+- Modify: `cmd/lmm/search.go`
+- Test: `cmd/lmm/search_test.go` (create or append — check for an existing file and follow the light cmd-test pattern)
+
+**Interfaces:**
+- Consumes: `service.SearchAllSources` (Task 1), `source.ErrNotSupported`, `domain.ModKey`.
+- Produces: `lmm search <query>` with no `--source` runs aggregate mode; with `--source` keeps single-source mode. Both modes render a SOURCE column. Aggregate warnings print to stderr as `warning: source <id>: <err>`. JSON output gains `"source"` per mod and a top-level `"warnings"` array (aggregate mode). Explicit `--source` against a non-searching source prints the §7 clean notice and exits non-zero WITHOUT a wrapped-error dump.
+
+- [ ] **Step 1: Write the failing test**
+
+The cmd layer uses light tests. Create/append `cmd/lmm/search_test.go`:
+
+```go
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchCmdStructure(t *testing.T) {
+	assert.Equal(t, "search <query>", searchCmd.Use)
+	flag := searchCmd.Flags().Lookup("source")
+	if assert.NotNil(t, flag) {
+		assert.Contains(t, flag.Usage, "all configured sources",
+			"help text must reflect the new aggregate default")
+	}
+}
+
+func TestCapabilityGapNotice(t *testing.T) {
+	err := fmt.Errorf("source %q: searching: %w", "id-only", source.ErrNotSupported)
+	notice, ok := capabilityGapNotice("id-only", err)
+	assert.True(t, ok)
+	assert.Contains(t, notice, "does not support searching")
+	assert.Contains(t, notice, "lmm install --source id-only")
+	assert.NotContains(t, notice, "operation not supported by this source",
+		"the raw wrapped error must not leak into the notice")
+
+	_, ok = capabilityGapNotice("x", errors.New("network down"))
+	assert.False(t, ok)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/lmm/ -run 'TestSearchCmdStructure|TestCapabilityGapNotice' -v`
+Expected: FAIL — flag usage text mismatch; `undefined: capabilityGapNotice`.
+
+- [ ] **Step 3: Implement**
+
+In `cmd/lmm/search.go`:
+
+1. Flag help: `"mod source to search (default: all configured sources)"`. Update `searchCmd.Long`'s "If --source is not specified..." sentence to say all configured sources are searched concurrently, and refresh the examples.
+2. Add the §7 helper:
+
+```go
+// capabilityGapNotice turns an ErrNotSupported search failure into a clean
+// one-line notice (design §7) instead of a wrapped-error dump. ok is false
+// for every other error.
+func capabilityGapNotice(sourceID string, err error) (string, bool) {
+	if !errors.Is(err, source.ErrNotSupported) {
+		return "", false
+	}
+	return fmt.Sprintf("source %q does not support searching; install by ID instead: lmm install --source %s --id <mod-id>", sourceID, sourceID), true
+}
+```
+
+(add the `source` package import).
+3. Restructure `doSearch`'s fetch block:
+
+```go
+	var mods []domain.Mod
+	var warnings []core.SourceWarning
+	var totalResults int
+
+	if searchSource == "" {
+		agg, err := service.SearchAllSources(ctx, game.ID, query, searchCategory, searchTags, 0, 0)
+		if err != nil {
+			// No ErrAuthRequired special-case here: an all-sources failure's
+			// joined error already names each source and its reason (including
+			// auth), and a per-source auth hint lives in the warnings path.
+			return fmt.Errorf("search failed: %w", err)
+		}
+		mods, warnings = agg.Mods, agg.Warnings
+		totalResults = len(mods)
+		for _, w := range warnings {
+			fmt.Fprintf(os.Stderr, "warning: source %s: %v\n", w.SourceID, w.Err)
+		}
+	} else {
+		sourceToUse, err := resolveSource(game, searchSource, false)
+		if err != nil {
+			return err
+		}
+		if verbose {
+			fmt.Printf("Searching for %q in %s (%s)...\n", query, game.Name, sourceToUse)
+		}
+		searchResult, err := service.SearchMods(ctx, sourceToUse, game.ID, query, searchCategory, searchTags, 0, 0)
+		if err != nil {
+			if notice, ok := capabilityGapNotice(sourceToUse, err); ok {
+				return errors.New(notice)
+			}
+			if errors.Is(err, domain.ErrAuthRequired) {
+				return authPromptError(sourceToUse)
+			}
+			return fmt.Errorf("search failed: %w", err)
+		}
+		mods = searchResult.Mods
+		totalResults = len(mods)
+	}
+```
+
+(The old single-source `resolveSource`-first shape goes away; keep `verbose` output sensible in aggregate mode, e.g. `Searching for %q in %s (all sources)...`.)
+4. Installed marking becomes source-aware: build `installedKeys := map[string]bool{}` from `domain.ModKey(im.SourceID, im.ID)` over ALL installed mods (drop the `im.SourceID == sourceToUse` filter), and look up `installedKeys[domain.ModKey(mod.SourceID, mod.ID)]`.
+5. Table: add a SOURCE column (both modes) — header `ID\tNAME\tAUTHOR\tVERSION\tSOURCE\t`, row value `mod.SourceID`, installed mark stays the last column. Adjust the separator row to match.
+6. JSON: `searchModJSON` gains `Source string \`json:"source"\``; `searchJSONOutput` gains `Warnings []string \`json:"warnings,omitempty"\`` (formatted `source <id>: <err>`); populate both. In aggregate mode the empty-result JSON path must still include warnings.
+
+- [ ] **Step 4: Run tests and verify manually**
+
+Run: `go test ./cmd/lmm/ -v && go build -o /tmp/lmm-p5 ./cmd/lmm && go test ./...`
+Expected: PASS. (Live aggregate behavior is exercised in Task 6's e2e and the final review.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add cmd/lmm/search.go cmd/lmm/search_test.go
+git commit -m "feat(cli): search all configured sources by default with source column"
+```
+
+---
+
+## Task 3: TUI provider — all-sources search and warnings
+
+**Files:**
+- Modify: `internal/tui/service.go` (SearchPage + prototypeProvider), `internal/tui/service_core.go` (coreProvider)
+- Test: `internal/tui/service_core_test.go` (append), `internal/tui/service_test.go` (append)
+
+**Interfaces:**
+- Consumes: `Service.SearchAllSources` (Task 1).
+- Produces: `DataProvider.Search(ctx, source, query, page)` treats `source == ""` as "all sources" (the interface signature is unchanged — `""` becomes a documented sentinel). `SearchPage` gains `Warnings []string` (already-formatted, display-ready). `coreProvider.Search("")` calls `svc.SearchAllSources` with `SearchPageSize`, maps warnings to `"<sourceID>: <err>"` strings, and marks installed via `domain.ModKey`. `prototypeProvider.Search("")` returns its full canned set (tagged with its one source) so `--prototype` mode exercises the UI.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/tui/service_core_test.go` (match its existing service-construction pattern — read it first; it builds a real `core.Service` with temp dirs and registered stub sources):
+
+```go
+func TestCoreProviderSearchAllSources(t *testing.T) {
+	// Arrange a service with two searchable sources the way this file's
+	// existing tests do (real core.Service + registered stubs), a game
+	// mapping both, then:
+	p := NewCoreProvider(svc, game, "default")
+
+	page, err := p.Search(context.Background(), "", "quer", 0)
+	require.NoError(t, err)
+	// Results from both sources present, each row's Source set:
+	sources := map[string]bool{}
+	for _, item := range page.Results {
+		sources[item.Source] = true
+	}
+	assert.Len(t, sources, 2)
+}
+
+func TestCoreProviderSearchAllSourcesWarnings(t *testing.T) {
+	// One good + one failing source registered; game maps both.
+	page, err := p.Search(context.Background(), "", "quer", 0)
+	require.NoError(t, err)
+	require.Len(t, page.Warnings, 1)
+	assert.Contains(t, page.Warnings[0], failingSourceID)
+	assert.NotEmpty(t, page.Results, "good source's results survive the failure")
+}
+```
+
+(These are intent sketches — flesh out the arrangement using the file's real helpers; the assertions are the contract. If no reusable stub-source helper exists in the tui test package, register `searchStubSource`-style stubs locally — the type from Task 1's core test can't be imported across test packages, so declare a local minimal copy.)
+
+Append to `internal/tui/service_test.go`:
+
+```go
+func TestPrototypeProviderSearchAllSources(t *testing.T) {
+	p := NewPrototypeProvider()
+	page, err := p.Search(context.Background(), "", "", 0)
+	require.NoError(t, err)
+	assert.NotEmpty(t, page.Results)
+	for _, item := range page.Results {
+		assert.NotEmpty(t, item.Source)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/tui/ -run 'TestCoreProviderSearchAll|TestPrototypeProviderSearchAll' -v`
+Expected: FAIL — `page.Warnings` undefined / empty-source Search returns an error or empty set today.
+
+- [ ] **Step 3: Implement**
+
+`internal/tui/service.go`:
+- `SearchPage` gains `Warnings []string` with a doc comment: per-source failures in all-sources mode, display-ready.
+- Document the sentinel on the `DataProvider.Search` doc comment: `source "" means all of the game's sources`.
+- `prototypeProvider.Search`: when `source == ""`, serve the same canned results it serves for its single source (tag `Source` on each item as it already does).
+
+`internal/tui/service_core.go` — in `coreProvider.Search`, branch on `source == ""`:
+
+```go
+	if source == "" {
+		agg, err := p.svc.SearchAllSources(ctx, p.game.ID, query, "", nil, page, SearchPageSize)
+		if err != nil {
+			return SearchPage{}, err
+		}
+		warnings := make([]string, 0, len(agg.Warnings))
+		for _, w := range agg.Warnings {
+			warnings = append(warnings, fmt.Sprintf("%s: %v", w.SourceID, w.Err))
+		}
+		// Map agg.Mods -> []ModItem exactly as the single-source path does
+		// (installed marking via domain.ModKey against GetInstalledMods),
+		// then return SearchPage{..., TotalCount: agg.TotalCount, Warnings: warnings}.
+	}
+```
+
+Factor the existing `source.SearchResult.Mods -> []ModItem` mapping into a shared helper if the two branches would otherwise duplicate it (they will — extract `func (p *coreProvider) modsToItems(mods []domain.Mod) []ModItem` or similar from the current body and use it in both).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/tui/ -race -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/tui/service.go internal/tui/service_core.go internal/tui/service_core_test.go internal/tui/service_test.go
+git commit -m "feat(tui): all-sources search mode in the data provider"
+```
+
+---
+
+## Task 4: TUI search UI — "All sources" default, source column, warning line
+
+**Files:**
+- Modify: `internal/tui/search.go` (sources list + labels), `internal/tui/app.go` (results pane column, header label, warning line)
+- Test: `internal/tui/search_test.go` (append), `internal/tui/app_test.go` (append if row rendering is asserted there — follow existing conventions)
+
+**Interfaces:**
+- Consumes: Task 3's `""` sentinel + `SearchPage.Warnings`.
+- Produces: the search screen's source cycle starts on "All sources" (`""` prepended to `provider.Sources()`; `sourceIdx` 0 default); the header shows `All sources` for the sentinel; cycling `s` still rotates through every real source and back; the results pane gains a source column (value `item.Source`) when in all-sources mode (single-source mode keeps today's columns); a one-line warning notice renders under the header when `page.Warnings` is non-empty (e.g. `⚠ 1 source unavailable: remote: connection refused` — truncate to width).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/tui/search_test.go` (drive `Model.Update` with key messages per the file's existing style — read it first for the constructor/helpers):
+
+```go
+func TestSearchDefaultsToAllSources(t *testing.T) {
+	// Build the model the way existing tests do (prototype provider).
+	// Assert: m.search.sources[0] == "" and m.search.source() == "" at start,
+	// and the search header/view contains "All sources".
+}
+
+func TestCycleSourceRotatesThroughAllThenReal(t *testing.T) {
+	// With prototype provider (one real source): press 's' once -> source()
+	// == "nexusmods"; press 's' again -> back to "" (All sources).
+	// (Cycling must now be enabled when len(sources) > 1 INCLUDING the
+	// sentinel — with one real source the list is ["", "nexusmods"].)
+}
+
+func TestSearchWarningLineRendered(t *testing.T) {
+	// Inject a searchResultMsg carrying a SearchPage with Warnings and
+	// assert the rendered searchView() contains the warning marker and the
+	// source id. Follow how existing tests inject result messages.
+}
+```
+
+(Intent sketches: flesh out against the real helper names — `newSearchModel`, `searchResultMsg{gen, page}`, `m.searchView()` etc. The assertions are the contract.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/tui/ -run 'TestSearchDefaults|TestCycleSource|TestSearchWarning' -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`internal/tui/search.go`:
+- `newSearchModel`: `s.sources = append([]string{""}, provider.Sources()...)` (the sentinel first ⇒ default). Add/adjust a `sourceLabel()` helper: `""` → `"All sources"`, else the ID — used everywhere the current code prints `s.source()`.
+- Anywhere that guards "no source configured" (`source() == ""` → `searchFailed`): rework — the sentinel is now a VALID search target; the invalid case is `len(provider.Sources()) == 0` (no real sources at all). Find that guard in `startSearch` and base it on the underlying real-source count.
+
+`internal/tui/app.go`:
+- Source-cycle key handling: the `len(sources) > 1` enable-check now naturally includes the sentinel (1 real source ⇒ list length 2 ⇒ cycling enabled — desired: users toggle All↔single).
+- `searchHeaderLines`: print the label via `sourceLabel()`.
+- `searchResultsPane`: when `m.search.source() == ""`, add a source column (dynamic width like the existing columns; keep single-source rendering unchanged).
+- `searchReadyView` (or wherever fits the layout): render `page.Warnings` as one truncated line above/below the results header when non-empty; style consistently with existing warning/status text.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/tui/ -race -v && go build ./...`
+Expected: PASS (all existing search/navigation tests still green — pay attention to tests that assumed sources[0] was a real source; update ONLY where the new sentinel legitimately changes the expectation, and say so in the report).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/tui/search.go internal/tui/app.go internal/tui/search_test.go
+git commit -m "feat(tui): default search to all sources with source labels and warnings"
+```
+
+---
+
+## Task 5: TUI Sources screen
+
+**Files:**
+- Modify: `internal/tui/keys.go` (ScreenSources + binding), `internal/tui/app.go` (routing, menu, view), `internal/tui/service.go` (SourceInfo + provider method + prototype impl), `internal/tui/service_core.go` (real impl)
+- Test: `internal/tui/sources_view_test.go` (create)
+
+**Interfaces:**
+- Produces:
+  - `SourceInfo{ID, Name, Type, Auth, Capabilities string}` in service.go (display-ready strings, mirroring `lmm source list` columns minus error rows — the TUI lists REGISTERED sources only; definition load errors remain CLI-only, note this in the doc comment)
+  - `DataProvider` gains `SourceInfos() []SourceInfo`
+  - `coreProvider.SourceInfos()`: iterate `svc.ListSources()` sorted by ID; Type via type-switch (`*custom.Directory` → "directory", `*custom.Manifest` → "manifest", `*custom.API` → "api", default "built-in"); Auth via `source.CapabilitiesOf` + the `interface{ IsAuthenticated() bool }` assertion (mirror cmd/lmm/source.go's `authState`); Capabilities via a summary like cmd's `capabilitySummary` (reimplement locally in the tui package — cmd/lmm helpers aren't importable)
+  - `prototypeProvider.SourceInfos()`: 2–3 static rows exercising the layout
+  - `ScreenSources` registered per the standard pattern: keys.go const + `screens` slice + `String()` case + KeyMap binding `"5"`; app.go `updateKey` case, `screenView()` case, `itemCount`, `selected` seed, `dashboardMenu` entry in BOTH layout branches; `sourcesView()` renderer following `profilesView`'s single-pane list style with columns ID / TYPE / AUTH / CAPABILITIES
+- Consumes: `source.CapabilitiesOf`, the custom source types.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/tui/sources_view_test.go` (follow app_test.go/navigation_test.go conventions):
+
+```go
+func TestSourcesScreenRegistered(t *testing.T) {
+	// screens slice contains ScreenSources; String() returns a non-default
+	// label; screenAt round-trips; pressing "5" from the dashboard navigates
+	// (drive Model.Update with the key like navigation_test.go does).
+}
+
+func TestSourceInfosPrototype(t *testing.T) {
+	p := NewPrototypeProvider()
+	infos := p.SourceInfos()
+	require.NotEmpty(t, infos)
+	for _, si := range infos {
+		assert.NotEmpty(t, si.ID)
+		assert.NotEmpty(t, si.Type)
+	}
+}
+
+func TestSourcesViewRenders(t *testing.T) {
+	// Prototype model, navigate to ScreenSources, assert the rendered view
+	// contains each prototype source's ID and TYPE and the column headers.
+}
+
+func TestCoreProviderSourceInfos(t *testing.T) {
+	// Real core.Service with a registered directory source (custom.NewDirectory
+	// over t.TempDir()) + a stub built-in: assert directory row has
+	// Type "directory", Auth "n/a" (no auth capability), and rows sorted by ID.
+}
+```
+
+(Intent sketches — flesh out with the package's real constructors; assertions are the contract.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/tui/ -run 'TestSources|TestSourceInfos' -v`
+Expected: FAIL — `undefined: ScreenSources`, `SourceInfos` not on the interface.
+
+- [ ] **Step 3: Implement**
+
+Follow the registration checklist from the Interfaces block exactly (keys.go: 3 touches; app.go: 5 touches incl. both dashboard-menu layout branches; service.go: type + interface method + prototype rows; service_core.go: real implementation). `sourcesView()` renders a header line, column headers, and one row per `SourceInfo` with the selected row highlighted like `profilesView` does; respect the layout/width conventions of the sibling views. Update the help overlay (`helpView`) with the new screen's key.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/tui/ -race -v && go build ./...`
+Expected: PASS, including all pre-existing navigation tests (the new screen changes `screens` length — check tests that pin the count or tab-cycle order and update them deliberately, noting each in the report).
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/tui/keys.go internal/tui/app.go internal/tui/service.go internal/tui/service_core.go internal/tui/sources_view_test.go
+git commit -m "feat(tui): read-only Sources screen"
+```
+
+---
+
+## Task 6: End-to-end aggregate test (acceptance criterion 1)
+
+**Files:**
+- Test: `internal/core/service_aggregate_e2e_test.go` (create)
+
+Pins #50 acceptance criterion 1 with REAL source implementations (not stubs): a directory source and a manifest source both return labeled results in one aggregate search; a failing remote source (dead-URL manifest) degrades to a warning without hiding the local results.
+
+- [ ] **Step 1: Write the test**
+
+Create `internal/core/service_aggregate_e2e_test.go` (`package core_test`):
+
+```go
+func TestAggregateSearchEndToEnd(t *testing.T) {
+	// Directory source: t.TempDir() with subdir "CoolLocalMod".
+	// Manifest source: local mods.yaml with mod "cool-remote" (reuse the
+	// manifest fixture style from service_manifest_source_test.go).
+	// Dead source: manifest def with URL https://127.0.0.1:1/mods.yaml
+	//   (AllowHTTP false, https scheme — construction is pure, fetch fails).
+	// Register all three via custom.New; game maps all three with "" values.
+
+	res, err := svc.SearchAllSources(ctx, game.ID, "cool", "", nil, 0, 20)
+	require.NoError(t, err, "dead source must not fail the aggregate")
+
+	bySource := map[string][]string{}
+	for _, m := range res.Mods {
+		bySource[m.SourceID] = append(bySource[m.SourceID], m.ID)
+	}
+	assert.Contains(t, bySource, "local-mods")
+	assert.Contains(t, bySource, "manifest-repo")
+	require.Len(t, res.Warnings, 1)
+	assert.Equal(t, "dead-repo", res.Warnings[0].SourceID)
+
+	// Every merged mod carries the lmm game id (the Phase 2/3 lesson).
+	for _, m := range res.Mods {
+		assert.Equal(t, game.ID, m.GameID)
+	}
+}
+```
+
+(Intent sketch — complete the arrangement with the real fixture helpers from the neighboring e2e files; every assertion stays. Also add a second test: the same setup queried through `svc.SearchMods` with an explicit single source still works — guarding that aggregate didn't regress single-source.)
+
+- [ ] **Step 2: Run and commit**
+
+Run: `go test ./internal/core/ -run TestAggregateSearch -race -v && go test ./...`
+Expected: PASS.
+
+```bash
+go fmt ./... && go vet ./...
+git add internal/core/service_aggregate_e2e_test.go
+git commit -m "test(core): aggregate search end-to-end with mixed real sources"
+```
+
+---
+
+## Task 7: Documentation and version bump
+
+**Files:**
+- Modify: `README.md`, `CHANGELOG.md`, `cmd/lmm/root.go` (version)
+
+ACCURACY RULE (twice-burned in this epic): verify every sentence against the code on this branch; capture real output with a scratch build.
+
+- [ ] **Step 1: Update docs**
+
+README.md:
+- Search docs: no `--source` = all configured sources concurrently; SOURCE column; per-source failures warn on stderr; `--source` narrows; the §7 notice for non-searching sources (real captured output).
+- TUI docs: "All sources" default + `s` cycling; the Sources screen (key `5`); note the TUI lists registered sources (definition load errors visible via `lmm source list`).
+- Custom Sources section: cross-reference that aggregate search is how multi-source games surface everything in one query.
+
+CHANGELOG.md — `[Unreleased]` → `### Added`:
+
+```markdown
+- Aggregate search: `lmm search` without `--source` now queries every source configured for the game concurrently, with per-source failures reported as warnings
+- Search results (CLI and TUI) show each mod's source; the TUI search defaults to "All sources"
+- TUI Sources screen (key `5`) mirroring `lmm source list`
+```
+
+Then `## [1.10.0] - <today>`, comparison links, `version = "1.10.0"`.
+
+- [ ] **Step 2: Final verification and commits**
+
+```bash
+go fmt ./... && go vet ./... && go test ./... -race
+git add README.md CHANGELOG.md
+git commit -m "docs: document aggregate search and the TUI Sources screen"
+git add cmd/lmm/root.go CHANGELOG.md
+git commit -m "chore: bump version to 1.10.0"
+```
+
+---
+
+## Out of Scope
+
+- TUI mutations (#37/#42) — capability-gating of actions lands there (recorded requirement: mutation UI must consult `CapabilitiesOf`)
+- Global re-ranking / cross-source dedup (explicitly excluded by design §5 v1)
+- #52 directory-source polish; deferred Phase 4 polish (url.Error unwrap unification, path-prefix validation, auth-guard dedup)


### PR DESCRIPTION
## Summary

- Moves all 25 completed implementation/design plan docs (v1.0 MVP era through the custom-sources epic, previously local-only) into `docs/plans/archive/` and commits them for historical reference
- `docs/plans/` now holds only in-flight plans — currently just the TUI roadmap (`2026-04-28-tui-implementation.md`), whose Phase 5 (mutations, #37/#42) is still pending
- Updates the stale `CLAUDE.md`/`AGENTS.md` "Implementation Plan" section, which still pointed at the long-shipped v1.0 plan, to describe the new layout

Docs-only change: no code, no version bump, no CHANGELOG entry (internal dev docs, not user-facing functionality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)