### PR TITLE
feat(tui): Phase 5a — mutating actions behind confirmations (v1.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - TUI quit now cancels any in-flight search or action context instead of leaving it running past program exit (#42 lifecycle item)
+- TUI: screen-cycling (`tab`/`shift+tab`, `↑↓`/`h`/`l`, and the direct screen-jump keys) no longer auto-focuses the search input when it lands on Search — only `/`, `3`, and selecting "Search Archives" from the Dashboard menu do (all three are explicit search intent); `Esc` still blurs. Corrects 1.10.0's Changed entry below, which described the old always-focus behavior as intentional
+- TUI: Installed Mods and Profiles rows no longer misalign on long names — both now derive proportional column widths from the panel width and hard-truncate every field instead of a fixed-width column with no truncation
+- TUI: the footer's opaque `e/x/D: mutate` hint is now explicit (`e: enable/disable · x: uninstall · D: deploy`), and no longer risks the footer line overflowing the terminal by one row on narrow widths
 
 ## [1.10.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-20
+
+### Added
+
+- TUI mutating actions behind confirmation prompts: enable/disable (`e`), uninstall (`x`), and deploy (`D`) on Installed Mods (`D` also works from the Dashboard), and profile switch (`enter` on a non-active Profiles row) with a plan preview — every action opens a confirmation modal (`y`/`enter` confirms, `n`/`esc` cancels) and reports its outcome on a status line, including a warning count when the underlying flow reported any
+- `--prototype` mode demos all of the above against simulated data, including a canned profile that demonstrates the profile-switch needs-downloads refusal
+- Core: mutation flows extracted from the CLI into `internal/core` (`EnableMod`/`DisableMod`, `UninstallMod`, `DeployProfile`, `PlanProfileSwitch`/`ApplyProfileSwitch`) so the TUI and CLI share the same logic; CLI behavior is unchanged
+
+### Changed
+
+- `lmm deploy --purge`'s per-mod `uninstall.before_each` hook-skip diagnostic now prints to stderr with the mod's name attached (was an unattributed line on stdout) — the one intentional CLI output change from this phase's core extraction
+
+### Fixed
+
+- TUI quit now cancels any in-flight search or action context instead of leaving it running past program exit (#42 lifecycle item)
+
 ## [1.10.0] - 2026-07-18
 
 ### Added
@@ -740,7 +756,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.7.0...v1.8.0

--- a/README.md
+++ b/README.md
@@ -145,19 +145,21 @@ lmm mod set-update 12345 --game skyrim-se --pin
 
 ### Terminal UI
 
-Browse your configured game, installed mods, and profiles interactively, search mod sources, and inspect the source registry:
+Browse your configured game, installed mods, and profiles interactively, search mod sources, inspect the source registry, and manage mods in place — enable/disable, uninstall, deploy, and switch profiles — with every mutating action behind a confirmation prompt:
 
 ```bash
-lmm tui                     # real data, read-only
+lmm tui                     # real data
 lmm tui --theme amber       # themes: wizardry (default), amber, dos, green
 lmm tui --prototype         # demo mode with static fake data
 ```
 
 Keys: `tab`/`h`/`l` cycle screens, `1`–`5` jump, `3` jumps to Search (any
 entry path focuses the input immediately; `5` opens Sources), `↑↓`/`j`/`k`
-move, `enter` open/select, `/` focus search from anywhere, type query,
-`enter` to search, `esc` unfocus (clears focus; afterward `s` cycles sources,
-number keys switch screens), `n`/`p` next/previous page, `?` help, `q` quit.
+move, `enter` open/select (on Profiles, switch to the selected profile),
+`/` focus search from anywhere, type query, `enter` to search, `esc` unfocus
+(clears focus; afterward `s` cycles sources, number keys switch screens),
+`n`/`p` next/previous page, `e`/`x`/`D` enable-disable/uninstall/deploy (see
+below), `?` help, `q` quit.
 
 The Search screen defaults to **All sources**, mirroring the CLI: the typed
 query runs concurrently against every source configured for the game. Press
@@ -174,7 +176,33 @@ built-in and custom — with the same ID/TYPE/AUTH/CAPABILITIES columns as
 source whose definition file failed to load (bad YAML, ID collision, etc.)
 has no row here — check `lmm source list` for those.
 
-Browsing and searching are read-only — install/update/deploy actions from the TUI arrive in a later release.
+On **Installed Mods**, `e` toggles the selected mod's enable/disable state
+(the direction follows its current status: disabled mods enable, everything
+else disables) and `x` uninstalls it — removing deployed files, cache, and
+its profile entry, running uninstall hooks along the way. `D` deploys the
+active profile (using its current enabled mods) from either Installed Mods
+or the Dashboard.
+
+On **Profiles**, `enter` on a profile other than the active one plans the
+switch and shows a preview: mods to enable/disable, or "No mod changes; set
+as default." when nothing would change. `enter` on the already-active
+profile just reports "Already on profile ..." with no modal. If the plan
+would need to download anything not already installed, the switch is
+refused with a message pointing at `lmm profile switch` — installing from
+the TUI is coming in a later phase.
+
+Every mutating action — enable/disable, uninstall, deploy, profile switch —
+opens a confirmation panel describing what will change before it runs:
+`y`/`enter` confirms, `n`/`esc` cancels, and only one action can be in
+flight at a time. Once it finishes, a one-line status message reports the
+outcome (including a warning count, if the flow reported any) and clears on
+your next keypress. `--prototype` mode demos all of these actions against
+simulated data, including one canned profile that always exercises the
+needs-downloads refusal.
+
+Installing a mod from search results and checking/applying updates from the
+TUI aren't available yet — use `lmm install` and `lmm update` for those
+until a later release.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -153,13 +153,15 @@ lmm tui --theme amber       # themes: wizardry (default), amber, dos, green
 lmm tui --prototype         # demo mode with static fake data
 ```
 
-Keys: `tab`/`h`/`l` cycle screens, `1`–`5` jump, `3` jumps to Search (any
-entry path focuses the input immediately; `5` opens Sources), `↑↓`/`j`/`k`
-move, `enter` open/select (on Profiles, switch to the selected profile),
-`/` focus search from anywhere, type query, `enter` to search, `esc` unfocus
-(clears focus; afterward `s` cycles sources, number keys switch screens),
-`n`/`p` next/previous page, `e`/`x`/`D` enable-disable/uninstall/deploy (see
-below), `?` help, `q` quit.
+Keys: `tab`/`h`/`l` cycle screens (landing on Search this way does not focus
+the input), `1`–`5` jump directly (`3` focuses search immediately, like `/`;
+`5` opens Sources), `↑↓`/`j`/`k` move, `enter` open/select (on Profiles,
+switch to the selected profile; selecting "Search Archives" from the
+Dashboard menu also focuses search — explicit search intent focuses,
+passive cycling doesn't), `/` focus search from anywhere, type query,
+`enter` to search, `esc` unfocus (clears focus; afterward `s` cycles
+sources, number keys switch screens), `n`/`p` next/previous page, `e`/`x`/`D`
+enable-disable/uninstall/deploy (see below), `?` help, `q` quit.
 
 The Search screen defaults to **All sources**, mirroring the CLI: the typed
 query runs concurrently against every source configured for the game. Press

--- a/cmd/lmm/deploy.go
+++ b/cmd/lmm/deploy.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
-	"github.com/DonovanMods/linux-mod-manager/internal/linker"
-	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 
 	"github.com/spf13/cobra"
 )
@@ -69,85 +67,90 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, args []string) error {
 	profileName := profileOrDefault(deployProfile)
 
-	// If --purge flag is set, purge all deployed mods first
-	// We remember which mods were enabled before purging so we can redeploy them
-	var enabledBeforePurge map[string]bool
-	if deployPurge {
-		// Remember enabled mods before purge
-		mods, err := service.GetInstalledMods(game.ID, profileName)
-		if err != nil {
-			return fmt.Errorf("getting installed mods: %w", err)
-		}
-		enabledBeforePurge = make(map[string]bool)
-		for _, mod := range mods {
-			if mod.Enabled {
-				enabledBeforePurge[mod.SourceID+":"+mod.ID] = true
-			}
-		}
-
-		if err := purgeDeployedMods(ctx, service, game, profileName, deployForce); err != nil {
-			return fmt.Errorf("purging mods: %w", err)
-		}
-	}
-
-	// Determine link method
-	var linkMethod domain.LinkMethod
+	var linkMethodOverride *domain.LinkMethod
 	if deployMethod != "" {
+		var m domain.LinkMethod
 		switch deployMethod {
 		case "symlink":
-			linkMethod = domain.LinkSymlink
+			m = domain.LinkSymlink
 		case "hardlink":
-			linkMethod = domain.LinkHardlink
+			m = domain.LinkHardlink
 		case "copy":
-			linkMethod = domain.LinkCopy
+			m = domain.LinkCopy
 		default:
 			return fmt.Errorf("invalid link method: %s (use: symlink, hardlink, or copy)", deployMethod)
 		}
-	} else {
-		linkMethod = service.GetGameLinkMethod(game)
+		linkMethodOverride = &m
+	}
+	methodName := service.GetGameLinkMethod(game).String()
+	if linkMethodOverride != nil {
+		methodName = linkMethodOverride.String()
 	}
 
-	lnk := linker.New(linkMethod)
-	installer := service.NewInstallerWithLinker(game, lnk)
-
-	// Get mods to deploy
-	var modsToDeploy []*domain.InstalledMod
-
+	opts := core.DeployOptions{
+		Purge:       deployPurge,
+		LinkMethod:  linkMethodOverride,
+		All:         deployAll,
+		Hooks:       getResolvedHooks(service, game, profileName),
+		HookRunner:  getHookRunner(service),
+		HookContext: makeHookContext(game),
+		Force:       deployForce,
+	}
 	if len(args) > 0 {
-		// Specific mod
-		modID := args[0]
-		mod, err := service.GetInstalledMod(deploySource, modID, game.ID, profileName)
-		if err != nil {
-			return fmt.Errorf("mod not found: %s", modID)
-		}
-		if !mod.Enabled && !deployAll {
-			return fmt.Errorf("mod %s is disabled - use --all to deploy disabled mods, or enable it with 'lmm mod enable %s'", mod.Name, modID)
-		}
-		modsToDeploy = append(modsToDeploy, mod)
-	} else {
-		// Get mods in profile load order (first = lowest priority)
-		mods, err := service.GetInstalledModsInProfileOrder(game.ID, profileName)
-		if err != nil {
-			return fmt.Errorf("getting installed mods: %w", err)
-		}
+		opts.ModID = args[0]
+		opts.SourceID = deploySource
+	}
 
-		for i := range mods {
-			shouldDeploy := false
-			if deployAll {
-				shouldDeploy = true
-			} else if enabledBeforePurge != nil {
-				shouldDeploy = enabledBeforePurge[mods[i].SourceID+":"+mods[i].ID]
-			} else {
-				shouldDeploy = mods[i].Enabled
-			}
+	// deployHeaderPrinted tracks whether we ever reached the deploy loop (as
+	// opposed to only a --purge pass, or neither): DeployProfile fires no
+	// per-mod progress events at all when there is nothing to deploy, which
+	// is exactly the "No mods to deploy" case the pre-extraction CLI checked
+	// via len(modsToDeploy) before it had been folded into the flow.
+	deployHeaderPrinted := false
+	printDeployHeaderOnce := func(total int) {
+		if deployHeaderPrinted {
+			return
+		}
+		deployHeaderPrinted = true
+		fmt.Printf("Deploying %d mod(s) using %s...\n\n", total, methodName)
+	}
 
-			if shouldDeploy {
-				modsToDeploy = append(modsToDeploy, &mods[i])
-			}
+	progress := func(p core.DeployProgress) {
+		if p.Phase == core.DeployPurging {
+			fmt.Printf("Purging %d mod(s) before deploy...\n\n", p.Total)
+			return
+		}
+		printDeployHeaderOnce(p.Total)
+		switch p.Phase {
+		case core.DeployBeforeEachSkipped:
+			fmt.Printf("  Skipped: %s\n", p.Detail)
+		case core.DeployRedownloading:
+			fmt.Printf("  %s %s - cache missing, re-downloading...\n", colorYellow("⚠"), p.ModName)
+		case core.DeployFallbackUsed:
+			fmt.Printf("  %s %s - stored file IDs not found, using primary\n", colorYellow("⚠"), p.ModName)
+		case core.DeployDownloading:
+			fmt.Printf("\r  ⬇ %s: %.1f%%", p.ModName, p.Percent)
+		case core.DeployDownloadFailed:
+			fmt.Println()
+			fmt.Printf("  %s %s - %s\n", colorRed("✗"), p.ModName, p.Detail)
+			fmt.Println()
+		case core.DeploySkipped:
+			fmt.Printf("  %s %s - %s\n", colorRed("✗"), p.ModName, p.Detail)
+		case core.DeployDeployed:
+			fmt.Printf("  %s %s\n", colorGreen("✓"), p.ModName)
 		}
 	}
 
-	if len(modsToDeploy) == 0 {
+	result, err := service.DeployProfile(ctx, game, profileName, opts, progress)
+	if err != nil {
+		// DeployProfile's error-path convention returns any diagnostics
+		// accumulated before the fatal error alongside it; print them now,
+		// or they'd otherwise be lost even though they already happened.
+		printDeployDiagnostics(result)
+		return err
+	}
+
+	if !deployHeaderPrinted {
 		if deployAll {
 			fmt.Println("No mods to deploy.")
 		} else {
@@ -156,163 +159,10 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 		return nil
 	}
 
-	// Set up hooks for deploy phase (uses install hooks)
-	hookRunner := getHookRunner(service)
-	resolvedHooks := getResolvedHooks(service, game, profileName)
-	hookCtx := makeHookContext(game)
-	var hookErrors []error
+	printDeployDiagnostics(result)
 
-	// Run install.before_all hook (for deploy phase)
-	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Install.BeforeAll != "" {
-		hookCtx.HookName = "install.before_all"
-		if _, err := hookRunner.Run(ctx, resolvedHooks.Install.BeforeAll, hookCtx); err != nil {
-			if !deployForce {
-				return fmt.Errorf("install.before_all hook failed: %w", err)
-			}
-			fmt.Fprintf(os.Stderr, "Warning: install.before_all hook failed (forced): %v\n", err)
-		}
-	}
-
-	methodName := linkMethod.String()
-	fmt.Printf("Deploying %d mod(s) using %s...\n\n", len(modsToDeploy), methodName)
-
-	var succeeded, failed int
-
-	for _, mod := range modsToDeploy {
-		// Run install.before_each hook
-		if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Install.BeforeEach != "" {
-			hookCtx.HookName = "install.before_each"
-			hookCtx.ModID = mod.ID
-			hookCtx.ModName = mod.Name
-			hookCtx.ModVersion = mod.Version
-			if _, err := hookRunner.Run(ctx, resolvedHooks.Install.BeforeEach, hookCtx); err != nil {
-				fmt.Printf("  Skipped: install.before_each hook failed: %v\n", err)
-				failed++
-				continue // Skip this mod, continue with others
-			}
-		}
-		// Check if mod is in cache
-		if !service.GetGameCache(game).Exists(game.ID, mod.SourceID, mod.ID, mod.Version) {
-			fmt.Printf("  %s %s - cache missing, re-downloading...\n", colorYellow("⚠"), mod.Name)
-
-			// Fetch mod info from source
-			fetchedMod, err := service.GetMod(ctx, mod.SourceID, game.ID, mod.ID)
-			if err != nil {
-				fmt.Printf("  %s %s - failed to fetch: %v\n", colorRed("✗"), mod.Name, err)
-				failed++
-				continue
-			}
-
-			// Get available files
-			files, err := service.GetModFiles(ctx, mod.SourceID, fetchedMod)
-			if err != nil || len(files) == 0 {
-				fmt.Printf("  %s %s - no files available\n", colorRed("✗"), mod.Name)
-				failed++
-				continue
-			}
-
-			// Find files to download - use stored FileIDs or fall back to primary
-			filesToDownload, usedFallback, err := selectFilesToDownload(files, mod.FileIDs)
-			if err != nil {
-				fmt.Printf("  %s %s - %v\n", colorRed("✗"), mod.Name, err)
-				failed++
-				continue
-			}
-			if usedFallback {
-				fmt.Printf("  %s %s - stored file IDs not found, using primary\n", colorYellow("⚠"), mod.Name)
-			}
-
-			// Download each file
-			downloadFailed := false
-			for _, selectedFile := range filesToDownload {
-				progressFn := func(p core.DownloadProgress) {
-					if p.TotalBytes > 0 {
-						fmt.Printf("\r  ⬇ %s: %.1f%%", mod.Name, p.Percentage)
-					}
-				}
-
-				_, err = service.DownloadMod(ctx, mod.SourceID, game, fetchedMod, selectedFile, progressFn)
-				if err != nil {
-					fmt.Println()
-					fmt.Printf("  %s %s - download failed: %v\n", colorRed("✗"), mod.Name, err)
-					downloadFailed = true
-					break
-				}
-			}
-			fmt.Println() // Clear progress line
-
-			if downloadFailed {
-				failed++
-				continue
-			}
-		}
-
-		// Undeploy first (remove old links/files)
-		if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
-			if verbose {
-				fmt.Printf("  Warning: undeploy %s: %v\n", mod.Name, err)
-			}
-		}
-
-		// Redeploy with new method
-		if err := installer.Install(ctx, game, &mod.Mod, profileName); err != nil {
-			fmt.Printf("  %s %s - %v\n", colorRed("✗"), mod.Name, err)
-			failed++
-			continue
-		}
-
-		// Update the link method in database
-		if err := service.SetModLinkMethod(mod.SourceID, mod.ID, game.ID, profileName, linkMethod); err != nil {
-			if verbose {
-				fmt.Printf("  Warning: could not update link method: %v\n", err)
-			}
-		}
-
-		// Mark mod as deployed (files are now in game directory)
-		if err := service.SetModDeployed(mod.SourceID, mod.ID, game.ID, profileName, true); err != nil {
-			if verbose {
-				fmt.Printf("  Warning: could not mark as deployed: %v\n", err)
-			}
-		}
-
-		fmt.Printf("  %s %s\n", colorGreen("✓"), mod.Name)
-		succeeded++
-
-		// Run install.after_each hook
-		if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Install.AfterEach != "" {
-			hookCtx.HookName = "install.after_each"
-			hookCtx.ModID = mod.ID
-			hookCtx.ModName = mod.Name
-			hookCtx.ModVersion = mod.Version
-			if _, err := hookRunner.Run(ctx, resolvedHooks.Install.AfterEach, hookCtx); err != nil {
-				hookErrors = append(hookErrors, fmt.Errorf("install.after_each hook failed for %s: %w", mod.ID, err))
-			}
-		}
-	}
-
-	// Run install.after_all hook (for deploy phase)
-	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Install.AfterAll != "" {
-		hookCtx.HookName = "install.after_all"
-		hookCtx.ModID = ""
-		hookCtx.ModName = ""
-		hookCtx.ModVersion = ""
-		if _, err := hookRunner.Run(ctx, resolvedHooks.Install.AfterAll, hookCtx); err != nil {
-			hookErrors = append(hookErrors, fmt.Errorf("install.after_all hook failed: %w", err))
-		}
-	}
-
-	// Apply profile overrides (INI tweaks, etc.)
-	if profile, err := config.LoadProfile(service.ConfigDir(), game.ID, profileName); err == nil && len(profile.Overrides) > 0 {
-		if err := core.ApplyProfileOverrides(game, profile); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: applying profile overrides: %v\n", err)
-		}
-	}
-
-	// Print hook warnings
-	printHookWarnings(hookErrors)
-
-	fmt.Printf("\nDeployed: %d", succeeded)
-	if failed > 0 {
+	fmt.Printf("\nDeployed: %d", result.Deployed)
+	if failed := len(result.Skipped); failed > 0 {
 		fmt.Printf(", Failed: %d", failed)
 	}
 	fmt.Println()
@@ -323,6 +173,27 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 	}
 
 	return nil
+}
+
+// printDeployDiagnostics prints result's accumulated diagnostics using the
+// display contract documented on core.DeployResult: Notes go to stdout,
+// only under --verbose (each entry already carries its historical prefix);
+// Warnings go to stderr, unconditionally. Safe to call with a nil result.
+// Mirrors printUninstallDiagnostics.
+func printDeployDiagnostics(result *core.DeployResult) {
+	if result == nil {
+		return
+	}
+
+	if verbose {
+		for _, n := range result.Notes {
+			fmt.Printf("  %s\n", n)
+		}
+	}
+
+	for _, w := range result.Warnings {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", w)
+	}
 }
 
 // findFilesByIDs finds downloadable files matching the given IDs

--- a/cmd/lmm/deploy.go
+++ b/cmd/lmm/deploy.go
@@ -115,11 +115,36 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 		fmt.Printf("Deploying %d mod(s) using %s...\n\n", total, methodName)
 	}
 
+	// progress prints every diagnostic and per-mod status line at its exact
+	// point of occurrence, driven entirely by core.DeployProfile's progress
+	// events - including diagnostics that also land in result.Warnings/
+	// .Notes (see core.DeployResult's doc comment). Those slices are never
+	// separately batch-printed below: every entry has a corresponding event
+	// here, so doing so would double-print. Phases that occur before the
+	// deploy loop starts (a forced before_all warning, anything from the
+	// --purge pass) return early, without calling printDeployHeaderOnce -
+	// they must print before "Deploying N mod(s)..." even exists.
 	progress := func(p core.DeployProgress) {
-		if p.Phase == core.DeployPurging {
-			fmt.Printf("Purging %d mod(s) before deploy...\n\n", p.Total)
+		switch p.Phase {
+		case core.DeployBeforeAllForced:
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", p.Detail)
+			return
+		case core.DeployPurging:
+			fmt.Printf("Purging %d mod(s) before deploy...\n", p.Total)
+			return
+		case core.PurgeWarning:
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", p.Detail)
+			return
+		case core.PurgeNote:
+			if verbose {
+				fmt.Printf("  %s\n", p.Detail)
+			}
+			return
+		case core.PurgeComplete:
+			fmt.Println()
 			return
 		}
+
 		printDeployHeaderOnce(p.Total)
 		switch p.Phase {
 		case core.DeployBeforeEachSkipped:
@@ -138,15 +163,20 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 			fmt.Printf("  %s %s - %s\n", colorRed("✗"), p.ModName, p.Detail)
 		case core.DeployDeployed:
 			fmt.Printf("  %s %s\n", colorGreen("✓"), p.ModName)
+		case core.DeployNote:
+			if verbose {
+				fmt.Printf("  %s\n", p.Detail)
+			}
+		case core.DeployWarning:
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", p.Detail)
 		}
 	}
 
 	result, err := service.DeployProfile(ctx, game, profileName, opts, progress)
 	if err != nil {
-		// DeployProfile's error-path convention returns any diagnostics
-		// accumulated before the fatal error alongside it; print them now,
-		// or they'd otherwise be lost even though they already happened.
-		printDeployDiagnostics(result)
+		// Diagnostics accumulated before a fatal error (DeployProfile's
+		// error-path convention returns them alongside it) were already
+		// printed above, live, via progress - nothing left to print here.
 		return err
 	}
 
@@ -158,8 +188,6 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 		}
 		return nil
 	}
-
-	printDeployDiagnostics(result)
 
 	fmt.Printf("\nDeployed: %d", result.Deployed)
 	if failed := len(result.Skipped); failed > 0 {
@@ -173,27 +201,6 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 	}
 
 	return nil
-}
-
-// printDeployDiagnostics prints result's accumulated diagnostics using the
-// display contract documented on core.DeployResult: Notes go to stdout,
-// only under --verbose (each entry already carries its historical prefix);
-// Warnings go to stderr, unconditionally. Safe to call with a nil result.
-// Mirrors printUninstallDiagnostics.
-func printDeployDiagnostics(result *core.DeployResult) {
-	if result == nil {
-		return
-	}
-
-	if verbose {
-		for _, n := range result.Notes {
-			fmt.Printf("  %s\n", n)
-		}
-	}
-
-	for _, w := range result.Warnings {
-		fmt.Fprintf(os.Stderr, "Warning: %v\n", w)
-	}
 }
 
 // findFilesByIDs finds downloadable files matching the given IDs

--- a/cmd/lmm/deploy.go
+++ b/cmd/lmm/deploy.go
@@ -155,6 +155,8 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 			fmt.Printf("  %s %s - stored file IDs not found, using primary\n", colorYellow("⚠"), p.ModName)
 		case core.DeployDownloading:
 			fmt.Printf("\r  ⬇ %s: %.1f%%", p.ModName, p.Percent)
+		case core.DeployDownloadDone:
+			fmt.Println()
 		case core.DeployDownloadFailed:
 			fmt.Println()
 			fmt.Printf("  %s %s - %s\n", colorRed("✗"), p.ModName, p.Detail)

--- a/cmd/lmm/deploy_test.go
+++ b/cmd/lmm/deploy_test.go
@@ -2,10 +2,17 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeployCmd_Structure(t *testing.T) {
@@ -42,4 +49,181 @@ func TestDeployCmd_NoGame(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no game specified")
+}
+
+// setupDoDeployTest builds a *core.Service plus a game and resets deploy's
+// package-level flag globals to sane defaults for calling doDeploy directly,
+// following setupDoUninstallTest's pattern. noColor is forced on so
+// assertions don't have to match ANSI escapes; verbose is left to the
+// caller. Callers seed their own installed mods/profile.
+func setupDoDeployTest(t *testing.T) (*core.Service, *domain.Game) {
+	t.Helper()
+
+	configDir = t.TempDir()
+	dataDir = t.TempDir()
+	gameDir := t.TempDir()
+
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: configDir, DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	oldSource, oldProfile, oldMethod, oldPurge, oldAll, oldForce, oldNoColor, oldNoHooks :=
+		deploySource, deployProfile, deployMethod, deployPurge, deployAll, deployForce, noColor, noHooks
+	deploySource = "src"
+	deployProfile = ""
+	deployMethod = ""
+	deployPurge = false
+	deployAll = false
+	deployForce = false
+	noColor = true // avoid asserting against ANSI escapes
+	noHooks = false
+	t.Cleanup(func() {
+		deploySource, deployProfile, deployMethod, deployPurge, deployAll, deployForce, noColor, noHooks =
+			oldSource, oldProfile, oldMethod, oldPurge, oldAll, oldForce, oldNoColor, oldNoHooks
+	})
+
+	return svc, game
+}
+
+// seedDeployableMod installs modID/name as enabled, stores fileName in its
+// cache, and adds it to the "default" profile so doDeploy will pick it up.
+func seedDeployableMod(t *testing.T, svc *core.Service, game *domain.Game, modID, name, fileName string) {
+	t.Helper()
+
+	require.NoError(t, svc.GetGameCache(game).Store(game.ID, "src", modID, "1.0", fileName, []byte("data")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: "src", Name: name, Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+	pm := svc.NewProfileManager()
+	if _, err := pm.Get(game.ID, "default"); err != nil {
+		require.ErrorIs(t, err, domain.ErrProfileNotFound)
+		_, err := pm.Create(game.ID, "default")
+		require.NoError(t, err)
+	}
+	require.NoError(t, pm.AddMod(game.ID, "default", domain.ModReference{SourceID: "src", ModID: modID, Version: "1.0"}))
+}
+
+// TestDoDeploy_Verbose_HappyPath_PrintsExpectedOutput guards doDeploy's
+// normal multi-mod console output end to end: the "Deploying N mod(s)
+// using METHOD..." header, one "  ✓ Name" line per mod in profile order,
+// and the "Deployed: N" summary - byte-identical (modulo color, disabled
+// here) to the pre-refactor CLI (git show 21db551~1:cmd/lmm/deploy.go).
+func TestDoDeploy_Verbose_HappyPath_PrintsExpectedOutput(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+	seedDeployableMod(t, svc, game, "b", "Mod B", "b.esp")
+
+	oldVerbose := verbose
+	verbose = true
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "Deploying 2 mod(s) using symlink...\n\n")
+	assert.Contains(t, out, "  ✓ Mod A\n")
+	assert.Contains(t, out, "  ✓ Mod B\n")
+	assert.Contains(t, out, "\nDeployed: 2\n")
+	assert.Less(t, strings.Index(out, "Mod A"), strings.Index(out, "Mod B"), "deploy order must follow profile order")
+
+	for _, f := range []string{"a.esp", "b.esp"} {
+		_, err := os.Lstat(filepath.Join(game.ModPath, f))
+		assert.NoError(t, err, "%s should be deployed", f)
+	}
+}
+
+// TestDoDeploy_AfterEachHookFailure_PrintsWarningToStderrUnconditionally
+// guards the Warnings display contract: an install.after_each hook failure
+// must reach stderr as "Warning: ..." even without --verbose, and must not
+// stop the mod from being reported as deployed (after_each is non-fatal).
+func TestDoDeploy_AfterEachHookFailure_PrintsWarningToStderrUnconditionally(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "1", "Test Mod", "plugin.esp")
+
+	scriptsDir := t.TempDir()
+	failScript := filepath.Join(scriptsDir, "after_each.sh")
+	require.NoError(t, os.WriteFile(failScript, []byte("#!/bin/bash\necho boom >&2\nexit 1\n"), 0755))
+	game.Hooks = domain.GameHooks{Install: domain.HookConfig{AfterEach: failScript}}
+
+	oldVerbose := verbose
+	verbose = false
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	var stdout string
+	stderr, cmdErr := captureStderrErr(t, func() error {
+		stdout = captureStdout(t, func() error {
+			return doDeploy(context.Background(), svc, game, nil)
+		})
+		return nil
+	})
+	require.NoError(t, cmdErr)
+
+	assert.Contains(t, stderr, "Warning: install.after_each hook failed for 1: ")
+	assert.Contains(t, stdout, "  ✓ Test Mod\n")
+	assert.Contains(t, stdout, "\nDeployed: 1\n")
+	assert.NotContains(t, stdout, "Warning:", "Warnings must go to stderr, not stdout")
+}
+
+// TestDoDeploy_Verbose_PrintsUndeployWarningNoteWithHistoricalPrefix guards
+// the Notes display contract for deploy's per-mod bookkeeping diagnostics:
+// a failed "undeploy old files before redeploy" step is recorded with its
+// historical "Warning: undeploy <name>: <err>" text and only shown under
+// --verbose, without stopping the mod from redeploying successfully.
+func TestDoDeploy_Verbose_PrintsUndeployWarningNoteWithHistoricalPrefix(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "1", "Test Mod", "plugin.esp")
+
+	// Deploy once for real, then corrupt the deployed symlink into a plain
+	// file so the symlink linker's Undeploy fails deterministically on the
+	// second pass ("not a symlink") - mirrors
+	// TestService_DisableMod_UndeployFailureIsNonFatal. The cache itself is
+	// untouched, so the subsequent Install still succeeds.
+	require.NoError(t, doDeploy(context.Background(), svc, game, nil))
+	deployedPath := filepath.Join(game.ModPath, "plugin.esp")
+	require.NoError(t, os.Remove(deployedPath))
+	require.NoError(t, os.WriteFile(deployedPath, []byte("not a symlink"), 0644))
+
+	oldVerbose := verbose
+	verbose = true
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "  Warning: undeploy Test Mod: ")
+	assert.Contains(t, out, "  ✓ Test Mod\n")
+	assert.Contains(t, out, "\nDeployed: 1\n")
+}
+
+// TestDoDeploy_NonVerbose_DoesNotPrintNotes guards the other half of the
+// Notes contract: without --verbose, Notes-derived diagnostics must not
+// appear at all.
+func TestDoDeploy_NonVerbose_DoesNotPrintNotes(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "1", "Test Mod", "plugin.esp")
+
+	require.NoError(t, doDeploy(context.Background(), svc, game, nil))
+	deployedPath := filepath.Join(game.ModPath, "plugin.esp")
+	require.NoError(t, os.Remove(deployedPath))
+	require.NoError(t, os.WriteFile(deployedPath, []byte("not a symlink"), 0644))
+
+	oldVerbose := verbose
+	verbose = false
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	assert.NotContains(t, out, "Warning: undeploy")
+	assert.Contains(t, out, "  ✓ Test Mod\n")
 }

--- a/cmd/lmm/deploy_test.go
+++ b/cmd/lmm/deploy_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +15,7 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -499,4 +503,91 @@ func TestDoDeploy_Verbose_PurgeBlankLine_AppearsAfterInlineDiagnosticsNotImmedia
 
 	between := out[diagIdx:deployHeaderIdx]
 	assert.Contains(t, between, "\n\n", "the blank line must appear after the inline purge diagnostic, before the deploy header")
+}
+
+// TestDoDeploy_MissingCacheRedownloadSuccess_PrintsBlankLineAfterDownload
+// guards finding F2 (CLI parity regression): the pre-extraction CLI printed
+// an unconditional `fmt.Println() // Clear progress line` immediately after
+// a cache-miss mod's redownload loop, on the success path (git show
+// b2ad559:cmd/lmm/deploy.go) - a blank line between "cache missing,
+// re-downloading..." and the mod's own "✓" success line. The extracted
+// flow (internal/core/flows.go's redeployFromSource) emits no event for
+// this on success, so doDeploy has nothing to print it from. A real custom
+// manifest source served over httptest provides a working redownload
+// (mockSourceWithDownloads/createTestZip are internal/core-only test
+// helpers, not available to cmd/lmm - mirrors
+// TestDoProfileSwitch_ProceedAccepted_HappyPath_PrintsExpectedOutput's
+// pattern in profile_test.go), so the mod actually reaches its "✓" line
+// instead of being skipped.
+func TestDoDeploy_MissingCacheRedownloadSuccess_PrintsBlankLineAfterDownload(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: redl
+    name: Redownload Mod
+    version: "1.0"
+    summary: A mod to redownload
+    files:
+      - id: main
+        filename: redownload.dat
+        version: "1.0"
+        url: %s/files/redownload.dat
+        primary: true
+`, srv.URL)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	mux.HandleFunc("/files/", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("archive bytes")) })
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "e2e-repo",
+		Name:      "E2E Repo",
+		Type:      custom.TypeManifest,
+		AllowHTTP: true,
+		Manifest:  &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(src)
+
+	// InstalledMod row exists (enabled, in the profile) but nothing was
+	// ever stored in the cache - forces DeployProfile's redownload branch.
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "redl", SourceID: "e2e-repo", Name: "Redownload Mod", Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.AddMod(game.ID, "default", domain.ModReference{SourceID: "e2e-repo", ModID: "redl", Version: "1.0"}))
+
+	oldVerbose := verbose
+	verbose = false
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	redownloadIdx := strings.Index(out, "cache missing, re-downloading...")
+	successIdx := strings.Index(out, "✓ Redownload Mod")
+	require.NotEqual(t, -1, redownloadIdx, "missing redownload diagnostic; got:\n%s", out)
+	require.NotEqual(t, -1, successIdx, "mod must actually redeploy successfully; got:\n%s", out)
+	require.Less(t, redownloadIdx, successIdx)
+
+	// The source reports Content-Length, so the download's progress readout
+	// prints via a bare '\r' (no trailing newline - core.DeployDownloading's
+	// handler above). The pre-extraction CLI's unconditional
+	// `fmt.Println() // Clear progress line` after the download loop (git
+	// show b2ad559:cmd/lmm/deploy.go) is what terminates that line with a
+	// real '\n' before the mod's own "✓" success line prints - without it,
+	// the percent readout and "✓ Redownload Mod" run together on one
+	// physical line.
+	assert.Contains(t, out, "\n  ✓ Redownload Mod", "the mod's success line must start on its own line, not run together with the redownload's progress readout")
+
+	_, err = os.Lstat(filepath.Join(game.ModPath, "redownload.dat"))
+	assert.NoError(t, err, "the redownloaded mod must still be deployed")
 }

--- a/cmd/lmm/deploy_test.go
+++ b/cmd/lmm/deploy_test.go
@@ -591,3 +591,88 @@ mods:
 	_, err = os.Lstat(filepath.Join(game.ModPath, "redownload.dat"))
 	assert.NoError(t, err, "the redownloaded mod must still be deployed")
 }
+
+// TestDoDeploy_MissingCacheRedownloadFailure_PrintsBlankLinesAroundDownloadError
+// guards finding D1: core.DeployProfile's cache-miss redownload path must
+// emit a DeployDownloadFailed event (not DeploySkipped) when the redownload
+// itself fails, so cmd/lmm's dedicated DeployDownloadFailed handler (which
+// prints a blank line, the "✗ <mod> - <detail>" line, then another blank
+// line) actually fires. Reference bytes (git show
+// b2ad559:cmd/lmm/deploy.go, the download-failure branch): "⚠
+// re-downloading..." / blank / "✗ <mod> - download failed: ..." / blank /
+// blank / "Deployed: 0, Failed: 1" - the pre-fix extraction lost both blank
+// lines around the ✗ line because the failure routed through DeploySkipped
+// instead, whose handler prints the ✗ line with no surrounding blank lines.
+// Mirrors TestDoDeploy_MissingCacheRedownloadSuccess_PrintsBlankLineAfterDownload's
+// real custom-manifest-source-over-httptest harness, but deliberately
+// registers no handler for the file URL so the download 404s deterministically.
+func TestDoDeploy_MissingCacheRedownloadFailure_PrintsBlankLinesAroundDownloadError(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: redlfail
+    name: Redownload Fail Mod
+    version: "1.0"
+    summary: A mod whose redownload fails
+    files:
+      - id: main
+        filename: redownload.dat
+        version: "1.0"
+        url: %s/files/redownload.dat
+        primary: true
+`, srv.URL)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	// Deliberately no handler registered for /files/ - the manifest's file
+	// URL 404s via the mux's default handler, making the redownload fail
+	// deterministically without needing to fake a network error.
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "e2e-repo-fail",
+		Name:      "E2E Repo Fail",
+		Type:      custom.TypeManifest,
+		AllowHTTP: true,
+		Manifest:  &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(src)
+
+	// InstalledMod row exists (enabled, in the profile) but nothing was ever
+	// stored in the cache - forces DeployProfile's redownload branch.
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "redlfail", SourceID: "e2e-repo-fail", Name: "Redownload Fail Mod", Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.AddMod(game.ID, "default", domain.ModReference{SourceID: "e2e-repo-fail", ModID: "redlfail", Version: "1.0"}))
+
+	oldVerbose := verbose
+	verbose = false
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	redownloadIdx := strings.Index(out, "cache missing, re-downloading...")
+	failIdx := strings.Index(out, "✗ Redownload Fail Mod - download failed:")
+	deployedIdx := strings.Index(out, "Deployed: 0, Failed: 1")
+	require.NotEqual(t, -1, redownloadIdx, "missing redownload diagnostic; got:\n%s", out)
+	require.NotEqual(t, -1, failIdx, "missing download-failure line; got:\n%s", out)
+	require.NotEqual(t, -1, deployedIdx, "missing summary line; got:\n%s", out)
+	require.Less(t, redownloadIdx, failIdx)
+	require.Less(t, failIdx, deployedIdx)
+
+	between1 := out[redownloadIdx:failIdx]
+	assert.Contains(t, between1, "\n\n", "a blank line must separate the re-downloading diagnostic from the ✗ line")
+
+	between2 := out[failIdx:deployedIdx]
+	assert.Contains(t, between2, "\n\n\n", "two blank lines must separate the ✗ line from the summary line (one from the ✗ handler's trailing blank, one from the summary line's own leading blank)")
+}

--- a/cmd/lmm/deploy_test.go
+++ b/cmd/lmm/deploy_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,9 +12,11 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
 )
 
 func TestDeployCmd_Structure(t *testing.T) {
@@ -49,6 +53,30 @@ func TestDeployCmd_NoGame(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no game specified")
+}
+
+// installBlockingTrigger opens a second connection to the SQLite file at
+// dbPath and installs a trigger that makes any UPDATE touching
+// installed_mods.link_method or installed_mods.deployed fail - used to
+// deterministically force SetModLinkMethod/SetModDeployed to error without
+// affecting any other table or column. Must be called after the
+// *core.Service that owns dbPath has already run its migrations (so the
+// installed_mods table exists). Mirrors the identically-named helper in
+// internal/core/flows_test.go.
+func installBlockingTrigger(t *testing.T, dbPath string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	_, err = conn.Exec(`
+		CREATE TRIGGER block_link_method_and_deployed_updates
+		BEFORE UPDATE OF link_method, deployed ON installed_mods
+		BEGIN
+			SELECT RAISE(ABORT, 'blocked for test');
+		END;
+	`)
+	require.NoError(t, err)
 }
 
 // setupDoDeployTest builds a *core.Service plus a game and resets deploy's
@@ -202,6 +230,9 @@ func TestDoDeploy_Verbose_PrintsUndeployWarningNoteWithHistoricalPrefix(t *testi
 	assert.Contains(t, out, "  Warning: undeploy Test Mod: ")
 	assert.Contains(t, out, "  ✓ Test Mod\n")
 	assert.Contains(t, out, "\nDeployed: 1\n")
+	assert.Equal(t, 1, strings.Count(out, "Warning: undeploy Test Mod:"), "must print exactly once, not double-printed via both an inline event and the end-of-run batch")
+	assert.Less(t, strings.Index(out, "Warning: undeploy Test Mod:"), strings.Index(out, "✓ Test Mod"),
+		"the undeploy warning must print inline, immediately before THIS mod's own success line - not batched at the end of the run (review finding 3)")
 }
 
 // TestDoDeploy_NonVerbose_DoesNotPrintNotes guards the other half of the
@@ -226,4 +257,246 @@ func TestDoDeploy_NonVerbose_DoesNotPrintNotes(t *testing.T) {
 
 	assert.NotContains(t, out, "Warning: undeploy")
 	assert.Contains(t, out, "  ✓ Test Mod\n")
+}
+
+// --- Fix wave 1: console-output positioning (review findings) ---
+
+// captureCombined redirects both os.Stdout and os.Stderr to the same pipe
+// for the duration of fn, preserving the relative order writes to either
+// stream occurred in - necessary to assert cross-stream ordering (e.g.
+// "does the forced before_all warning on stderr print before the header on
+// stdout"), which captureStdout/captureStderrErr can't do since each only
+// captures one stream. fn is expected to succeed; use captureStdout/
+// captureStderrErr directly for error-path assertions.
+func captureCombined(t *testing.T, fn func() error) string {
+	t.Helper()
+	oldOut, oldErr := os.Stdout, os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout, os.Stderr = w, w
+	defer func() { os.Stdout, os.Stderr = oldOut, oldErr }()
+
+	fnErr := fn()
+	require.NoError(t, w.Close(), "closing write end of the pipe")
+	out, readErr := io.ReadAll(r)
+	require.NoError(t, r.Close())
+
+	require.NoError(t, fnErr)
+	require.NoError(t, readErr)
+	return string(out)
+}
+
+// allIndexes returns the start index of every non-overlapping occurrence of
+// substr in s.
+func allIndexes(s, substr string) []int {
+	var idxs []int
+	for offset := 0; ; {
+		i := strings.Index(s[offset:], substr)
+		if i == -1 {
+			return idxs
+		}
+		idxs = append(idxs, offset+i)
+		offset += i + len(substr)
+	}
+}
+
+// TestDoDeploy_ForcedBeforeAllWarning_PrintsBeforeDeployHeader guards review
+// finding 1 (deploy side): a forced install.before_all hook failure must be
+// the FIRST thing doDeploy prints, before the "Deploying N mod(s)..."
+// header - it was the first line of output in the pre-extraction CLI
+// (git show 45470e8:cmd/lmm/deploy.go). Printed unconditionally (no
+// --verbose needed), matching the Warnings display contract.
+func TestDoDeploy_ForcedBeforeAllWarning_PrintsBeforeDeployHeader(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "1", "Test Mod", "plugin.esp")
+
+	scriptsDir := t.TempDir()
+	failScript := filepath.Join(scriptsDir, "before_all.sh")
+	require.NoError(t, os.WriteFile(failScript, []byte("#!/bin/bash\necho boom >&2\nexit 1\n"), 0755))
+	game.Hooks = domain.GameHooks{Install: domain.HookConfig{BeforeAll: failScript}}
+
+	oldForce := deployForce
+	deployForce = true
+	t.Cleanup(func() { deployForce = oldForce })
+
+	out := captureCombined(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	warnIdx := strings.Index(out, "Warning: install.before_all hook failed (forced): ")
+	headerIdx := strings.Index(out, "Deploying 1 mod(s) using symlink...")
+	require.NotEqual(t, -1, warnIdx, "missing forced before_all warning; got:\n%s", out)
+	require.NotEqual(t, -1, headerIdx, "missing deploy header; got:\n%s", out)
+	assert.Less(t, warnIdx, headerIdx, "the forced before_all warning must print before the deploy header")
+}
+
+// TestDoDeploy_ForcedPurgeBeforeAllWarning_PrintsBeforePurgeHeader guards
+// review finding 1 (purge side): a forced uninstall.before_all hook failure
+// during --purge must print before the "Purging N mod(s) before
+// deploy..." header, mirroring the pre-extraction purgeDeployedMods
+// (git show 45470e8:cmd/lmm/purge.go).
+func TestDoDeploy_ForcedPurgeBeforeAllWarning_PrintsBeforePurgeHeader(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "1", "Test Mod", "plugin.esp")
+
+	scriptsDir := t.TempDir()
+	failScript := filepath.Join(scriptsDir, "before_all.sh")
+	require.NoError(t, os.WriteFile(failScript, []byte("#!/bin/bash\necho boom >&2\nexit 1\n"), 0755))
+	game.Hooks = domain.GameHooks{Uninstall: domain.HookConfig{BeforeAll: failScript}}
+
+	oldPurge, oldForce := deployPurge, deployForce
+	deployPurge = true
+	deployForce = true
+	t.Cleanup(func() { deployPurge, deployForce = oldPurge, oldForce })
+
+	out := captureCombined(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	warnIdx := strings.Index(out, "Warning: uninstall.before_all hook failed (forced): ")
+	purgeHeaderIdx := strings.Index(out, "Purging 1 mod(s) before deploy...")
+	require.NotEqual(t, -1, warnIdx, "missing forced purge before_all warning; got:\n%s", out)
+	require.NotEqual(t, -1, purgeHeaderIdx, "missing purge header; got:\n%s", out)
+	assert.Less(t, warnIdx, purgeHeaderIdx, "the forced purge before_all warning must print before the purge header")
+}
+
+// TestDoDeploy_Verbose_LinkMethodAndMarkDeployedWarnings_PrintAdjacentToTheirMod
+// guards review finding 3's other two deploy-loop diagnostics: a failed
+// SetModLinkMethod and a failed SetModDeployed both produce text with NO
+// mod identity in it ("Warning: could not update link method: ..."), so
+// console position - printed immediately before THAT mod's own "✓" line -
+// was the ONLY attribution mechanism pre-extraction. Two mods are seeded so
+// a batched (mis-attributed) implementation is distinguishable from a
+// correctly interleaved one.
+//
+// SetModLinkMethod/SetModDeployed are plain UPDATEs against installed_mods,
+// but Install/Uninstall also write to the DB (deployed_files) - so a
+// blanket write-lock would fail Install itself before ever reaching
+// SetModLinkMethod/SetModDeployed, defeating the test. Instead, a second
+// connection installs a real SQLite trigger that aborts ONLY updates to
+// installed_mods' link_method/deployed columns (see installBlockingTrigger),
+// leaving deployed_files and every other installed_mods column untouched -
+// deterministic, and narrow enough that Install/Uninstall still succeed.
+func TestDoDeploy_Verbose_LinkMethodAndMarkDeployedWarnings_PrintAdjacentToTheirMod(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+	seedDeployableMod(t, svc, game, "b", "Mod B", "b.esp")
+
+	oldVerbose := verbose
+	verbose = true
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	installBlockingTrigger(t, filepath.Join(dataDir, "lmm.db"))
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	modAIdx := strings.Index(out, "✓ Mod A")
+	modBIdx := strings.Index(out, "✓ Mod B")
+	require.NotEqual(t, -1, modAIdx, "missing Mod A success line; got:\n%s", out)
+	require.NotEqual(t, -1, modBIdx, "missing Mod B success line; got:\n%s", out)
+
+	linkWarnings := allIndexes(out, "Warning: could not update link method:")
+	deployedWarnings := allIndexes(out, "Warning: could not mark as deployed:")
+	require.Len(t, linkWarnings, 2, "one link-method warning per mod; got:\n%s", out)
+	require.Len(t, deployedWarnings, 2, "one mark-deployed warning per mod; got:\n%s", out)
+
+	// Mod A's pair must both precede "✓ Mod A"; Mod B's pair must both fall
+	// strictly between "✓ Mod A" and "✓ Mod B" - proof they're interleaved
+	// per-mod, not batched at the end (which would put all four warnings
+	// after both ✓ lines, and be indistinguishable from each other).
+	assert.Less(t, linkWarnings[0], modAIdx)
+	assert.Less(t, deployedWarnings[0], modAIdx)
+	assert.Greater(t, linkWarnings[1], modAIdx)
+	assert.Less(t, linkWarnings[1], modBIdx)
+	assert.Greater(t, deployedWarnings[1], modAIdx)
+	assert.Less(t, deployedWarnings[1], modBIdx)
+}
+
+// TestDoDeploy_OverridesWarning_PrintsBeforeAfterEachAfterAllHookWarnings
+// guards review finding 2: the pre-extraction CLI printed the
+// profile-overrides warning before its batched after_each/after_all hook
+// warnings, even though (both pre- and post-extraction) after_each/
+// after_all are computed earlier in the function than the overrides check -
+// the overrides warning was printed immediately when computed, while the
+// hook warnings were accumulated and only printed afterward via
+// printHookWarnings. All three land on stderr, unconditionally.
+func TestDoDeploy_OverridesWarning_PrintsBeforeAfterEachAfterAllHookWarnings(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "1", "Test Mod", "plugin.esp")
+
+	pm := svc.NewProfileManager()
+	profile, err := pm.Get(game.ID, "default")
+	require.NoError(t, err)
+	// An absolute override path is rejected by ApplyProfileOverrides
+	// deterministically - no filesystem trickery required.
+	profile.Overrides = map[string][]byte{"/etc/passwd": []byte("x")}
+	require.NoError(t, config.SaveProfile(svc.ConfigDir(), profile))
+
+	scriptsDir := t.TempDir()
+	afterEachScript := filepath.Join(scriptsDir, "after_each.sh")
+	require.NoError(t, os.WriteFile(afterEachScript, []byte("#!/bin/bash\necho boom >&2\nexit 1\n"), 0755))
+	afterAllScript := filepath.Join(scriptsDir, "after_all.sh")
+	require.NoError(t, os.WriteFile(afterAllScript, []byte("#!/bin/bash\necho boom >&2\nexit 1\n"), 0755))
+	game.Hooks = domain.GameHooks{Install: domain.HookConfig{AfterEach: afterEachScript, AfterAll: afterAllScript}}
+
+	stderr, cmdErr := captureStderrErr(t, func() error {
+		captureStdout(t, func() error { //nolint:errcheck // stdout content unused; the deploy itself must still succeed
+			return doDeploy(context.Background(), svc, game, nil)
+		})
+		return nil
+	})
+	require.NoError(t, cmdErr)
+
+	overridesIdx := strings.Index(stderr, "Warning: applying profile overrides:")
+	afterEachIdx := strings.Index(stderr, "Warning: install.after_each hook failed")
+	afterAllIdx := strings.Index(stderr, "Warning: install.after_all hook failed")
+	require.NotEqual(t, -1, overridesIdx, "missing overrides warning; got:\n%s", stderr)
+	require.NotEqual(t, -1, afterEachIdx, "missing after_each warning; got:\n%s", stderr)
+	require.NotEqual(t, -1, afterAllIdx, "missing after_all warning; got:\n%s", stderr)
+	assert.Less(t, overridesIdx, afterEachIdx, "overrides warning must print before the after_each hook warning")
+	assert.Less(t, overridesIdx, afterAllIdx, "overrides warning must print before the after_all hook warning")
+}
+
+// TestDoDeploy_Verbose_PurgeBlankLine_AppearsAfterInlineDiagnosticsNotImmediatelyAfterHeader
+// guards review finding 4: the pre-extraction purgeDeployedMods printed its
+// closing blank line at the END of the purge phase (after any inline
+// purge diagnostics), not immediately after the "Purging N mod(s) before
+// deploy..." header. Corrupts a previously-deployed symlink into a plain
+// file so purge's own Uninstall call fails deterministically ("not a
+// symlink"), producing an inline --verbose purge diagnostic to place the
+// blank line after.
+func TestDoDeploy_Verbose_PurgeBlankLine_AppearsAfterInlineDiagnosticsNotImmediatelyAfterHeader(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "1", "Test Mod", "plugin.esp")
+
+	require.NoError(t, doDeploy(context.Background(), svc, game, nil))
+	deployedPath := filepath.Join(game.ModPath, "plugin.esp")
+	require.NoError(t, os.Remove(deployedPath))
+	require.NoError(t, os.WriteFile(deployedPath, []byte("not a symlink"), 0644))
+
+	oldPurge, oldVerbose := deployPurge, verbose
+	deployPurge = true
+	verbose = true
+	t.Cleanup(func() { deployPurge, verbose = oldPurge, oldVerbose })
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	assert.NotContains(t, out, "Purging 1 mod(s) before deploy...\n\n",
+		"no blank line may appear immediately after the purge header - it belongs after any inline purge diagnostics")
+
+	purgeHeaderIdx := strings.Index(out, "Purging 1 mod(s) before deploy...")
+	diagIdx := strings.Index(out, "⚠ Test Mod")
+	deployHeaderIdx := strings.Index(out, "Deploying 1 mod(s) using symlink...")
+	require.NotEqual(t, -1, purgeHeaderIdx, "missing purge header; got:\n%s", out)
+	require.NotEqual(t, -1, diagIdx, "missing inline purge diagnostic; got:\n%s", out)
+	require.NotEqual(t, -1, deployHeaderIdx, "missing deploy header; got:\n%s", out)
+	require.Less(t, purgeHeaderIdx, diagIdx)
+	require.Less(t, diagIdx, deployHeaderIdx)
+
+	between := out[diagIdx:deployHeaderIdx]
+	assert.Contains(t, between, "\n\n", "the blank line must appear after the inline purge diagnostic, before the deploy header")
 }

--- a/cmd/lmm/mod.go
+++ b/cmd/lmm/mod.go
@@ -210,32 +210,20 @@ func doModEnable(ctx context.Context, service *core.Service, game *domain.Game, 
 
 	profileName := profileOrDefault(modProfile)
 
-	// Get the mod to verify it exists
+	// Get the mod to verify it exists and get its name for display
 	mod, err := service.GetInstalledMod(modSource, modID, game.ID, profileName)
 	if err != nil {
 		return fmt.Errorf("mod not found: %s", modID)
 	}
 
-	if mod.Enabled {
+	changed, err := service.EnableMod(ctx, game, profileName, modSource, modID)
+	if err != nil {
+		return err
+	}
+
+	if !changed {
 		fmt.Printf("%s is already enabled.\n", mod.Name)
 		return nil
-	}
-
-	// Check if mod is in cache
-	if !service.GetGameCache(game).Exists(game.ID, modSource, modID, mod.Version) {
-		return fmt.Errorf("mod not found in cache - try reinstalling with 'lmm install --id %s'", modID)
-	}
-
-	// Deploy mod files from cache
-	installer := service.GetInstaller(game)
-
-	if err := installer.Install(ctx, game, &mod.Mod, profileName); err != nil {
-		return fmt.Errorf("failed to deploy mod: %w", err)
-	}
-
-	// Update enabled flag in database
-	if err := service.SetModEnabled(modSource, modID, game.ID, profileName, true); err != nil {
-		return fmt.Errorf("failed to update mod status: %w", err)
 	}
 
 	fmt.Printf("✓ Enabled: %s\n", mod.Name)
@@ -258,30 +246,20 @@ func doModDisable(ctx context.Context, service *core.Service, game *domain.Game,
 
 	profileName := profileOrDefault(modProfile)
 
-	// Get the mod to verify it exists
+	// Get the mod to verify it exists and get its name for display
 	mod, err := service.GetInstalledMod(modSource, modID, game.ID, profileName)
 	if err != nil {
 		return fmt.Errorf("mod not found: %s", modID)
 	}
 
-	if !mod.Enabled {
+	changed, err := service.DisableMod(ctx, game, profileName, modSource, modID)
+	if err != nil {
+		return err
+	}
+
+	if !changed {
 		fmt.Printf("%s is already disabled.\n", mod.Name)
 		return nil
-	}
-
-	// Undeploy mod files from game directory
-	installer := service.GetInstaller(game)
-
-	if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
-		// Warn but continue - files may have been manually removed
-		if verbose {
-			fmt.Printf("  Warning: failed to undeploy some files: %v\n", err)
-		}
-	}
-
-	// Update enabled flag in database
-	if err := service.SetModEnabled(modSource, modID, game.ID, profileName, false); err != nil {
-		return fmt.Errorf("failed to update mod status: %w", err)
 	}
 
 	fmt.Printf("✓ Disabled: %s (files removed from game, kept in cache)\n", mod.Name)

--- a/cmd/lmm/profile.go
+++ b/cmd/lmm/profile.go
@@ -259,125 +259,51 @@ func runProfileSwitch(cmd *cobra.Command, args []string) error {
 	})
 }
 
+// doProfileSwitch owns plan-printing, the "Proceed?" confirmation prompt,
+// and event-driven console output; the diff computation and execution live
+// in core.PlanProfileSwitch/core.ApplyProfileSwitch (see the task report).
+// The prompt deliberately stays here rather than in core: core never blocks
+// on user input.
 func doProfileSwitch(ctx context.Context, service *core.Service, game *domain.Game, targetName string) error {
-	pm := getProfileManager(service)
-
-	// Get target profile
-	targetProfile, err := pm.Get(game.ID, targetName)
+	plan, err := service.PlanProfileSwitch(ctx, game, targetName)
 	if err != nil {
-		return fmt.Errorf("profile not found: %s", targetName)
+		return err
 	}
 
-	// Get current profile
-	currentProfile, err := pm.GetDefault(game.ID)
-	var currentName string
-	if err != nil {
-		currentName = "default"
-	} else {
-		currentName = currentProfile.Name
-	}
-
-	if currentName == targetName {
+	if plan.AlreadyActive {
 		fmt.Printf("Already on profile: %s\n", targetName)
 		return nil
 	}
 
-	// Get installed mods for current profile
-	currentMods, _ := service.GetInstalledMods(game.ID, currentName)
-
-	// Build lookup of current enabled mods
-	currentEnabled := make(map[string]*domain.InstalledMod)
-	for i := range currentMods {
-		if currentMods[i].Enabled {
-			key := currentMods[i].SourceID + ":" + currentMods[i].ID
-			currentEnabled[key] = &currentMods[i]
-		}
-	}
-
-	// Build set of target profile mod keys
-	targetKeys := make(map[string]domain.ModReference)
-	for _, mr := range targetProfile.Mods {
-		key := mr.SourceID + ":" + mr.ModID
-		targetKeys[key] = mr
-	}
-
-	// Get all installed mods (any profile) to check what's available
-	allInstalled := make(map[string]*domain.InstalledMod)
-	allMods, _ := service.GetInstalledMods(game.ID, targetName)
-	for i := range allMods {
-		key := allMods[i].SourceID + ":" + allMods[i].ID
-		allInstalled[key] = &allMods[i]
-	}
-	// Also add from current profile
-	for i := range currentMods {
-		key := currentMods[i].SourceID + ":" + currentMods[i].ID
-		allInstalled[key] = &currentMods[i]
-	}
-
-	// Calculate differences
-	var toDisable []*domain.InstalledMod
-	var toEnable []*domain.InstalledMod
-	var toInstall []domain.ModReference
-	needsRedownloadSet := make(map[string]bool) // Track which mods are re-downloads
-
-	// Mods enabled in current profile but not in target - disable
-	for key, im := range currentEnabled {
-		if _, inTarget := targetKeys[key]; !inTarget {
-			toDisable = append(toDisable, im)
-		}
-	}
-
-	// Mods in target profile
-	for key, ref := range targetKeys {
-		if im, installed := allInstalled[key]; installed {
-			// Already installed - check if cache exists
-			if !service.GetGameCache(game).Exists(game.ID, im.SourceID, im.ID, im.Version) {
-				// Cache missing - need to re-download, preserve FileIDs from installed mod
-				refWithFileIDs := ref
-				refWithFileIDs.FileIDs = im.FileIDs
-				toInstall = append(toInstall, refWithFileIDs)
-				needsRedownloadSet[key] = true
-			} else if !im.Enabled {
-				toEnable = append(toEnable, im)
-			} else if _, wasCurrent := currentEnabled[key]; !wasCurrent {
-				// Was installed but not in current profile's enabled set
-				toEnable = append(toEnable, im)
-			}
-		} else {
-			// Not installed at all
-			toInstall = append(toInstall, ref)
-		}
-	}
-
-	// Show changes
 	fmt.Printf("Switching to profile: %s\n\n", targetName)
 
-	if len(toDisable) == 0 && len(toEnable) == 0 && len(toInstall) == 0 {
-		// No mod changes, just switch the default
-		if err := pm.SetDefault(game.ID, targetName); err != nil {
-			return fmt.Errorf("setting default profile: %w", err)
+	if plan.NoChanges {
+		// No mod changes, just switch the default - ApplyProfileSwitch's
+		// three loops are all empty, so this is exactly a SetDefault call.
+		if _, err := service.ApplyProfileSwitch(ctx, game, plan, nil); err != nil {
+			return err
 		}
 		fmt.Printf("✓ Switched to profile: %s\n", targetName)
 		return nil
 	}
 
-	if len(toDisable) > 0 {
-		fmt.Printf("Will disable %d mod(s):\n", len(toDisable))
-		for _, im := range toDisable {
+	if len(plan.ToDisable) > 0 {
+		fmt.Printf("Will disable %d mod(s):\n", len(plan.ToDisable))
+		for _, im := range plan.ToDisable {
 			fmt.Printf("  - %s (%s)\n", im.Name, im.ID)
 		}
 	}
 
-	if len(toEnable) > 0 {
-		fmt.Printf("Will enable %d mod(s):\n", len(toEnable))
-		for _, im := range toEnable {
+	if len(plan.ToEnable) > 0 {
+		fmt.Printf("Will enable %d mod(s):\n", len(plan.ToEnable))
+		for _, im := range plan.ToEnable {
 			fmt.Printf("  + %s (%s)\n", im.Name, im.ID)
 		}
 	}
 
-	if len(toInstall) > 0 {
-		fmt.Printf("Will install %d mod(s):\n", len(toInstall))
-		for _, ref := range toInstall {
+	if len(plan.ToInstall) > 0 {
+		fmt.Printf("Will install %d mod(s):\n", len(plan.ToInstall))
+		for _, ref := range plan.ToInstall {
 			fmt.Printf("  ↓ %s:%s v%s\n", ref.SourceID, ref.ModID, ref.Version)
 		}
 	}
@@ -393,142 +319,56 @@ func doProfileSwitch(ctx context.Context, service *core.Service, game *domain.Ga
 		return nil
 	}
 
-	installer := service.GetInstaller(game)
-
-	// Disable mods
-	for _, im := range toDisable {
-		if err := installer.Uninstall(ctx, game, &im.Mod, currentName); err != nil {
+	// progress prints every diagnostic and per-mod status line at its exact
+	// point of occurrence, driven entirely by core.ApplyProfileSwitch's
+	// progress events - doProfileSwitch never wrote to stderr, so every
+	// printed diagnostic here is --verbose-gated stdout (a Note), matching
+	// the SwitchResult.Notes display contract. result.Notes is never
+	// separately batch-printed below: every entry has a corresponding event
+	// here already.
+	progress := func(p core.DeployProgress) {
+		switch p.Phase {
+		case core.SwitchDisableNote:
 			if verbose {
-				fmt.Printf("  Warning: failed to undeploy %s: %v\n", im.Name, err)
+				fmt.Printf("  %s\n", p.Detail)
 			}
-		}
-		if err := service.SetModEnabled(im.SourceID, im.ID, game.ID, currentName, false); err != nil {
+		case core.SwitchDisabled:
+			fmt.Printf("  ✓ Disabled: %s\n", p.ModName)
+		case core.SwitchEnableNote:
 			if verbose {
-				fmt.Printf("  Warning: failed to update %s: %v\n", im.Name, err)
+				fmt.Printf("  %s\n", p.Detail)
 			}
-		}
-		fmt.Printf("  ✓ Disabled: %s\n", im.Name)
-	}
-
-	// Enable mods
-	for _, im := range toEnable {
-		if err := installer.Install(ctx, game, &im.Mod, targetName); err != nil {
-			if verbose {
-				fmt.Printf("  Warning: failed to deploy %s: %v\n", im.Name, err)
-			}
-			continue
-		}
-		if err := service.SetModEnabled(im.SourceID, im.ID, game.ID, targetName, true); err != nil {
-			if verbose {
-				fmt.Printf("  Warning: failed to update %s: %v\n", im.Name, err)
-			}
-		}
-		fmt.Printf("  ✓ Enabled: %s\n", im.Name)
-	}
-
-	// Install missing mods
-	if len(toInstall) > 0 {
-		fmt.Println("\nInstalling missing mods...")
-		for _, ref := range toInstall {
-			fmt.Printf("  Installing %s:%s...\n", ref.SourceID, ref.ModID)
-
-			// Fetch mod details
-			mod, err := service.GetMod(ctx, ref.SourceID, game.ID, ref.ModID)
-			if err != nil {
-				fmt.Printf("    Error: failed to fetch mod: %v\n", err)
-				continue
-			}
-
-			// Get files
-			files, err := service.GetModFiles(ctx, ref.SourceID, mod)
-			if err != nil {
-				fmt.Printf("    Error: failed to get files: %v\n", err)
-				continue
-			}
-
-			if len(files) == 0 {
-				fmt.Printf("    Error: no downloadable files\n")
-				continue
-			}
-
-			// Select files to download - use FileIDs from ref (populated for re-downloads from installed mod, or from profile for new installs)
-			filesToDownload, usedFallback, err := selectFilesToDownload(files, ref.FileIDs)
-			if err != nil {
-				fmt.Printf("    Error: %v\n", err)
-				continue
-			}
-			if usedFallback && len(ref.FileIDs) > 0 {
-				fmt.Printf("    Warning: stored file IDs not found, using primary\n")
-			}
-
-			// Download each file
-			progressFn := func(p core.DownloadProgress) {
-				if p.TotalBytes > 0 {
-					fmt.Printf("\r    Downloading: %.1f%%", p.Percentage)
-				}
-			}
-
-			var downloadedFileIDs []string
-			downloadFailed := false
-			for _, selectedFile := range filesToDownload {
-				_, err = service.DownloadMod(ctx, ref.SourceID, game, mod, selectedFile, progressFn)
-				if err != nil {
-					fmt.Println()
-					fmt.Printf("    Error: download failed: %v\n", err)
-					downloadFailed = true
-					break
-				}
-				downloadedFileIDs = append(downloadedFileIDs, selectedFile.ID)
-			}
+		case core.SwitchEnabled:
+			fmt.Printf("  ✓ Enabled: %s\n", p.ModName)
+		case core.SwitchInstalling:
+			fmt.Println("\nInstalling missing mods...")
+		case core.SwitchInstallingMod:
+			fmt.Printf("  Installing %s:%s...\n", p.SourceID, p.ModID)
+		case core.SwitchInstallError:
+			fmt.Printf("    Error: %s\n", p.Detail)
+		case core.SwitchFallbackUsed:
+			fmt.Printf("    Warning: stored file IDs not found, using primary\n")
+		case core.SwitchDownloading:
+			fmt.Printf("\r    Downloading: %.1f%%", p.Percent)
+		case core.SwitchDownloadFailed:
 			fmt.Println()
-
-			if downloadFailed {
-				continue
+			fmt.Printf("    Error: %s\n", p.Detail)
+		case core.SwitchDownloadDone:
+			fmt.Println()
+		case core.SwitchInstalled:
+			fmt.Printf("    ✓ Installed: %s\n", p.ModName)
+		case core.SwitchInstallNote:
+			if verbose {
+				fmt.Printf("    %s\n", p.Detail)
 			}
-
-			// Deploy
-			if err := installer.Install(ctx, game, mod, targetName); err != nil {
-				fmt.Printf("    Error: deploy failed: %v\n", err)
-				continue
-			}
-
-			// Save to DB. Normalize GameID to the lmm game (not the
-			// source-mapped value Service.GetMod stamped onto mod.GameID for
-			// querying the source) so every DB read, which queries by the
-			// lmm game ID, can find this row again.
-			installedMod := &domain.InstalledMod{
-				Mod:          *mod,
-				ProfileName:  targetName,
-				UpdatePolicy: domain.UpdateNotify,
-				Enabled:      true,
-				FileIDs:      downloadedFileIDs,
-			}
-			installedMod.Mod.GameID = game.ID
-			if err := service.SaveInstalledMod(installedMod); err != nil {
-				fmt.Printf("    Error: save failed: %v\n", err)
-				continue
-			}
-
-			// Update profile with actual downloaded FileIDs
-			modRef := domain.ModReference{
-				SourceID: mod.SourceID,
-				ModID:    mod.ID,
-				Version:  mod.Version,
-				FileIDs:  downloadedFileIDs,
-			}
-			if err := pm.UpsertMod(game.ID, targetName, modRef); err != nil {
-				if verbose {
-					fmt.Printf("    Warning: could not update profile: %v\n", err)
-				}
-			}
-
-			fmt.Printf("    ✓ Installed: %s\n", mod.Name)
 		}
 	}
 
-	// Set new profile as default
-	if err := pm.SetDefault(game.ID, targetName); err != nil {
-		return fmt.Errorf("setting default profile: %w", err)
+	if _, err := service.ApplyProfileSwitch(ctx, game, plan, progress); err != nil {
+		// Diagnostics accumulated before a fatal error (ApplyProfileSwitch's
+		// error-path convention returns them alongside it) were already
+		// printed above, live, via progress - nothing left to print here.
+		return err
 	}
 
 	fmt.Printf("\n✓ Switched to profile: %s\n", targetName)

--- a/cmd/lmm/profile_test.go
+++ b/cmd/lmm/profile_test.go
@@ -2,12 +2,21 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProfileCmd_Structure(t *testing.T) {
@@ -123,4 +132,257 @@ func TestSelectPrimaryFile_EmptySlice(t *testing.T) {
 	var files []domain.DownloadableFile
 	result := selectPrimaryFile(files)
 	assert.Nil(t, result)
+}
+
+// --- doProfileSwitch (Task 4 CLI refit) ---
+
+// withStdin temporarily replaces os.Stdin with a pipe pre-loaded with input,
+// for exercising doProfileSwitch's "Proceed? [Y/n]" prompt. readPromptLine
+// reads directly from os.Stdin with no injectable seam (unlike
+// promptMultiSelectionFrom elsewhere in this package), so the swap happens
+// here instead.
+func withStdin(t *testing.T, input string, fn func()) {
+	t.Helper()
+	old := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { os.Stdin = old }()
+	os.Stdin = r
+
+	_, err = w.WriteString(input)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	fn()
+}
+
+// setupDoProfileSwitchTest builds a *core.Service plus a game with a
+// "default" profile already created and set as the active default,
+// mirroring setupDoDeployTest's pattern. Callers seed their own additional
+// profiles/mods.
+func setupDoProfileSwitchTest(t *testing.T) (*core.Service, *domain.Game) {
+	t.Helper()
+
+	configDir = t.TempDir()
+	dataDir = t.TempDir()
+	gameDir := t.TempDir()
+
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: configDir, DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	oldVerbose := verbose
+	verbose = false
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	pm := getProfileManager(svc)
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+
+	return svc, game
+}
+
+func TestDoProfileSwitch_AlreadyActive_PrintsMessageAndReturnsNil(t *testing.T) {
+	svc, game := setupDoProfileSwitchTest(t)
+
+	out := captureStdout(t, func() error {
+		return doProfileSwitch(context.Background(), svc, game, "default")
+	})
+
+	assert.Equal(t, "Already on profile: default\n", out)
+}
+
+// TestDoProfileSwitch_NoChanges_SwitchesDefaultWithoutPrompting guards
+// doProfileSwitch's fast path: when the target profile's mod set already
+// matches, the CLI switches the default without ever prompting (no stdin
+// interaction needed) and prints the plan header immediately followed by
+// the short "✓ Switched" message - no leading blank line, unlike the
+// mutation path's final message (see the happy-path test below).
+func TestDoProfileSwitch_NoChanges_SwitchesDefaultWithoutPrompting(t *testing.T) {
+	svc, game := setupDoProfileSwitchTest(t)
+	pm := getProfileManager(svc)
+	_, err := pm.Create(game.ID, "other")
+	require.NoError(t, err)
+
+	seedDeployableMod(t, svc, game, "shared", "Shared Mod", "shared.esp")
+	require.NoError(t, pm.AddMod(game.ID, "other", domain.ModReference{SourceID: "src", ModID: "shared", Version: "1.0"}))
+
+	out := captureStdout(t, func() error {
+		return doProfileSwitch(context.Background(), svc, game, "other")
+	})
+
+	assert.Equal(t, "Switching to profile: other\n\n✓ Switched to profile: other\n", out)
+
+	def, err := pm.GetDefault(game.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "other", def.Name)
+}
+
+// TestDoProfileSwitch_PrintsPlanAndPrompts_ProceedDeclined_NoMutations
+// guards the plan printout (byte-identical to the pre-extraction "Will
+// disable/enable/install" blocks, printed purely from the SwitchPlan
+// struct) and that declining the prompt performs zero mutations - not even
+// SetDefault.
+func TestDoProfileSwitch_PrintsPlanAndPrompts_ProceedDeclined_NoMutations(t *testing.T) {
+	svc, game := setupDoProfileSwitchTest(t)
+	pm := getProfileManager(svc)
+	_, err := pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	seedDeployableMod(t, svc, game, "disable-me", "Disable Me", "disable.esp")
+
+	var out string
+	withStdin(t, "n\n", func() {
+		out = captureStdout(t, func() error {
+			return doProfileSwitch(context.Background(), svc, game, "target")
+		})
+	})
+
+	assert.Contains(t, out, "Switching to profile: target\n\n")
+	assert.Contains(t, out, "Will disable 1 mod(s):\n")
+	assert.Contains(t, out, "  - Disable Me (disable-me)\n")
+	assert.Contains(t, out, "\nProceed? [Y/n]: ")
+	assert.Contains(t, out, "Cancelled.\n")
+
+	def, err := pm.GetDefault(game.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "default", def.Name, "declining must not switch the default profile")
+
+	mod, err := svc.GetInstalledMod("src", "disable-me", "g1", "default")
+	require.NoError(t, err)
+	assert.True(t, mod.Enabled, "declining must not disable any mod")
+}
+
+// TestDoProfileSwitch_ProceedAccepted_HappyPath_PrintsExpectedOutput guards
+// doProfileSwitch's full apply path end to end (disable, enable, install,
+// SetDefault) byte-identically to the pre-extraction CLI, across all three
+// plan buckets in one switch. The install bucket uses a real custom
+// manifest source served over httptest, mirroring
+// TestDoInstall_VisibleUnderLMMGameIDWhenSourceMappingDiffers's pattern
+// (mockSourceWithDownloads/createTestZip are internal/core-only test
+// helpers, not available to cmd/lmm).
+func TestDoProfileSwitch_ProceedAccepted_HappyPath_PrintsExpectedOutput(t *testing.T) {
+	svc, game := setupDoProfileSwitchTest(t)
+	game.DeployMode = domain.DeployCopy
+	pm := getProfileManager(svc)
+	_, err := pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	// disable-me: enabled under "default", absent from "target".
+	seedDeployableMod(t, svc, game, "disable-me", "Disable Me", "disable.esp")
+
+	// enable-me: installed (cached) but disabled, under "target" already.
+	require.NoError(t, svc.GetGameCache(game).Store(game.ID, "src", "enable-me", "1.0", "enable.esp", []byte("e")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "enable-me", SourceID: "src", Name: "Enable Me", Version: "1.0", GameID: game.ID},
+		ProfileName:  "target",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      false,
+	}))
+	require.NoError(t, pm.AddMod(game.ID, "target", domain.ModReference{SourceID: "src", ModID: "enable-me", Version: "1.0"}))
+
+	// install-me: referenced by "target" only, not installed at all.
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: install-me
+    name: Install Me
+    version: "1.0"
+    summary: A mod to install
+    files:
+      - id: main
+        filename: install-me.dat
+        version: "1.0"
+        url: %s/files/install-me.dat
+        primary: true
+`, srv.URL)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	mux.HandleFunc("/files/", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("archive bytes")) })
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "e2e-repo",
+		Name:      "E2E Repo",
+		Type:      custom.TypeManifest,
+		AllowHTTP: true,
+		Manifest:  &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(src)
+	require.NoError(t, pm.AddMod(game.ID, "target", domain.ModReference{SourceID: "e2e-repo", ModID: "install-me", Version: "1.0"}))
+
+	var out string
+	withStdin(t, "y\n", func() {
+		out = captureStdout(t, func() error {
+			return doProfileSwitch(context.Background(), svc, game, "target")
+		})
+	})
+
+	assert.Contains(t, out, "Switching to profile: target\n\n")
+	assert.Contains(t, out, "Will disable 1 mod(s):\n  - Disable Me (disable-me)\n")
+	assert.Contains(t, out, "Will enable 1 mod(s):\n  + Enable Me (enable-me)\n")
+	assert.Contains(t, out, "Will install 1 mod(s):\n  ↓ e2e-repo:install-me v1.0\n")
+	assert.Contains(t, out, "\nProceed? [Y/n]: ")
+	assert.Contains(t, out, "  ✓ Disabled: Disable Me\n")
+	assert.Contains(t, out, "  ✓ Enabled: Enable Me\n")
+	assert.Contains(t, out, "\nInstalling missing mods...\n")
+	assert.Contains(t, out, "  Installing e2e-repo:install-me...\n")
+	assert.Contains(t, out, "    ✓ Installed: Install Me\n")
+	assert.Contains(t, out, "\n✓ Switched to profile: target\n")
+
+	def, err := pm.GetDefault(game.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "target", def.Name)
+
+	_, err = os.Lstat(filepath.Join(game.ModPath, "enable.esp"))
+	assert.NoError(t, err, "enable.esp should be deployed")
+	_, err = os.Lstat(filepath.Join(game.ModPath, "install-me.dat"))
+	assert.NoError(t, err, "install-me.dat should be deployed")
+	_, err = os.Lstat(filepath.Join(game.ModPath, "disable.esp"))
+	assert.True(t, os.IsNotExist(err), "disable.esp should be undeployed")
+
+	installed, err := svc.GetInstalledMod("e2e-repo", "install-me", "g1", "target")
+	require.NoError(t, err)
+	assert.Equal(t, "g1", installed.GameID, "persisted GameID must be normalized to the lmm game")
+}
+
+// TestDoProfileSwitch_VerboseNotePath_UndeployFailurePrintsUnderVerbose
+// guards the CLI's wiring of SwitchDisableNote events to stdout, gated by
+// --verbose - doProfileSwitch never writes to stderr, unlike deploy/
+// uninstall (see the task report).
+func TestDoProfileSwitch_VerboseNotePath_UndeployFailurePrintsUnderVerbose(t *testing.T) {
+	svc, game := setupDoProfileSwitchTest(t)
+	pm := getProfileManager(svc)
+	_, err := pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	seedDeployableMod(t, svc, game, "1", "Test Mod", "plugin.esp")
+	// seedDeployableMod only seeds the cache/DB/profile - actually deploy the
+	// mod first so there is a real symlink to corrupt.
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: game.ID}, "default"))
+	// Corrupt the deployed symlink so Uninstall fails deterministically.
+	deployedPath := filepath.Join(game.ModPath, "plugin.esp")
+	require.NoError(t, os.Remove(deployedPath))
+	require.NoError(t, os.WriteFile(deployedPath, []byte("not a symlink"), 0644))
+
+	oldVerbose := verbose
+	verbose = true
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	var out string
+	withStdin(t, "y\n", func() {
+		out = captureStdout(t, func() error {
+			return doProfileSwitch(context.Background(), svc, game, "target")
+		})
+	})
+
+	assert.Contains(t, out, "  Warning: failed to undeploy Test Mod: ")
+	assert.Contains(t, out, "  ✓ Disabled: Test Mod\n")
 }

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -23,7 +23,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.10.0"
+	version = "1.11.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/tui.go
+++ b/cmd/lmm/tui.go
@@ -42,7 +42,7 @@ func init() {
 
 func runTUI(cmd *cobra.Command, args []string) error {
 	if tuiOptions.prototype {
-		model, err := tui.NewModel(tui.Options{Theme: tuiOptions.theme, Provider: tui.NewPrototypeProvider(), Ctx: cmd.Context()})
+		model, err := tui.NewPrototypeModel(tui.Options{Theme: tuiOptions.theme, Ctx: cmd.Context()})
 		if err != nil {
 			return err
 		}
@@ -63,6 +63,7 @@ func runTUI(cmd *cobra.Command, args []string) error {
 		model, err := tui.NewModel(tui.Options{
 			Theme:    tuiOptions.theme,
 			Provider: tui.NewCoreProvider(svc, game, profileName),
+			Actions:  tui.NewCoreActions(svc, game, profileName),
 			Ctx:      ctx,
 		})
 		if err != nil {

--- a/cmd/lmm/tui.go
+++ b/cmd/lmm/tui.go
@@ -25,8 +25,11 @@ var tuiCmd = &cobra.Command{
 
 Shows the configured game's installed mods, profiles, and status using the
 same config, database, and game resolution as the CLI commands. Search mod
-sources interactively. Read-only: browsing and searching never install,
-update, deploy, or delete anything.
+sources interactively, inspect the source registry, and manage mods in
+place - enable/disable, uninstall, deploy, and switch profiles - with every
+mutating action behind a confirmation prompt. Installing a mod from search
+results and checking/applying updates aren't available yet - use
+'lmm install' and 'lmm update' for those until a later release.
 
 Use --prototype for a demo mode backed by static fake data:
 

--- a/cmd/lmm/uninstall.go
+++ b/cmd/lmm/uninstall.go
@@ -87,94 +87,23 @@ func doUninstall(ctx context.Context, service *core.Service, game *domain.Game, 
 		}
 	}
 
-	// Set up hooks
-	hookRunner := getHookRunner(service)
-	resolvedHooks := getResolvedHooks(service, game, profileName)
-	hookCtx := makeHookContext(game)
-	var hookErrors []error
-
-	// Run uninstall.before_all hook (for single mod, this also serves as before_each)
-	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Uninstall.BeforeAll != "" {
-		hookCtx.HookName = "uninstall.before_all"
-		if _, err := hookRunner.Run(ctx, resolvedHooks.Uninstall.BeforeAll, hookCtx); err != nil {
-			if !uninstallForce {
-				return fmt.Errorf("uninstall.before_all hook failed: %w", err)
-			}
-			fmt.Fprintf(os.Stderr, "Warning: uninstall.before_all hook failed (forced): %v\n", err)
-		}
+	opts := core.UninstallOptions{
+		KeepCache:   uninstallKeep,
+		Hooks:       getResolvedHooks(service, game, profileName),
+		HookRunner:  getHookRunner(service),
+		HookContext: makeHookContext(game),
+		Force:       uninstallForce,
+		Verbose:     verbose,
 	}
 
-	// Run uninstall.before_each hook
-	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Uninstall.BeforeEach != "" {
-		hookCtx.HookName = "uninstall.before_each"
-		hookCtx.ModID = installedMod.ID
-		hookCtx.ModName = installedMod.Name
-		hookCtx.ModVersion = installedMod.Version
-		if _, err := hookRunner.Run(ctx, resolvedHooks.Uninstall.BeforeEach, hookCtx); err != nil {
-			if !uninstallForce {
-				return fmt.Errorf("uninstall.before_each hook failed: %w", err)
-			}
-			fmt.Fprintf(os.Stderr, "Warning: uninstall.before_each hook failed (forced): %v\n", err)
-		}
+	result, err := service.UninstallMod(ctx, game, profileName, installedMod.SourceID, modID, opts)
+	if err != nil {
+		return err
 	}
 
-	// Undeploy files from game directory
-	installer := service.GetInstaller(game)
-
-	if err := installer.Uninstall(ctx, game, &installedMod.Mod, profileName); err != nil {
-		// Warn but continue - files may have been manually removed
-		if verbose {
-			fmt.Printf("  Warning: failed to undeploy some files: %v\n", err)
-		}
+	for _, w := range result.Warnings {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", w)
 	}
-
-	// Clean up cache unless --keep-cache is set
-	if !uninstallKeep {
-		if err := service.GetGameCache(game).Delete(game.ID, installedMod.SourceID, modID, installedMod.Version); err != nil {
-			if verbose {
-				fmt.Printf("  Warning: failed to clean cache: %v\n", err)
-			}
-		}
-	}
-
-	// Remove from database
-	if err := service.DeleteInstalledMod(installedMod.SourceID, modID, game.ID, profileName); err != nil {
-		return fmt.Errorf("failed to remove mod record: %w", err)
-	}
-
-	// Remove from profile
-	pm := getProfileManager(service)
-	if err := pm.RemoveMod(game.ID, profileName, installedMod.SourceID, modID); err != nil {
-		// Don't fail if not in profile
-		if verbose {
-			fmt.Printf("  Note: %v\n", err)
-		}
-	}
-
-	// Run uninstall.after_each hook
-	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Uninstall.AfterEach != "" {
-		hookCtx.HookName = "uninstall.after_each"
-		hookCtx.ModID = installedMod.ID
-		hookCtx.ModName = installedMod.Name
-		hookCtx.ModVersion = installedMod.Version
-		if _, err := hookRunner.Run(ctx, resolvedHooks.Uninstall.AfterEach, hookCtx); err != nil {
-			hookErrors = append(hookErrors, fmt.Errorf("uninstall.after_each hook failed: %w", err))
-		}
-	}
-
-	// Run uninstall.after_all hook
-	if hookRunner != nil && resolvedHooks != nil && resolvedHooks.Uninstall.AfterAll != "" {
-		hookCtx.HookName = "uninstall.after_all"
-		hookCtx.ModID = ""
-		hookCtx.ModName = ""
-		hookCtx.ModVersion = ""
-		if _, err := hookRunner.Run(ctx, resolvedHooks.Uninstall.AfterAll, hookCtx); err != nil {
-			hookErrors = append(hookErrors, fmt.Errorf("uninstall.after_all hook failed: %w", err))
-		}
-	}
-
-	// Print hook warnings
-	printHookWarnings(hookErrors)
 
 	fmt.Printf("✓ Uninstalled: %s\n", installedMod.Name)
 	fmt.Printf("  Removed from profile: %s\n", profileName)

--- a/cmd/lmm/uninstall.go
+++ b/cmd/lmm/uninstall.go
@@ -93,12 +93,20 @@ func doUninstall(ctx context.Context, service *core.Service, game *domain.Game, 
 		HookRunner:  getHookRunner(service),
 		HookContext: makeHookContext(game),
 		Force:       uninstallForce,
-		Verbose:     verbose,
 	}
 
 	result, err := service.UninstallMod(ctx, game, profileName, installedMod.SourceID, modID, opts)
 	if err != nil {
 		return err
+	}
+
+	// Notes already carry their historical prefix word ("Warning: "/
+	// "Note: ") and are only ever shown under --verbose, matching the
+	// pre-extraction CLI's `if verbose { ... }` gating exactly.
+	if verbose {
+		for _, n := range result.Notes {
+			fmt.Printf("  %s\n", n)
+		}
 	}
 
 	for _, w := range result.Warnings {

--- a/cmd/lmm/uninstall.go
+++ b/cmd/lmm/uninstall.go
@@ -97,21 +97,15 @@ func doUninstall(ctx context.Context, service *core.Service, game *domain.Game, 
 
 	result, err := service.UninstallMod(ctx, game, profileName, installedMod.SourceID, modID, opts)
 	if err != nil {
+		// UninstallMod's error-path convention returns any diagnostics
+		// accumulated before the fatal error alongside it (see
+		// UninstallResult's doc comment); print them now, or they'd
+		// otherwise be lost even though they already happened.
+		printUninstallDiagnostics(result)
 		return err
 	}
 
-	// Notes already carry their historical prefix word ("Warning: "/
-	// "Note: ") and are only ever shown under --verbose, matching the
-	// pre-extraction CLI's `if verbose { ... }` gating exactly.
-	if verbose {
-		for _, n := range result.Notes {
-			fmt.Printf("  %s\n", n)
-		}
-	}
-
-	for _, w := range result.Warnings {
-		fmt.Fprintf(os.Stderr, "Warning: %v\n", w)
-	}
+	printUninstallDiagnostics(result)
 
 	fmt.Printf("✓ Uninstalled: %s\n", installedMod.Name)
 	fmt.Printf("  Removed from profile: %s\n", profileName)
@@ -121,4 +115,26 @@ func doUninstall(ctx context.Context, service *core.Service, game *domain.Game, 
 	}
 
 	return nil
+}
+
+// printUninstallDiagnostics prints result's accumulated diagnostics using
+// the display contract documented on core.UninstallResult: Notes go to
+// stdout, only under --verbose (each entry already carries its historical
+// prefix word); Warnings go to stderr, unconditionally. Safe to call with a
+// nil result (nothing to print) - result is nil only when UninstallMod
+// failed before it could allocate the result struct.
+func printUninstallDiagnostics(result *core.UninstallResult) {
+	if result == nil {
+		return
+	}
+
+	if verbose {
+		for _, n := range result.Notes {
+			fmt.Printf("  %s\n", n)
+		}
+	}
+
+	for _, w := range result.Warnings {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", w)
+	}
 }

--- a/cmd/lmm/uninstall_test.go
+++ b/cmd/lmm/uninstall_test.go
@@ -2,10 +2,17 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestUninstallCmd_Structure tests the uninstall command structure
@@ -88,4 +95,160 @@ func TestUninstallCmd_GameNotFound(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "game not found")
+}
+
+// setupDoUninstallTest builds a *core.Service plus a mod that will fail to
+// undeploy (its cache directory was never created, so
+// Installer.Uninstall's cache.ListFiles call fails deterministically) and
+// resets the uninstall command's package-level flag globals to sane
+// defaults for calling doUninstall directly. Callers set globals.verbose
+// themselves.
+func setupDoUninstallTest(t *testing.T) (*core.Service, *domain.Game) {
+	t.Helper()
+
+	configDir = t.TempDir()
+	dataDir = t.TempDir()
+	gameDir := t.TempDir()
+
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: configDir, DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "1", SourceID: "src", Name: "Test Mod", Version: "1.0", GameID: "g1"},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+	pm := svc.NewProfileManager()
+	_, err = pm.Create("g1", "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.AddMod("g1", "default", domain.ModReference{SourceID: "src", ModID: "1", Version: "1.0"}))
+
+	oldSource, oldProfile, oldKeep, oldForce := uninstallSource, uninstallProfile, uninstallKeep, uninstallForce
+	uninstallSource = ""
+	uninstallProfile = ""
+	uninstallKeep = false
+	uninstallForce = false
+	t.Cleanup(func() {
+		uninstallSource, uninstallProfile, uninstallKeep, uninstallForce = oldSource, oldProfile, oldKeep, oldForce
+	})
+
+	return svc, game
+}
+
+// TestDoUninstall_Verbose_PrintsUndeployFailureNoteWithHistoricalPrefix
+// guards FINDING 1 of the Task 2 review: the undeploy-failure diagnostic
+// must be printed to stdout, under --verbose only, with its historical
+// "  Warning: failed to undeploy some files: <err>\n" bytes - byte-identical
+// to the pre-refactor CLI (git show 1c092df:cmd/lmm/uninstall.go).
+func TestDoUninstall_Verbose_PrintsUndeployFailureNoteWithHistoricalPrefix(t *testing.T) {
+	svc, game := setupDoUninstallTest(t)
+
+	oldVerbose := verbose
+	verbose = true
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	out := captureStdout(t, func() error {
+		return doUninstall(context.Background(), svc, game, "1")
+	})
+
+	assert.Contains(t, out, "  Warning: failed to undeploy some files: ")
+	assert.Contains(t, out, "✓ Uninstalled: Test Mod")
+}
+
+// TestDoUninstall_NonVerbose_DoesNotPrintNotes guards the other half of
+// FINDING 1: without --verbose, the Notes-derived diagnostics must not
+// appear at all, matching the pre-extraction CLI's `if verbose { ... }`
+// gating.
+func TestDoUninstall_NonVerbose_DoesNotPrintNotes(t *testing.T) {
+	svc, game := setupDoUninstallTest(t)
+
+	oldVerbose := verbose
+	verbose = false
+	t.Cleanup(func() { verbose = oldVerbose })
+
+	out := captureStdout(t, func() error {
+		return doUninstall(context.Background(), svc, game, "1")
+	})
+
+	assert.NotContains(t, out, "Warning:")
+	assert.NotContains(t, out, "Note:")
+	assert.Contains(t, out, "✓ Uninstalled: Test Mod")
+}
+
+// TestDoUninstall_Verbose_PrintsAllThreeHistoricalNotesByteIdentically
+// end-to-end verifies FINDING 1 for all three drifted diagnostics at once:
+// undeploy failure, cache-delete failure (both via a blocked cache
+// directory - see TestService_UninstallMod_UndeployAndCacheDeleteFailures_RecordedAsNotesWithHistoricalPrefixes
+// in internal/core/flows_test.go for why one obstruction fails both), and
+// profile-removal (no profile ever created). Asserts the printed lines are
+// byte-identical to `git show 1c092df:cmd/lmm/uninstall.go`'s
+// `fmt.Printf("  Warning: failed to undeploy some files: %v\n", err)`,
+// `fmt.Printf("  Warning: failed to clean cache: %v\n", err)`, and
+// `fmt.Printf("  Note: %v\n", err)`.
+func TestDoUninstall_Verbose_PrintsAllThreeHistoricalNotesByteIdentically(t *testing.T) {
+	configDir = t.TempDir()
+	dataDir = t.TempDir()
+	gameDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: configDir, DataDir: dataDir, CacheDir: cacheDir,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "1", SourceID: "src", Name: "Test Mod", Version: "1.0", GameID: "g1"},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+	// No profile created -> profile-removal note.
+
+	// Block the mod's cache directory with a regular file -> undeploy and
+	// cache-delete both fail deterministically (ENOTDIR, not permissions).
+	modPath := svc.GetGameCache(game).ModPath("g1", "src", "1", "1.0")
+	blockedParent := filepath.Dir(modPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(blockedParent), 0755))
+	require.NoError(t, os.WriteFile(blockedParent, []byte("blocked"), 0644))
+
+	oldSource, oldProfile, oldKeep, oldForce, oldVerbose := uninstallSource, uninstallProfile, uninstallKeep, uninstallForce, verbose
+	uninstallSource = ""
+	uninstallProfile = ""
+	uninstallKeep = false
+	uninstallForce = false
+	verbose = true
+	t.Cleanup(func() {
+		uninstallSource, uninstallProfile, uninstallKeep, uninstallForce, verbose = oldSource, oldProfile, oldKeep, oldForce, oldVerbose
+	})
+
+	out := captureStdout(t, func() error {
+		return doUninstall(context.Background(), svc, game, "1")
+	})
+
+	lines := strings.Split(out, "\n")
+	foundUndeploy, foundCache, foundNote := false, false, false
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "  Warning: failed to undeploy some files: "):
+			foundUndeploy = true
+		case strings.HasPrefix(line, "  Warning: failed to clean cache: "):
+			foundCache = true
+		case strings.HasPrefix(line, "  Note: "):
+			foundNote = true
+		}
+	}
+
+	assert.True(t, foundUndeploy, "missing byte-identical undeploy-failure note; got:\n%s", out)
+	assert.True(t, foundCache, "missing byte-identical cache-delete-failure note; got:\n%s", out)
+	assert.True(t, foundNote, "missing byte-identical profile-removal note; got:\n%s", out)
+	assert.Contains(t, out, "✓ Uninstalled: Test Mod")
 }

--- a/cmd/lmm/uninstall_test.go
+++ b/cmd/lmm/uninstall_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
 )
 
 // TestUninstallCmd_Structure tests the uninstall command structure
@@ -251,4 +254,104 @@ func TestDoUninstall_Verbose_PrintsAllThreeHistoricalNotesByteIdentically(t *tes
 	assert.True(t, foundCache, "missing byte-identical cache-delete-failure note; got:\n%s", out)
 	assert.True(t, foundNote, "missing byte-identical profile-removal note; got:\n%s", out)
 	assert.Contains(t, out, "✓ Uninstalled: Test Mod")
+}
+
+// captureStderrErr redirects os.Stderr for the duration of fn, returning
+// both the captured output and fn's own error. Unlike captureStdout (which
+// requires fn to succeed), this is for exercising doUninstall's error path.
+func captureStderrErr(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	fnErr := fn()
+	require.NoError(t, w.Close(), "closing write end of the pipe")
+	out, readErr := io.ReadAll(r)
+	require.NoError(t, r.Close())
+	require.NoError(t, readErr)
+	return string(out), fnErr
+}
+
+// TestDoUninstall_ErrorPath_PrintsAccumulatedWarningsToStderr guards the
+// Task 2 review finding that a fatal error hit after diagnostics had
+// already accumulated discarded them (`return nil, err`), even though the
+// pre-refactor CLI had already printed them inline by that point. doUninstall
+// must now print result.Warnings to stderr (unconditionally) before
+// returning the error, using the same print loop as the success path.
+//
+// Reproduces the scenario: a forced (--force) uninstall.before_each hook
+// failure is recorded as a Warning, then UninstallMod hits a genuinely
+// fatal DeleteInstalledMod failure - forced deterministically by holding a
+// write lock on the same SQLite file for the call's duration (see
+// TestService_UninstallMod_FatalErrorAfterAccumulatedDiagnostic_ReturnsPartialResult
+// in internal/core/flows_test.go for why this is not a timing race).
+func TestDoUninstall_ErrorPath_PrintsAccumulatedWarningsToStderr(t *testing.T) {
+	configDir = t.TempDir()
+	dataDir = t.TempDir()
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: configDir, DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	failScript := filepath.Join(scriptsDir, "before_each.sh")
+	require.NoError(t, os.WriteFile(failScript, []byte("#!/bin/bash\necho boom >&2\nexit 1\n"), 0755))
+
+	game := &domain.Game{
+		ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink,
+		Hooks: domain.GameHooks{Uninstall: domain.HookConfig{BeforeEach: failScript}},
+	}
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "1", SourceID: "src", Name: "Test Mod", Version: "1.0", GameID: "g1"},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+	pm := svc.NewProfileManager()
+	_, err = pm.Create("g1", "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.AddMod("g1", "default", domain.ModReference{SourceID: "src", ModID: "1", Version: "1.0"}))
+
+	oldSource, oldProfile, oldKeep, oldForce, oldVerbose, oldNoHooks := uninstallSource, uninstallProfile, uninstallKeep, uninstallForce, verbose, noHooks
+	uninstallSource = ""
+	uninstallProfile = ""
+	uninstallKeep = false
+	uninstallForce = true // hook failure becomes a Warning instead of aborting immediately
+	verbose = false
+	noHooks = false
+	t.Cleanup(func() {
+		uninstallSource, uninstallProfile, uninstallKeep, uninstallForce, verbose, noHooks = oldSource, oldProfile, oldKeep, oldForce, oldVerbose, oldNoHooks
+	})
+
+	// Hold a real write lock on the DB for the call's duration so
+	// DeleteInstalledMod fails deterministically after the before_each
+	// Warning has already been recorded. A dedicated connection issues
+	// "BEGIN IMMEDIATE" directly - a plain sql.Tx's default deferred BEGIN
+	// does NOT take a lock until its first statement runs, so it doesn't
+	// work here (see the core-level test for the same finding).
+	dbPath := filepath.Join(dataDir, "lmm.db")
+	locker, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer locker.Close()
+	locker.SetMaxOpenConns(1)
+	conn, err := locker.Conn(context.Background())
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.ExecContext(context.Background(), "BEGIN IMMEDIATE")
+	require.NoError(t, err)
+	defer conn.ExecContext(context.Background(), "ROLLBACK") //nolint:errcheck // best-effort cleanup
+
+	stderr, cmdErr := captureStderrErr(t, func() error {
+		return doUninstall(context.Background(), svc, game, "1")
+	})
+	require.Error(t, cmdErr, "DeleteInstalledMod must fail while another writer holds the file lock")
+	assert.Contains(t, cmdErr.Error(), "failed to remove mod record")
+	assert.Contains(t, stderr, "Warning: uninstall.before_each hook failed (forced): ", "the accumulated Warning must still reach stderr despite the command failing")
 }

--- a/docs/plans/2026-04-28-tui-implementation.md
+++ b/docs/plans/2026-04-28-tui-implementation.md
@@ -4,18 +4,27 @@
 **Scope:** Add a Bubble Tea/Lip Gloss TUI to `lmm`, starting with visual prototypes and iterating toward a real service-backed interface.
 **Out of scope:** Replacing the existing CLI, changing config formats, implementing image thumbnails, background update daemons, or redesigning core mod-management behavior.
 
-> **Status (2026-07-13): Phases 0–4 are COMPLETE** — Phases 0–3 shipped as **v1.4.0**
+> **Status (2026-07-20): Phases 0–5a are COMPLETE** — Phases 0–3 shipped as **v1.4.0**
 > (PRs #31/#33/#34/#36/#38; issues #30/#32/#35), Phase 4 (search and detail browsing)
-> shipped as **v1.5.0** (PR #41; issue #40; tag `v1.5.0`).
-> **Phase 5 (safe mutating actions) is next.** Before planning it, read:
+> shipped as **v1.5.0** (PR #41; issue #40; tag `v1.5.0`), and **Phase 5a** (enable/
+> disable, uninstall, deploy, and profile switch, each behind a confirmation modal,
+> plus the async action machinery, status line, and `--prototype` parity) shipped as
+> **v1.11.0**.
+> **Phase 5b (install selected search result; check/apply updates — network actions
+> that need real progress reporting) is next.** Before planning it, read:
 >
-> - this file's Phase 5 section AND the **"CLI-parity coverage and roadmap gaps"**
->   tables below (the audit ADDED `uninstall` to Phase 5),
-> - **issue #37** (Phase 5/6 scope additions + lifecycle carry-forwards),
-> - **issue #42** (short/narrow-terminal hardening + polish backlog), and
+> - this file's Phase 5 section, now annotated with what 5a delivered vs. what's
+>   left for 5b, AND the **"CLI-parity coverage and roadmap gaps"** tables below,
+> - **issue #37** (Phase 5/6 scope additions + lifecycle carry-forwards — still
+>   open; 5a shipped the `uninstall` addition it called out, the remaining items
+>   are Phase 6),
+> - **issue #42** (short/narrow-terminal hardening + polish backlog — 5a closed the
+>   "quit doesn't cancel in-flight search/action contexts" lifecycle item), and
 > - the Phase 4 review note: `tui.ModItem` has no mod `ID` field — add it before
 >   install-from-search; mutations belong in a separate writer interface so the
->   read-only `DataProvider` stays provably read-only.
+>   read-only `DataProvider` stays provably read-only. (5a added `ModItem.ID` and
+>   the `ActionProvider` write-side seam described there; 5b builds directly on
+>   both.)
 >
 > Branches come off `main` (protected — PRs only). Execution records (local-only):
 > `docs/plans/2026-07-13-tui-phase2-close-and-phase3.md`,
@@ -400,15 +409,24 @@ lmm tui --prototype --theme dos
 
 ## Phase 5 — Safe mutating actions
 
+> **Phase 5a ✅ (complete, v1.11.0):** enable/disable, uninstall, deploy, and
+> profile switch, each behind a confirmation modal. **Phase 5b (not started):**
+> install selected search result; check/apply updates. See the annotations
+> below for exactly what's delivered vs. remaining.
+
 **Goal:** Add install/update/enable/disable/profile actions behind explicit confirmations.
 
 **Initial action set:**
 
-- Enable/disable installed mod.
-- Switch profile.
-- Deploy current profile.
-- Install selected search result.
-- Check/apply updates.
+- Enable/disable installed mod. — **5a**: `e` on Installed Mods.
+- Switch profile. — **5a**: `enter` on a non-active Profiles row, with a plan
+  preview (mods to enable/disable, or "no changes"); refuses instead of
+  downloading if the plan needs mods the TUI doesn't have installed yet.
+- Deploy current profile. — **5a**: `D` on Installed Mods or Dashboard.
+- Uninstall installed mod. — **5a**: `x` on Installed Mods. Added to this set
+  by the CLI-parity audit below (issue #37); not in the phase's original scope.
+- Install selected search result. — **5b**, not started.
+- Check/apply updates. — **5b**, not started.
 
 **Tasks:**
 
@@ -417,20 +435,48 @@ lmm tui --prototype --theme dos
    - affected game/profile/mods
    - expected file impact when known
    - confirm/cancel keys
+   - **5a: delivered** — `actionModalView` (internal/tui/actions.go) renders
+     title, game/profile/mods detail lines (with qualitative file impact,
+     e.g. "Files will be deployed to the game directory."), and the
+     confirm/cancel hint, for all four 5a actions.
 2. Add async command execution pattern for long-running operations.
+   - **5a: delivered** — `buildAction`/`promptAction` dispatch each
+     confirmed action as a cancelable `tea.Cmd`, staleness-tagged by
+     generation.
 3. Add progress/status messages for downloads, deploys, and updates.
+   - **5a: partial** — a static "working" status while an action is in
+     flight, plus a one-line outcome/warning summary on completion; deploy
+     has no live per-mod progress yet (`coreProvider.DeployProfile` passes a
+     nil progress callback). Downloads and updates aren't in 5a's action set
+     at all. Real progress streaming (`core.DeployProgress`, download
+     percentages) is **5b** work.
 4. Prevent duplicate actions while one is running.
+   - **5a: delivered** — single-flight guard in `buildAction`/`promptAction`.
 5. Refresh affected views after successful action.
+   - **5a: delivered**, and broader than originally scoped — 5a refreshes
+     (`m.loadData`) after every action outcome, success **or** failure, since
+     the underlying flows are multi-step and an error doesn't imply nothing
+     changed.
 6. Surface failure details without losing the user's current screen.
+   - **5a: delivered** — failures render as an error-styled status line; the
+     screen underneath is untouched.
 7. Add tests for confirmation routing and cancellation.
+   - **5a: delivered** — `internal/tui/actions_test.go`, `mutations_test.go`.
 
-**Exit criteria:**
+**Exit criteria** (scoped to 5a's action set — enable/disable, uninstall,
+deploy, profile switch):
 
-- Mutating actions require confirmation.
-- Cancelling leaves state unchanged.
-- Successful actions refresh visible data.
-- Errors are visible and recoverable.
-- `go test ./...` passes.
+- Mutating actions require confirmation. — **satisfied**
+- Cancelling leaves state unchanged. — **satisfied** (`n`/`esc` clears the
+  pending modal without calling the provider)
+- Successful actions refresh visible data. — **satisfied** (see Task 5 note:
+  failed actions refresh too)
+- Errors are visible and recoverable. — **satisfied** (status line, no lost
+  screen)
+- `go test ./...` passes. — **satisfied**
+
+5b (install-from-search, check/apply updates) will need its own pass at
+these criteria once real network/progress actions exist.
 
 ---
 

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -267,6 +267,19 @@ const (
 	// DeployDownloadFailed: a file for ModName failed to download; the mod
 	// is skipped. Detail is the reason.
 	DeployDownloadFailed
+	// DeployDownloadDone fires once, after a cache-miss mod's redownload
+	// loop finishes without error, mirroring the pre-extraction CLI's
+	// unconditional `fmt.Println() // Clear progress line` immediately
+	// after the download loop (git show b2ad559:cmd/lmm/deploy.go) - it
+	// terminates DeployDownloading's carriage-returned progress line with a
+	// real newline before the mod's own DeployDeployed line prints. Unlike
+	// its ApplyProfileSwitch analog (SwitchDownloadDone), which fires on
+	// both success and failure since doProfileSwitch's equivalent Println
+	// sat unconditionally after its own loop, redeployFromSource's failure
+	// path returns immediately via a DeploySkipped event instead (see
+	// skip() below) without reaching this point - so this phase covers the
+	// success path only.
+	DeployDownloadDone
 	// DeploySkipped: ModName was skipped for a reason other than a hook or
 	// download failure (fetch failure, no files available, file-selection
 	// failure, or an outright deploy/install failure). Detail is the reason.
@@ -774,6 +787,10 @@ func (s *Service) redeployFromSource(ctx context.Context, game *domain.Game, mod
 			return skip(fmt.Sprintf("download failed: %v", err))
 		}
 	}
+
+	done := base
+	done.Phase = DeployDownloadDone
+	emit(done)
 
 	return false
 }

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// EnableMod deploys an installed-but-disabled mod's files from the cache to
+// the game directory and marks it enabled in the database. Returns
+// (false, nil) — not an error — if the mod was already enabled.
+func (s *Service) EnableMod(ctx context.Context, game *domain.Game, profileName, sourceID, modID string) (bool, error) {
+	mod, err := s.GetInstalledMod(sourceID, modID, game.ID, profileName)
+	if err != nil {
+		return false, fmt.Errorf("getting installed mod %s: %w", modID, err)
+	}
+
+	if mod.Enabled {
+		return false, nil
+	}
+
+	if !s.GetGameCache(game).Exists(game.ID, sourceID, modID, mod.Version) {
+		return false, fmt.Errorf("mod not found in cache - try reinstalling with 'lmm install --id %s'", modID)
+	}
+
+	installer := s.GetInstaller(game)
+	if err := installer.Install(ctx, game, &mod.Mod, profileName); err != nil {
+		return false, fmt.Errorf("failed to deploy mod: %w", err)
+	}
+
+	if err := s.SetModEnabled(sourceID, modID, game.ID, profileName, true); err != nil {
+		return false, fmt.Errorf("failed to update mod status: %w", err)
+	}
+
+	return true, nil
+}
+
+// DisableMod undeploys the mod's files from the game directory — the cache
+// entry is kept so the mod can be re-enabled later without downloading again
+// — and marks it disabled in the database. Returns (false, nil) — not an
+// error — if the mod was already disabled.
+//
+// Undeploy failures are treated as non-fatal: the game files may already
+// have been removed manually, and refusing to record the user's intent to
+// disable the mod would leave it stuck. This mirrors the pre-extraction CLI,
+// which warned (under --verbose) but always continued to flip the DB state.
+func (s *Service) DisableMod(ctx context.Context, game *domain.Game, profileName, sourceID, modID string) (bool, error) {
+	mod, err := s.GetInstalledMod(sourceID, modID, game.ID, profileName)
+	if err != nil {
+		return false, fmt.Errorf("getting installed mod %s: %w", modID, err)
+	}
+
+	if !mod.Enabled {
+		return false, nil
+	}
+
+	installer := s.GetInstaller(game)
+	_ = installer.Uninstall(ctx, game, &mod.Mod, profileName) //nolint:errcheck // best-effort undeploy; see doc comment
+
+	if err := s.SetModEnabled(sourceID, modID, game.ID, profileName, false); err != nil {
+		return false, fmt.Errorf("failed to update mod status: %w", err)
+	}
+
+	return true, nil
+}

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -64,3 +64,123 @@ func (s *Service) DisableMod(ctx context.Context, game *domain.Game, profileName
 
 	return true, nil
 }
+
+// UninstallOptions configures UninstallMod.
+type UninstallOptions struct {
+	KeepCache bool // --keep-cache: skip deleting the mod's cache entry
+
+	// Hook plumbing, mirroring BatchOptions. Hooks and/or HookRunner may be
+	// nil to skip hook execution entirely (e.g. --no-hooks).
+	Hooks       *ResolvedHooks
+	HookRunner  *HookRunner
+	HookContext HookContext
+	Force       bool // continue past a failing uninstall.before_* hook (warn instead of fail)
+
+	// Verbose gates the operational (non-hook) diagnostics recorded in
+	// Warnings — undeploy failure, cache-delete failure, and the
+	// profile-removal note — mirroring the pre-extraction CLI's `if
+	// verbose { ... }` guards around those three messages. Hook after_*
+	// failures are always recorded regardless of Verbose, matching the
+	// CLI's unconditional printHookWarnings behavior. Callers that always
+	// want full diagnostics (e.g. the TUI) should set Verbose: true.
+	Verbose bool
+}
+
+// UninstallResult reports the outcome of UninstallMod.
+type UninstallResult struct {
+	Warnings []string // non-fatal issues encountered while uninstalling
+}
+
+// UninstallMod removes a mod from the profile: runs uninstall hooks,
+// undeploys files, deletes the cache entry (unless KeepCache), removes the
+// DB row, and removes the mod from the profile YAML.
+//
+// Hook failure semantics (matching the pre-extraction CLI's doUninstall):
+//   - uninstall.before_all / uninstall.before_each: a failure aborts the
+//     operation with an error, unless Force is set, in which case it is
+//     recorded as a warning and the uninstall proceeds.
+//   - uninstall.after_each / uninstall.after_all: always non-fatal; a
+//     failure is recorded as a warning after every other step has already
+//     committed.
+//
+// Undeploy failures, cache-delete failures, and a failure to remove the mod
+// from the profile (e.g. the DB and profile have drifted out of sync) are
+// all non-fatal and recorded as warnings; the operation still completes.
+func (s *Service) UninstallMod(ctx context.Context, game *domain.Game, profileName, sourceID, modID string, opts UninstallOptions) (*UninstallResult, error) {
+	mod, err := s.GetInstalledMod(sourceID, modID, game.ID, profileName)
+	if err != nil {
+		return nil, fmt.Errorf("getting installed mod %s: %w", modID, err)
+	}
+
+	result := &UninstallResult{}
+	hookCtx := opts.HookContext
+
+	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.before_all", opts.Hooks.GetUninstallBeforeAll()); err != nil {
+		if !opts.Force {
+			return nil, fmt.Errorf("uninstall.before_all hook failed: %w", err)
+		}
+		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.before_all hook failed (forced): %v", err))
+	}
+
+	hookCtx.ModID = mod.ID
+	hookCtx.ModName = mod.Name
+	hookCtx.ModVersion = mod.Version
+	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.before_each", opts.Hooks.GetUninstallBeforeEach()); err != nil {
+		if !opts.Force {
+			return nil, fmt.Errorf("uninstall.before_each hook failed: %w", err)
+		}
+		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.before_each hook failed (forced): %v", err))
+	}
+
+	installer := s.GetInstaller(game)
+	if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
+		// Warn but continue - files may have been manually removed.
+		if opts.Verbose {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("failed to undeploy some files: %v", err))
+		}
+	}
+
+	if !opts.KeepCache {
+		if err := s.GetGameCache(game).Delete(game.ID, mod.SourceID, modID, mod.Version); err != nil {
+			if opts.Verbose {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("failed to clean cache: %v", err))
+			}
+		}
+	}
+
+	if err := s.DeleteInstalledMod(mod.SourceID, modID, game.ID, profileName); err != nil {
+		return nil, fmt.Errorf("failed to remove mod record: %w", err)
+	}
+
+	if err := s.NewProfileManager().RemoveMod(game.ID, profileName, mod.SourceID, modID); err != nil {
+		// Don't fail if not in profile.
+		if opts.Verbose {
+			result.Warnings = append(result.Warnings, err.Error())
+		}
+	}
+
+	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_each", opts.Hooks.GetUninstallAfterEach()); err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.after_each hook failed: %v", err))
+	}
+
+	hookCtx.ModID = ""
+	hookCtx.ModName = ""
+	hookCtx.ModVersion = ""
+	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_all", opts.Hooks.GetUninstallAfterAll()); err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.after_all hook failed: %v", err))
+	}
+
+	return result, nil
+}
+
+// runUninstallHook runs command (a hook script path) via runner if both are
+// set, updating hookCtx.HookName first. No-op if runner is nil or command
+// is empty (hooks disabled, or that particular hook isn't configured).
+func runUninstallHook(ctx context.Context, runner *HookRunner, hookCtx *HookContext, hookName, command string) error {
+	if runner == nil || command == "" {
+		return nil
+	}
+	hookCtx.HookName = hookName
+	_, err := runner.Run(ctx, command, *hookCtx)
+	return err
+}

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -101,6 +101,9 @@ type UninstallOptions struct {
 //     caller that wants byte-identical pre-extraction output should print
 //     each entry to stdout ONLY under --verbose, verbatim, e.g.
 //     `fmt.Printf("  %s\n", n)`.
+//
+// On error, the returned result carries any diagnostics accumulated before
+// the failure; callers should surface them alongside the error.
 type UninstallResult struct {
 	Warnings []string // unconditional, stderr, audience: operator/always-visible
 	Notes    []string // --verbose-gated, stdout, audience: diagnostic detail
@@ -134,7 +137,7 @@ func (s *Service) UninstallMod(ctx context.Context, game *domain.Game, profileNa
 
 	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.before_all", opts.Hooks.GetUninstallBeforeAll()); err != nil {
 		if !opts.Force {
-			return nil, fmt.Errorf("uninstall.before_all hook failed: %w", err)
+			return result, fmt.Errorf("uninstall.before_all hook failed: %w", err)
 		}
 		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.before_all hook failed (forced): %v", err))
 	}
@@ -144,7 +147,7 @@ func (s *Service) UninstallMod(ctx context.Context, game *domain.Game, profileNa
 	hookCtx.ModVersion = mod.Version
 	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.before_each", opts.Hooks.GetUninstallBeforeEach()); err != nil {
 		if !opts.Force {
-			return nil, fmt.Errorf("uninstall.before_each hook failed: %w", err)
+			return result, fmt.Errorf("uninstall.before_each hook failed: %w", err)
 		}
 		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.before_each hook failed (forced): %v", err))
 	}
@@ -164,7 +167,7 @@ func (s *Service) UninstallMod(ctx context.Context, game *domain.Game, profileNa
 	}
 
 	if err := s.DeleteInstalledMod(mod.SourceID, modID, game.ID, profileName); err != nil {
-		return nil, fmt.Errorf("failed to remove mod record: %w", err)
+		return result, fmt.Errorf("failed to remove mod record: %w", err)
 	}
 
 	if err := s.NewProfileManager().RemoveMod(game.ID, profileName, mod.SourceID, modID); err != nil {

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -76,19 +76,34 @@ type UninstallOptions struct {
 	HookContext HookContext
 	Force       bool // continue past a failing uninstall.before_* hook (warn instead of fail)
 
-	// Verbose gates the operational (non-hook) diagnostics recorded in
-	// Warnings — undeploy failure, cache-delete failure, and the
-	// profile-removal note — mirroring the pre-extraction CLI's `if
-	// verbose { ... }` guards around those three messages. Hook after_*
-	// failures are always recorded regardless of Verbose, matching the
-	// CLI's unconditional printHookWarnings behavior. Callers that always
-	// want full diagnostics (e.g. the TUI) should set Verbose: true.
-	Verbose bool
+	// No verbosity concept lives here: core never gates or prints
+	// diagnostics. UninstallResult.Notes and .Warnings are always fully
+	// populated; it is the caller's (CLI's/TUI's) job to decide what to
+	// display and under what conditions. See UninstallResult's doc comment.
 }
 
-// UninstallResult reports the outcome of UninstallMod.
+// UninstallResult reports the outcome of UninstallMod. Every entry in both
+// slices below is always recorded — UninstallMod has no verbosity concept —
+// but the two slices carry different display contracts for callers to honor
+// (this is the convention Tasks 3-4 should follow too):
+//
+//   - Warnings holds diagnostics the pre-extraction CLI printed
+//     unconditionally to stderr regardless of --verbose (hook failures:
+//     uninstall.before_* when Force is set, and uninstall.after_*, which is
+//     always non-fatal). Callers should print each entry to stderr,
+//     unconditionally, e.g. `fmt.Fprintf(os.Stderr, "Warning: %v\n", w)`.
+//   - Notes holds operational diagnostics the pre-extraction CLI only
+//     printed under --verbose (undeploy failure, cache-delete failure, and
+//     a failure to remove the mod from the profile). Each entry already
+//     carries its historical prefix word baked into the text ("Warning: "
+//     for undeploy/cache-delete, "Note: " for the profile-removal message,
+//     matching the pre-extraction CLI's exact wording for each), so a
+//     caller that wants byte-identical pre-extraction output should print
+//     each entry to stdout ONLY under --verbose, verbatim, e.g.
+//     `fmt.Printf("  %s\n", n)`.
 type UninstallResult struct {
-	Warnings []string // non-fatal issues encountered while uninstalling
+	Warnings []string // unconditional, stderr, audience: operator/always-visible
+	Notes    []string // --verbose-gated, stdout, audience: diagnostic detail
 }
 
 // UninstallMod removes a mod from the profile: runs uninstall hooks,
@@ -98,14 +113,16 @@ type UninstallResult struct {
 // Hook failure semantics (matching the pre-extraction CLI's doUninstall):
 //   - uninstall.before_all / uninstall.before_each: a failure aborts the
 //     operation with an error, unless Force is set, in which case it is
-//     recorded as a warning and the uninstall proceeds.
+//     recorded in Warnings and the uninstall proceeds.
 //   - uninstall.after_each / uninstall.after_all: always non-fatal; a
-//     failure is recorded as a warning after every other step has already
+//     failure is recorded in Warnings after every other step has already
 //     committed.
 //
 // Undeploy failures, cache-delete failures, and a failure to remove the mod
 // from the profile (e.g. the DB and profile have drifted out of sync) are
-// all non-fatal and recorded as warnings; the operation still completes.
+// all non-fatal and always recorded in Notes; the operation still
+// completes. See UninstallResult's doc comment for the Warnings/Notes
+// display contract.
 func (s *Service) UninstallMod(ctx context.Context, game *domain.Game, profileName, sourceID, modID string, opts UninstallOptions) (*UninstallResult, error) {
 	mod, err := s.GetInstalledMod(sourceID, modID, game.ID, profileName)
 	if err != nil {
@@ -134,17 +151,15 @@ func (s *Service) UninstallMod(ctx context.Context, game *domain.Game, profileNa
 
 	installer := s.GetInstaller(game)
 	if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
-		// Warn but continue - files may have been manually removed.
-		if opts.Verbose {
-			result.Warnings = append(result.Warnings, fmt.Sprintf("failed to undeploy some files: %v", err))
-		}
+		// Non-fatal - files may have been manually removed. Always
+		// recorded; the historical "Warning: " prefix is baked into the
+		// text itself (see UninstallResult's doc comment).
+		result.Notes = append(result.Notes, fmt.Sprintf("Warning: failed to undeploy some files: %v", err))
 	}
 
 	if !opts.KeepCache {
 		if err := s.GetGameCache(game).Delete(game.ID, mod.SourceID, modID, mod.Version); err != nil {
-			if opts.Verbose {
-				result.Warnings = append(result.Warnings, fmt.Sprintf("failed to clean cache: %v", err))
-			}
+			result.Notes = append(result.Notes, fmt.Sprintf("Warning: failed to clean cache: %v", err))
 		}
 	}
 
@@ -153,10 +168,9 @@ func (s *Service) UninstallMod(ctx context.Context, game *domain.Game, profileNa
 	}
 
 	if err := s.NewProfileManager().RemoveMod(game.ID, profileName, mod.SourceID, modID); err != nil {
-		// Don't fail if not in profile.
-		if opts.Verbose {
-			result.Warnings = append(result.Warnings, err.Error())
-		}
+		// Don't fail if not in profile. Always recorded, historical "Note: "
+		// prefix baked into the text (see UninstallResult's doc comment).
+		result.Notes = append(result.Notes, fmt.Sprintf("Note: %v", err))
 	}
 
 	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_each", opts.Hooks.GetUninstallAfterEach()); err != nil {

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -984,11 +984,7 @@ func (s *Service) PlanProfileSwitch(ctx context.Context, game *domain.Game, targ
 
 // SwitchResult reports the outcome of ApplyProfileSwitch. As with
 // DeployResult/UninstallResult, every Notes entry is always recorded - there
-// is no verbosity concept in core. Unlike those two flows, doProfileSwitch
-// never printed anything to stderr, so SwitchResult has no diagnostic that
-// belongs in a Warnings bucket; the field exists only for API consistency
-// with DeployResult/UninstallResult and is always empty for this flow (see
-// the task report).
+// is no verbosity concept in core.
 //
 //   - Notes holds every diagnostic doProfileSwitch only printed under
 //     --verbose: failed Uninstall/SetModEnabled during the disable loop,
@@ -1009,7 +1005,6 @@ func (s *Service) PlanProfileSwitch(ctx context.Context, game *domain.Game, targ
 // before the failure; callers should surface them alongside the error.
 type SwitchResult struct {
 	Disabled, Enabled, Installed int
-	Warnings                     []string // always empty for this flow; see doc comment
 	Notes                        []string
 }
 

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -332,6 +332,91 @@ const (
 	// immediately after the purge header instead of at the end of the
 	// purge phase.
 	PurgeComplete
+
+	// --- Task 4: ApplyProfileSwitch progress events, extending this same
+	// DeployPhase enum (per the task brief: "reuse DeployProgress and its
+	// phase-constant pattern - extend, don't fork") rather than introducing
+	// a parallel SwitchProgress/SwitchPhase pair. ApplyProfileSwitch is a
+	// behavior-preserving extraction of cmd/lmm/profile.go's doProfileSwitch;
+	// every phase below corresponds to exactly one of doProfileSwitch's
+	// fmt.Print* call sites - see the task report for the full mapping.
+	// Unlike DeployProfile, doProfileSwitch never printed to stderr at all,
+	// so none of these have a Warnings-bucket counterpart: every
+	// SwitchResult diagnostic below is a Note (--verbose-gated stdout). ---
+
+	// SwitchDisableNote fires for each of the disable loop's two possible
+	// per-mod diagnostics (a failed Uninstall, then a failed SetModEnabled),
+	// mirroring doProfileSwitch's "  Warning: failed to undeploy %s: %v" /
+	// "  Warning: failed to update %s: %v" - both --verbose-gated stdout
+	// prints. Detail carries the historical "Warning: " prefix baked in; a
+	// caller wanting byte-identical output prints
+	// `if verbose { fmt.Printf("  %s\n", p.Detail) }`.
+	SwitchDisableNote
+	// SwitchDisabled fires once a mod's disable step has finished
+	// (regardless of whether SwitchDisableNote fired for it) -
+	// doProfileSwitch always disables the DB row and always prints
+	// "  ✓ Disabled: %s" even when the undeploy/DB update above it failed.
+	// ModName is set.
+	SwitchDisabled
+	// SwitchEnableNote mirrors SwitchDisableNote for the enable loop's two
+	// diagnostics (a failed Install, then a failed SetModEnabled). Unlike
+	// the disable loop, a failed Install is fatal FOR THAT MOD ONLY: the mod
+	// is skipped (no SwitchEnabled event follows) - see doProfileSwitch's
+	// `continue` after the Install failure branch.
+	SwitchEnableNote
+	// SwitchEnabled fires once a mod has been successfully deployed (and
+	// enabled, or deployed but its SetModEnabled bookkeeping failed - see
+	// SwitchEnableNote), mirroring "  ✓ Enabled: %s".
+	SwitchEnabled
+	// SwitchInstalling fires once, before the install loop, only when there
+	// is at least one mod to install (Total = len(SwitchPlan.ToInstall)),
+	// mirroring doProfileSwitch's "\nInstalling missing mods...".
+	SwitchInstalling
+	// SwitchInstallingMod fires once per mod to install, before it is even
+	// fetched - SourceID/ModID are the only identity available at this
+	// point, mirroring "  Installing %s:%s...".
+	SwitchInstallingMod
+	// SwitchInstallError fires for any of the install loop's mod-fatal-only
+	// failure reasons (fetch, get-files, no-files, file-selection, deploy,
+	// or save), each already worded to match its historical text exactly
+	// (Detail is printed verbatim as "    Error: %s"). Unlike
+	// DeployProfile's DeploySkipped, these are NOT accumulated into any
+	// SwitchResult slice - doProfileSwitch never printed a final
+	// skipped-count summary for profile switch, so there is nothing to
+	// accumulate beyond the live event.
+	SwitchInstallError
+	// SwitchFallbackUsed fires when a to-be-installed mod's stored file IDs
+	// were not found on the source and the primary file was used instead,
+	// mirroring doProfileSwitch's unconditional (NOT --verbose-gated)
+	// "    Warning: stored file IDs not found, using primary".
+	SwitchFallbackUsed
+	// SwitchDownloading mirrors DeployDownloading for the install loop's
+	// download progress (Percent set, gated the same way: only once the
+	// source declares a total size).
+	SwitchDownloading
+	// SwitchDownloadFailed fires when a file download fails; Detail is
+	// "download failed: %v". A caller wanting byte-identical output prints a
+	// blank line then "    Error: %s" with Detail - see SwitchDownloadDone's
+	// doc comment for why the blank line isn't included here.
+	SwitchDownloadFailed
+	// SwitchDownloadDone fires once per install-loop mod after its download
+	// loop finishes, on both success and failure - doProfileSwitch's
+	// `fmt.Println()` after the loop runs unconditionally either way. A
+	// caller wanting byte-identical output prints a bare blank line here;
+	// combined with SwitchDownloadFailed's own leading blank line, a failed
+	// download reproduces the original's blank/error/blank sequence, and a
+	// successful one reproduces its single trailing blank line.
+	SwitchDownloadDone
+	// SwitchInstalled fires once a to-be-installed mod has been fetched,
+	// downloaded, deployed, and saved to the DB, mirroring "    ✓ Installed:
+	// %s". ModName is set (mod.Name, now known).
+	SwitchInstalled
+	// SwitchInstallNote fires when UpsertMod (recording the profile's
+	// FileIDs) fails after a successful install - the sole --verbose-gated
+	// diagnostic in the install loop, mirroring "    Warning: could not
+	// update profile: %v" (4-space indent, one level deeper than
+	// SwitchDisableNote/SwitchEnableNote's 2-space Notes).
+	SwitchInstallNote
 )
 
 // DeployProgress reports incremental status during DeployProfile. Index and
@@ -346,9 +431,14 @@ type DeployProgress struct {
 	Index, Total int
 	ModName      string
 	ModID        string
-	Phase        DeployPhase
-	Detail       string
-	Percent      float64
+	// SourceID is populated by ApplyProfileSwitch's install-loop events
+	// (SwitchInstallingMod onward), where a mod's SourceID:ModID pair is the
+	// only identity known before it has even been fetched (no ModName yet).
+	// DeployProfile's own events never set it (zero value, ignored).
+	SourceID string
+	Phase    DeployPhase
+	Detail   string
+	Percent  float64
 }
 
 // DeployResult reports the outcome of DeployProfile. As with UninstallResult
@@ -769,4 +859,346 @@ func (s *Service) purgeForDeploy(ctx context.Context, game *domain.Game, profile
 	linker.CleanupEmptyDirs(game.ModPath)
 	emit(DeployProgress{Phase: PurgeComplete})
 	return nil
+}
+
+// SwitchPlan is the pure, displayable diff between the currently-active
+// default profile and a target profile - computed by PlanProfileSwitch with
+// zero side effects, so a caller (the CLI, or eventually the TUI) can render
+// it (in a print block or a confirmation modal) before deciding whether to
+// call ApplyProfileSwitch. This is a behavior-preserving extraction of
+// cmd/lmm/profile.go's doProfileSwitch's diff computation (through its
+// "Show changes" print block) - see the task report for the exact mapping.
+//
+// CRITICAL: this mirrors the CLI's OWN diff algorithm, which is distinct
+// from (and does not call) ProfileManager.Switch - see the task report for
+// why both exist.
+type SwitchPlan struct {
+	GameID, From, To string
+
+	ToEnable  []domain.InstalledMod // installed+disabled (or installed under a different profile) -> enable, deployed under To
+	ToDisable []domain.InstalledMod // enabled under From but absent from To -> disable, undeployed under From
+	ToInstall []domain.ModReference // in To but not installed anywhere -> download+install (FileIDs preserved from the installed mod's own record when this is really a cache-miss redeploy - see PlanProfileSwitch)
+
+	NoChanges     bool // To's mod set matches From's content-wise; only SetDefault is needed
+	AlreadyActive bool // To is already the active default profile; nothing to plan
+}
+
+// PlanProfileSwitch computes the diff between game's currently-active
+// default profile and target, without mutating anything (no DB writes, no
+// filesystem changes, no deploys) - callers may call this speculatively (to
+// render a confirmation modal) and discard the result without consequence.
+// See SwitchPlan's doc comment; ctx is accepted for API consistency with the
+// rest of Service's methods and future-proofing, even though today's
+// algorithm performs no I/O that needs it.
+func (s *Service) PlanProfileSwitch(ctx context.Context, game *domain.Game, target string) (*SwitchPlan, error) {
+	pm := s.NewProfileManager()
+
+	targetProfile, err := pm.Get(game.ID, target)
+	if err != nil {
+		return nil, fmt.Errorf("profile not found: %s", target)
+	}
+
+	currentProfile, err := pm.GetDefault(game.ID)
+	var currentName string
+	if err != nil {
+		currentName = "default"
+	} else {
+		currentName = currentProfile.Name
+	}
+
+	if currentName == target {
+		return &SwitchPlan{GameID: game.ID, From: currentName, To: target, AlreadyActive: true}, nil
+	}
+
+	// currentMods/allMods errors are ignored, matching doProfileSwitch
+	// exactly (a missing/unreadable profile's mods are simply treated as
+	// empty rather than aborting the plan).
+	currentMods, _ := s.GetInstalledMods(game.ID, currentName)
+
+	currentEnabled := make(map[string]*domain.InstalledMod)
+	for i := range currentMods {
+		if currentMods[i].Enabled {
+			currentEnabled[domain.ModKey(currentMods[i].SourceID, currentMods[i].ID)] = &currentMods[i]
+		}
+	}
+
+	targetKeys := make(map[string]domain.ModReference)
+	for _, mr := range targetProfile.Mods {
+		targetKeys[domain.ModKey(mr.SourceID, mr.ModID)] = mr
+	}
+
+	// allInstalled merges what's installed under the target profile with
+	// what's installed under the current one (current wins on key
+	// collision) - doProfileSwitch's "Get all installed mods (any profile)
+	// to check what's available", which despite the comment only actually
+	// considers these two profiles.
+	allInstalled := make(map[string]*domain.InstalledMod)
+	allMods, _ := s.GetInstalledMods(game.ID, target)
+	for i := range allMods {
+		allInstalled[domain.ModKey(allMods[i].SourceID, allMods[i].ID)] = &allMods[i]
+	}
+	for i := range currentMods {
+		allInstalled[domain.ModKey(currentMods[i].SourceID, currentMods[i].ID)] = &currentMods[i]
+	}
+
+	var toDisable, toEnable []domain.InstalledMod
+	var toInstall []domain.ModReference
+
+	for key, im := range currentEnabled {
+		if _, inTarget := targetKeys[key]; !inTarget {
+			toDisable = append(toDisable, *im)
+		}
+	}
+
+	for key, ref := range targetKeys {
+		im, installed := allInstalled[key]
+		switch {
+		case !installed:
+			toInstall = append(toInstall, ref)
+		case !s.GetGameCache(game).Exists(game.ID, im.SourceID, im.ID, im.Version):
+			// Cache missing - needs a redownload; preserve the installed
+			// mod's own FileIDs (not the profile YAML's, which may be
+			// empty or stale).
+			refWithFileIDs := ref
+			refWithFileIDs.FileIDs = im.FileIDs
+			toInstall = append(toInstall, refWithFileIDs)
+		case !im.Enabled:
+			toEnable = append(toEnable, *im)
+		default:
+			// Installed, cached, and enabled - but was it enabled under the
+			// CURRENT profile? If not (e.g. it was only ever enabled under
+			// some other profile), it still needs an explicit enable pass
+			// for the target.
+			if _, wasCurrent := currentEnabled[key]; !wasCurrent {
+				toEnable = append(toEnable, *im)
+			}
+		}
+	}
+
+	return &SwitchPlan{
+		GameID: game.ID, From: currentName, To: target,
+		ToDisable: toDisable, ToEnable: toEnable, ToInstall: toInstall,
+		NoChanges: len(toDisable) == 0 && len(toEnable) == 0 && len(toInstall) == 0,
+	}, nil
+}
+
+// SwitchResult reports the outcome of ApplyProfileSwitch. As with
+// DeployResult/UninstallResult, every Notes entry is always recorded - there
+// is no verbosity concept in core. Unlike those two flows, doProfileSwitch
+// never printed anything to stderr, so SwitchResult has no diagnostic that
+// belongs in a Warnings bucket; the field exists only for API consistency
+// with DeployResult/UninstallResult and is always empty for this flow (see
+// the task report).
+//
+//   - Notes holds every diagnostic doProfileSwitch only printed under
+//     --verbose: failed Uninstall/SetModEnabled during the disable loop,
+//     failed Install/SetModEnabled during the enable loop, and a failed
+//     UpsertMod during the install loop. Each entry already carries its
+//     historical "Warning: " prefix, matching doProfileSwitch's exact
+//     wording; a caller wanting byte-identical output should print each
+//     entry to stdout ONLY under --verbose, e.g. `fmt.Printf("  %s\n", n)`
+//     (disable/enable loop notes) or `fmt.Printf("    %s\n", n)` (the
+//     install loop's profile-update note, one indent level deeper).
+//
+// Every Notes entry is ALSO reported via the progress callback at the exact
+// point it is appended (SwitchDisableNote/SwitchEnableNote/SwitchInstallNote
+// - see each DeployPhase constant's doc comment), with Detail equal to the
+// slice entry verbatim.
+//
+// On error, the returned result carries any diagnostics/counts accumulated
+// before the failure; callers should surface them alongside the error.
+type SwitchResult struct {
+	Disabled, Enabled, Installed int
+	Warnings                     []string // always empty for this flow; see doc comment
+	Notes                        []string
+}
+
+// ApplyProfileSwitch executes a plan produced by PlanProfileSwitch: disables
+// every ToDisable mod, then enables every ToEnable mod, then downloads and
+// installs every ToInstall mod, and finally calls ProfileManager.SetDefault
+// to make plan.To the active profile - in that order, matching
+// doProfileSwitch exactly. progress may be nil.
+//
+// doProfileSwitch runs no install/uninstall hooks at all (unlike
+// DeployProfile/UninstallMod), so ApplyProfileSwitch doesn't either - there
+// is deliberately no hook plumbing in its signature or DeployOptions-style
+// options struct, since profile switch takes no CLI flags beyond the target
+// profile name.
+func (s *Service) ApplyProfileSwitch(ctx context.Context, game *domain.Game, plan *SwitchPlan, progress func(DeployProgress)) (*SwitchResult, error) {
+	result := &SwitchResult{}
+	emit := func(p DeployProgress) {
+		if progress != nil {
+			progress(p)
+		}
+	}
+
+	installer := s.GetInstaller(game)
+	pm := s.NewProfileManager()
+
+	totalDisable := len(plan.ToDisable)
+	for idx := range plan.ToDisable {
+		im := plan.ToDisable[idx]
+		base := DeployProgress{Index: idx + 1, Total: totalDisable, ModName: im.Name, ModID: im.ID}
+
+		if err := installer.Uninstall(ctx, game, &im.Mod, plan.From); err != nil {
+			msg := fmt.Sprintf("Warning: failed to undeploy %s: %v", im.Name, err)
+			result.Notes = append(result.Notes, msg)
+			evt := base
+			evt.Phase, evt.Detail = SwitchDisableNote, msg
+			emit(evt)
+		}
+		if err := s.SetModEnabled(im.SourceID, im.ID, game.ID, plan.From, false); err != nil {
+			msg := fmt.Sprintf("Warning: failed to update %s: %v", im.Name, err)
+			result.Notes = append(result.Notes, msg)
+			evt := base
+			evt.Phase, evt.Detail = SwitchDisableNote, msg
+			emit(evt)
+		}
+
+		result.Disabled++
+		evt := base
+		evt.Phase = SwitchDisabled
+		emit(evt)
+	}
+
+	totalEnable := len(plan.ToEnable)
+	for idx := range plan.ToEnable {
+		im := plan.ToEnable[idx]
+		base := DeployProgress{Index: idx + 1, Total: totalEnable, ModName: im.Name, ModID: im.ID}
+
+		if err := installer.Install(ctx, game, &im.Mod, plan.To); err != nil {
+			msg := fmt.Sprintf("Warning: failed to deploy %s: %v", im.Name, err)
+			result.Notes = append(result.Notes, msg)
+			evt := base
+			evt.Phase, evt.Detail = SwitchEnableNote, msg
+			emit(evt)
+			continue
+		}
+		if err := s.SetModEnabled(im.SourceID, im.ID, game.ID, plan.To, true); err != nil {
+			msg := fmt.Sprintf("Warning: failed to update %s: %v", im.Name, err)
+			result.Notes = append(result.Notes, msg)
+			evt := base
+			evt.Phase, evt.Detail = SwitchEnableNote, msg
+			emit(evt)
+		}
+
+		result.Enabled++
+		evt := base
+		evt.Phase = SwitchEnabled
+		emit(evt)
+	}
+
+	if totalInstall := len(plan.ToInstall); totalInstall > 0 {
+		emit(DeployProgress{Phase: SwitchInstalling, Total: totalInstall})
+
+		for idx, ref := range plan.ToInstall {
+			base := DeployProgress{Index: idx + 1, Total: totalInstall, SourceID: ref.SourceID, ModID: ref.ModID}
+			installingEvt := base
+			installingEvt.Phase = SwitchInstallingMod
+			emit(installingEvt)
+
+			fail := func(reason string) {
+				evt := base
+				evt.Phase, evt.Detail = SwitchInstallError, reason
+				emit(evt)
+			}
+
+			mod, err := s.GetMod(ctx, ref.SourceID, game.ID, ref.ModID)
+			if err != nil {
+				fail(fmt.Sprintf("failed to fetch mod: %v", err))
+				continue
+			}
+			base.ModName = mod.Name
+
+			files, err := s.GetModFiles(ctx, ref.SourceID, mod)
+			if err != nil {
+				fail(fmt.Sprintf("failed to get files: %v", err))
+				continue
+			}
+			if len(files) == 0 {
+				fail("no downloadable files")
+				continue
+			}
+
+			filesToDownload, usedFallback, err := selectDeployFiles(files, ref.FileIDs)
+			if err != nil {
+				fail(err.Error())
+				continue
+			}
+			if usedFallback && len(ref.FileIDs) > 0 {
+				fallbackEvt := base
+				fallbackEvt.Phase = SwitchFallbackUsed
+				emit(fallbackEvt)
+			}
+
+			var downloadedFileIDs []string
+			downloadFailed := false
+			for _, file := range filesToDownload {
+				progressFn := func(p DownloadProgress) {
+					if p.TotalBytes > 0 {
+						dl := base
+						dl.Phase, dl.Percent = SwitchDownloading, p.Percentage
+						emit(dl)
+					}
+				}
+				if _, err := s.DownloadMod(ctx, ref.SourceID, game, mod, file, progressFn); err != nil {
+					evt := base
+					evt.Phase, evt.Detail = SwitchDownloadFailed, fmt.Sprintf("download failed: %v", err)
+					emit(evt)
+					downloadFailed = true
+					break
+				}
+				downloadedFileIDs = append(downloadedFileIDs, file.ID)
+			}
+			doneEvt := base
+			doneEvt.Phase = SwitchDownloadDone
+			emit(doneEvt)
+
+			if downloadFailed {
+				continue
+			}
+
+			if err := installer.Install(ctx, game, mod, plan.To); err != nil {
+				fail(fmt.Sprintf("deploy failed: %v", err))
+				continue
+			}
+
+			// Save to DB. Normalize GameID to the lmm game (not the
+			// source-mapped value Service.GetMod may have stamped onto
+			// mod.GameID for querying the source) so every DB read, which
+			// queries by the lmm game ID, can find this row again.
+			installedMod := &domain.InstalledMod{
+				Mod:          *mod,
+				ProfileName:  plan.To,
+				UpdatePolicy: domain.UpdateNotify,
+				Enabled:      true,
+				FileIDs:      downloadedFileIDs,
+			}
+			installedMod.Mod.GameID = game.ID
+			if err := s.SaveInstalledMod(installedMod); err != nil {
+				fail(fmt.Sprintf("save failed: %v", err))
+				continue
+			}
+
+			modRef := domain.ModReference{SourceID: mod.SourceID, ModID: mod.ID, Version: mod.Version, FileIDs: downloadedFileIDs}
+			if err := pm.UpsertMod(game.ID, plan.To, modRef); err != nil {
+				msg := fmt.Sprintf("Warning: could not update profile: %v", err)
+				result.Notes = append(result.Notes, msg)
+				evt := base
+				evt.Phase, evt.Detail = SwitchInstallNote, msg
+				emit(evt)
+			}
+
+			result.Installed++
+			installedEvt := base
+			installedEvt.Phase = SwitchInstalled
+			emit(installedEvt)
+		}
+	}
+
+	if err := pm.SetDefault(game.ID, plan.To); err != nil {
+		return result, fmt.Errorf("setting default profile: %w", err)
+	}
+
+	return result, nil
 }

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/linker"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 )
 
 // EnableMod deploys an installed-but-disabled mod's files from the cache to
@@ -135,7 +137,7 @@ func (s *Service) UninstallMod(ctx context.Context, game *domain.Game, profileNa
 	result := &UninstallResult{}
 	hookCtx := opts.HookContext
 
-	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.before_all", opts.Hooks.GetUninstallBeforeAll()); err != nil {
+	if err := runHook(ctx, opts.HookRunner, &hookCtx, "uninstall.before_all", opts.Hooks.GetUninstallBeforeAll()); err != nil {
 		if !opts.Force {
 			return result, fmt.Errorf("uninstall.before_all hook failed: %w", err)
 		}
@@ -145,7 +147,7 @@ func (s *Service) UninstallMod(ctx context.Context, game *domain.Game, profileNa
 	hookCtx.ModID = mod.ID
 	hookCtx.ModName = mod.Name
 	hookCtx.ModVersion = mod.Version
-	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.before_each", opts.Hooks.GetUninstallBeforeEach()); err != nil {
+	if err := runHook(ctx, opts.HookRunner, &hookCtx, "uninstall.before_each", opts.Hooks.GetUninstallBeforeEach()); err != nil {
 		if !opts.Force {
 			return result, fmt.Errorf("uninstall.before_each hook failed: %w", err)
 		}
@@ -176,28 +178,460 @@ func (s *Service) UninstallMod(ctx context.Context, game *domain.Game, profileNa
 		result.Notes = append(result.Notes, fmt.Sprintf("Note: %v", err))
 	}
 
-	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_each", opts.Hooks.GetUninstallAfterEach()); err != nil {
+	if err := runHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_each", opts.Hooks.GetUninstallAfterEach()); err != nil {
 		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.after_each hook failed: %v", err))
 	}
 
 	hookCtx.ModID = ""
 	hookCtx.ModName = ""
 	hookCtx.ModVersion = ""
-	if err := runUninstallHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_all", opts.Hooks.GetUninstallAfterAll()); err != nil {
+	if err := runHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_all", opts.Hooks.GetUninstallAfterAll()); err != nil {
 		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.after_all hook failed: %v", err))
 	}
 
 	return result, nil
 }
 
-// runUninstallHook runs command (a hook script path) via runner if both are
-// set, updating hookCtx.HookName first. No-op if runner is nil or command
-// is empty (hooks disabled, or that particular hook isn't configured).
-func runUninstallHook(ctx context.Context, runner *HookRunner, hookCtx *HookContext, hookName, command string) error {
+// runHook runs command (a hook script path) via runner if both are set,
+// updating hookCtx.HookName first. No-op if runner is nil or command is
+// empty (hooks disabled, or that particular hook isn't configured). Shared
+// by UninstallMod and DeployProfile - hookName ("install.before_all",
+// "uninstall.after_each", ...) is just a label passed through to the script
+// environment, so one helper covers both hook namespaces.
+func runHook(ctx context.Context, runner *HookRunner, hookCtx *HookContext, hookName, command string) error {
 	if runner == nil || command == "" {
 		return nil
 	}
 	hookCtx.HookName = hookName
 	_, err := runner.Run(ctx, command, *hookCtx)
 	return err
+}
+
+// DeployOptions configures DeployProfile.
+type DeployOptions struct {
+	Purge bool // --purge: undeploy every installed mod (regardless of ModID/All) before deploying, remembering which were enabled beforehand for the profile-wide selection below.
+
+	// LinkMethod overrides the link method used for this deploy (--method).
+	// nil (the zero value) means "use the game's effective link method" via
+	// Service.GetGameLinkMethod. A pointer is used, rather than a bare
+	// domain.LinkMethod with its zero value as the "unset" sentinel, because
+	// domain.LinkMethod's zero value (LinkSymlink) is itself a valid,
+	// explicit choice - it cannot double as "no override" without losing
+	// the ability to explicitly request symlink. See the task report.
+	LinkMethod *domain.LinkMethod
+
+	// ModID/SourceID restrict the deploy to a single mod (`lmm deploy
+	// <mod-id>`). Both empty (the default) deploys every mod in profile
+	// order, subject to All. SourceID selects which source's copy of ModID
+	// to deploy - the CLI's --source flag, default "nexusmods".
+	ModID    string
+	SourceID string
+
+	All bool // --all: include disabled mods in a full-profile deploy, or allow deploying a disabled ModID.
+
+	// Hook plumbing, mirroring UninstallOptions. Hooks and/or HookRunner may
+	// be nil to skip hook execution entirely (e.g. --no-hooks). The deploy
+	// pass runs install.* hooks; the purge pass (when Purge is set) runs
+	// uninstall.* hooks, matching the pre-extraction CLI's doDeploy/
+	// purgeDeployedMods split.
+	Hooks       *ResolvedHooks
+	HookRunner  *HookRunner
+	HookContext HookContext
+	Force       bool // continue past a failing before_* hook (warn instead of fail)
+}
+
+// DeployPhase identifies what DeployProfile is doing for the mod named in a
+// DeployProgress event (or, for DeployPurging, for the purge pass as a
+// whole), letting callers (CLI, TUI) render phase-appropriate UI without
+// needing to know how a deploy is actually carried out.
+type DeployPhase int
+
+const (
+	// DeployPurging fires once, before any purge-phase mod is touched, when
+	// Purge is set and there is at least one installed mod to purge. Total
+	// is the number of mods being purged; Index and ModName are zero/empty.
+	DeployPurging DeployPhase = iota
+	// DeployBeforeEachSkipped: install.before_each failed for ModName: the
+	// mod is skipped (added to DeployResult.Skipped). Detail is the reason.
+	DeployBeforeEachSkipped
+	// DeployRedownloading: ModName's cache entry is missing; DeployProfile
+	// is re-fetching it from source.
+	DeployRedownloading
+	// DeployFallbackUsed: ModName's stored file IDs were not found on the
+	// source; falling back to the primary file.
+	DeployFallbackUsed
+	// DeployDownloading: a file for ModName is downloading. Percent is the
+	// 0-100 completion (only reported once the source declares a total
+	// size, matching the pre-extraction CLI's progress callback gating).
+	DeployDownloading
+	// DeployDownloadFailed: a file for ModName failed to download; the mod
+	// is skipped. Detail is the reason.
+	DeployDownloadFailed
+	// DeploySkipped: ModName was skipped for a reason other than a hook or
+	// download failure (fetch failure, no files available, file-selection
+	// failure, or an outright deploy/install failure). Detail is the reason.
+	DeploySkipped
+	// DeployDeployed: ModName was (re)deployed successfully.
+	DeployDeployed
+)
+
+// DeployProgress reports incremental status during DeployProfile. Index and
+// Total describe ModName's position among the mods being deployed (both
+// zero for the DeployPurging event, which precedes and is independent of
+// that count). Detail and Percent are populated only for the phases
+// documented on DeployPhase's constants; both are zero otherwise.
+type DeployProgress struct {
+	Index, Total int
+	ModName      string
+	Phase        DeployPhase
+	Detail       string
+	Percent      float64
+}
+
+// DeployResult reports the outcome of DeployProfile. As with UninstallResult
+// (see its doc comment), every entry below is always recorded - there is no
+// verbosity concept in core - but Warnings and Notes carry the same two
+// display contracts Task 2 established:
+//
+//   - Warnings holds diagnostics the pre-extraction CLI printed
+//     unconditionally to stderr: install.before_all (when forced),
+//     install.after_each/after_all hook failures, and a profile-overrides
+//     application failure. Callers should print each entry to stderr,
+//     unconditionally, e.g. `fmt.Fprintf(os.Stderr, "Warning: %v\n", w)`.
+//   - Notes holds operational diagnostics the pre-extraction CLI only
+//     printed under --verbose: a failed undeploy-before-redeploy, a failed
+//     SetModLinkMethod, and a failed SetModDeployed, all per mod, plus (for
+//     a --purge pass) the equivalent per-mod undeploy/SetModDeployed
+//     failures from purging. Each entry already carries its historical
+//     prefix ("Warning: " for the deploy-loop trio, "⚠ " for the purge
+//     trio) baked into the text, matching each one's pre-extraction
+//     wording; a caller wanting byte-identical pre-extraction output should
+//     print each entry to stdout ONLY under --verbose, verbatim, e.g.
+//     `fmt.Printf("  %s\n", n)`. See the task report for why these are
+//     accumulated-and-printed-at-the-end rather than interleaved with the
+//     progress callback's real-time per-mod output (as they were,
+//     inconsistently, pre-extraction).
+//
+// Skipped carries one "<mod name>: <reason>" entry per mod that did not
+// deploy, for any reason (hook failure, download failure, install
+// failure); the pre-extraction CLI printed each of these unconditionally
+// as it happened; DeployProgress's DeployBeforeEachSkipped/
+// DeployDownloadFailed/DeploySkipped events carry the same reason text in
+// real time for callers that want to print them as they occur instead of
+// (or in addition to) at the end.
+//
+// On error, the returned result carries any diagnostics accumulated before
+// the failure; callers should surface them alongside the error.
+type DeployResult struct {
+	Deployed int
+	Skipped  []string
+	Warnings []string
+	Notes    []string
+}
+
+// errNoDeployFiles mirrors cmd/lmm's errNoDownloadableFiles for the
+// redeploy-after-cache-miss path. DeployProfile duplicates a small slice of
+// cmd/lmm/profile.go's selectFilesToDownload/selectPrimaryFile logic here
+// (see selectDeployFiles below) instead of importing it, because
+// internal/core cannot import cmd/lmm and this task's scope explicitly
+// excludes touching profile.go to hoist it out; see the task report.
+var errNoDeployFiles = fmt.Errorf("no downloadable files")
+
+// selectDeployFiles picks the file(s) to (re)download for a cache-miss mod:
+// the files matching storedFileIDs if any are found, else the primary file
+// (first file with IsPrimary, or simply the first file), reporting whether
+// it had to fall back. Mirrors cmd/lmm/profile.go's selectFilesToDownload.
+func selectDeployFiles(files []domain.DownloadableFile, storedFileIDs []string) ([]*domain.DownloadableFile, bool, error) {
+	if len(files) == 0 {
+		return nil, false, errNoDeployFiles
+	}
+	primary := func() *domain.DownloadableFile {
+		for i := range files {
+			if files[i].IsPrimary {
+				return &files[i]
+			}
+		}
+		return &files[0]
+	}
+	if len(storedFileIDs) > 0 {
+		idSet := make(map[string]bool, len(storedFileIDs))
+		for _, id := range storedFileIDs {
+			idSet[id] = true
+		}
+		var found []*domain.DownloadableFile
+		for i := range files {
+			if idSet[files[i].ID] {
+				found = append(found, &files[i])
+			}
+		}
+		if len(found) > 0 {
+			return found, false, nil
+		}
+		return []*domain.DownloadableFile{primary()}, true, nil
+	}
+	return []*domain.DownloadableFile{primary()}, false, nil
+}
+
+// DeployProfile redeploys the mods of a profile in profile order: an
+// optional --purge pass first (undeploying every installed mod), then for
+// each mod to deploy - re-downloading from source if its cache entry is
+// missing - an undeploy-then-install cycle recording the effective link
+// method and deployed state, and finally applying any profile overrides.
+// This is a behavior-preserving extraction of the pre-extraction CLI's
+// doDeploy (cmd/lmm/deploy.go) and purgeDeployedMods (cmd/lmm/purge.go, the
+// --purge-before-deploy call only - the standalone `lmm purge` command is
+// untouched by this extraction); see the task report for the exact mapping.
+//
+// progress may be nil. When non-nil, it is called synchronously from this
+// function for every notable event - see DeployPhase's constants for what
+// each one means and what Detail/Percent carry.
+func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileName string, opts DeployOptions, progress func(DeployProgress)) (*DeployResult, error) {
+	result := &DeployResult{}
+	emit := func(p DeployProgress) {
+		if progress != nil {
+			progress(p)
+		}
+	}
+
+	var enabledBeforePurge map[string]bool
+	if opts.Purge {
+		mods, err := s.GetInstalledMods(game.ID, profileName)
+		if err != nil {
+			return result, fmt.Errorf("getting installed mods: %w", err)
+		}
+		enabledBeforePurge = make(map[string]bool)
+		for _, m := range mods {
+			if m.Enabled {
+				enabledBeforePurge[domain.ModKey(m.SourceID, m.ID)] = true
+			}
+		}
+		if err := s.purgeForDeploy(ctx, game, profileName, mods, opts, result, emit); err != nil {
+			return result, fmt.Errorf("purging mods: %w", err)
+		}
+	}
+
+	linkMethod := s.GetGameLinkMethod(game)
+	if opts.LinkMethod != nil {
+		linkMethod = *opts.LinkMethod
+	}
+	installer := s.NewInstallerWithLinker(game, s.GetLinker(linkMethod))
+
+	var modsToDeploy []*domain.InstalledMod
+	if opts.ModID != "" {
+		mod, err := s.GetInstalledMod(opts.SourceID, opts.ModID, game.ID, profileName)
+		if err != nil {
+			return result, fmt.Errorf("mod not found: %s", opts.ModID)
+		}
+		if !mod.Enabled && !opts.All {
+			return result, fmt.Errorf("mod %s is disabled - use --all to deploy disabled mods, or enable it with 'lmm mod enable %s'", mod.Name, opts.ModID)
+		}
+		modsToDeploy = append(modsToDeploy, mod)
+	} else {
+		mods, err := s.GetInstalledModsInProfileOrder(game.ID, profileName)
+		if err != nil {
+			return result, fmt.Errorf("getting installed mods: %w", err)
+		}
+		for i := range mods {
+			var shouldDeploy bool
+			switch {
+			case opts.All:
+				shouldDeploy = true
+			case enabledBeforePurge != nil:
+				shouldDeploy = enabledBeforePurge[domain.ModKey(mods[i].SourceID, mods[i].ID)]
+			default:
+				shouldDeploy = mods[i].Enabled
+			}
+			if shouldDeploy {
+				modsToDeploy = append(modsToDeploy, &mods[i])
+			}
+		}
+	}
+
+	if len(modsToDeploy) == 0 {
+		return result, nil
+	}
+
+	hookCtx := opts.HookContext
+	if err := runHook(ctx, opts.HookRunner, &hookCtx, "install.before_all", opts.Hooks.GetInstallBeforeAll()); err != nil {
+		if !opts.Force {
+			return result, fmt.Errorf("install.before_all hook failed: %w", err)
+		}
+		result.Warnings = append(result.Warnings, fmt.Sprintf("install.before_all hook failed (forced): %v", err))
+	}
+
+	total := len(modsToDeploy)
+	for idx, mod := range modsToDeploy {
+		base := DeployProgress{Index: idx + 1, Total: total, ModName: mod.Name}
+
+		hookCtx.ModID, hookCtx.ModName, hookCtx.ModVersion = mod.ID, mod.Name, mod.Version
+		if err := runHook(ctx, opts.HookRunner, &hookCtx, "install.before_each", opts.Hooks.GetInstallBeforeEach()); err != nil {
+			reason := fmt.Sprintf("install.before_each hook failed: %v", err)
+			evt := base
+			evt.Phase, evt.Detail = DeployBeforeEachSkipped, reason
+			emit(evt)
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: %s", mod.Name, reason))
+			continue
+		}
+
+		if !s.GetGameCache(game).Exists(game.ID, mod.SourceID, mod.ID, mod.Version) {
+			if skipped := s.redeployFromSource(ctx, game, mod, base, emit, result); skipped {
+				continue
+			}
+		}
+
+		if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
+			result.Notes = append(result.Notes, fmt.Sprintf("Warning: undeploy %s: %v", mod.Name, err))
+		}
+
+		if err := installer.Install(ctx, game, &mod.Mod, profileName); err != nil {
+			reason := err.Error()
+			evt := base
+			evt.Phase, evt.Detail = DeploySkipped, reason
+			emit(evt)
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: %s", mod.Name, reason))
+			continue
+		}
+
+		if err := s.SetModLinkMethod(mod.SourceID, mod.ID, game.ID, profileName, linkMethod); err != nil {
+			result.Notes = append(result.Notes, fmt.Sprintf("Warning: could not update link method: %v", err))
+		}
+		if err := s.SetModDeployed(mod.SourceID, mod.ID, game.ID, profileName, true); err != nil {
+			result.Notes = append(result.Notes, fmt.Sprintf("Warning: could not mark as deployed: %v", err))
+		}
+
+		result.Deployed++
+		evt := base
+		evt.Phase = DeployDeployed
+		emit(evt)
+
+		if err := runHook(ctx, opts.HookRunner, &hookCtx, "install.after_each", opts.Hooks.GetInstallAfterEach()); err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("install.after_each hook failed for %s: %v", mod.ID, err))
+		}
+	}
+
+	hookCtx.ModID, hookCtx.ModName, hookCtx.ModVersion = "", "", ""
+	if err := runHook(ctx, opts.HookRunner, &hookCtx, "install.after_all", opts.Hooks.GetInstallAfterAll()); err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("install.after_all hook failed: %v", err))
+	}
+
+	if profile, err := config.LoadProfile(s.configDir, game.ID, profileName); err == nil && len(profile.Overrides) > 0 {
+		if err := ApplyProfileOverrides(game, profile); err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("applying profile overrides: %v", err))
+		}
+	}
+
+	return result, nil
+}
+
+// redeployFromSource re-fetches mod from source and downloads its file(s)
+// into the cache when DeployProfile finds the cache entry missing,
+// mirroring doDeploy's cache-miss branch exactly, including its one
+// preserved quirk: the freshly-fetched *domain.Mod (not the InstalledMod's
+// own, possibly-stale, Mod) is what gets downloaded, while the InstalledMod
+// row's own Mod is what DeployProfile installs from afterward - see the
+// task report. Returns true if the mod was skipped (added to
+// result.Skipped and reported via emit) and the caller must not proceed to
+// undeploy/install it.
+func (s *Service) redeployFromSource(ctx context.Context, game *domain.Game, mod *domain.InstalledMod, base DeployProgress, emit func(DeployProgress), result *DeployResult) bool {
+	skip := func(reason string) bool {
+		evt := base
+		evt.Phase, evt.Detail = DeploySkipped, reason
+		emit(evt)
+		result.Skipped = append(result.Skipped, fmt.Sprintf("%s: %s", mod.Name, reason))
+		return true
+	}
+
+	redl := base
+	redl.Phase = DeployRedownloading
+	emit(redl)
+
+	fetchedMod, err := s.GetMod(ctx, mod.SourceID, game.ID, mod.ID)
+	if err != nil {
+		return skip(fmt.Sprintf("failed to fetch: %v", err))
+	}
+
+	files, err := s.GetModFiles(ctx, mod.SourceID, fetchedMod)
+	if err != nil || len(files) == 0 {
+		return skip("no files available")
+	}
+
+	filesToDownload, usedFallback, err := selectDeployFiles(files, mod.FileIDs)
+	if err != nil {
+		return skip(err.Error())
+	}
+	if usedFallback {
+		fb := base
+		fb.Phase = DeployFallbackUsed
+		emit(fb)
+	}
+
+	for _, file := range filesToDownload {
+		progressFn := func(p DownloadProgress) {
+			if p.TotalBytes > 0 {
+				dl := base
+				dl.Phase, dl.Percent = DeployDownloading, p.Percentage
+				emit(dl)
+			}
+		}
+		if _, err := s.DownloadMod(ctx, mod.SourceID, game, fetchedMod, file, progressFn); err != nil {
+			return skip(fmt.Sprintf("download failed: %v", err))
+		}
+	}
+
+	return false
+}
+
+// purgeForDeploy undeploys every currently-installed mod in profileName
+// before DeployProfile redeploys them, mirroring the pre-extraction CLI's
+// purgeDeployedMods (used only by `lmm deploy --purge`; the standalone `lmm
+// purge` command, and its own purgeDeployedMods call site, are untouched by
+// this task). See DeployResult's doc comment for where each diagnostic
+// below ends up.
+func (s *Service) purgeForDeploy(ctx context.Context, game *domain.Game, profileName string, mods []domain.InstalledMod, opts DeployOptions, result *DeployResult, emit func(DeployProgress)) error {
+	if len(mods) == 0 {
+		return nil
+	}
+
+	hookCtx := opts.HookContext
+	if err := runHook(ctx, opts.HookRunner, &hookCtx, "uninstall.before_all", opts.Hooks.GetUninstallBeforeAll()); err != nil {
+		if !opts.Force {
+			return fmt.Errorf("uninstall.before_all hook failed: %w", err)
+		}
+		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.before_all hook failed (forced): %v", err))
+	}
+
+	installer := s.GetInstaller(game)
+	emit(DeployProgress{Phase: DeployPurging, Total: len(mods)})
+
+	for _, mod := range mods {
+		hookCtx.ModID, hookCtx.ModName, hookCtx.ModVersion = mod.ID, mod.Name, mod.Version
+		if err := runHook(ctx, opts.HookRunner, &hookCtx, "uninstall.before_each", opts.Hooks.GetUninstallBeforeEach()); err != nil {
+			// Matches purgeDeployedMods: skip this mod (leave it deployed),
+			// keep going. The pre-extraction CLI printed this unconditionally
+			// to stdout ("  Skipped: ..."); recorded here as a Warning
+			// (unconditional, stderr) instead - see the task report.
+			result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.before_each hook failed for %s during purge (not purged): %v", mod.Name, err))
+			continue
+		}
+
+		if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
+			result.Notes = append(result.Notes, fmt.Sprintf("⚠ %s - %v", mod.Name, err))
+		}
+
+		if err := s.SetModDeployed(mod.SourceID, mod.ID, game.ID, profileName, false); err != nil {
+			result.Notes = append(result.Notes, fmt.Sprintf("⚠ %s - failed to mark as not deployed: %v", mod.Name, err))
+		}
+
+		if err := runHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_each", opts.Hooks.GetUninstallAfterEach()); err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.after_each hook failed for %s: %v", mod.ID, err))
+		}
+	}
+
+	hookCtx.ModID, hookCtx.ModName, hookCtx.ModVersion = "", "", ""
+	if err := runHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_all", opts.Hooks.GetUninstallAfterAll()); err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.after_all hook failed: %v", err))
+	}
+
+	linker.CleanupEmptyDirs(game.ModPath)
+	return nil
 }

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -276,8 +276,8 @@ const (
 	// its ApplyProfileSwitch analog (SwitchDownloadDone), which fires on
 	// both success and failure since doProfileSwitch's equivalent Println
 	// sat unconditionally after its own loop, redeployFromSource's failure
-	// path returns immediately via a DeploySkipped event instead (see
-	// skip() below) without reaching this point - so this phase covers the
+	// path returns immediately via a DeployDownloadFailed event instead (see
+	// below) without reaching this point - so this phase covers the
 	// success path only.
 	DeployDownloadDone
 	// DeploySkipped: ModName was skipped for a reason other than a hook or
@@ -784,7 +784,12 @@ func (s *Service) redeployFromSource(ctx context.Context, game *domain.Game, mod
 			}
 		}
 		if _, err := s.DownloadMod(ctx, mod.SourceID, game, fetchedMod, file, progressFn); err != nil {
-			return skip(fmt.Sprintf("download failed: %v", err))
+			reason := fmt.Sprintf("download failed: %v", err)
+			evt := base
+			evt.Phase, evt.Detail = DeployDownloadFailed, reason
+			emit(evt)
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: %s", mod.Name, reason))
+			return true
 		}
 	}
 

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -273,16 +273,79 @@ const (
 	DeploySkipped
 	// DeployDeployed: ModName was (re)deployed successfully.
 	DeployDeployed
+
+	// --- Fix wave 1: every remaining Warnings/Notes diagnostic gets an
+	// event at its exact point of occurrence, restoring the pre-extraction
+	// CLI's console positioning (see DeployResult's doc comment for the
+	// full Warnings/Notes -> event mapping and task-3-report.md's "Fix
+	// wave 1" entry for the review findings these fix). ---
+
+	// DeployBeforeAllForced fires once, immediately, when install.before_all
+	// (a deploy) or uninstall.before_all (a --purge pass) fails and Force is
+	// set: the pre-extraction CLI printed this warning as the very first
+	// line of output, before anything else (the "Purging..."/"Deploying..."
+	// header included) - so this event always precedes DeployPurging and
+	// any other event. No mod is in scope (Index/Total/ModName/ModID are
+	// zero); Detail matches the DeployResult.Warnings entry verbatim.
+	DeployBeforeAllForced
+	// DeployNote fires wherever DeployProfile appends an entry to
+	// DeployResult.Notes for a specific mod during the main deploy loop
+	// (a failed undeploy-before-redeploy, a failed SetModLinkMethod, or a
+	// failed SetModDeployed), at the exact point it happens - always
+	// before that same mod's own DeployDeployed event, matching the
+	// pre-extraction CLI's inline ordering. ModName/ModID identify the
+	// mod; for the latter two diagnostics, whose historical text carries
+	// no mod identity at all, the event's ModName/ModID are the ONLY way
+	// to attribute the diagnostic to a mod.
+	DeployNote
+	// DeployWarning fires wherever DeployProfile appends an entry to
+	// DeployResult.Warnings other than a DeployBeforeAllForced one: a
+	// failed install.after_each hook (ModName/ModID set), a failed
+	// install.after_all hook, or a failed ApplyProfileOverrides (neither
+	// has a mod in scope). The pre-extraction CLI printed the overrides
+	// warning immediately once computed, then its batched hook warnings
+	// (after_each in mod order, then after_all) right after - so
+	// DeployProfile emits the overrides DeployWarning (if any) first, then
+	// the after_each/after_all ones, reproducing that print order without
+	// changing when each check actually runs (see DeployProfile's body).
+	DeployWarning
+	// PurgeWarning fires wherever a --purge pass appends an entry to
+	// DeployResult.Warnings: a skipped uninstall.before_each mod (fires
+	// inline, per mod, as it happens), or a failed uninstall.after_each/
+	// after_all hook (fires after the whole purge loop has finished, in
+	// mod order then after_all - mirroring the pre-extraction
+	// purgeDeployedMods, which accumulated these and printed them
+	// together, after every per-mod line, via printHookWarnings).
+	PurgeWarning
+	// PurgeNote fires wherever a --purge pass appends an entry to
+	// DeployResult.Notes for a specific mod (a failed undeploy, or a
+	// failed SetModDeployed(false)), inline, immediately after that
+	// operation - mirroring the pre-extraction purgeDeployedMods's
+	// --verbose-gated "⚠ " lines.
+	PurgeNote
+	// PurgeComplete fires once, after a non-empty --purge pass has
+	// finished everything (including its own hook warnings) but before
+	// DeployProfile moves on to gathering mods to deploy. It carries no
+	// data; a caller wanting byte-identical pre-extraction output prints
+	// exactly one blank line here - purgeDeployedMods's own final
+	// `fmt.Println()`, which the initial extraction had misplaced
+	// immediately after the purge header instead of at the end of the
+	// purge phase.
+	PurgeComplete
 )
 
 // DeployProgress reports incremental status during DeployProfile. Index and
 // Total describe ModName's position among the mods being deployed (both
-// zero for the DeployPurging event, which precedes and is independent of
-// that count). Detail and Percent are populated only for the phases
-// documented on DeployPhase's constants; both are zero otherwise.
+// zero for phases with no mod/count in scope - see each DeployPhase
+// constant's doc comment). ModID accompanies ModName wherever a specific
+// mod is in scope; for phases whose historical text carries no mod name at
+// all (DeployNote's link-method/mark-deployed cases), it is the only
+// attribution available. Detail and Percent are populated only for the
+// phases documented on DeployPhase's constants; both are zero otherwise.
 type DeployProgress struct {
 	Index, Total int
 	ModName      string
+	ModID        string
 	Phase        DeployPhase
 	Detail       string
 	Percent      float64
@@ -294,10 +357,12 @@ type DeployProgress struct {
 // display contracts Task 2 established:
 //
 //   - Warnings holds diagnostics the pre-extraction CLI printed
-//     unconditionally to stderr: install.before_all (when forced),
-//     install.after_each/after_all hook failures, and a profile-overrides
-//     application failure. Callers should print each entry to stderr,
-//     unconditionally, e.g. `fmt.Fprintf(os.Stderr, "Warning: %v\n", w)`.
+//     unconditionally to stderr: install.before_all/uninstall.before_all
+//     (when forced), a skipped uninstall.before_each during purge,
+//     install/uninstall after_each/after_all hook failures, and a
+//     profile-overrides application failure. Callers should print each
+//     entry to stderr, unconditionally, e.g.
+//     `fmt.Fprintf(os.Stderr, "Warning: %v\n", w)`.
 //   - Notes holds operational diagnostics the pre-extraction CLI only
 //     printed under --verbose: a failed undeploy-before-redeploy, a failed
 //     SetModLinkMethod, and a failed SetModDeployed, all per mod, plus (for
@@ -307,10 +372,17 @@ type DeployProgress struct {
 //     trio) baked into the text, matching each one's pre-extraction
 //     wording; a caller wanting byte-identical pre-extraction output should
 //     print each entry to stdout ONLY under --verbose, verbatim, e.g.
-//     `fmt.Printf("  %s\n", n)`. See the task report for why these are
-//     accumulated-and-printed-at-the-end rather than interleaved with the
-//     progress callback's real-time per-mod output (as they were,
-//     inconsistently, pre-extraction).
+//     `fmt.Printf("  %s\n", n)`.
+//
+// Every entry in both slices is ALSO reported via the progress callback at
+// the exact point it is appended (DeployBeforeAllForced/DeployNote/
+// DeployWarning/PurgeWarning/PurgeNote - see each DeployPhase constant's
+// doc comment for which), with Detail equal to the slice entry verbatim and
+// the phase itself indicating which display contract above applies. A
+// caller driving its console output entirely from progress events (as
+// cmd/lmm's doDeploy does) gets pre-extraction-accurate positioning; the
+// slices remain here, unconditionally, for callers that only want the
+// final, order-independent summary.
 //
 // Skipped carries one "<mod name>: <reason>" entry per mod that did not
 // deploy, for any reason (hook failure, download failure, install
@@ -456,12 +528,23 @@ func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileN
 		if !opts.Force {
 			return result, fmt.Errorf("install.before_all hook failed: %w", err)
 		}
-		result.Warnings = append(result.Warnings, fmt.Sprintf("install.before_all hook failed (forced): %v", err))
+		msg := fmt.Sprintf("install.before_all hook failed (forced): %v", err)
+		result.Warnings = append(result.Warnings, msg)
+		emit(DeployProgress{Phase: DeployBeforeAllForced, Detail: msg})
 	}
+
+	// deferredWarnings holds install.after_each (per mod, in loop order)
+	// and install.after_all DeployWarning events: the pre-extraction CLI
+	// printed these together, AFTER the profile-overrides warning below,
+	// even though both hooks run earlier in the function - see
+	// DeployWarning's doc comment. Emission (and therefore printing) is
+	// deferred to preserve that order; the Warnings slice itself is still
+	// appended to at the natural point, unchanged.
+	var deferredWarnings []DeployProgress
 
 	total := len(modsToDeploy)
 	for idx, mod := range modsToDeploy {
-		base := DeployProgress{Index: idx + 1, Total: total, ModName: mod.Name}
+		base := DeployProgress{Index: idx + 1, Total: total, ModName: mod.Name, ModID: mod.ID}
 
 		hookCtx.ModID, hookCtx.ModName, hookCtx.ModVersion = mod.ID, mod.Name, mod.Version
 		if err := runHook(ctx, opts.HookRunner, &hookCtx, "install.before_each", opts.Hooks.GetInstallBeforeEach()); err != nil {
@@ -480,7 +563,11 @@ func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileN
 		}
 
 		if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
-			result.Notes = append(result.Notes, fmt.Sprintf("Warning: undeploy %s: %v", mod.Name, err))
+			msg := fmt.Sprintf("Warning: undeploy %s: %v", mod.Name, err)
+			result.Notes = append(result.Notes, msg)
+			evt := base
+			evt.Phase, evt.Detail = DeployNote, msg
+			emit(evt)
 		}
 
 		if err := installer.Install(ctx, game, &mod.Mod, profileName); err != nil {
@@ -493,10 +580,18 @@ func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileN
 		}
 
 		if err := s.SetModLinkMethod(mod.SourceID, mod.ID, game.ID, profileName, linkMethod); err != nil {
-			result.Notes = append(result.Notes, fmt.Sprintf("Warning: could not update link method: %v", err))
+			msg := fmt.Sprintf("Warning: could not update link method: %v", err)
+			result.Notes = append(result.Notes, msg)
+			evt := base
+			evt.Phase, evt.Detail = DeployNote, msg
+			emit(evt)
 		}
 		if err := s.SetModDeployed(mod.SourceID, mod.ID, game.ID, profileName, true); err != nil {
-			result.Notes = append(result.Notes, fmt.Sprintf("Warning: could not mark as deployed: %v", err))
+			msg := fmt.Sprintf("Warning: could not mark as deployed: %v", err)
+			result.Notes = append(result.Notes, msg)
+			evt := base
+			evt.Phase, evt.Detail = DeployNote, msg
+			emit(evt)
 		}
 
 		result.Deployed++
@@ -505,19 +600,31 @@ func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileN
 		emit(evt)
 
 		if err := runHook(ctx, opts.HookRunner, &hookCtx, "install.after_each", opts.Hooks.GetInstallAfterEach()); err != nil {
-			result.Warnings = append(result.Warnings, fmt.Sprintf("install.after_each hook failed for %s: %v", mod.ID, err))
+			msg := fmt.Sprintf("install.after_each hook failed for %s: %v", mod.ID, err)
+			result.Warnings = append(result.Warnings, msg)
+			evt := base
+			evt.Phase, evt.Detail = DeployWarning, msg
+			deferredWarnings = append(deferredWarnings, evt)
 		}
 	}
 
 	hookCtx.ModID, hookCtx.ModName, hookCtx.ModVersion = "", "", ""
 	if err := runHook(ctx, opts.HookRunner, &hookCtx, "install.after_all", opts.Hooks.GetInstallAfterAll()); err != nil {
-		result.Warnings = append(result.Warnings, fmt.Sprintf("install.after_all hook failed: %v", err))
+		msg := fmt.Sprintf("install.after_all hook failed: %v", err)
+		result.Warnings = append(result.Warnings, msg)
+		deferredWarnings = append(deferredWarnings, DeployProgress{Phase: DeployWarning, Detail: msg})
 	}
 
 	if profile, err := config.LoadProfile(s.configDir, game.ID, profileName); err == nil && len(profile.Overrides) > 0 {
 		if err := ApplyProfileOverrides(game, profile); err != nil {
-			result.Warnings = append(result.Warnings, fmt.Sprintf("applying profile overrides: %v", err))
+			msg := fmt.Sprintf("applying profile overrides: %v", err)
+			result.Warnings = append(result.Warnings, msg)
+			emit(DeployProgress{Phase: DeployWarning, Detail: msg})
 		}
+	}
+
+	for _, w := range deferredWarnings {
+		emit(w)
 	}
 
 	return result, nil
@@ -597,11 +704,24 @@ func (s *Service) purgeForDeploy(ctx context.Context, game *domain.Game, profile
 		if !opts.Force {
 			return fmt.Errorf("uninstall.before_all hook failed: %w", err)
 		}
-		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.before_all hook failed (forced): %v", err))
+		msg := fmt.Sprintf("uninstall.before_all hook failed (forced): %v", err)
+		result.Warnings = append(result.Warnings, msg)
+		emit(DeployProgress{Phase: DeployBeforeAllForced, Detail: msg})
 	}
 
 	installer := s.GetInstaller(game)
 	emit(DeployProgress{Phase: DeployPurging, Total: len(mods)})
+
+	// deferredWarnings holds uninstall.after_each (per mod, in loop order)
+	// and uninstall.after_all PurgeWarning events: the pre-extraction
+	// purgeDeployedMods accumulated these during/after the loop and only
+	// printed them together, via printHookWarnings, once the whole loop
+	// had finished - so emission is deferred to right after the loop,
+	// mirroring that. Unlike DeployProfile's deploy-loop equivalent,
+	// nothing else needs to print between the loop ending and these -
+	// purgeDeployedMods went straight from printHookWarnings to
+	// CleanupEmptyDirs/the closing blank line.
+	var deferredWarnings []DeployProgress
 
 	for _, mod := range mods {
 		hookCtx.ModID, hookCtx.ModName, hookCtx.ModVersion = mod.ID, mod.Name, mod.Version
@@ -610,28 +730,43 @@ func (s *Service) purgeForDeploy(ctx context.Context, game *domain.Game, profile
 			// keep going. The pre-extraction CLI printed this unconditionally
 			// to stdout ("  Skipped: ..."); recorded here as a Warning
 			// (unconditional, stderr) instead - see the task report.
-			result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.before_each hook failed for %s during purge (not purged): %v", mod.Name, err))
+			msg := fmt.Sprintf("uninstall.before_each hook failed for %s during purge (not purged): %v", mod.Name, err)
+			result.Warnings = append(result.Warnings, msg)
+			emit(DeployProgress{Phase: PurgeWarning, ModName: mod.Name, ModID: mod.ID, Detail: msg})
 			continue
 		}
 
 		if err := installer.Uninstall(ctx, game, &mod.Mod, profileName); err != nil {
-			result.Notes = append(result.Notes, fmt.Sprintf("⚠ %s - %v", mod.Name, err))
+			msg := fmt.Sprintf("⚠ %s - %v", mod.Name, err)
+			result.Notes = append(result.Notes, msg)
+			emit(DeployProgress{Phase: PurgeNote, ModName: mod.Name, ModID: mod.ID, Detail: msg})
 		}
 
 		if err := s.SetModDeployed(mod.SourceID, mod.ID, game.ID, profileName, false); err != nil {
-			result.Notes = append(result.Notes, fmt.Sprintf("⚠ %s - failed to mark as not deployed: %v", mod.Name, err))
+			msg := fmt.Sprintf("⚠ %s - failed to mark as not deployed: %v", mod.Name, err)
+			result.Notes = append(result.Notes, msg)
+			emit(DeployProgress{Phase: PurgeNote, ModName: mod.Name, ModID: mod.ID, Detail: msg})
 		}
 
 		if err := runHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_each", opts.Hooks.GetUninstallAfterEach()); err != nil {
-			result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.after_each hook failed for %s: %v", mod.ID, err))
+			msg := fmt.Sprintf("uninstall.after_each hook failed for %s: %v", mod.ID, err)
+			result.Warnings = append(result.Warnings, msg)
+			deferredWarnings = append(deferredWarnings, DeployProgress{Phase: PurgeWarning, ModName: mod.Name, ModID: mod.ID, Detail: msg})
 		}
 	}
 
 	hookCtx.ModID, hookCtx.ModName, hookCtx.ModVersion = "", "", ""
 	if err := runHook(ctx, opts.HookRunner, &hookCtx, "uninstall.after_all", opts.Hooks.GetUninstallAfterAll()); err != nil {
-		result.Warnings = append(result.Warnings, fmt.Sprintf("uninstall.after_all hook failed: %v", err))
+		msg := fmt.Sprintf("uninstall.after_all hook failed: %v", err)
+		result.Warnings = append(result.Warnings, msg)
+		deferredWarnings = append(deferredWarnings, DeployProgress{Phase: PurgeWarning, Detail: msg})
+	}
+
+	for _, w := range deferredWarnings {
+		emit(w)
 	}
 
 	linker.CleanupEmptyDirs(game.ModPath)
+	emit(DeployProgress{Phase: PurgeComplete})
 	return nil
 }

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -951,6 +951,64 @@ func TestService_DeployProfile_MissingCacheAndFetchFailure_SkipsMod(t *testing.T
 	assert.Contains(t, result.Skipped[0], "failed to fetch")
 }
 
+// TestService_DeployProfile_MissingCacheAndDownloadFailure_EmitsDeployDownloadFailedEvent
+// guards finding D1: when the redownload itself starts (GetMod/GetModFiles
+// succeed) but the actual file download fails, redeployFromSource must emit
+// a DeployDownloadFailed event - not DeploySkipped - so cmd/lmm's dedicated
+// DeployDownloadFailed handler (blank line / "✗ <mod> - <detail>" / blank
+// line, matching the pre-extraction CLI) actually fires instead of
+// DeploySkipped's bare, unpadded "✗" line. result.Skipped accounting must be
+// unchanged (the mod still gets exactly one "<mod>: <reason>" entry), and
+// DeploySkipped must NOT also fire for this mod - that would double-print
+// under cmd/lmm's handler. Uses mockSourceWithDownloads without ever calling
+// AddDownload, so its httptest server 404s the file request deterministically.
+func TestService_DeployProfile_MissingCacheAndDownloadFailure_EmitsDeployDownloadFailedEvent(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	mock := newMockSourceWithDownloads("src")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+	// Deliberately no AddDownload call - the mock's httptest server 404s any
+	// file request, making the download fail deterministically.
+
+	mockMod := &domain.Mod{ID: "1", SourceID: "src", Name: "Download Fail Mod", Version: "1.0", GameID: "g1"}
+	mock.AddMod("g1", mockMod)
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          *mockMod,
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	var events []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err, "a per-mod download failure must not fail the whole deploy")
+	require.NotNil(t, result)
+
+	assert.Equal(t, 0, result.Deployed)
+	require.Len(t, result.Skipped, 1, "accounting must be unchanged: exactly one Skipped entry")
+	assert.Contains(t, result.Skipped[0], "Download Fail Mod: download failed:")
+
+	var failEvt *core.DeployProgress
+	for i := range events {
+		assert.NotEqual(t, core.DeploySkipped, events[i].Phase,
+			"DeploySkipped must not also fire for a download failure - see DeploySkipped's doc comment ('a reason other than a hook or download failure') and cmd/lmm/deploy.go's DeploySkipped handler, which would double-print alongside DeployDownloadFailed's")
+		if events[i].Phase == core.DeployDownloadFailed {
+			failEvt = &events[i]
+		}
+	}
+	require.NotNil(t, failEvt, "DeployDownloadFailed event must fire on download failure")
+	assert.Equal(t, "Download Fail Mod", failEvt.ModName)
+	assert.Equal(t, "1", failEvt.ModID)
+	assert.Contains(t, failEvt.Detail, "download failed:")
+}
+
 // TestService_DeployProfile_HookOrder proves install.before_all ->
 // install.before_each -> (deploy) -> install.after_each -> install.after_all
 // ordering, mirroring TestService_UninstallMod_HookOrder.

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -1,0 +1,238 @@
+package core_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFlowsTestService returns a *core.Service backed by fresh temp dirs
+// (config/data/cache), matching the construction pattern used throughout
+// service_test.go.
+func newFlowsTestService(t *testing.T) *core.Service {
+	t.Helper()
+	cfg := core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+	return svc
+}
+
+// seedInstalledMod stores the given files in the game's cache (when files is
+// non-nil) and saves an InstalledMod DB record for source/mod/version with
+// the requested Enabled state.
+func seedInstalledMod(t *testing.T, svc *core.Service, game *domain.Game, sourceID, modID, version string, enabled bool, files map[string][]byte) {
+	t.Helper()
+
+	gameCache := svc.GetGameCache(game)
+	for path, content := range files {
+		require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, path, content))
+	}
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       modID,
+			SourceID: sourceID,
+			Name:     "Test Mod",
+			Version:  version,
+			GameID:   game.ID,
+		},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      enabled,
+	}))
+}
+
+// --- EnableMod ---
+
+func TestService_EnableMod_DeploysDisabledMod(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", false, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+
+	changed, err := svc.EnableMod(context.Background(), game, "default", "src", "1")
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+	assert.NoError(t, err, "plugin.esp should be deployed to the game dir")
+
+	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+	assert.True(t, mod.Enabled)
+}
+
+func TestService_EnableMod_AlreadyEnabledIsNoop(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+
+	changed, err := svc.EnableMod(context.Background(), game, "default", "src", "1")
+	require.NoError(t, err)
+	assert.False(t, changed)
+
+	_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+	assert.True(t, os.IsNotExist(err), "no-op enable must not deploy files")
+}
+
+func TestService_EnableMod_MissingCacheErrors(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	// Installed-mod record exists, but nothing was ever stored in the cache.
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", false, nil)
+
+	changed, err := svc.EnableMod(context.Background(), game, "default", "src", "1")
+	require.Error(t, err)
+	assert.False(t, changed)
+	assert.Contains(t, err.Error(), "not found in cache")
+
+	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+	assert.False(t, mod.Enabled, "DB must remain untouched when cache is missing")
+}
+
+func TestService_EnableMod_DeployFailurePropagatesAndLeavesDBUntouched(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", false, map[string][]byte{
+		"blocked/plugin.esp": []byte("data"),
+	})
+
+	// Block deployment deterministically (not permission-based, so this is
+	// stable under both root and non-root test runners): "blocked" already
+	// exists as a regular file, so the linker's os.MkdirAll(filepath.Dir(dst))
+	// fails, exercising the same failure family as
+	// TestInstaller_Install_DeployFailureRollsBackAndClearsDB.
+	require.NoError(t, os.WriteFile(filepath.Join(gameDir, "blocked"), []byte("occupied"), 0644))
+
+	changed, err := svc.EnableMod(context.Background(), game, "default", "src", "1")
+	require.Error(t, err)
+	assert.False(t, changed)
+	assert.Contains(t, err.Error(), "failed to deploy mod")
+
+	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+	assert.False(t, mod.Enabled, "DB must remain untouched on deploy failure")
+}
+
+func TestService_EnableMod_UnknownModReturnsErrModNotFound(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	changed, err := svc.EnableMod(context.Background(), game, "default", "src", "missing")
+	require.Error(t, err)
+	assert.False(t, changed)
+	assert.ErrorIs(t, err, domain.ErrModNotFound)
+}
+
+// --- DisableMod ---
+
+func TestService_DisableMod_UndeploysEnabledMod(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+
+	// Deploy the files first so there's something to undeploy (mirrors an
+	// install that happened earlier).
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	changed, err := svc.DisableMod(context.Background(), game, "default", "src", "1")
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+	assert.True(t, os.IsNotExist(err), "plugin.esp should be removed from the game dir")
+
+	assert.True(t, svc.GetGameCache(game).Exists("g1", "src", "1", "1.0"), "cache entry must be preserved")
+
+	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+	assert.False(t, mod.Enabled)
+}
+
+func TestService_DisableMod_AlreadyDisabledIsNoop(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", false, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+
+	changed, err := svc.DisableMod(context.Background(), game, "default", "src", "1")
+	require.NoError(t, err)
+	assert.False(t, changed)
+}
+
+func TestService_DisableMod_UnknownModReturnsErrModNotFound(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	changed, err := svc.DisableMod(context.Background(), game, "default", "src", "missing")
+	require.Error(t, err)
+	assert.False(t, changed)
+	assert.ErrorIs(t, err, domain.ErrModNotFound)
+}
+
+// TestService_DisableMod_UndeployFailureIsNonFatal guards a deliberate
+// behavior-preservation decision (documented in the task report): the
+// pre-extraction CLI (doModDisable) treated Uninstall failures as non-fatal
+// ("warn but continue" under --verbose) because files may already have been
+// removed manually. DisableMod preserves the *functional* outcome — DB still
+// flips to disabled — even when undeploying fails.
+func TestService_DisableMod_UndeployFailureIsNonFatal(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	// Corrupt the deployed file into a plain file (not a symlink) so the
+	// symlink linker's Undeploy fails deterministically ("not a symlink").
+	deployedPath := filepath.Join(gameDir, "plugin.esp")
+	require.NoError(t, os.Remove(deployedPath))
+	require.NoError(t, os.WriteFile(deployedPath, []byte("not a symlink"), 0644))
+
+	changed, err := svc.DisableMod(context.Background(), game, "default", "src", "1")
+	require.NoError(t, err, "undeploy failures must not fail DisableMod")
+	assert.True(t, changed)
+
+	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+	assert.False(t, mod.Enabled, "DB should still flip to disabled even when undeploy is best-effort")
+}

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -822,44 +822,44 @@ func TestService_DeployProfile_LinkMethodOverrideHonored(t *testing.T) {
 }
 
 // TestService_DeployProfile_PurgeRemovesFilesFirstAndPreservesEnabledSet
-// guards --purge's two documented behaviors: (1) every installed mod -
-// enabled or not - is undeployed before anything redeploys, and (2) the
-// redeploy pass only includes mods that were enabled BEFORE the purge
-// (doDeploy's enabledBeforePurge map), mirroring the pre-extraction CLI.
+// guards --purge's two documented behaviors. The disabled mod is the key
+// witness for "removed first": it is excluded from the redeploy pass
+// entirely (never reaches the main per-mod loop, which also happens to
+// undeploy-then-install), so its file's removal can only be explained by
+// the purge pass itself. The enabled mod is the witness for "enabled set
+// preserved": only it redeploys after the purge.
 func TestService_DeployProfile_PurgeRemovesFilesFirstAndPreservesEnabledSet(t *testing.T) {
 	svc := newFlowsTestService(t)
 	gameDir := t.TempDir()
 	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
 
-	seedInstalledMod(t, svc, game, "src", "enabled-mod", "1.0", true, map[string][]byte{"enabled.esp": []byte("e")})
-	seedInstalledMod(t, svc, game, "src", "disabled-mod", "1.0", false, map[string][]byte{"disabled.esp": []byte("d")})
-	seedProfileWithMod(t, svc, "g1", "default", "src", "enabled-mod", "1.0")
-	seedProfileWithMod(t, svc, "g1", "default", "src", "disabled-mod", "1.0")
+	seedInstalledMod(t, svc, game, "src", "kept-mod", "1.0", true, map[string][]byte{"kept.esp": []byte("k")})
+	seedInstalledMod(t, svc, game, "src", "purged-mod", "1.0", false, map[string][]byte{"purged.esp": []byte("p")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "kept-mod", "1.0")
+	seedProfileWithMod(t, svc, "g1", "default", "src", "purged-mod", "1.0")
 
 	installer := svc.GetInstaller(game)
-	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "enabled-mod", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "purged-mod", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
 
-	deployedPath := filepath.Join(gameDir, "enabled.esp")
-	_, err := os.Lstat(deployedPath)
-	require.NoError(t, err, "precondition: file must be deployed before purge")
+	purgedPath := filepath.Join(gameDir, "purged.esp")
+	_, err := os.Lstat(purgedPath)
+	require.NoError(t, err, "precondition: the disabled mod's file must be deployed before purge")
 
-	var sawRemovalDuringPurge bool
+	var purgeTotal int
 	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{Purge: true}, func(p core.DeployProgress) {
 		if p.Phase == core.DeployPurging {
-			assert.Equal(t, 2, p.Total, "purge must consider every installed mod, enabled or not")
-			_, statErr := os.Lstat(deployedPath)
-			sawRemovalDuringPurge = os.IsNotExist(statErr)
+			purgeTotal = p.Total
 		}
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.True(t, sawRemovalDuringPurge, "purge must remove previously-deployed files before the redeploy pass begins")
+	assert.Equal(t, 2, purgeTotal, "purge must consider every installed mod, enabled or not")
 
 	assert.Equal(t, 1, result.Deployed, "only the mod enabled before the purge should redeploy")
-	_, err = os.Lstat(deployedPath)
+	_, err = os.Lstat(filepath.Join(gameDir, "kept.esp"))
 	assert.NoError(t, err, "the previously-enabled mod should be redeployed after purge")
-	_, err = os.Lstat(filepath.Join(gameDir, "disabled.esp"))
-	assert.True(t, os.IsNotExist(err), "the disabled mod must not be redeployed after purge")
+	_, err = os.Lstat(purgedPath)
+	assert.True(t, os.IsNotExist(err), "the disabled mod's file must be removed by purge and never redeployed - proof purge actually undeploys mods excluded from the redeploy pass")
 }
 
 // TestService_DeployProfile_MissingCacheModRedownloads guards doDeploy's

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -1631,3 +1631,801 @@ exit 1`)
 	assert.Less(t, overridesIdx, afterEachIdx, "overrides warning must be emitted before the after_each hook warning")
 	assert.Less(t, overridesIdx, afterAllIdx, "overrides warning must be emitted before the after_all hook warning")
 }
+
+// --- PlanProfileSwitch / ApplyProfileSwitch (Task 4) ---
+//
+// These extract doProfileSwitch (cmd/lmm/profile.go) into a pure diff
+// computation (PlanProfileSwitch) plus an execution step (ApplyProfileSwitch)
+// that reuses the DeployProgress carrier/phase-constant pattern established
+// by Task 3, extended with Switch*-prefixed phases rather than a parallel
+// SwitchProgress type - see the task report for the full phase mapping.
+
+// seedInstalledModUnderProfile is seedNamedInstalledMod with a
+// caller-supplied ProfileName, needed because the pre-extraction
+// doProfileSwitch's enable-loop calls SetModEnabled(..., targetName, ...) -
+// the NEW profile's name, not the mod's own current ProfileName (see the
+// task report) - so a toEnable mod's DB row must already live under the
+// target profile name for that call to find and update it.
+func seedInstalledModUnderProfile(t *testing.T, svc *core.Service, game *domain.Game, profileName, sourceID, modID, name, version string, enabled bool, files map[string][]byte) {
+	t.Helper()
+
+	gameCache := svc.GetGameCache(game)
+	for path, content := range files {
+		require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, path, content))
+	}
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       modID,
+			SourceID: sourceID,
+			Name:     name,
+			Version:  version,
+			GameID:   game.ID,
+		},
+		ProfileName:  profileName,
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      enabled,
+	}))
+}
+
+// installEnabledBlockingTrigger mirrors installBlockingTrigger but targets
+// installed_mods.enabled specifically, isolating SetModEnabled failures from
+// SetModLinkMethod/SetModDeployed (which installBlockingTrigger blocks) or
+// any other column.
+func installEnabledBlockingTrigger(t *testing.T, dbPath string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	_, err = conn.Exec(`
+		CREATE TRIGGER block_enabled_updates
+		BEFORE UPDATE OF enabled ON installed_mods
+		BEGIN
+			SELECT RAISE(ABORT, 'blocked for test');
+		END;
+	`)
+	require.NoError(t, err)
+}
+
+// --- PlanProfileSwitch ---
+
+func TestService_PlanProfileSwitch_AlreadyActive(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+
+	plan, err := svc.PlanProfileSwitch(context.Background(), game, "default")
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	assert.True(t, plan.AlreadyActive)
+	assert.Equal(t, "g1", plan.GameID)
+	assert.Equal(t, "default", plan.From)
+	assert.Equal(t, "default", plan.To)
+	assert.False(t, plan.NoChanges)
+	assert.Empty(t, plan.ToDisable)
+	assert.Empty(t, plan.ToEnable)
+	assert.Empty(t, plan.ToInstall)
+}
+
+// TestService_PlanProfileSwitch_NoChangesWhenModSetsMatch guards the no-op
+// fast path: when the target profile's mod set already matches what's
+// enabled under the current default profile, PlanProfileSwitch reports
+// NoChanges (only SetDefault is needed) - mirroring doProfileSwitch's
+// "No mod changes, just switch the default" branch.
+func TestService_PlanProfileSwitch_NoChangesWhenModSetsMatch(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "other")
+	require.NoError(t, err)
+
+	seedInstalledMod(t, svc, game, "src", "shared", "1.0", true, map[string][]byte{"shared.esp": []byte("s")})
+	require.NoError(t, pm.AddMod(game.ID, "default", domain.ModReference{SourceID: "src", ModID: "shared", Version: "1.0"}))
+	require.NoError(t, pm.AddMod(game.ID, "other", domain.ModReference{SourceID: "src", ModID: "shared", Version: "1.0"}))
+
+	plan, err := svc.PlanProfileSwitch(context.Background(), game, "other")
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	assert.False(t, plan.AlreadyActive)
+	assert.True(t, plan.NoChanges)
+	assert.Empty(t, plan.ToDisable)
+	assert.Empty(t, plan.ToEnable)
+	assert.Empty(t, plan.ToInstall)
+}
+
+// TestService_PlanProfileSwitch_ComputesDisableEnableInstallBuckets guards
+// the diff algorithm's three buckets in one mixed scenario: a mod only in
+// the current profile's enabled set goes to ToDisable, a mod installed (and
+// cached) but disabled that the target references goes to ToEnable, and a
+// mod the target references with no DB row at all goes to ToInstall.
+func TestService_PlanProfileSwitch_ComputesDisableEnableInstallBuckets(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	// modC: enabled under "default", absent from "target" -> ToDisable.
+	seedNamedInstalledMod(t, svc, game, "src", "modC", "Mod C", "1.0", true, map[string][]byte{"c.esp": []byte("c")})
+	require.NoError(t, pm.AddMod(game.ID, "default", domain.ModReference{SourceID: "src", ModID: "modC", Version: "1.0"}))
+
+	// modB: installed (under "default") but disabled, cached, referenced by
+	// "target" -> ToEnable.
+	seedNamedInstalledMod(t, svc, game, "src", "modB", "Mod B", "1.0", false, map[string][]byte{"b.esp": []byte("b")})
+	require.NoError(t, pm.AddMod(game.ID, "target", domain.ModReference{SourceID: "src", ModID: "modB", Version: "1.0"}))
+
+	// modD: referenced by "target" only, no DB row at all -> ToInstall.
+	require.NoError(t, pm.AddMod(game.ID, "target", domain.ModReference{SourceID: "src", ModID: "modD", Version: "2.0"}))
+
+	plan, err := svc.PlanProfileSwitch(context.Background(), game, "target")
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	assert.False(t, plan.NoChanges)
+
+	require.Len(t, plan.ToDisable, 1)
+	assert.Equal(t, "modC", plan.ToDisable[0].ID)
+
+	require.Len(t, plan.ToEnable, 1)
+	assert.Equal(t, "modB", plan.ToEnable[0].ID)
+
+	require.Len(t, plan.ToInstall, 1)
+	assert.Equal(t, "modD", plan.ToInstall[0].ModID)
+	assert.Equal(t, "2.0", plan.ToInstall[0].Version)
+}
+
+// TestService_PlanProfileSwitch_CacheMissForcesReinstallWithPreservedFileIDs
+// guards doProfileSwitch's re-download branch: when a mod the target
+// profile references IS installed in the DB but its cache entry is gone,
+// PlanProfileSwitch classifies it as ToInstall (not ToEnable) and carries
+// over the installed mod's own FileIDs (not the profile YAML's, which may be
+// empty or stale) so the redownload uses the same files.
+func TestService_PlanProfileSwitch_CacheMissForcesReinstallWithPreservedFileIDs(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	// DB row exists (with FileIDs), but nothing was ever stored in the cache.
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "modE", SourceID: "src", Name: "Mod E", Version: "1.0", GameID: "g1"},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+		FileIDs:      []string{"f1", "f2"},
+	}))
+	// Profile YAML's own FileIDs are deliberately absent, to prove
+	// PlanProfileSwitch uses the INSTALLED mod's FileIDs, not the profile's.
+	require.NoError(t, pm.AddMod(game.ID, "target", domain.ModReference{SourceID: "src", ModID: "modE", Version: "1.0"}))
+
+	plan, err := svc.PlanProfileSwitch(context.Background(), game, "target")
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	require.Len(t, plan.ToInstall, 1)
+	assert.Equal(t, "modE", plan.ToInstall[0].ModID)
+	assert.Equal(t, []string{"f1", "f2"}, plan.ToInstall[0].FileIDs)
+	assert.Empty(t, plan.ToEnable, "a cache-miss mod must be reinstalled, not merely re-enabled")
+}
+
+func TestService_PlanProfileSwitch_UnknownTargetProfileReturnsError(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	plan, err := svc.PlanProfileSwitch(context.Background(), game, "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "profile not found: missing")
+	assert.Nil(t, plan)
+}
+
+// TestService_PlanProfileSwitch_PerformsZeroMutations guards the
+// "pure computation" contract the TUI depends on: calling
+// PlanProfileSwitch speculatively (e.g. to render a confirmation modal) and
+// discarding the result must leave the DB, cache, and profile YAMLs
+// byte-for-byte untouched.
+func TestService_PlanProfileSwitch_PerformsZeroMutations(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	seedNamedInstalledMod(t, svc, game, "src", "modC", "Mod C", "1.0", true, map[string][]byte{"c.esp": []byte("c")})
+	require.NoError(t, pm.AddMod(game.ID, "default", domain.ModReference{SourceID: "src", ModID: "modC", Version: "1.0"}))
+	seedNamedInstalledMod(t, svc, game, "src", "modB", "Mod B", "1.0", false, map[string][]byte{"b.esp": []byte("b")})
+	require.NoError(t, pm.AddMod(game.ID, "target", domain.ModReference{SourceID: "src", ModID: "modB", Version: "1.0"}))
+	require.NoError(t, pm.AddMod(game.ID, "target", domain.ModReference{SourceID: "src", ModID: "modD", Version: "2.0"}))
+
+	defaultPath := filepath.Join(svc.ConfigDir(), "games", "g1", "profiles", "default.yaml")
+	targetPath := filepath.Join(svc.ConfigDir(), "games", "g1", "profiles", "target.yaml")
+	beforeDefault, err := os.ReadFile(defaultPath)
+	require.NoError(t, err)
+	beforeTarget, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	beforeMods, err := svc.GetInstalledMods("g1", "default")
+	require.NoError(t, err)
+
+	plan, err := svc.PlanProfileSwitch(context.Background(), game, "target")
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	require.False(t, plan.NoChanges, "sanity: this scenario must exercise all three diff buckets")
+
+	afterDefault, err := os.ReadFile(defaultPath)
+	require.NoError(t, err)
+	afterTarget, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, beforeDefault, afterDefault, "profile YAML must be byte-for-byte unchanged after planning")
+	assert.Equal(t, beforeTarget, afterTarget, "profile YAML must be byte-for-byte unchanged after planning")
+
+	afterMods, err := svc.GetInstalledMods("g1", "default")
+	require.NoError(t, err)
+	assert.Equal(t, beforeMods, afterMods, "DB rows must be untouched after planning")
+
+	_, err = os.Lstat(filepath.Join(gameDir, "b.esp"))
+	assert.True(t, os.IsNotExist(err), "planning must not deploy any files")
+}
+
+// --- ApplyProfileSwitch ---
+
+// TestService_ApplyProfileSwitch_ExecutesDisableThenEnableThenInstall_SetDefaultLastAndUnchangedOnFailure
+// guards doProfileSwitch's overall execution order (disable loop, then
+// enable loop, then install loop, with SetDefault always last) and the
+// error-path convention: SetDefault's own failure must not discard the
+// Disabled/Enabled/Installed accounting from everything that already ran
+// before it, and must leave the previous default profile in place. The
+// target profile is deliberately never created, so both the install loop's
+// UpsertMod call and the final SetDefault call fail deterministically
+// (ErrProfileNotFound) - UpsertMod's failure is expected and non-fatal (see
+// TestService_ApplyProfileSwitch_FatalSetDefaultErrorAfterAccumulatedDiagnostics_ReturnsPartialResult
+// for a dedicated, isolated test of that same convention).
+func TestService_ApplyProfileSwitch_ExecutesDisableThenEnableThenInstall_SetDefaultLastAndUnchangedOnFailure(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+
+	seedNamedInstalledMod(t, svc, game, "src", "disable-me", "Disable Me", "1.0", true, map[string][]byte{"disable.esp": []byte("d")})
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "disable-me", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+	seedInstalledModUnderProfile(t, svc, game, "target", "src", "enable-me", "Enable Me", "1.0", false, map[string][]byte{"enable.esp": []byte("e")})
+
+	disableMod, err := svc.GetInstalledMod("src", "disable-me", "g1", "default")
+	require.NoError(t, err)
+	enableMod, err := svc.GetInstalledMod("src", "enable-me", "g1", "target")
+	require.NoError(t, err)
+
+	mock := newMockSourceWithDownloads("src")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+	tmpDir := t.TempDir()
+	zipPath := createTestZip(t, tmpDir, map[string]string{"install.esp": "payload"})
+	zipContent, err := os.ReadFile(zipPath)
+	require.NoError(t, err)
+	mock.AddDownload("1", zipContent)
+	mock.AddMod("g1", &domain.Mod{ID: "install-me", SourceID: "src", Name: "Install Me", Version: "1.0", GameID: "g1"})
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		ToDisable: []domain.InstalledMod{*disableMod},
+		ToEnable:  []domain.InstalledMod{*enableMod},
+		ToInstall: []domain.ModReference{{SourceID: "src", ModID: "install-me", Version: "1.0"}},
+	}
+
+	var events []core.DeployProgress
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.Error(t, err, "SetDefault must fail deterministically: target profile was never created")
+	assert.Contains(t, err.Error(), "setting default profile")
+	require.NotNil(t, result, "counts/diagnostics accumulated before the fatal SetDefault error must not be discarded")
+	assert.Equal(t, 1, result.Disabled)
+	assert.Equal(t, 1, result.Enabled)
+	assert.Equal(t, 1, result.Installed)
+	require.Len(t, result.Notes, 1, "the install loop's UpsertMod failure (target profile doesn't exist) must be recorded")
+	assert.Contains(t, result.Notes[0], "could not update profile")
+
+	var disabledIdx, enabledIdx, installingIdx = -1, -1, -1
+	for i, e := range events {
+		switch e.Phase {
+		case core.SwitchDisabled:
+			disabledIdx = i
+		case core.SwitchEnabled:
+			if enabledIdx == -1 {
+				enabledIdx = i
+			}
+		case core.SwitchInstalling:
+			installingIdx = i
+		}
+	}
+	require.NotEqual(t, -1, disabledIdx, "expected a SwitchDisabled event")
+	require.NotEqual(t, -1, enabledIdx, "expected a SwitchEnabled event")
+	require.NotEqual(t, -1, installingIdx, "expected a SwitchInstalling event")
+	assert.Less(t, disabledIdx, enabledIdx, "disable phase must complete before the enable phase starts")
+	assert.Less(t, enabledIdx, installingIdx, "enable phase must complete before the install phase starts")
+
+	def, err := pm.GetDefault(game.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "default", def.Name, "a failed SetDefault must leave the previous default profile in place")
+}
+
+// TestService_ApplyProfileSwitch_DisableLoop_UndeployAndSetEnabledFailuresAreNonFatalNotes_SuccessEventStillFires
+// guards doProfileSwitch's disable-loop semantics: BOTH a failed Uninstall
+// and a failed SetModEnabled are recorded as Notes (never Warnings, never
+// fatal) and the mod is still counted as Disabled with its success event
+// still firing - the disable loop always "wins" regardless of either
+// sub-step's outcome, unlike the enable loop (see the InstallFailureSkipsMod
+// test below).
+func TestService_ApplyProfileSwitch_DisableLoop_UndeployAndSetEnabledFailuresAreNonFatalNotes_SuccessEventStillFires(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	seedNamedInstalledMod(t, svc, game, "src", "1", "Test Mod", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	// Corrupt the deployed symlink so Uninstall fails deterministically.
+	deployedPath := filepath.Join(gameDir, "plugin.esp")
+	require.NoError(t, os.Remove(deployedPath))
+	require.NoError(t, os.WriteFile(deployedPath, []byte("not a symlink"), 0644))
+
+	// Block updates to installed_mods.enabled so SetModEnabled fails too.
+	installEnabledBlockingTrigger(t, filepath.Join(dataDir, "lmm.db"))
+
+	disableMod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		ToDisable: []domain.InstalledMod{*disableMod},
+	}
+
+	var events []core.DeployProgress
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Disabled, "the mod must still be counted as disabled despite both failures")
+	require.Len(t, result.Notes, 2)
+	assert.True(t, strings.HasPrefix(result.Notes[0], "Warning: failed to undeploy Test Mod: "), "note[0]: %q", result.Notes[0])
+	assert.True(t, strings.HasPrefix(result.Notes[1], "Warning: failed to update Test Mod: "), "note[1]: %q", result.Notes[1])
+
+	var noteEvents []core.DeployProgress
+	disabledIdx := -1
+	for i, e := range events {
+		if e.Phase == core.SwitchDisableNote {
+			noteEvents = append(noteEvents, e)
+		}
+		if e.Phase == core.SwitchDisabled {
+			disabledIdx = i
+		}
+	}
+	require.Len(t, noteEvents, 2)
+	assert.Equal(t, result.Notes[0], noteEvents[0].Detail)
+	assert.Equal(t, result.Notes[1], noteEvents[1].Detail)
+	require.NotEqual(t, -1, disabledIdx, "expected a SwitchDisabled event despite both failures")
+	assert.Greater(t, disabledIdx, 0, "the success event must come after the note events")
+}
+
+// TestService_ApplyProfileSwitch_EnableLoop_InstallFailureSkipsModEntirely
+// guards the enable loop's differing semantics from the disable loop: a
+// failed Install is fatal FOR THAT MOD ONLY - it is recorded as a Note, but
+// SetModEnabled is never called and no SwitchEnabled event fires, mirroring
+// doProfileSwitch's `continue` immediately after the Install failure branch.
+func TestService_ApplyProfileSwitch_EnableLoop_InstallFailureSkipsModEntirely(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	// Block deployment deterministically: "blocked" already exists as a
+	// regular file, so the linker's os.MkdirAll(filepath.Dir(dst)) fails -
+	// mirrors TestService_EnableMod_DeployFailurePropagatesAndLeavesDBUntouched.
+	seedInstalledModUnderProfile(t, svc, game, "target", "src", "1", "Test Mod", "1.0", false, map[string][]byte{"blocked/plugin.esp": []byte("data")})
+	require.NoError(t, os.WriteFile(filepath.Join(gameDir, "blocked"), []byte("occupied"), 0644))
+
+	enableMod, err := svc.GetInstalledMod("src", "1", "g1", "target")
+	require.NoError(t, err)
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		ToEnable: []domain.InstalledMod{*enableMod},
+	}
+
+	var events []core.DeployProgress
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err, "an Install failure must not fail the whole switch")
+	require.NotNil(t, result)
+	assert.Equal(t, 0, result.Enabled)
+	require.Len(t, result.Notes, 1)
+	assert.True(t, strings.HasPrefix(result.Notes[0], "Warning: failed to deploy Test Mod: "), "note: %q", result.Notes[0])
+
+	for _, e := range events {
+		assert.NotEqual(t, core.SwitchEnabled, e.Phase, "no SwitchEnabled event must fire for a mod whose Install failed")
+	}
+
+	mod, err := svc.GetInstalledMod("src", "1", "g1", "target")
+	require.NoError(t, err)
+	assert.False(t, mod.Enabled, "SetModEnabled must never be called after a failed Install")
+}
+
+// TestService_ApplyProfileSwitch_EnableLoop_SetModEnabledFailureIsNonFatalNote
+// guards the enable loop's OTHER sub-step: when Install succeeds but
+// SetModEnabled fails, the mod is still counted as Enabled and its success
+// event still fires - contrasting with the Install-failure case above.
+func TestService_ApplyProfileSwitch_EnableLoop_SetModEnabledFailureIsNonFatalNote(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	seedInstalledModUnderProfile(t, svc, game, "target", "src", "1", "Test Mod", "1.0", false, map[string][]byte{"plugin.esp": []byte("data")})
+	installEnabledBlockingTrigger(t, filepath.Join(dataDir, "lmm.db"))
+
+	enableMod, err := svc.GetInstalledMod("src", "1", "g1", "target")
+	require.NoError(t, err)
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		ToEnable: []domain.InstalledMod{*enableMod},
+	}
+
+	var events []core.DeployProgress
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Enabled, "Install still succeeded, so the mod must still be counted as enabled")
+	require.Len(t, result.Notes, 1)
+	assert.True(t, strings.HasPrefix(result.Notes[0], "Warning: failed to update Test Mod: "))
+
+	var sawEnabled bool
+	for _, e := range events {
+		if e.Phase == core.SwitchEnabled {
+			sawEnabled = true
+		}
+	}
+	assert.True(t, sawEnabled, "a SwitchEnabled event must still fire despite the SetModEnabled failure")
+
+	_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+	assert.NoError(t, err, "the mod must still have been deployed")
+}
+
+// TestService_ApplyProfileSwitch_InstallLoop_FetchFailureSkipsModAndContinuesToNextMod
+// guards the install loop's per-ref isolation: a mod whose source isn't
+// registered (GetMod fails) is skipped via a SwitchInstallError event and
+// does not stop the remaining ToInstall entries from installing.
+func TestService_ApplyProfileSwitch_InstallLoop_FetchFailureSkipsModAndContinuesToNextMod(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	mock := newMockSourceWithDownloads("src")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+	tmpDir := t.TempDir()
+	zipPath := createTestZip(t, tmpDir, map[string]string{"good.esp": "payload"})
+	zipContent, err := os.ReadFile(zipPath)
+	require.NoError(t, err)
+	mock.AddDownload("1", zipContent)
+	mock.AddMod("g1", &domain.Mod{ID: "good", SourceID: "src", Name: "Good Mod", Version: "1.0", GameID: "g1"})
+	// "bad" is never registered with the mock source, so GetMod fails.
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		ToInstall: []domain.ModReference{
+			{SourceID: "src", ModID: "bad", Version: "1.0"},
+			{SourceID: "src", ModID: "good", Version: "1.0"},
+		},
+	}
+
+	var events []core.DeployProgress
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err, "a per-mod fetch failure must not fail the whole switch")
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Installed, "the good mod must still install")
+
+	var errEvt *core.DeployProgress
+	for i := range events {
+		if events[i].Phase == core.SwitchInstallError {
+			errEvt = &events[i]
+			break
+		}
+	}
+	require.NotNil(t, errEvt)
+	assert.Equal(t, "bad", errEvt.ModID)
+	assert.Contains(t, errEvt.Detail, "failed to fetch mod")
+
+	_, err = os.Lstat(filepath.Join(gameDir, "good.esp"))
+	assert.NoError(t, err, "the second mod must still be installed")
+}
+
+// TestService_ApplyProfileSwitch_InstallLoop_DownloadFailureEmitsBlankErrorBlankSequence
+// guards the dual-event sequence (SwitchDownloadFailed then, always,
+// SwitchDownloadDone) that reproduces doProfileSwitch's exact
+// blank-line/error/blank-line console sequence on a failed download - see
+// SwitchDownloadDone's doc comment.
+func TestService_ApplyProfileSwitch_InstallLoop_DownloadFailureEmitsBlankErrorBlankSequence(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	mock := newMockSourceWithDownloads("src") // no AddDownload: the server 404s every file ID
+	defer mock.Close()
+	svc.RegisterSource(mock)
+	mock.AddMod("g1", &domain.Mod{ID: "mod1", SourceID: "src", Name: "Mod One", Version: "1.0", GameID: "g1"})
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		ToInstall: []domain.ModReference{{SourceID: "src", ModID: "mod1", Version: "1.0"}},
+	}
+
+	var events []core.DeployProgress
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 0, result.Installed)
+
+	var failIdx, doneIdx = -1, -1
+	for i, e := range events {
+		switch e.Phase {
+		case core.SwitchDownloadFailed:
+			failIdx = i
+		case core.SwitchDownloadDone:
+			doneIdx = i
+		}
+	}
+	require.NotEqual(t, -1, failIdx, "expected a SwitchDownloadFailed event")
+	require.NotEqual(t, -1, doneIdx, "expected a SwitchDownloadDone event")
+	assert.Less(t, failIdx, doneIdx, "the loop-done event must fire after the failure event, mirroring the unconditional trailing blank line")
+	assert.Contains(t, events[failIdx].Detail, "download failed")
+}
+
+// TestService_ApplyProfileSwitch_InstallLoop_FallbackUsedWhenStoredFileIDsNotFound
+// guards SwitchFallbackUsed: when a ToInstall ref's FileIDs don't match any
+// file the source currently offers, ApplyProfileSwitch falls back to the
+// primary file and reports it.
+func TestService_ApplyProfileSwitch_InstallLoop_FallbackUsedWhenStoredFileIDsNotFound(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	mock := newMockSourceWithDownloads("src")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+	tmpDir := t.TempDir()
+	zipPath := createTestZip(t, tmpDir, map[string]string{"mod1.esp": "payload"})
+	zipContent, err := os.ReadFile(zipPath)
+	require.NoError(t, err)
+	mock.AddDownload("1", zipContent) // mockSource.GetModFiles always returns file ID "1"
+	mock.AddMod("g1", &domain.Mod{ID: "mod1", SourceID: "src", Name: "Mod One", Version: "1.0", GameID: "g1"})
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		// "stale-id" does not match the mock source's file ID ("1"), forcing
+		// the primary-file fallback.
+		ToInstall: []domain.ModReference{{SourceID: "src", ModID: "mod1", Version: "1.0", FileIDs: []string{"stale-id"}}},
+	}
+
+	var events []core.DeployProgress
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Installed)
+
+	var sawFallback bool
+	for _, e := range events {
+		if e.Phase == core.SwitchFallbackUsed {
+			sawFallback = true
+		}
+	}
+	assert.True(t, sawFallback, "expected a SwitchFallbackUsed event")
+}
+
+// TestService_ApplyProfileSwitch_InstallLoop_SavesWithNormalizedGameID
+// regression-guards the P3 orphaning bug class (see profile_gameid_test.go's
+// CLI-level counterpart): Service.GetMod may stamp a source-mapped GameID
+// onto the fetched *domain.Mod, but the InstalledMod row ApplyProfileSwitch
+// saves must always be normalized to the lmm game.ID, so every other DB read
+// (which queries by the lmm game ID) can find it again.
+func TestService_ApplyProfileSwitch_InstallLoop_SavesWithNormalizedGameID(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	mock := newMockSourceWithDownloads("src")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+	tmpDir := t.TempDir()
+	zipPath := createTestZip(t, tmpDir, map[string]string{"mod1.esp": "payload"})
+	zipContent, err := os.ReadFile(zipPath)
+	require.NoError(t, err)
+	mock.AddDownload("1", zipContent)
+	// The mock mod's own GameID deliberately differs from game.ID ("g1"),
+	// mirroring what Service.GetMod stamps on when a source-mapped ID is in
+	// play - the saved row must NOT inherit this value.
+	mock.AddMod("g1", &domain.Mod{ID: "mod1", SourceID: "src", Name: "Mod One", Version: "1.0", GameID: "source-mapped-id"})
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		ToInstall: []domain.ModReference{{SourceID: "src", ModID: "mod1", Version: "1.0"}},
+	}
+
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Installed)
+
+	installed, err := svc.GetInstalledMod("src", "mod1", "g1", "target")
+	require.NoError(t, err, "the installed row must be visible under the lmm game ID")
+	assert.Equal(t, "g1", installed.GameID, "persisted GameID must be normalized to the lmm game, not the source-mapped value")
+}
+
+// TestService_ApplyProfileSwitch_FatalSetDefaultErrorAfterAccumulatedDiagnostics_ReturnsPartialResult
+// guards the Task 2/3 error-path convention applied to ApplyProfileSwitch: a
+// fatal error (here, SetDefault) must not discard the SwitchResult
+// accumulated up to that point. Isolated to the simplest possible scenario
+// (no disable/enable buckets) so it stands independently of
+// TestService_ApplyProfileSwitch_ExecutesDisableThenEnableThenInstall_SetDefaultLastAndUnchangedOnFailure,
+// which exercises the same convention but with all three buckets active.
+func TestService_ApplyProfileSwitch_FatalSetDefaultErrorAfterAccumulatedDiagnostics_ReturnsPartialResult(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	// "target" is never created, so both UpsertMod and the final SetDefault
+	// fail deterministically.
+
+	mock := newMockSourceWithDownloads("src")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+	tmpDir := t.TempDir()
+	zipPath := createTestZip(t, tmpDir, map[string]string{"mod1.esp": "payload"})
+	zipContent, err := os.ReadFile(zipPath)
+	require.NoError(t, err)
+	mock.AddDownload("1", zipContent)
+	mock.AddMod("g1", &domain.Mod{ID: "mod1", SourceID: "src", Name: "Mod One", Version: "1.0", GameID: "g1"})
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		ToInstall: []domain.ModReference{{SourceID: "src", ModID: "mod1", Version: "1.0"}},
+	}
+
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "setting default profile")
+	require.NotNil(t, result, "the result accumulated before the fatal error must not be discarded")
+	assert.Equal(t, 1, result.Installed, "the install itself succeeded before the later fatal SetDefault error")
+	require.Len(t, result.Notes, 1)
+	assert.Contains(t, result.Notes[0], "could not update profile")
+}
+
+// TestService_ApplyProfileSwitch_NilProgressCallbackIsSafe guards that
+// progress may be nil per the required API (mirroring
+// TestService_DeployProfile_NilProgressCallbackIsSafe).
+func TestService_ApplyProfileSwitch_NilProgressCallbackIsSafe(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	seedNamedInstalledMod(t, svc, game, "src", "1", "Test Mod", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	disableMod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		ToDisable: []domain.InstalledMod{*disableMod},
+	}
+
+	assert.NotPanics(t, func() {
+		result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, nil)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, 1, result.Disabled)
+	})
+}

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,32 @@ func seedInstalledMod(t *testing.T, svc *core.Service, game *domain.Game, source
 			ID:       modID,
 			SourceID: sourceID,
 			Name:     "Test Mod",
+			Version:  version,
+			GameID:   game.ID,
+		},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      enabled,
+	}))
+}
+
+// seedNamedInstalledMod is seedInstalledMod with a caller-supplied Name,
+// needed whenever a test must tell mods apart by name (seedInstalledMod
+// hardcodes "Test Mod" for every mod, which is fine for single-mod tests but
+// useless for asserting deploy order or per-mod skip/progress identity).
+func seedNamedInstalledMod(t *testing.T, svc *core.Service, game *domain.Game, sourceID, modID, name, version string, enabled bool, files map[string][]byte) {
+	t.Helper()
+
+	gameCache := svc.GetGameCache(game)
+	for path, content := range files {
+		require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, path, content))
+	}
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       modID,
+			SourceID: sourceID,
+			Name:     name,
 			Version:  version,
 			GameID:   game.ID,
 		},
@@ -722,4 +749,504 @@ exit 1`)
 
 	_, err = svc.GetInstalledMod("src", "1", "g1", "default")
 	assert.ErrorIs(t, err, domain.ErrModNotFound, "DB row should already be removed by the time after_each runs")
+}
+
+// --- DeployProfile ---
+
+// TestService_DeployProfile_MultiModDeploysInProfileOrder guards doDeploy's
+// "no args" gathering step (GetInstalledModsInProfileOrder): deploy order
+// must follow the profile's mod order, not DB insertion order or any other
+// incidental ordering.
+func TestService_DeployProfile_MultiModDeploysInProfileOrder(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedNamedInstalledMod(t, svc, game, "src", "c", "Mod C", "1.0", true, map[string][]byte{"c.esp": []byte("c")})
+	seedNamedInstalledMod(t, svc, game, "src", "a", "Mod A", "1.0", true, map[string][]byte{"a.esp": []byte("a")})
+	seedNamedInstalledMod(t, svc, game, "src", "b", "Mod B", "1.0", true, map[string][]byte{"b.esp": []byte("b")})
+
+	// Profile order deliberately differs from DB insertion order (c, a, b).
+	seedProfileWithMod(t, svc, "g1", "default", "src", "c", "1.0")
+	seedProfileWithMod(t, svc, "g1", "default", "src", "a", "1.0")
+	seedProfileWithMod(t, svc, "g1", "default", "src", "b", "1.0")
+
+	var events []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 3, result.Deployed)
+	assert.Empty(t, result.Skipped)
+
+	var order []string
+	for _, e := range events {
+		if e.Phase == core.DeployDeployed {
+			order = append(order, e.ModName)
+		}
+	}
+	assert.Equal(t, []string{"Mod C", "Mod A", "Mod B"}, order, "deploy order must follow profile order")
+
+	for _, f := range []string{"c.esp", "a.esp", "b.esp"} {
+		_, err := os.Lstat(filepath.Join(gameDir, f))
+		assert.NoError(t, err, "%s should be deployed", f)
+	}
+}
+
+// TestService_DeployProfile_LinkMethodOverrideHonored guards the --method
+// override: DeployOptions.LinkMethod (a *domain.LinkMethod, not a bare
+// value - see the task report for why) must both change how files are
+// linked and be persisted via SetModLinkMethod.
+func TestService_DeployProfile_LinkMethodOverrideHonored(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	override := domain.LinkCopy
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{LinkMethod: &override}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Deployed)
+
+	info, err := os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink, "override to copy method must not leave a symlink")
+
+	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+	assert.Equal(t, domain.LinkCopy, mod.LinkMethod, "SetModLinkMethod must record the override")
+}
+
+// TestService_DeployProfile_PurgeRemovesFilesFirstAndPreservesEnabledSet
+// guards --purge's two documented behaviors: (1) every installed mod -
+// enabled or not - is undeployed before anything redeploys, and (2) the
+// redeploy pass only includes mods that were enabled BEFORE the purge
+// (doDeploy's enabledBeforePurge map), mirroring the pre-extraction CLI.
+func TestService_DeployProfile_PurgeRemovesFilesFirstAndPreservesEnabledSet(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "enabled-mod", "1.0", true, map[string][]byte{"enabled.esp": []byte("e")})
+	seedInstalledMod(t, svc, game, "src", "disabled-mod", "1.0", false, map[string][]byte{"disabled.esp": []byte("d")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "enabled-mod", "1.0")
+	seedProfileWithMod(t, svc, "g1", "default", "src", "disabled-mod", "1.0")
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "enabled-mod", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	deployedPath := filepath.Join(gameDir, "enabled.esp")
+	_, err := os.Lstat(deployedPath)
+	require.NoError(t, err, "precondition: file must be deployed before purge")
+
+	var sawRemovalDuringPurge bool
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{Purge: true}, func(p core.DeployProgress) {
+		if p.Phase == core.DeployPurging {
+			assert.Equal(t, 2, p.Total, "purge must consider every installed mod, enabled or not")
+			_, statErr := os.Lstat(deployedPath)
+			sawRemovalDuringPurge = os.IsNotExist(statErr)
+		}
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, sawRemovalDuringPurge, "purge must remove previously-deployed files before the redeploy pass begins")
+
+	assert.Equal(t, 1, result.Deployed, "only the mod enabled before the purge should redeploy")
+	_, err = os.Lstat(deployedPath)
+	assert.NoError(t, err, "the previously-enabled mod should be redeployed after purge")
+	_, err = os.Lstat(filepath.Join(gameDir, "disabled.esp"))
+	assert.True(t, os.IsNotExist(err), "the disabled mod must not be redeployed after purge")
+}
+
+// TestService_DeployProfile_MissingCacheModRedownloads guards doDeploy's
+// cache-miss path: when a mod's cache entry is gone, DeployProfile re-fetches
+// it from source (GetMod -> GetModFiles -> DownloadMod) and still deploys it
+// - a missing cache is not fatal to the mod, matching the pre-extraction CLI.
+func TestService_DeployProfile_MissingCacheModRedownloads(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	mock := newMockSourceWithDownloads("src")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+
+	tmpDir := t.TempDir()
+	zipPath := createTestZip(t, tmpDir, map[string]string{"plugin.esp": "payload"})
+	zipContent, err := os.ReadFile(zipPath)
+	require.NoError(t, err)
+	mock.AddDownload("1", zipContent) // mockSource.GetModFiles always returns file ID "1"
+
+	mockMod := &domain.Mod{ID: "1", SourceID: "src", Name: "Redownload Mod", Version: "1.0", GameID: "g1"}
+	mock.AddMod("g1", mockMod)
+
+	// InstalledMod record exists, but nothing was ever stored in the cache.
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          *mockMod,
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	var phases []core.DeployPhase
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		phases = append(phases, p.Phase)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Deployed)
+	assert.Empty(t, result.Skipped)
+	assert.Contains(t, phases, core.DeployRedownloading)
+
+	_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+	assert.NoError(t, err, "redownloaded file should be deployed")
+}
+
+// TestService_DeployProfile_MissingCacheAndFetchFailure_SkipsMod guards the
+// other half of the cache-miss path: when the redownload itself can't even
+// start (GetMod fails - here because no source is registered for "src"),
+// doDeploy skips that mod and continues rather than aborting.
+func TestService_DeployProfile_MissingCacheAndFetchFailure_SkipsMod(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, nil)
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, nil)
+	require.NoError(t, err, "a per-mod fetch failure must not fail the whole deploy")
+	require.NotNil(t, result)
+	assert.Equal(t, 0, result.Deployed)
+	require.Len(t, result.Skipped, 1)
+	assert.Contains(t, result.Skipped[0], "failed to fetch")
+}
+
+// TestService_DeployProfile_HookOrder proves install.before_all ->
+// install.before_each -> (deploy) -> install.after_each -> install.after_all
+// ordering, mirroring TestService_UninstallMod_HookOrder.
+func TestService_DeployProfile_HookOrder(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	deployedFile := filepath.Join(gameDir, "plugin.esp")
+	callLog := filepath.Join(scriptsDir, "calls.log")
+
+	beforeAllScript := createTestScript(t, scriptsDir, "before_all.sh", `#!/bin/bash
+echo "before_all" >> `+callLog+`
+exit 0`)
+	beforeEachScript := createTestScript(t, scriptsDir, "before_each.sh", `#!/bin/bash
+echo "before_each" >> `+callLog+`
+exit 0`)
+	afterEachScript := createTestScript(t, scriptsDir, "after_each.sh", `#!/bin/bash
+if [ -e `+deployedFile+` ]; then
+  echo "after_each:deployed" >> `+callLog+`
+else
+  echo "after_each:missing" >> `+callLog+`
+fi
+exit 0`)
+	afterAllScript := createTestScript(t, scriptsDir, "after_all.sh", `#!/bin/bash
+echo "after_all" >> `+callLog+`
+exit 0`)
+
+	hooks := &core.ResolvedHooks{Install: domain.HookConfig{
+		BeforeAll: beforeAllScript, BeforeEach: beforeEachScript,
+		AfterEach: afterEachScript, AfterAll: afterAllScript,
+	}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{
+		Hooks: hooks, HookRunner: runner,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Deployed)
+
+	logContent, err := os.ReadFile(callLog)
+	require.NoError(t, err)
+	assert.Equal(t, "before_all\nbefore_each\nafter_each:deployed\nafter_all\n", string(logContent))
+}
+
+// TestService_DeployProfile_BeforeEachHookFailure_SkipsModAndContinues
+// guards deploy's before_each semantics, which differ from uninstall's: a
+// failing install.before_each hook skips only that mod (added to
+// result.Skipped) and the loop continues with the rest, rather than
+// aborting the whole operation.
+func TestService_DeployProfile_BeforeEachHookFailure_SkipsModAndContinues(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedNamedInstalledMod(t, svc, game, "src", "bad", "Bad Mod", "1.0", true, map[string][]byte{"bad.esp": []byte("b")})
+	seedNamedInstalledMod(t, svc, game, "src", "good", "Good Mod", "1.0", true, map[string][]byte{"good.esp": []byte("g")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "bad", "1.0")
+	seedProfileWithMod(t, svc, "g1", "default", "src", "good", "1.0")
+
+	beforeEachScript := createTestScript(t, scriptsDir, "before_each.sh", `#!/bin/bash
+if [ "$LMM_MOD_ID" = "bad" ]; then
+  echo "boom" >&2
+  exit 1
+fi
+exit 0`)
+	hooks := &core.ResolvedHooks{Install: domain.HookConfig{BeforeEach: beforeEachScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{
+		Hooks: hooks, HookRunner: runner,
+	}, nil)
+	require.NoError(t, err, "a before_each hook failure must skip that mod, not fail the deploy")
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Deployed)
+	require.Len(t, result.Skipped, 1)
+	assert.Contains(t, result.Skipped[0], "Bad Mod")
+	assert.Contains(t, result.Skipped[0], "install.before_each hook failed")
+
+	_, err = os.Lstat(filepath.Join(gameDir, "good.esp"))
+	assert.NoError(t, err, "the other mod must still deploy")
+}
+
+// TestService_DeployProfile_BeforeAllHookFails_AbortsUnlessForce mirrors
+// TestService_UninstallMod_BeforeAllHookFails_AbortsUnlessForce: a failing
+// install.before_all hook aborts the whole deploy unless Force is set, in
+// which case it becomes a Warning and the deploy proceeds.
+func TestService_DeployProfile_BeforeAllHookFails_AbortsUnlessForce(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	failScript := createTestScript(t, scriptsDir, "before_all.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	hooks := &core.ResolvedHooks{Install: domain.HookConfig{BeforeAll: failScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	t.Run("fatal without Force", func(t *testing.T) {
+		result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{
+			Hooks: hooks, HookRunner: runner,
+		}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "install.before_all hook failed")
+		require.NotNil(t, result)
+		assert.Equal(t, 0, result.Deployed)
+
+		_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+		assert.True(t, os.IsNotExist(err), "nothing should deploy on a fatal before_all failure")
+	})
+
+	t.Run("forced continues with a warning", func(t *testing.T) {
+		result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{
+			Hooks: hooks, HookRunner: runner, Force: true,
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, 1, result.Deployed)
+		require.Len(t, result.Warnings, 1)
+		assert.Contains(t, result.Warnings[0], "install.before_all hook failed")
+		assert.Contains(t, result.Warnings[0], "forced")
+	})
+}
+
+// TestService_DeployProfile_AppliesProfileOverrides guards the final step of
+// doDeploy: profile.Overrides (INI tweaks etc.) are written into the game's
+// install directory via core.ApplyProfileOverrides after the deploy loop.
+func TestService_DeployProfile_AppliesProfileOverrides(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	installDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, InstallPath: installDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	profile, err := svc.NewProfileManager().Get("g1", "default")
+	require.NoError(t, err)
+	profile.Overrides = map[string][]byte{"tweaks.ini": []byte("[General]\nfoo=bar\n")}
+	require.NoError(t, config.SaveProfile(svc.ConfigDir(), profile))
+
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Deployed)
+
+	content, err := os.ReadFile(filepath.Join(installDir, "tweaks.ini"))
+	require.NoError(t, err)
+	assert.Equal(t, "[General]\nfoo=bar\n", string(content))
+}
+
+// TestService_DeployProfile_FatalErrorAfterAccumulatedDiagnostic_ReturnsPartialResult
+// guards the error-path convention from Task 2 (commit 45470e8): once the
+// result struct exists, a later fatal error must still return it, not
+// discard it. Here, a forced uninstall.before_all failure during --purge
+// records a Warning, and the subsequent single-mod lookup (an unknown
+// ModID) fails fatally - the Warning recorded during purge must still come
+// back with the error.
+func TestService_DeployProfile_FatalErrorAfterAccumulatedDiagnostic_ReturnsPartialResult(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	failScript := createTestScript(t, scriptsDir, "before_all.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	hooks := &core.ResolvedHooks{Uninstall: domain.HookConfig{BeforeAll: failScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{
+		Purge: true, ModID: "does-not-exist", SourceID: "src",
+		Hooks: hooks, HookRunner: runner, Force: true,
+	}, nil)
+	require.Error(t, err, "an unknown ModID must fail the deploy")
+	assert.Contains(t, err.Error(), "mod not found")
+	require.NotNil(t, result, "diagnostics accumulated during purge must not be discarded")
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "uninstall.before_all hook failed")
+	assert.Contains(t, result.Warnings[0], "forced")
+}
+
+// TestService_DeployProfile_ProgressCallback_IndexTotalModNameSequence
+// guards the Index/Total/ModName sequence a 3-mod deploy reports.
+func TestService_DeployProfile_ProgressCallback_IndexTotalModNameSequence(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedNamedInstalledMod(t, svc, game, "src", "1", "Mod One", "1.0", true, map[string][]byte{"one.esp": []byte("1")})
+	seedNamedInstalledMod(t, svc, game, "src", "2", "Mod Two", "1.0", true, map[string][]byte{"two.esp": []byte("2")})
+	seedNamedInstalledMod(t, svc, game, "src", "3", "Mod Three", "1.0", true, map[string][]byte{"three.esp": []byte("3")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+	seedProfileWithMod(t, svc, "g1", "default", "src", "2", "1.0")
+	seedProfileWithMod(t, svc, "g1", "default", "src", "3", "1.0")
+
+	var seen []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		if p.Phase == core.DeployDeployed {
+			seen = append(seen, p)
+		}
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, seen, 3)
+	for i, p := range seen {
+		assert.Equal(t, i+1, p.Index)
+		assert.Equal(t, 3, p.Total)
+	}
+	assert.Equal(t, "Mod One", seen[0].ModName)
+	assert.Equal(t, "Mod Two", seen[1].ModName)
+	assert.Equal(t, "Mod Three", seen[2].ModName)
+}
+
+// TestService_DeployProfile_NilProgressCallbackIsSafe guards that progress
+// may be nil per the required API.
+func TestService_DeployProfile_NilProgressCallbackIsSafe(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	assert.NotPanics(t, func() {
+		result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, 1, result.Deployed)
+	})
+}
+
+// TestService_DeployProfile_SingleModByID guards the `lmm deploy <mod-id>`
+// path: DeployOptions.ModID/SourceID restrict the deploy to a single mod,
+// bypassing profile-order gathering entirely (no profile needs to exist).
+func TestService_DeployProfile_SingleModByID(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedNamedInstalledMod(t, svc, game, "src", "1", "Mod One", "1.0", true, map[string][]byte{"one.esp": []byte("1")})
+	seedNamedInstalledMod(t, svc, game, "src", "2", "Mod Two", "1.0", true, map[string][]byte{"two.esp": []byte("2")})
+
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{ModID: "1", SourceID: "src"}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Deployed)
+
+	_, err = os.Lstat(filepath.Join(gameDir, "one.esp"))
+	assert.NoError(t, err)
+	_, err = os.Lstat(filepath.Join(gameDir, "two.esp"))
+	assert.True(t, os.IsNotExist(err), "only the requested mod should deploy")
+}
+
+// TestService_DeployProfile_SingleModDisabled_RequiresAll guards doDeploy's
+// disabled-single-mod guard: deploying a specific disabled ModID fails
+// unless All is set.
+func TestService_DeployProfile_SingleModDisabled_RequiresAll(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", false, map[string][]byte{"plugin.esp": []byte("data")})
+
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{ModID: "1", SourceID: "src"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disabled")
+	require.NotNil(t, result)
+	assert.Equal(t, 0, result.Deployed)
+
+	result, err = svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{ModID: "1", SourceID: "src", All: true}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Deployed)
+}
+
+// TestService_DeployProfile_ZeroModsToDeploy_NoHooksFired guards doDeploy's
+// early return when nothing qualifies to deploy (here: a disabled mod with
+// All unset): DeployProfile must return an empty result without firing any
+// hooks at all, matching the pre-extraction CLI which returns before ever
+// setting up hooks.
+func TestService_DeployProfile_ZeroModsToDeploy_NoHooksFired(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", false, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	callLog := filepath.Join(scriptsDir, "calls.log")
+	beforeAllScript := createTestScript(t, scriptsDir, "before_all.sh", `#!/bin/bash
+echo "before_all" >> `+callLog+`
+exit 0`)
+	hooks := &core.ResolvedHooks{Install: domain.HookConfig{BeforeAll: beforeAllScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{
+		Hooks: hooks, HookRunner: runner,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 0, result.Deployed)
+	assert.Empty(t, result.Skipped)
+
+	_, err = os.Stat(callLog)
+	assert.True(t, os.IsNotExist(err), "install.before_all must not fire when there is nothing to deploy")
 }

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -270,6 +271,7 @@ func TestService_UninstallMod_FullUninstall(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Warnings)
+	assert.Empty(t, result.Notes)
 
 	_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
 	assert.True(t, os.IsNotExist(err), "deployed file should be undeployed")
@@ -300,6 +302,8 @@ func TestService_UninstallMod_KeepCache(t *testing.T) {
 	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{KeepCache: true})
 	require.NoError(t, err)
 	require.NotNil(t, result)
+	assert.Empty(t, result.Warnings)
+	assert.Empty(t, result.Notes)
 
 	_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
 	assert.True(t, os.IsNotExist(err), "deployed file should still be undeployed")
@@ -376,6 +380,7 @@ exit 0`)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Warnings)
+	assert.Empty(t, result.Notes)
 
 	logContent, err := os.ReadFile(callLog)
 	require.NoError(t, err)
@@ -441,6 +446,62 @@ exit 1`)
 	})
 }
 
+// TestService_UninstallMod_BeforeAllHookFails_AbortsUnlessForce mirrors
+// TestService_UninstallMod_BeforeEachHookFails_AbortsUnlessForce for the
+// uninstall.before_all branch, which is a separate hand-duplicated code path
+// in UninstallMod (see the review that flagged it as untested).
+func TestService_UninstallMod_BeforeAllHookFails_AbortsUnlessForce(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	failScript := createTestScript(t, scriptsDir, "before_all.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	hooks := &core.ResolvedHooks{Uninstall: domain.HookConfig{BeforeAll: failScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	t.Run("fatal without Force", func(t *testing.T) {
+		result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{
+			Hooks:      hooks,
+			HookRunner: runner,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uninstall.before_all hook failed")
+		assert.Nil(t, result)
+
+		// Nothing should have changed: mod still installed, file still deployed.
+		_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+		assert.NoError(t, err, "deployed file must survive a fatal before_all failure")
+		_, err = svc.GetInstalledMod("src", "1", "g1", "default")
+		assert.NoError(t, err, "DB row must survive a fatal before_all failure")
+	})
+
+	t.Run("forced continues with a warning", func(t *testing.T) {
+		result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{
+			Hooks:      hooks,
+			HookRunner: runner,
+			Force:      true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.Warnings, 1)
+		assert.Contains(t, result.Warnings[0], "uninstall.before_all hook failed")
+		assert.Contains(t, result.Warnings[0], "forced")
+
+		_, err = svc.GetInstalledMod("src", "1", "g1", "default")
+		assert.ErrorIs(t, err, domain.ErrModNotFound, "forced uninstall must still remove the DB row")
+	})
+}
+
 func TestService_UninstallMod_UnknownModReturnsErrModNotFound(t *testing.T) {
 	svc := newFlowsTestService(t)
 	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
@@ -454,8 +515,12 @@ func TestService_UninstallMod_UnknownModReturnsErrModNotFound(t *testing.T) {
 // TestService_UninstallMod_ProfileDesyncWarnsAndContinues guards the
 // "don't fail if not in profile" partial-failure path from the
 // pre-extraction doUninstall: if the DB row exists but the profile can't be
-// updated (e.g. no profile file, or the mod isn't listed in it), that is a
-// warning, not a fatal error - the DB row is still removed.
+// updated (e.g. no profile file, or the mod isn't listed in it), that is
+// recorded as a Note (not a Warning, and not a fatal error) - the DB row is
+// still removed. UninstallMod records this unconditionally: there is no
+// verbosity concept in core (UninstallOptions has no Verbose field) - the
+// CLI is solely responsible for deciding whether to display it, under
+// --verbose, matching the pre-extraction CLI's "Note: %v" (gated) print.
 func TestService_UninstallMod_ProfileDesyncWarnsAndContinues(t *testing.T) {
 	svc := newFlowsTestService(t)
 	gameDir := t.TempDir()
@@ -466,45 +531,89 @@ func TestService_UninstallMod_ProfileDesyncWarnsAndContinues(t *testing.T) {
 		"plugin.esp": []byte("data"),
 	})
 
-	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{Verbose: true})
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{})
 	require.NoError(t, err, "a profile-removal failure must not fail the uninstall")
 	require.NotNil(t, result)
-	require.Len(t, result.Warnings, 1)
-	assert.Contains(t, result.Warnings[0], domain.ErrProfileNotFound.Error())
+	assert.Empty(t, result.Warnings, "the profile-removal diagnostic must not leak into Warnings")
+	require.Len(t, result.Notes, 1)
+	assert.True(t, strings.HasPrefix(result.Notes[0], "Note: "), "must carry its historical CLI prefix: %q", result.Notes[0])
+	assert.Contains(t, result.Notes[0], domain.ErrProfileNotFound.Error())
 
 	_, err = svc.GetInstalledMod("src", "1", "g1", "default")
-	assert.ErrorIs(t, err, domain.ErrModNotFound, "DB row should still be removed despite the profile warning")
+	assert.ErrorIs(t, err, domain.ErrModNotFound, "DB row should still be removed despite the profile note")
 }
 
-// TestService_UninstallMod_VerboseGatesOperationalWarnings guards the
-// deliberate behavior-preservation decision (documented in the task
-// report): the pre-extraction CLI only printed the undeploy-failure,
-// cache-delete-failure, and profile-removal notes when --verbose was set.
-// UninstallOptions.Verbose reproduces that gating for the Warnings that
-// come from those three call sites; hook after_* failures are always
-// recorded regardless of Verbose (see TestService_UninstallMod_HookOrder's
-// sibling assertions and the AfterHookFailure test below).
-func TestService_UninstallMod_VerboseGatesOperationalWarnings(t *testing.T) {
+// TestService_UninstallMod_UndeployFailure_RecordedAsNoteWithHistoricalPrefix
+// guards the exact text (including its historical "Warning: " prefix) of the
+// undeploy-failure diagnostic. The mod is never actually cached, so
+// Installer.Uninstall's cache.ListFiles call fails deterministically
+// (directory does not exist) without relying on filesystem permissions. The
+// profile is pre-seeded so profile removal succeeds silently, isolating this
+// one diagnostic.
+func TestService_UninstallMod_UndeployFailure_RecordedAsNoteWithHistoricalPrefix(t *testing.T) {
 	svc := newFlowsTestService(t)
 	gameDir := t.TempDir()
 	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
 
-	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
-		"plugin.esp": []byte("data"),
-	})
-	// No profile created, so pm.RemoveMod always fails with ErrProfileNotFound.
+	// No cache files stored (files: nil) - Installer.Uninstall's
+	// cache.ListFiles call fails because the mod's cache directory was
+	// never created.
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, nil)
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
 
-	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{Verbose: false})
-	require.NoError(t, err)
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{})
+	require.NoError(t, err, "an undeploy failure must not fail the uninstall")
 	require.NotNil(t, result)
-	assert.Empty(t, result.Warnings, "non-verbose run must not surface the operational profile-removal note")
+	assert.Empty(t, result.Warnings, "the undeploy diagnostic must not leak into Warnings")
+	require.Len(t, result.Notes, 1)
+	assert.True(t, strings.HasPrefix(result.Notes[0], "Warning: failed to undeploy some files: "), "must carry its historical CLI prefix: %q", result.Notes[0])
+
+	_, err = svc.GetInstalledMod("src", "1", "g1", "default")
+	assert.ErrorIs(t, err, domain.ErrModNotFound, "DB row should still be removed despite the undeploy note")
+}
+
+// TestService_UninstallMod_UndeployAndCacheDeleteFailures_RecordedAsNotesWithHistoricalPrefixes
+// guards the exact text (including historical "Warning: " prefixes) of the
+// undeploy-failure and cache-delete-failure diagnostics together. Both
+// Installer.Uninstall (via cache.ListFiles) and Cache.Delete (via
+// os.RemoveAll) resolve the identical on-disk mod path, so a single
+// structural obstruction - a regular file in place of the mod's cache
+// directory - deterministically fails both without relying on filesystem
+// permissions (unlike a read-only directory, this also fails when tests run
+// as root).
+func TestService_UninstallMod_UndeployAndCacheDeleteFailures_RecordedAsNotesWithHistoricalPrefixes(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	// No cache files stored (files: nil); the mod's cache directory is
+	// created below only as a blocking regular file, never a real directory.
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, nil)
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	modPath := svc.GetGameCache(game).ModPath("g1", "src", "1", "1.0")
+	blockedParent := filepath.Dir(modPath) // .../g1/src-1, normally a directory
+	require.NoError(t, os.MkdirAll(filepath.Dir(blockedParent), 0755))
+	require.NoError(t, os.WriteFile(blockedParent, []byte("blocked"), 0644))
+
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{})
+	require.NoError(t, err, "undeploy and cache-delete failures must not fail the uninstall")
+	require.NotNil(t, result)
+	assert.Empty(t, result.Warnings, "operational diagnostics must not leak into Warnings")
+	require.Len(t, result.Notes, 2)
+	assert.True(t, strings.HasPrefix(result.Notes[0], "Warning: failed to undeploy some files: "), "note[0] must carry its historical CLI prefix: %q", result.Notes[0])
+	assert.True(t, strings.HasPrefix(result.Notes[1], "Warning: failed to clean cache: "), "note[1] must carry its historical CLI prefix: %q", result.Notes[1])
+
+	_, err = svc.GetInstalledMod("src", "1", "g1", "default")
+	assert.ErrorIs(t, err, domain.ErrModNotFound, "DB row should still be removed despite the failures")
 }
 
 // TestService_UninstallMod_AfterEachHookFailure_IsNonFatalWarning guards
 // that after_each/after_all hook failures never fail the uninstall (they
 // run after every other step has already committed) and are always
-// recorded in Warnings regardless of Verbose, matching the pre-extraction
-// CLI's unconditional printHookWarnings behavior.
+// recorded in Warnings, matching the pre-extraction CLI's unconditional
+// printHookWarnings behavior. Unlike Notes, Warnings entries are printed by
+// the CLI unconditionally (regardless of --verbose).
 func TestService_UninstallMod_AfterEachHookFailure_IsNonFatalWarning(t *testing.T) {
 	svc := newFlowsTestService(t)
 	gameDir := t.TempDir()
@@ -528,7 +637,6 @@ exit 1`)
 	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{
 		Hooks:      hooks,
 		HookRunner: runner,
-		Verbose:    false,
 	})
 	require.NoError(t, err, "after_each failures must not fail UninstallMod")
 	require.NotNil(t, result)

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
 )
 
 // newFlowsTestService returns a *core.Service backed by fresh temp dirs
@@ -420,7 +422,9 @@ exit 1`)
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "uninstall.before_each hook failed")
-		assert.Nil(t, result)
+		require.NotNil(t, result, "the (empty) result must still be returned alongside a fatal error, not discarded")
+		assert.Empty(t, result.Warnings)
+		assert.Empty(t, result.Notes)
 
 		// Nothing should have changed: mod still installed, file still deployed.
 		_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
@@ -476,7 +480,9 @@ exit 1`)
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "uninstall.before_all hook failed")
-		assert.Nil(t, result)
+		require.NotNil(t, result, "the (empty) result must still be returned alongside a fatal error, not discarded")
+		assert.Empty(t, result.Warnings)
+		assert.Empty(t, result.Notes)
 
 		// Nothing should have changed: mod still installed, file still deployed.
 		_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
@@ -500,6 +506,77 @@ exit 1`)
 		_, err = svc.GetInstalledMod("src", "1", "g1", "default")
 		assert.ErrorIs(t, err, domain.ErrModNotFound, "forced uninstall must still remove the DB row")
 	})
+}
+
+// TestService_UninstallMod_FatalErrorAfterAccumulatedDiagnostic_ReturnsPartialResult
+// guards the error-path convention amendment flagged by the Task 2 review:
+// once the result struct exists, every fatal return must carry the
+// partially-populated result instead of discarding it (see
+// UninstallResult's doc comment), so the CLI can still surface diagnostics
+// that already "happened" before the fatal error hit.
+//
+// DeleteInstalledMod is the only fatal step in UninstallMod that can be
+// reached *after* a diagnostic has already been recorded: before_all/
+// before_each are fatal-by-default (nothing accumulated yet when they
+// abort) unless Force is set, in which case their failures become Warnings
+// and execution continues - and DeleteInstalledMod is the sole remaining
+// fatal step downstream of that. This test forces it to fail by holding a
+// real write lock on the same SQLite file - a dedicated second connection
+// issues "BEGIN IMMEDIATE" directly (a plain sql.Tx's default deferred
+// BEGIN does NOT take a lock until its first statement runs, so it doesn't
+// work here) and never commits, for the call's duration. WAL-mode readers
+// (GetInstalledMod) proceed unaffected, but the writer (DeleteInstalledMod)
+// deterministically gets SQLITE_BUSY (busy_timeout defaults to 0, so it's
+// an immediate error, not a timing-dependent race).
+func TestService_UninstallMod_FatalErrorAfterAccumulatedDiagnostic_ReturnsPartialResult(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	failScript := createTestScript(t, scriptsDir, "before_each.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	hooks := &core.ResolvedHooks{Uninstall: domain.HookConfig{BeforeEach: failScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	dbPath := filepath.Join(dataDir, "lmm.db")
+	locker, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer locker.Close()
+	locker.SetMaxOpenConns(1)
+	conn, err := locker.Conn(context.Background())
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.ExecContext(context.Background(), "BEGIN IMMEDIATE")
+	require.NoError(t, err)
+	defer conn.ExecContext(context.Background(), "ROLLBACK") //nolint:errcheck // best-effort cleanup
+
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{
+		Hooks:      hooks,
+		HookRunner: runner,
+		Force:      true,
+	})
+	require.Error(t, err, "DeleteInstalledMod must fail while another writer holds the file lock")
+	assert.Contains(t, err.Error(), "failed to remove mod record")
+	require.NotNil(t, result, "the result accumulated before the fatal error must not be discarded")
+	require.Len(t, result.Warnings, 1, "the forced before_each hook failure must have been recorded before the later fatal error")
+	assert.Contains(t, result.Warnings[0], "uninstall.before_each hook failed")
+	assert.Contains(t, result.Warnings[0], "forced")
 }
 
 func TestService_UninstallMod_UnknownModReturnsErrModNotFound(t *testing.T) {

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -235,4 +236,305 @@ func TestService_DisableMod_UndeployFailureIsNonFatal(t *testing.T) {
 	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
 	require.NoError(t, err)
 	assert.False(t, mod.Enabled, "DB should still flip to disabled even when undeploy is best-effort")
+}
+
+// --- UninstallMod ---
+
+// seedProfileWithMod creates profileName (if needed) and adds a reference to
+// source/mod/version, mirroring the state left behind by a real install.
+func seedProfileWithMod(t *testing.T, svc *core.Service, gameID, profileName, sourceID, modID, version string) {
+	t.Helper()
+	pm := svc.NewProfileManager()
+	if _, err := pm.Get(gameID, profileName); err != nil {
+		require.ErrorIs(t, err, domain.ErrProfileNotFound)
+		_, err := pm.Create(gameID, profileName)
+		require.NoError(t, err)
+	}
+	require.NoError(t, pm.AddMod(gameID, profileName, domain.ModReference{SourceID: sourceID, ModID: modID, Version: version}))
+}
+
+func TestService_UninstallMod_FullUninstall(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Warnings)
+
+	_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+	assert.True(t, os.IsNotExist(err), "deployed file should be undeployed")
+
+	assert.False(t, svc.GetGameCache(game).Exists("g1", "src", "1", "1.0"), "cache entry should be deleted")
+
+	_, err = svc.GetInstalledMod("src", "1", "g1", "default")
+	assert.ErrorIs(t, err, domain.ErrModNotFound, "DB row should be removed")
+
+	profile, err := svc.NewProfileManager().Get("g1", "default")
+	require.NoError(t, err)
+	assert.Empty(t, profile.Mods, "profile should no longer list the mod")
+}
+
+func TestService_UninstallMod_KeepCache(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{KeepCache: true})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+	assert.True(t, os.IsNotExist(err), "deployed file should still be undeployed")
+
+	assert.True(t, svc.GetGameCache(game).Exists("g1", "src", "1", "1.0"), "cache entry must survive with KeepCache")
+
+	_, err = svc.GetInstalledMod("src", "1", "g1", "default")
+	assert.ErrorIs(t, err, domain.ErrModNotFound, "DB row should still be removed")
+
+	profile, err := svc.NewProfileManager().Get("g1", "default")
+	require.NoError(t, err)
+	assert.Empty(t, profile.Mods, "profile should still no longer list the mod")
+}
+
+// TestService_UninstallMod_HookOrder proves before_each runs before the
+// mod's files are undeployed, and after_each runs after the mod has been
+// removed from the profile (mirroring doUninstall's step ordering:
+// hooks -> undeploy -> cache delete -> DB delete -> profile remove -> after
+// hooks).
+func TestService_UninstallMod_HookOrder(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	deployedFile := filepath.Join(gameDir, "plugin.esp")
+	profilePath := filepath.Join(svc.ConfigDir(), "games", "g1", "profiles", "default.yaml")
+	callLog := filepath.Join(scriptsDir, "calls.log")
+
+	beforeAllScript := createTestScript(t, scriptsDir, "before_all.sh", `#!/bin/bash
+echo "before_all" >> `+callLog+`
+exit 0`)
+	beforeEachScript := createTestScript(t, scriptsDir, "before_each.sh", `#!/bin/bash
+if [ -e `+deployedFile+` ]; then
+  echo "before_each:deployed" >> `+callLog+`
+else
+  echo "before_each:undeployed" >> `+callLog+`
+fi
+exit 0`)
+	afterEachScript := createTestScript(t, scriptsDir, "after_each.sh", `#!/bin/bash
+if grep -q mod_id `+profilePath+` 2>/dev/null; then
+  echo "after_each:still_in_profile" >> `+callLog+`
+else
+  echo "after_each:removed_from_profile" >> `+callLog+`
+fi
+exit 0`)
+	afterAllScript := createTestScript(t, scriptsDir, "after_all.sh", `#!/bin/bash
+echo "after_all" >> `+callLog+`
+exit 0`)
+
+	hooks := &core.ResolvedHooks{
+		Uninstall: domain.HookConfig{
+			BeforeAll:  beforeAllScript,
+			BeforeEach: beforeEachScript,
+			AfterEach:  afterEachScript,
+			AfterAll:   afterAllScript,
+		},
+	}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{
+		Hooks:       hooks,
+		HookRunner:  runner,
+		HookContext: core.HookContext{GameID: game.ID, GamePath: game.InstallPath, ModPath: game.ModPath},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Warnings)
+
+	logContent, err := os.ReadFile(callLog)
+	require.NoError(t, err)
+	expectedLog := "before_all\nbefore_each:deployed\nafter_each:removed_from_profile\nafter_all\n"
+	assert.Equal(t, expectedLog, string(logContent))
+}
+
+// TestService_UninstallMod_BeforeEachHookFails_AbortsUnlessForce guards the
+// fatal-by-default hook semantics of the pre-extraction doUninstall: a
+// failing uninstall.before_* hook aborts the whole operation (nothing is
+// undeployed, uninstalled, or removed from the DB/profile) unless Force is
+// set, in which case the failure becomes a warning and the uninstall
+// proceeds.
+func TestService_UninstallMod_BeforeEachHookFails_AbortsUnlessForce(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	failScript := createTestScript(t, scriptsDir, "before_each.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	hooks := &core.ResolvedHooks{Uninstall: domain.HookConfig{BeforeEach: failScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	t.Run("fatal without Force", func(t *testing.T) {
+		result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{
+			Hooks:      hooks,
+			HookRunner: runner,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uninstall.before_each hook failed")
+		assert.Nil(t, result)
+
+		// Nothing should have changed: mod still installed, file still deployed.
+		_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+		assert.NoError(t, err, "deployed file must survive a fatal before_each failure")
+		_, err = svc.GetInstalledMod("src", "1", "g1", "default")
+		assert.NoError(t, err, "DB row must survive a fatal before_each failure")
+	})
+
+	t.Run("forced continues with a warning", func(t *testing.T) {
+		result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{
+			Hooks:      hooks,
+			HookRunner: runner,
+			Force:      true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.Warnings, 1)
+		assert.Contains(t, result.Warnings[0], "uninstall.before_each hook failed")
+		assert.Contains(t, result.Warnings[0], "forced")
+
+		_, err = svc.GetInstalledMod("src", "1", "g1", "default")
+		assert.ErrorIs(t, err, domain.ErrModNotFound, "forced uninstall must still remove the DB row")
+	})
+}
+
+func TestService_UninstallMod_UnknownModReturnsErrModNotFound(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "missing", core.UninstallOptions{})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, domain.ErrModNotFound)
+}
+
+// TestService_UninstallMod_ProfileDesyncWarnsAndContinues guards the
+// "don't fail if not in profile" partial-failure path from the
+// pre-extraction doUninstall: if the DB row exists but the profile can't be
+// updated (e.g. no profile file, or the mod isn't listed in it), that is a
+// warning, not a fatal error - the DB row is still removed.
+func TestService_UninstallMod_ProfileDesyncWarnsAndContinues(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	// DB row + cache exist, but no profile was ever created for "default".
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{Verbose: true})
+	require.NoError(t, err, "a profile-removal failure must not fail the uninstall")
+	require.NotNil(t, result)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], domain.ErrProfileNotFound.Error())
+
+	_, err = svc.GetInstalledMod("src", "1", "g1", "default")
+	assert.ErrorIs(t, err, domain.ErrModNotFound, "DB row should still be removed despite the profile warning")
+}
+
+// TestService_UninstallMod_VerboseGatesOperationalWarnings guards the
+// deliberate behavior-preservation decision (documented in the task
+// report): the pre-extraction CLI only printed the undeploy-failure,
+// cache-delete-failure, and profile-removal notes when --verbose was set.
+// UninstallOptions.Verbose reproduces that gating for the Warnings that
+// come from those three call sites; hook after_* failures are always
+// recorded regardless of Verbose (see TestService_UninstallMod_HookOrder's
+// sibling assertions and the AfterHookFailure test below).
+func TestService_UninstallMod_VerboseGatesOperationalWarnings(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+	// No profile created, so pm.RemoveMod always fails with ErrProfileNotFound.
+
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{Verbose: false})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Warnings, "non-verbose run must not surface the operational profile-removal note")
+}
+
+// TestService_UninstallMod_AfterEachHookFailure_IsNonFatalWarning guards
+// that after_each/after_all hook failures never fail the uninstall (they
+// run after every other step has already committed) and are always
+// recorded in Warnings regardless of Verbose, matching the pre-extraction
+// CLI's unconditional printHookWarnings behavior.
+func TestService_UninstallMod_AfterEachHookFailure_IsNonFatalWarning(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+
+	failScript := createTestScript(t, scriptsDir, "after_each.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	hooks := &core.ResolvedHooks{Uninstall: domain.HookConfig{AfterEach: failScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{
+		Hooks:      hooks,
+		HookRunner: runner,
+		Verbose:    false,
+	})
+	require.NoError(t, err, "after_each failures must not fail UninstallMod")
+	require.NotNil(t, result)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "uninstall.after_each hook failed")
+
+	_, err = svc.GetInstalledMod("src", "1", "g1", "default")
+	assert.ErrorIs(t, err, domain.ErrModNotFound, "DB row should already be removed by the time after_each runs")
 }

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -283,6 +283,30 @@ func seedProfileWithMod(t *testing.T, svc *core.Service, gameID, profileName, so
 	require.NoError(t, pm.AddMod(gameID, profileName, domain.ModReference{SourceID: sourceID, ModID: modID, Version: version}))
 }
 
+// installBlockingTrigger opens a second connection to the SQLite file at
+// dbPath and installs a trigger that makes any UPDATE touching
+// installed_mods.link_method or installed_mods.deployed fail - used to
+// deterministically force SetModLinkMethod/SetModDeployed to error without
+// affecting any other table or column (see the technique note on
+// TestService_DeployProfile_PerModNoteDiagnostics_CarryModAttributionAndPrecedeSuccessEvent).
+// Must be called after the *core.Service that owns dbPath has already run
+// its migrations (so the installed_mods table exists).
+func installBlockingTrigger(t *testing.T, dbPath string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	_, err = conn.Exec(`
+		CREATE TRIGGER block_link_method_and_deployed_updates
+		BEFORE UPDATE OF link_method, deployed ON installed_mods
+		BEGIN
+			SELECT RAISE(ABORT, 'blocked for test');
+		END;
+	`)
+	require.NoError(t, err)
+}
+
 func TestService_UninstallMod_FullUninstall(t *testing.T) {
 	svc := newFlowsTestService(t)
 	gameDir := t.TempDir()
@@ -1249,4 +1273,361 @@ exit 0`)
 
 	_, err = os.Stat(callLog)
 	assert.True(t, os.IsNotExist(err), "install.before_all must not fire when there is nothing to deploy")
+}
+
+// --- Fix wave 1: progress-event positioning (review findings) ---
+//
+// The tests below guard DeployProgress events added to restore the
+// pre-extraction CLI's console positioning for diagnostics that Task 3
+// correctly accumulated into DeployResult.Warnings/Notes but only surfaced
+// via progress events for a subset of cases (DeployBeforeEachSkipped/
+// DeployDownloadFailed/DeploySkipped). See the task-3-report.md "Fix wave 1"
+// entry for the full mapping.
+
+// TestService_DeployProfile_ForcedBeforeAllWarning_EmitsEventBeforeAnythingElse
+// guards finding 1 (deploy side): a forced install.before_all failure must
+// be reported via a DeployBeforeAllForced event before any other event -
+// the pre-extraction CLI printed this warning as the very first line of
+// output, before the "Deploying N mod(s)..." header.
+func TestService_DeployProfile_ForcedBeforeAllWarning_EmitsEventBeforeAnythingElse(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	failScript := createTestScript(t, scriptsDir, "before_all.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	hooks := &core.ResolvedHooks{Install: domain.HookConfig{BeforeAll: failScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	var events []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{
+		Hooks: hooks, HookRunner: runner, Force: true,
+	}, func(p core.DeployProgress) { events = append(events, p) })
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.NotEmpty(t, events)
+	assert.Equal(t, core.DeployBeforeAllForced, events[0].Phase, "the forced before_all warning must be the first event emitted")
+	assert.Contains(t, events[0].Detail, "install.before_all hook failed")
+	assert.Contains(t, events[0].Detail, "forced")
+	assert.Equal(t, events[0].Detail, result.Warnings[0], "the event's Detail must match the recorded Warning text verbatim")
+
+	require.Greater(t, len(events), 1, "at least one later event (the mod itself deploying) must exist")
+	assert.NotEqual(t, core.DeployBeforeAllForced, events[1].Phase)
+}
+
+// TestService_DeployProfile_PurgeForcedBeforeAllWarning_EmitsEventBeforePurgingEvent
+// guards finding 1 (purge side): a forced uninstall.before_all failure
+// during --purge must be reported before the DeployPurging event (which the
+// CLI uses to print the "Purging N mod(s) before deploy..." header).
+func TestService_DeployProfile_PurgeForcedBeforeAllWarning_EmitsEventBeforePurgingEvent(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	failScript := createTestScript(t, scriptsDir, "before_all.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	hooks := &core.ResolvedHooks{Uninstall: domain.HookConfig{BeforeAll: failScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	var events []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{
+		Purge: true, Hooks: hooks, HookRunner: runner, Force: true,
+	}, func(p core.DeployProgress) { events = append(events, p) })
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.GreaterOrEqual(t, len(events), 2)
+	assert.Equal(t, core.DeployBeforeAllForced, events[0].Phase)
+	assert.Contains(t, events[0].Detail, "uninstall.before_all hook failed")
+	assert.Contains(t, events[0].Detail, "forced")
+	assert.Equal(t, core.DeployPurging, events[1].Phase, "the purge header event must come right after the forced warning")
+}
+
+// TestService_DeployProfile_PerModNoteDiagnostics_CarryModAttributionAndPrecedeSuccessEvent
+// guards finding 3 (deploy loop): a failed SetModLinkMethod and a failed
+// SetModDeployed both produce text with NO mod identity in it
+// ("Warning: could not update link method: ..."), so position (via the
+// event's ModName/ModID and its place in the event stream, before that same
+// mod's DeployDeployed event) is the ONLY way to attribute either
+// diagnostic to a mod. Two mods are seeded so a batched/misattributed
+// implementation is distinguishable from a correctly-interleaved one: both
+// mods' Note events must appear before THEIR OWN DeployDeployed event, not
+// after both mods have already "succeeded".
+//
+// SetModLinkMethod/SetModDeployed are both plain UPDATEs against
+// installed_mods, but Install/Uninstall also write to the DB (deployed_files,
+// via SaveDeployedFile/DeleteDeployedFiles) - so a blanket write-lock
+// (the BEGIN IMMEDIATE technique
+// TestService_UninstallMod_FatalErrorAfterAccumulatedDiagnostic_ReturnsPartialResult
+// uses) would fail Install itself before ever reaching SetModLinkMethod/
+// SetModDeployed, defeating the test. Instead, a second connection installs
+// a real SQLite trigger that aborts ONLY updates to installed_mods'
+// link_method/deployed columns, leaving every other table (deployed_files)
+// and every other installed_mods column untouched - deterministic, and
+// narrow enough that Install/Uninstall still succeed normally.
+func TestService_DeployProfile_PerModNoteDiagnostics_CarryModAttributionAndPrecedeSuccessEvent(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedNamedInstalledMod(t, svc, game, "src", "a", "Mod A", "1.0", true, map[string][]byte{"a.esp": []byte("a")})
+	seedNamedInstalledMod(t, svc, game, "src", "b", "Mod B", "1.0", true, map[string][]byte{"b.esp": []byte("b")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "a", "1.0")
+	seedProfileWithMod(t, svc, "g1", "default", "src", "b", "1.0")
+
+	installBlockingTrigger(t, filepath.Join(dataDir, "lmm.db"))
+
+	var events []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err, "SetModLinkMethod/SetModDeployed failures must not fail the deploy")
+	require.NotNil(t, result)
+	assert.Equal(t, 2, result.Deployed, "both mods must still deploy despite the bookkeeping failures")
+	require.Len(t, result.Notes, 4, "2 mods x (link-method + mark-deployed) failures")
+
+	// Find each mod's DeployDeployed index and confirm its two DeployNote
+	// events (with matching ModName/ModID) both appear before it.
+	for _, modName := range []string{"Mod A", "Mod B"} {
+		var noteIdxs []int
+		var deployedIdx = -1
+		for i, e := range events {
+			if e.ModName != modName {
+				continue
+			}
+			switch e.Phase {
+			case core.DeployNote:
+				noteIdxs = append(noteIdxs, i)
+			case core.DeployDeployed:
+				deployedIdx = i
+			}
+		}
+		require.Len(t, noteIdxs, 2, "%s must have exactly 2 DeployNote events (link-method + mark-deployed)", modName)
+		require.NotEqual(t, -1, deployedIdx, "%s must have a DeployDeployed event", modName)
+		for _, ni := range noteIdxs {
+			assert.Less(t, ni, deployedIdx, "%s's Note events must precede its own DeployDeployed event", modName)
+		}
+	}
+}
+
+// TestService_DeployProfile_UndeployFailureEmitsNoteEventBeforeSuccessEvent
+// guards finding 3's third deploy-loop diagnostic (undeploy-before-redeploy
+// failure, flows.go's "Warning: undeploy %s: %v" - the only one of the
+// three whose text DOES carry a mod name already), corrupting a previously
+// deployed symlink into a plain file so the redeploy's own undeploy step
+// fails deterministically, mirroring
+// TestService_DisableMod_UndeployFailureIsNonFatal.
+func TestService_DeployProfile_UndeployFailureEmitsNoteEventBeforeSuccessEvent(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedNamedInstalledMod(t, svc, game, "src", "1", "Test Mod", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+	deployedPath := filepath.Join(gameDir, "plugin.esp")
+	require.NoError(t, os.Remove(deployedPath))
+	require.NoError(t, os.WriteFile(deployedPath, []byte("not a symlink"), 0644))
+
+	var events []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Deployed)
+	require.Len(t, result.Notes, 1)
+	assert.True(t, strings.HasPrefix(result.Notes[0], "Warning: undeploy Test Mod: "))
+
+	require.Len(t, events, 2)
+	assert.Equal(t, core.DeployNote, events[0].Phase)
+	assert.Equal(t, "Test Mod", events[0].ModName)
+	assert.Equal(t, "1", events[0].ModID)
+	assert.Equal(t, result.Notes[0], events[0].Detail)
+	assert.Equal(t, core.DeployDeployed, events[1].Phase, "the Note event must precede the success event")
+}
+
+// TestService_DeployProfile_PurgeBeforeEachSkip_EmitsWarningEventWithModAttribution
+// guards finding 3's purge-side case: purgeForDeploy's before_each-skip
+// diagnostic must fire a PurgeWarning event with the skipped mod's
+// attribution, at the point it happens (inline with that mod), not batched.
+func TestService_DeployProfile_PurgeBeforeEachSkip_EmitsWarningEventWithModAttribution(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedNamedInstalledMod(t, svc, game, "src", "bad", "Bad Mod", "1.0", true, map[string][]byte{"bad.esp": []byte("b")})
+	seedNamedInstalledMod(t, svc, game, "src", "good", "Good Mod", "1.0", true, map[string][]byte{"good.esp": []byte("g")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "bad", "1.0")
+	seedProfileWithMod(t, svc, "g1", "default", "src", "good", "1.0")
+
+	beforeEachScript := createTestScript(t, scriptsDir, "before_each.sh", `#!/bin/bash
+if [ "$LMM_MOD_ID" = "bad" ]; then
+  echo "boom" >&2
+  exit 1
+fi
+exit 0`)
+	hooks := &core.ResolvedHooks{Uninstall: domain.HookConfig{BeforeEach: beforeEachScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	var events []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{
+		Purge: true, All: true, Hooks: hooks, HookRunner: runner,
+	}, func(p core.DeployProgress) { events = append(events, p) })
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var found *core.DeployProgress
+	for i := range events {
+		if events[i].Phase == core.PurgeWarning && events[i].ModName == "Bad Mod" {
+			found = &events[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "expected a PurgeWarning event attributed to Bad Mod")
+	assert.Equal(t, "bad", found.ModID)
+	assert.Contains(t, found.Detail, "uninstall.before_each hook failed")
+	assert.Contains(t, result.Warnings, found.Detail, "the event's Detail must match the recorded Warning text verbatim")
+}
+
+// TestService_DeployProfile_PurgeUndeployFailureEmitsNoteEvent guards
+// finding 3's "finish the pattern" scope: purgeForDeploy's own per-mod ⚠
+// undeploy-failure Note (previously batched, same as the deploy loop's
+// equivalent) must fire inline via a PurgeNote event. Reuses the
+// symlink-corruption technique, then triggers a --purge deploy so purge's
+// own Uninstall call hits the same "not a symlink" failure.
+func TestService_DeployProfile_PurgeUndeployFailureEmitsNoteEvent(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedNamedInstalledMod(t, svc, game, "src", "1", "Test Mod", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+	deployedPath := filepath.Join(gameDir, "plugin.esp")
+	require.NoError(t, os.Remove(deployedPath))
+	require.NoError(t, os.WriteFile(deployedPath, []byte("not a symlink"), 0644))
+
+	var events []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{Purge: true}, func(p core.DeployProgress) {
+		events = append(events, p)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var found *core.DeployProgress
+	for i := range events {
+		if events[i].Phase == core.PurgeNote {
+			found = &events[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "expected a PurgeNote event for the purge-phase undeploy failure")
+	assert.Equal(t, "Test Mod", found.ModName)
+	assert.True(t, strings.HasPrefix(found.Detail, "⚠ Test Mod - "))
+	assert.Contains(t, result.Notes, found.Detail)
+
+	// PurgeNote must be emitted before DeployPurging's redeploy-phase
+	// events (it belongs to the purge phase).
+	purgingIdx, noteIdx := -1, -1
+	for i, e := range events {
+		if e.Phase == core.DeployPurging {
+			purgingIdx = i
+		}
+		if e.Phase == core.PurgeNote && noteIdx == -1 {
+			noteIdx = i
+		}
+	}
+	require.NotEqual(t, -1, purgingIdx)
+	assert.Greater(t, noteIdx, purgingIdx, "the purge-phase note must come after the DeployPurging header event, still within the purge phase")
+}
+
+// TestService_DeployProfile_OverridesWarningEmittedBeforeDeferredHookWarnings
+// guards finding 2: the pre-extraction CLI printed the profile-overrides
+// warning (computed and printed immediately once the deploy loop and
+// install.after_all hook had already run) BEFORE its batched hook-warning
+// print (install.after_each entries in mod order, then install.after_all) -
+// even though, in both the pre-extraction CLI and this flow, after_each/
+// after_all are computed earlier in the function than the overrides check.
+// DeployProfile reproduces this by deferring the after_each/after_all
+// DeployWarning events (queued, not emitted immediately) until after the
+// overrides DeployWarning has been emitted - execution order (and the
+// Warnings slice's append order) is unchanged; only the moment each event
+// is *emitted* (and hence printed) is deferred.
+func TestService_DeployProfile_OverridesWarningEmittedBeforeDeferredHookWarnings(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	installDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, InstallPath: installDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	profile, err := svc.NewProfileManager().Get("g1", "default")
+	require.NoError(t, err)
+	// An absolute override path is rejected by ApplyProfileOverrides
+	// deterministically, with no filesystem trickery required.
+	profile.Overrides = map[string][]byte{"/etc/passwd": []byte("x")}
+	require.NoError(t, config.SaveProfile(svc.ConfigDir(), profile))
+
+	afterEachScript := createTestScript(t, scriptsDir, "after_each.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	afterAllScript := createTestScript(t, scriptsDir, "after_all.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	hooks := &core.ResolvedHooks{Install: domain.HookConfig{AfterEach: afterEachScript, AfterAll: afterAllScript}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	var events []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{
+		Hooks: hooks, HookRunner: runner,
+	}, func(p core.DeployProgress) { events = append(events, p) })
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Deployed)
+	require.Len(t, result.Warnings, 3, "after_each + after_all + overrides")
+
+	overridesIdx, afterEachIdx, afterAllIdx := -1, -1, -1
+	for i, e := range events {
+		if e.Phase != core.DeployWarning {
+			continue
+		}
+		switch {
+		case strings.Contains(e.Detail, "applying profile overrides"):
+			overridesIdx = i
+		case strings.Contains(e.Detail, "after_each"):
+			afterEachIdx = i
+		case strings.Contains(e.Detail, "after_all"):
+			afterAllIdx = i
+		}
+	}
+	require.NotEqual(t, -1, overridesIdx, "expected an overrides DeployWarning event")
+	require.NotEqual(t, -1, afterEachIdx, "expected an after_each DeployWarning event")
+	require.NotEqual(t, -1, afterAllIdx, "expected an after_all DeployWarning event")
+	assert.Less(t, overridesIdx, afterEachIdx, "overrides warning must be emitted before the after_each hook warning")
+	assert.Less(t, overridesIdx, afterAllIdx, "overrides warning must be emitted before the after_all hook warning")
 }

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -1,0 +1,305 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// actionKind identifies which mutation a pendingAction/actionDoneMsg/
+// actionFailedMsg represents, for callers (Task 7's keybindings) that branch
+// on it — e.g. to route a completed switch's outcome differently from a
+// completed uninstall.
+type actionKind int
+
+const (
+	actionEnable actionKind = iota
+	actionDisable
+	actionUninstall
+	actionDeploy
+	actionSwitch
+)
+
+// pendingAction is a caller-built (Task 7) description of one mutation
+// awaiting user confirmation. confirm is normally built by buildAction and
+// is only ever invoked once, when the user confirms — see
+// updatePendingActionKey.
+type pendingAction struct {
+	kind    actionKind
+	title   string   // e.g. `Uninstall "SkyUI"?`
+	detail  []string // affected game/profile/mods; Task 7 fills per action
+	confirm func() tea.Cmd
+}
+
+// actionModel is the Model's mutation-machinery sub-state: the pending
+// confirmation (if any), the single-flight guard, the staleness generation,
+// the in-flight action's cancel func, and the last outcome/error rendered
+// as the status line.
+type actionModel struct {
+	pending       *pendingAction
+	running       bool
+	gen           int
+	cancel        context.CancelFunc
+	status        string
+	statusIsError bool
+}
+
+// actionDoneMsg carries a completed action's outcome, tagged with the
+// generation established when the action was built (see buildAction) so a
+// superseded result can be discarded.
+type actionDoneMsg struct {
+	gen     int
+	kind    actionKind
+	outcome ActionOutcome
+}
+
+// actionFailedMsg carries a failed action's error, tagged like
+// actionDoneMsg.
+type actionFailedMsg struct {
+	gen  int
+	kind actionKind
+	err  error
+}
+
+// actionModalMaxDetailLines is the normal-case cap on how many detail lines
+// the confirmation modal shows before collapsing the remainder into a
+// "+N more" line (see actionModalView). actionModalView additionally derives
+// a dynamic floor from the actual panel height, so an unusually short
+// terminal can't grow the modal past its height budget even though this
+// constant alone wouldn't prevent that.
+const actionModalMaxDetailLines = 8
+
+// buildAction constructs the pendingAction a caller (Task 7's keybinding
+// handlers) passes to promptAction. It owns the two pieces of bookkeeping
+// this task is responsible for:
+//
+//   - A cancelable context derived from m.ctx, stored as action.cancel so
+//     quit (see quitCmd) or a later action can tear it down. Any cancel func
+//     already there — e.g. a still-running action nobody's message has
+//     arrived for — is cancelled first, matching actionModel.cancel's
+//     "cancelled ... on new action" contract.
+//   - The gen tag actionDoneMsg/actionFailedMsg carry, baked into the
+//     confirm closure here (at build/show time) rather than inside
+//     updatePendingActionKey's confirm branch. confirm is an opaque
+//     func() tea.Cmd built once by this method, so build time is the only
+//     point that can attach a consistent gen to whatever message the
+//     eventual call produces. Nothing can bump action.gen between a
+//     pendingAction being built and it being confirmed — promptAction's own
+//     single-flight guard blocks any other action from starting first — so
+//     the gen captured here is still current at confirm time: the
+//     observable contract ("a stale gen is discarded entirely") holds
+//     regardless of the exact instant the bump happens.
+//
+// Single-flight: buildAction applies the same guard promptAction does
+// (running or already pending) and, if it fails, leaves m and its gen/cancel
+// state completely untouched, returning a no-op pendingAction instead. This
+// means a caller that builds an action before calling promptAction (the
+// normal two-step usage) can never corrupt an in-flight action's bookkeeping
+// even if it forgets to check the guard itself — promptAction's own refusal
+// to show the no-op pendingAction is just belt-and-suspenders on top.
+func (m Model) buildAction(kind actionKind, title string, detail []string, do func(context.Context) (ActionOutcome, error)) (Model, pendingAction) {
+	if m.action.running || m.action.pending != nil {
+		return m, pendingAction{kind: kind, title: title, detail: detail, confirm: func() tea.Cmd { return nil }}
+	}
+
+	if m.action.cancel != nil {
+		m.action.cancel()
+	}
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.action.cancel = cancel
+	m.action.gen++
+	gen := m.action.gen
+
+	pa := pendingAction{
+		kind:   kind,
+		title:  title,
+		detail: detail,
+		confirm: func() tea.Cmd {
+			return func() tea.Msg {
+				outcome, err := do(ctx)
+				if err != nil {
+					return actionFailedMsg{gen: gen, kind: kind, err: err}
+				}
+				return actionDoneMsg{gen: gen, kind: kind, outcome: outcome}
+			}
+		},
+	}
+	return m, pa
+}
+
+// promptAction shows pa as the confirmation modal (rule 1): this is the only
+// method that sets action.pending, and it never calls the ActionProvider
+// itself — nothing mutates until confirm (see updatePendingActionKey).
+// While an action is already running, or a confirmation is already up, the
+// request is ignored (single-flight) rather than queued or replacing what's
+// already shown.
+func (m Model) promptAction(pa pendingAction) Model {
+	if m.action.running || m.action.pending != nil {
+		return m
+	}
+	m.action.pending = &pa
+	return m
+}
+
+// updatePendingActionKey handles every key while a confirmation modal is
+// shown: y/enter confirms (dispatch pa.confirm(), mark running, clear
+// pending — see buildAction's doc comment for why gen/cancel are already
+// established by the time this runs, rather than bumped here); n/esc
+// cancels, leaving every other piece of action/search/screen state
+// untouched and making no ActionProvider call; quit keys still quit (via
+// quitCmd, which also tears down the modal's now-abandoned context); every
+// other key is swallowed so nothing behind the modal can react to it.
+func (m Model) updatePendingActionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, m.keys.Quit):
+		return m, m.quitCmd()
+	case key.Matches(msg, m.keys.ConfirmAction):
+		pa := m.action.pending
+		m.action.pending = nil
+		m.action.running = true
+		return m, pa.confirm()
+	case key.Matches(msg, m.keys.CancelAction):
+		m.action.pending = nil
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+
+// quitCmd cancels any in-flight action and any in-flight search (the #42
+// lifecycle carry-forward: search.cancel was previously never invoked on
+// quit) before returning tea.Quit, so goroutines reading a context derived
+// from either observe cancellation instead of leaking past program exit.
+func (m Model) quitCmd() tea.Cmd {
+	if m.action.cancel != nil {
+		m.action.cancel()
+	}
+	if m.search.cancel != nil {
+		m.search.cancel()
+	}
+	return tea.Quit
+}
+
+// isQuitKey reports whether msg actually triggers tea.Quit given the current
+// focus context: ctrl+c always quits; the rest of Quit's bound keys (a bare
+// "q") only quit outside the focused search input, where "q" is otherwise
+// typed as a literal character (see updateKey's focused-input branch). Used
+// to decide whether a keypress should clear the status line (rule 8: any
+// keypress that isn't a modal response and isn't quit clears it) without
+// wrongly skipping the clear on a "q" that's actually being typed into the
+// search box.
+func (m Model) isQuitKey(msg tea.KeyMsg) bool {
+	if !key.Matches(msg, m.keys.Quit) {
+		return false
+	}
+	if m.screen == ScreenSearch && m.search.input.Focused() {
+		return msg.String() == "ctrl+c"
+	}
+	return true
+}
+
+// clampSelections clamps every screen's selected index to that screen's
+// current list length. A post-action refresh (dataLoadedMsg) can shrink any
+// list out from under whatever row was selected — most notably an uninstall
+// shrinking the mods list — and without this, selected can walk off the end
+// of the list (the Phase 4 #42 selection-drift note this must not
+// reintroduce).
+func (m Model) clampSelections() {
+	for _, screen := range screens {
+		max := m.itemCount(screen) - 1
+		switch {
+		case max < 0:
+			m.selected[screen] = 0
+		case m.selected[screen] > max:
+			m.selected[screen] = max
+		case m.selected[screen] < 0:
+			m.selected[screen] = 0
+		}
+	}
+}
+
+// formatOutcomeStatus renders a completed ActionOutcome as the one-line
+// status text (rule 4): the outcome's own Message, plus its single warning
+// appended after an em dash, or an "(N warnings)" count suffix when there is
+// more than one — chosen so the status line never grows past one line
+// regardless of how many warnings a flow reports.
+func formatOutcomeStatus(outcome ActionOutcome) string {
+	switch len(outcome.Warnings) {
+	case 0:
+		return outcome.Message
+	case 1:
+		return outcome.Message + " — " + outcome.Warnings[0]
+	default:
+		return fmt.Sprintf("%s (%d warnings)", outcome.Message, len(outcome.Warnings))
+	}
+}
+
+// singleLine collapses embedded newlines so a multi-line error (e.g. a
+// joined multi-source failure, or a *domain.DeployError's multi-part text)
+// can never grow the one-row status line past its budget.
+func singleLine(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", " "), "\n", " ")
+}
+
+// statusLine renders the action status line (last mutation's outcome or
+// error) truncated to the terminal's content width — "" when no status is
+// set, matching contentChromeHeight's height-budget accounting: an unset
+// status renders (and occupies) nothing, not a blank row. Truncation
+// happens here, at render time, against the CURRENT availableWidth(), not
+// when the status was set (rule 5): statusLine is called fresh on every
+// View(), so a resize re-truncates the same stored text.
+func (m Model) statusLine() string {
+	if m.action.status == "" {
+		return ""
+	}
+	style := m.theme.MutedText
+	if m.action.statusIsError {
+		style = m.theme.DangerText
+	}
+	return truncate(style.Render(m.action.status), m.availableWidth())
+}
+
+// actionModalView renders the pending confirmation as a bordered panel that
+// REPLACES the screen content (chrome/footer stay unchanged) — the simplest
+// way to preserve the exact-height render invariant every other screen
+// already holds, since an overlay composite would need its own height
+// bookkeeping layered on top of whatever screen it covers.
+func (m Model) actionModalView() string {
+	width := m.availableWidth()
+	height := m.availableContentHeight()
+	panelContentWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
+	panelContentHeight := max(height-m.theme.Panel.GetVerticalBorderSize(), 1)
+
+	pa := m.action.pending
+	lines := []string{truncate(m.theme.PanelTitle.Render(pa.title), panelContentWidth)}
+
+	// Fixed lines: title, blank separator, hint (3 total). Whatever
+	// vertical room remains, capped at actionModalMaxDetailLines, is
+	// available for detail rows — minus one more if a "+N more" line is
+	// needed to name the overflow. Deriving the cap from panelContentHeight
+	// (not just the constant) keeps the exact-height invariant even at
+	// terminal sizes shorter than this modal's normal case.
+	const fixedLines = 3
+	budget := min(actionModalMaxDetailLines, max(panelContentHeight-fixedLines, 0))
+
+	detail := pa.detail
+	if len(detail) > budget {
+		shown := max(budget-1, 0)
+		more := len(detail) - shown
+		for _, d := range detail[:shown] {
+			lines = append(lines, truncate(d, panelContentWidth))
+		}
+		lines = append(lines, m.theme.MutedText.Render(fmt.Sprintf("+%d more", more)))
+	} else {
+		for _, d := range detail {
+			lines = append(lines, truncate(d, panelContentWidth))
+		}
+	}
+
+	lines = append(lines, "", m.theme.MutedText.Render("y/enter confirm · n/esc cancel"))
+
+	return m.panelWithHeight(width, height).Render(strings.Join(lines, "\n"))
+}

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -54,6 +54,12 @@ type actionDoneMsg struct {
 	gen     int
 	kind    actionKind
 	outcome ActionOutcome
+	// switchedTo is set only by the profile-switch action (actionSwitch, via
+	// buildAction's switchedTo parameter - see resolvePlanResult in
+	// mutations.go), naming the profile the switch just applied. Every other
+	// action leaves it "" (the zero value), which app.go's actionDoneMsg
+	// handler treats as "nothing to rebind" - see rebindProfile.
+	switchedTo string
 }
 
 // actionFailedMsg carries a failed action's error, tagged like
@@ -100,7 +106,12 @@ const actionModalMaxDetailLines = 8
 // normal two-step usage) can never corrupt an in-flight action's bookkeeping
 // even if it forgets to check the guard itself — promptAction's own refusal
 // to show the no-op pendingAction is just belt-and-suspenders on top.
-func (m Model) buildAction(kind actionKind, title string, detail []string, do func(context.Context) (ActionOutcome, error)) (Model, pendingAction) {
+//
+// switchedTo is carried verbatim into the eventual actionDoneMsg (see that
+// type's doc comment): every caller except resolvePlanResult's actionSwitch
+// build passes "" here, since only a profile switch has a session-rebind
+// consequence for app.go's actionDoneMsg handler to act on.
+func (m Model) buildAction(kind actionKind, title string, detail []string, switchedTo string, do func(context.Context) (ActionOutcome, error)) (Model, pendingAction) {
 	if m.action.running || m.action.pending != nil {
 		return m, pendingAction{kind: kind, title: title, detail: detail, confirm: func() tea.Cmd { return nil }}
 	}
@@ -123,11 +134,44 @@ func (m Model) buildAction(kind actionKind, title string, detail []string, do fu
 				if err != nil {
 					return actionFailedMsg{gen: gen, kind: kind, err: err}
 				}
-				return actionDoneMsg{gen: gen, kind: kind, outcome: outcome}
+				return actionDoneMsg{gen: gen, kind: kind, outcome: outcome, switchedTo: switchedTo}
 			}
 		},
 	}
 	return m, pa
+}
+
+// profileRebinder is implemented by DataProvider/ActionProvider values that
+// carry a per-session active-profile binding (currently *coreProvider only
+// - see service_core.go's SetProfile), letting a successful TUI-driven
+// profile switch rebind the session without reconstructing the provider.
+// It's deliberately NOT part of the DataProvider/ActionProvider interfaces
+// themselves (both stay frozen at their documented read-only/write-only
+// contracts) - rebindProfile below reaches it via an optional type
+// assertion instead. prototypeProvider does not implement this: its own
+// ApplyProfileSwitch already flips the canned data's Active profile
+// in-place (see actions_provider.go), so a second flip here would
+// double-apply; simply not implementing the interface makes rebindProfile a
+// no-op for it, with no special-casing required.
+type profileRebinder interface {
+	SetProfile(name string)
+}
+
+// rebindProfile rebinds every provider/actions instance that supports it
+// (see profileRebinder) to name. cmd/lmm/tui.go currently wires m.provider
+// and m.actions from two SEPARATE *coreProvider instances - one per
+// NewCoreProvider/NewCoreActions call (see their doc comments in
+// service_core.go) - so both are rebound independently here rather than
+// assuming they're the same pointer; this stays correct even if a future
+// wiring change shares one instance between both fields, since rebinding
+// the same pointer twice is a harmless no-op.
+func (m Model) rebindProfile(name string) {
+	if rb, ok := m.provider.(profileRebinder); ok {
+		rb.SetProfile(name)
+	}
+	if rb, ok := m.actions.(profileRebinder); ok {
+		rb.SetProfile(name)
+	}
 }
 
 // promptAction shows pa as the confirmation modal (rule 1): this is the only

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
 )
 
 // ActionProvider is the write-side seam over the core mutation flows
@@ -84,10 +86,11 @@ func mergeDiagnostics(warnings, notes []string) []string {
 // adjust Stats.Enabled/Installed accordingly; DeployProfile and the profile
 // switch pair report plausible, data-derived Outcomes. PlanProfileSwitch's
 // diff is fake but consistent - it never invents a phantom ToInstall entry
-// (there is no real "mod exists on some source but isn't cached" concept in
-// canned data), so ApplyProfileSwitch's NeedsDownloads refusal exists here
-// purely for interface-contract parity with coreProvider and is not
-// exercised by the prototype's own deterministic planner.
+// out of thin air; the ONE exception is prototype.NeedsDownloadProfileName,
+// a canned profile whose Mods list deliberately references an ID absent
+// from InstalledMods (see prototype/data.go) so --prototype mode can demo
+// ApplyProfileSwitch's NeedsDownloads refusal end to end. Every other
+// canned profile leaves Mods unset and is unaffected.
 
 // findInstalledIndex returns the index of the InstalledMods entry matching
 // (sourceID, id), or -1 if none matches.
@@ -162,28 +165,56 @@ func (p *prototypeProvider) activeProfileName() string {
 	return p.data.Profile.Name
 }
 
-func (p *prototypeProvider) profileExists(name string) bool {
+// findProfile returns the canned Profiles entry named name, or false if
+// none matches.
+func (p *prototypeProvider) findProfile(name string) (prototype.Profile, bool) {
 	for _, pr := range p.data.Profiles {
 		if pr.Name == name {
-			return true
+			return pr, true
 		}
 	}
-	return false
+	return prototype.Profile{}, false
+}
+
+// needsDownloads reports, for each ID in profile.Mods, whether it names an
+// InstalledMods entry - and returns a NeedsDownloads-shaped entry for every
+// one that doesn't. All canned mods use source "nexusmods" (see
+// prototype/data.go), so that source is hardcoded here; this is demo-only
+// plumbing, not a general (source, id) reference. Every profile except
+// prototype.NeedsDownloadProfileName leaves Mods unset, so this returns nil
+// for them - the alternating Enable/Disable plan below is unaffected.
+func (p *prototypeProvider) needsDownloads(profile prototype.Profile) []string {
+	var needs []string
+	for _, id := range profile.Mods {
+		if p.findInstalledIndex("nexusmods", id) < 0 {
+			needs = append(needs, fmt.Sprintf("nexusmods:%s v1.0", id))
+		}
+	}
+	return needs
 }
 
 // PlanProfileSwitch computes a fake-but-consistent plan from prototype
 // data: alternating InstalledMods entries (by index) toggle between the two
 // buckets, giving a plausible, deterministic, non-empty mix of Enable/
-// Disable for any target profile other than the active one. See this file's
-// package doc comment on why NeedsDownloads is always empty here.
+// Disable for any target profile other than the active one. The one
+// exception is prototype.NeedsDownloadProfileName (see needsDownloads and
+// this file's package doc comment), which short-circuits straight to a
+// NeedsDownloads-only plan instead - ApplyProfileSwitch refuses on that
+// alone, so there's no need to also compute a bucket split that could never
+// be applied.
 func (p *prototypeProvider) PlanProfileSwitch(_ context.Context, profileName string) (SwitchPlanView, error) {
-	if !p.profileExists(profileName) {
+	target, ok := p.findProfile(profileName)
+	if !ok {
 		return SwitchPlanView{}, fmt.Errorf("profile not found: %s", profileName)
 	}
 
 	current := p.activeProfileName()
 	if profileName == current {
 		return SwitchPlanView{From: current, To: profileName, AlreadyActive: true}, nil
+	}
+
+	if needs := p.needsDownloads(target); len(needs) > 0 {
+		return SwitchPlanView{From: current, To: profileName, NeedsDownloads: needs}, nil
 	}
 
 	var enable, disable []string
@@ -206,10 +237,10 @@ func (p *prototypeProvider) PlanProfileSwitch(_ context.Context, profileName str
 	}, nil
 }
 
-// ApplyProfileSwitch re-plans and applies, refusing (mirroring coreProvider,
-// for interface-contract parity - see this file's package doc comment on
-// why this branch is unreachable via the prototype's own planner today) if
-// the fresh plan has NeedsDownloads entries.
+// ApplyProfileSwitch re-plans and applies, refusing (mirroring coreProvider)
+// if the fresh plan has NeedsDownloads entries - reachable via the
+// prototype's own planner for prototype.NeedsDownloadProfileName (see this
+// file's package doc comment).
 func (p *prototypeProvider) ApplyProfileSwitch(ctx context.Context, profileName string) (ActionOutcome, error) {
 	view, err := p.PlanProfileSwitch(ctx, profileName)
 	if err != nil {

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -1,0 +1,243 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ActionProvider is the write-side seam over the core mutation flows
+// (Service.EnableMod/DisableMod/UninstallMod/DeployProfile/
+// PlanProfileSwitch/ApplyProfileSwitch). It is deliberately separate from
+// DataProvider: DataProvider stays provably read-only (nothing in its
+// interface can mutate app state), and implementations of one need not
+// implement the other - though coreProvider and prototypeProvider both do,
+// each on its own single struct (see NewCoreActions and NewPrototypeProvider
+// for how a caller obtains each role).
+//
+// Every method that returns an error must not mutate anything: EnableMod/
+// DisableMod/UninstallMod/DeployProfile propagate the underlying flow's own
+// error-path guarantees, and ApplyProfileSwitch's own NeedsDownloads refusal
+// (see its doc comment) is checked before any mutation is attempted.
+type ActionProvider interface {
+	EnableMod(ctx context.Context, item ModItem) (ActionOutcome, error)
+	DisableMod(ctx context.Context, item ModItem) (ActionOutcome, error)
+	UninstallMod(ctx context.Context, item ModItem) (ActionOutcome, error)
+	DeployProfile(ctx context.Context) (ActionOutcome, error)
+	PlanProfileSwitch(ctx context.Context, profile string) (SwitchPlanView, error)
+	ApplyProfileSwitch(ctx context.Context, profile string) (ActionOutcome, error)
+}
+
+// ActionOutcome is what the TUI status line renders after a successful
+// ActionProvider call. Message and each Warnings entry are TUI-facing
+// English composed by the provider (not core, which never prints or
+// formats for a specific caller) and are expected to be truncated to panel
+// width by the renderer - keep them short and specific.
+type ActionOutcome struct {
+	Message  string   // one-line success summary, e.g. `Enabled "SkyUI"` / "Deployed 5 mod(s)"
+	Warnings []string // non-fatal diagnostics: the underlying flow result's Warnings then Notes, in that order
+}
+
+// SwitchPlanView is the render model for the profile-switch confirmation
+// modal, mapped from core.SwitchPlan (see coreProvider's switchPlanView) or
+// computed directly from prototype demo data.
+type SwitchPlanView struct {
+	From, To       string
+	Enable         []string // mod names to enable
+	Disable        []string // mod names to disable
+	NeedsDownloads []string // mod refs requiring download - 5a refuses to ApplyProfileSwitch a plan with any of these (see ApplyProfileSwitch's doc comment); Plan itself never refuses, so a modal can still explain why
+	NoChanges      bool
+	AlreadyActive  bool
+}
+
+// errProfileNeedsDownloads is ApplyProfileSwitch's exact refusal error (see
+// its doc comment on coreProvider and the prototype implementation below):
+// 5a's TUI has no download/install path yet, so a plan that would require
+// one is refused outright rather than silently doing less than the CLI.
+var errProfileNeedsDownloads = errors.New("profile needs downloads — use 'lmm profile switch' until TUI install ships")
+
+// mergeDiagnostics composes an ActionOutcome.Warnings slice from a flow
+// result's own Warnings and Notes fields, in that order - the contract
+// documented on ActionOutcome.Warnings. Returns nil (not an empty slice)
+// when both inputs are empty, matching every other TUI DataProvider
+// method's "no diagnostics" convention.
+func mergeDiagnostics(warnings, notes []string) []string {
+	if len(warnings) == 0 && len(notes) == 0 {
+		return nil
+	}
+	merged := make([]string, 0, len(warnings)+len(notes))
+	merged = append(merged, warnings...)
+	merged = append(merged, notes...)
+	return merged
+}
+
+// --- prototypeProvider: ActionProvider ---
+//
+// Simulated and side-effect-free outside prototypeProvider's own in-memory
+// data field (see service.go's DataProvider methods on the same type):
+// EnableMod/DisableMod/UninstallMod flip or remove InstalledMods entries and
+// adjust Stats.Enabled/Installed accordingly; DeployProfile and the profile
+// switch pair report plausible, data-derived Outcomes. PlanProfileSwitch's
+// diff is fake but consistent - it never invents a phantom ToInstall entry
+// (there is no real "mod exists on some source but isn't cached" concept in
+// canned data), so ApplyProfileSwitch's NeedsDownloads refusal exists here
+// purely for interface-contract parity with coreProvider and is not
+// exercised by the prototype's own deterministic planner.
+
+// findInstalledIndex returns the index of the InstalledMods entry matching
+// (sourceID, id), or -1 if none matches.
+func (p *prototypeProvider) findInstalledIndex(sourceID, id string) int {
+	for i, mod := range p.data.InstalledMods {
+		if mod.Source == sourceID && mod.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p *prototypeProvider) EnableMod(_ context.Context, item ModItem) (ActionOutcome, error) {
+	idx := p.findInstalledIndex(item.Source, item.ID)
+	if idx < 0 {
+		return ActionOutcome{}, fmt.Errorf("mod not found: %s", item.ID)
+	}
+	if p.data.InstalledMods[idx].Status != "disabled" {
+		return ActionOutcome{Message: fmt.Sprintf("%q is already enabled", item.Name)}, nil
+	}
+	p.data.InstalledMods[idx].Status = "installed"
+	p.data.Stats.Enabled++
+	return ActionOutcome{Message: fmt.Sprintf("Enabled %q", item.Name)}, nil
+}
+
+func (p *prototypeProvider) DisableMod(_ context.Context, item ModItem) (ActionOutcome, error) {
+	idx := p.findInstalledIndex(item.Source, item.ID)
+	if idx < 0 {
+		return ActionOutcome{}, fmt.Errorf("mod not found: %s", item.ID)
+	}
+	if p.data.InstalledMods[idx].Status == "disabled" {
+		return ActionOutcome{Message: fmt.Sprintf("%q is already disabled", item.Name)}, nil
+	}
+	p.data.InstalledMods[idx].Status = "disabled"
+	p.data.Stats.Enabled--
+	return ActionOutcome{Message: fmt.Sprintf("Disabled %q", item.Name)}, nil
+}
+
+func (p *prototypeProvider) UninstallMod(_ context.Context, item ModItem) (ActionOutcome, error) {
+	idx := p.findInstalledIndex(item.Source, item.ID)
+	if idx < 0 {
+		return ActionOutcome{}, fmt.Errorf("mod not found: %s", item.ID)
+	}
+	wasEnabled := p.data.InstalledMods[idx].Status != "disabled"
+	p.data.InstalledMods = append(p.data.InstalledMods[:idx], p.data.InstalledMods[idx+1:]...)
+	p.data.Stats.Installed--
+	if wasEnabled {
+		p.data.Stats.Enabled--
+	}
+	return ActionOutcome{Message: fmt.Sprintf("Uninstalled %q", item.Name)}, nil
+}
+
+func (p *prototypeProvider) DeployProfile(_ context.Context) (ActionOutcome, error) {
+	deployed := 0
+	for _, mod := range p.data.InstalledMods {
+		if mod.Status != "disabled" {
+			deployed++
+		}
+	}
+	return ActionOutcome{Message: fmt.Sprintf("Deployed %d mod(s)", deployed)}, nil
+}
+
+// activeProfileName returns the canned Profiles entry currently marked
+// Active, falling back to data.Profile.Name (kept in sync by
+// ApplyProfileSwitch) if none is marked.
+func (p *prototypeProvider) activeProfileName() string {
+	for _, pr := range p.data.Profiles {
+		if pr.Active {
+			return pr.Name
+		}
+	}
+	return p.data.Profile.Name
+}
+
+func (p *prototypeProvider) profileExists(name string) bool {
+	for _, pr := range p.data.Profiles {
+		if pr.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// PlanProfileSwitch computes a fake-but-consistent plan from prototype
+// data: alternating InstalledMods entries (by index) toggle between the two
+// buckets, giving a plausible, deterministic, non-empty mix of Enable/
+// Disable for any target profile other than the active one. See this file's
+// package doc comment on why NeedsDownloads is always empty here.
+func (p *prototypeProvider) PlanProfileSwitch(_ context.Context, profileName string) (SwitchPlanView, error) {
+	if !p.profileExists(profileName) {
+		return SwitchPlanView{}, fmt.Errorf("profile not found: %s", profileName)
+	}
+
+	current := p.activeProfileName()
+	if profileName == current {
+		return SwitchPlanView{From: current, To: profileName, AlreadyActive: true}, nil
+	}
+
+	var enable, disable []string
+	for i, mod := range p.data.InstalledMods {
+		if i%2 == 0 {
+			if mod.Status == "disabled" {
+				enable = append(enable, mod.Name)
+			}
+		} else if mod.Status != "disabled" {
+			disable = append(disable, mod.Name)
+		}
+	}
+
+	return SwitchPlanView{
+		From:      current,
+		To:        profileName,
+		Enable:    enable,
+		Disable:   disable,
+		NoChanges: len(enable) == 0 && len(disable) == 0,
+	}, nil
+}
+
+// ApplyProfileSwitch re-plans and applies, refusing (mirroring coreProvider,
+// for interface-contract parity - see this file's package doc comment on
+// why this branch is unreachable via the prototype's own planner today) if
+// the fresh plan has NeedsDownloads entries.
+func (p *prototypeProvider) ApplyProfileSwitch(ctx context.Context, profileName string) (ActionOutcome, error) {
+	view, err := p.PlanProfileSwitch(ctx, profileName)
+	if err != nil {
+		return ActionOutcome{}, err
+	}
+	if view.AlreadyActive {
+		return ActionOutcome{Message: fmt.Sprintf("Already on profile %q", profileName)}, nil
+	}
+	if len(view.NeedsDownloads) > 0 {
+		return ActionOutcome{}, errProfileNeedsDownloads
+	}
+
+	enable := make(map[string]bool, len(view.Enable))
+	for _, name := range view.Enable {
+		enable[name] = true
+	}
+	disable := make(map[string]bool, len(view.Disable))
+	for _, name := range view.Disable {
+		disable[name] = true
+	}
+	for i := range p.data.InstalledMods {
+		switch name := p.data.InstalledMods[i].Name; {
+		case enable[name]:
+			p.data.InstalledMods[i].Status = "installed"
+		case disable[name]:
+			p.data.InstalledMods[i].Status = "disabled"
+		}
+	}
+
+	for i := range p.data.Profiles {
+		p.data.Profiles[i].Active = p.data.Profiles[i].Name == profileName
+	}
+	p.data.Profile.Name = profileName
+
+	return ActionOutcome{Message: fmt.Sprintf("Switched to %q", profileName)}, nil
+}

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -15,10 +15,15 @@ import (
 // each on its own single struct (see NewCoreActions and NewPrototypeProvider
 // for how a caller obtains each role).
 //
-// Every method that returns an error must not mutate anything: EnableMod/
-// DisableMod/UninstallMod/DeployProfile propagate the underlying flow's own
-// error-path guarantees, and ApplyProfileSwitch's own NeedsDownloads refusal
-// (see its doc comment) is checked before any mutation is attempted.
+// Error semantics: an error does NOT imply nothing changed. The underlying
+// flows are multi-step (deploy files then flip DB state; undeploy, delete
+// cache, then delete the DB row; whole per-mod loops before SetDefault); a
+// failure partway leaves earlier steps applied. Callers must treat any error
+// as "state may have partially changed": refresh data after every action,
+// success or failure, and never offer undo/retry affordances that assume a
+// failed action was a no-op. PlanProfileSwitch is the exception: planning is
+// pure and never mutates. ApplyProfileSwitch's NeedsDownloads refusal is
+// also mutation-free (it refuses before executing).
 type ActionProvider interface {
 	EnableMod(ctx context.Context, item ModItem) (ActionOutcome, error)
 	DisableMod(ctx context.Context, item ModItem) (ActionOutcome, error)

--- a/internal/tui/actions_provider_test.go
+++ b/internal/tui/actions_provider_test.go
@@ -1,0 +1,287 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- prototypeProvider: ActionProvider ---
+
+// TestPrototypeProviderImplementsActionProvider guards the design decision
+// that a single *prototypeProvider instance satisfies both DataProvider and
+// ActionProvider: NewPrototypeProvider's static return type stays
+// DataProvider (unchanged, so no existing callers break), but the
+// underlying concrete value can be type-asserted to ActionProvider so a
+// caller (Task 6/7's --prototype wiring) can drive both roles from ONE
+// instance and see actions reflected in subsequent reads - see the actions
+// tests below, which rely on exactly this.
+func TestPrototypeProviderImplementsActionProvider(t *testing.T) {
+	t.Parallel()
+
+	_, ok := NewPrototypeProvider().(ActionProvider)
+	require.True(t, ok, "prototypeProvider must implement ActionProvider so a single instance can serve both roles")
+}
+
+func TestPrototypeProviderActions_EnableMod_FlipsStatusVisibleInRepeatedOverview(t *testing.T) {
+	t.Parallel()
+
+	provider := NewPrototypeProvider()
+	actions := provider.(ActionProvider)
+
+	outcome, err := actions.EnableMod(context.Background(), ModItem{ID: "alternate-start", Source: "nexusmods", Name: "Alternate Start"})
+	require.NoError(t, err)
+	assert.Equal(t, `Enabled "Alternate Start"`, outcome.Message)
+
+	_, mods, err := provider.Overview(context.Background())
+	require.NoError(t, err)
+	item := requireModByID(t, mods, "alternate-start")
+	assert.NotEqual(t, "disabled", item.Status, "the SAME provider instance must reflect the enable on the next Overview call")
+}
+
+func TestPrototypeProviderActions_EnableMod_AlreadyEnabledMessage(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	outcome, err := actions.EnableMod(context.Background(), ModItem{ID: "skyui", Source: "nexusmods", Name: "SkyUI"})
+	require.NoError(t, err)
+	assert.Equal(t, `"SkyUI" is already enabled`, outcome.Message)
+}
+
+func TestPrototypeProviderActions_DisableMod_FlipsStatusVisibleInRepeatedOverview(t *testing.T) {
+	t.Parallel()
+
+	provider := NewPrototypeProvider()
+	actions := provider.(ActionProvider)
+
+	outcome, err := actions.DisableMod(context.Background(), ModItem{ID: "skyui", Source: "nexusmods", Name: "SkyUI"})
+	require.NoError(t, err)
+	assert.Equal(t, `Disabled "SkyUI"`, outcome.Message)
+
+	_, mods, err := provider.Overview(context.Background())
+	require.NoError(t, err)
+	item := requireModByID(t, mods, "skyui")
+	assert.Equal(t, "disabled", item.Status)
+}
+
+func TestPrototypeProviderActions_DisableMod_AlreadyDisabledMessage(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	outcome, err := actions.DisableMod(context.Background(), ModItem{ID: "alternate-start", Source: "nexusmods", Name: "Alternate Start"})
+	require.NoError(t, err)
+	assert.Equal(t, `"Alternate Start" is already disabled`, outcome.Message)
+}
+
+func TestPrototypeProviderActions_UninstallMod_RemovesFromRepeatedOverview(t *testing.T) {
+	t.Parallel()
+
+	provider := NewPrototypeProvider()
+	actions := provider.(ActionProvider)
+
+	_, before, err := provider.Overview(context.Background())
+	require.NoError(t, err)
+
+	outcome, err := actions.UninstallMod(context.Background(), ModItem{ID: "skyui", Source: "nexusmods", Name: "SkyUI"})
+	require.NoError(t, err)
+	assert.Equal(t, `Uninstalled "SkyUI"`, outcome.Message)
+
+	_, after, err := provider.Overview(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, after, len(before)-1)
+	for _, m := range after {
+		assert.NotEqual(t, "skyui", m.ID, "an uninstalled mod must be gone from a repeated Overview")
+	}
+}
+
+func TestPrototypeProviderActions_UnknownModErrors(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+	unknown := ModItem{ID: "does-not-exist", Source: "nexusmods", Name: "Nope"}
+
+	_, err := actions.EnableMod(context.Background(), unknown)
+	assert.Error(t, err)
+	_, err = actions.DisableMod(context.Background(), unknown)
+	assert.Error(t, err)
+	_, err = actions.UninstallMod(context.Background(), unknown)
+	assert.Error(t, err)
+}
+
+func TestPrototypeProviderActions_DeployProfile_ReturnsPlausibleOutcome(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	outcome, err := actions.DeployProfile(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, outcome.Message)
+}
+
+func TestPrototypeProviderActions_PlanProfileSwitch_ComputesFakeConsistentPlan(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	view, err := actions.PlanProfileSwitch(context.Background(), "vanilla-plus")
+	require.NoError(t, err)
+	assert.Equal(t, "survival", view.From)
+	assert.Equal(t, "vanilla-plus", view.To)
+	assert.False(t, view.AlreadyActive)
+	assert.Empty(t, view.NeedsDownloads, "the prototype never invents phantom downloads")
+}
+
+func TestPrototypeProviderActions_PlanProfileSwitch_AlreadyActive(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	view, err := actions.PlanProfileSwitch(context.Background(), "survival")
+	require.NoError(t, err)
+	assert.True(t, view.AlreadyActive)
+	assert.Equal(t, "survival", view.From)
+	assert.Equal(t, "survival", view.To)
+}
+
+func TestPrototypeProviderActions_PlanProfileSwitch_UnknownProfileErrors(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	_, err := actions.PlanProfileSwitch(context.Background(), "does-not-exist")
+	assert.Error(t, err)
+}
+
+func TestPrototypeProviderActions_ApplyProfileSwitch_UpdatesActiveProfileVisibleInProfiles(t *testing.T) {
+	t.Parallel()
+
+	provider := NewPrototypeProvider()
+	actions := provider.(ActionProvider)
+
+	outcome, err := actions.ApplyProfileSwitch(context.Background(), "vanilla-plus")
+	require.NoError(t, err)
+	assert.Equal(t, `Switched to "vanilla-plus"`, outcome.Message)
+
+	profiles, err := provider.Profiles(context.Background())
+	require.NoError(t, err)
+	byName := map[string]ProfileItem{}
+	for _, p := range profiles {
+		byName[p.Name] = p
+	}
+	assert.True(t, byName["vanilla-plus"].Active, "the SAME provider instance must reflect the switch")
+	assert.False(t, byName["survival"].Active)
+}
+
+func TestPrototypeProviderActions_ApplyProfileSwitch_AlreadyActive(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	outcome, err := actions.ApplyProfileSwitch(context.Background(), "survival")
+	require.NoError(t, err)
+	assert.Equal(t, `Already on profile "survival"`, outcome.Message)
+}
+
+func TestPrototypeProviderActions_ApplyProfileSwitch_UnknownProfileErrors(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	_, err := actions.ApplyProfileSwitch(context.Background(), "does-not-exist")
+	assert.Error(t, err)
+}
+
+func requireModByID(t *testing.T, mods []ModItem, id string) ModItem {
+	t.Helper()
+	for _, m := range mods {
+		if m.ID == id {
+			return m
+		}
+	}
+	t.Fatalf("mod %q not found in %+v", id, mods)
+	return ModItem{}
+}
+
+// --- Test fakes for Tasks 6-7 ---
+
+func TestRecordingActionsRecordsCallsAndReturnsConfiguredOutcomes(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{
+		EnableOutcome:    ActionOutcome{Message: "enabled"},
+		DisableOutcome:   ActionOutcome{Message: "disabled"},
+		UninstallOutcome: ActionOutcome{Message: "uninstalled"},
+		DeployOutcome:    ActionOutcome{Message: "deployed"},
+		ApplyOutcome:     ActionOutcome{Message: "applied"},
+		PlanView:         SwitchPlanView{From: "a", To: "b"},
+	}
+
+	item := ModItem{ID: "1", Source: "src", Name: "Test"}
+	ctx := context.Background()
+
+	enableOutcome, err := rec.EnableMod(ctx, item)
+	require.NoError(t, err)
+	assert.Equal(t, "enabled", enableOutcome.Message)
+
+	disableOutcome, err := rec.DisableMod(ctx, item)
+	require.NoError(t, err)
+	assert.Equal(t, "disabled", disableOutcome.Message)
+
+	uninstallOutcome, err := rec.UninstallMod(ctx, item)
+	require.NoError(t, err)
+	assert.Equal(t, "uninstalled", uninstallOutcome.Message)
+
+	deployOutcome, err := rec.DeployProfile(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "deployed", deployOutcome.Message)
+
+	view, err := rec.PlanProfileSwitch(ctx, "target")
+	require.NoError(t, err)
+	assert.Equal(t, "a", view.From)
+
+	applyOutcome, err := rec.ApplyProfileSwitch(ctx, "target")
+	require.NoError(t, err)
+	assert.Equal(t, "applied", applyOutcome.Message)
+
+	assert.Equal(t, []ModItem{item}, rec.EnableCalls)
+	assert.Equal(t, []ModItem{item}, rec.DisableCalls)
+	assert.Equal(t, []ModItem{item}, rec.UninstallCalls)
+	assert.Equal(t, 1, rec.DeployCalls)
+	assert.Equal(t, []string{"target"}, rec.PlanCalls)
+	assert.Equal(t, []string{"target"}, rec.ApplyCalls)
+}
+
+func TestFailingActionsErrorsOnEveryMethod(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	f := failingActions{Err: sentinel}
+	item := ModItem{ID: "1", Source: "src", Name: "Test"}
+	ctx := context.Background()
+
+	_, err := f.EnableMod(ctx, item)
+	assert.ErrorIs(t, err, sentinel)
+	_, err = f.DisableMod(ctx, item)
+	assert.ErrorIs(t, err, sentinel)
+	_, err = f.UninstallMod(ctx, item)
+	assert.ErrorIs(t, err, sentinel)
+	_, err = f.DeployProfile(ctx)
+	assert.ErrorIs(t, err, sentinel)
+	_, err = f.PlanProfileSwitch(ctx, "target")
+	assert.ErrorIs(t, err, sentinel)
+	_, err = f.ApplyProfileSwitch(ctx, "target")
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestFailingActionsDefaultsToGenericErrorWhenUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	f := failingActions{}
+	_, err := f.EnableMod(context.Background(), ModItem{})
+	require.Error(t, err)
+}

--- a/internal/tui/actions_provider_test.go
+++ b/internal/tui/actions_provider_test.go
@@ -209,6 +209,94 @@ func requireModByID(t *testing.T, mods []ModItem, id string) ModItem {
 
 // --- Test fakes for Tasks 6-7 ---
 
+// recordingActions implements ActionProvider, recording every call's
+// arguments and returning caller-configured outcomes/errors - for Tasks 6-7
+// to verify keybinding/modal wiring calls the right method with the right
+// arguments, without needing a real core.Service or the prototype dataset.
+// Mirrors app_test.go's recordingProvider (the equivalent DataProvider
+// fake), one field set per method rather than a single delegate+hook, since
+// ActionProvider callers need to configure a distinct outcome per method.
+type recordingActions struct {
+	EnableCalls    []ModItem
+	DisableCalls   []ModItem
+	UninstallCalls []ModItem
+	DeployCalls    int
+	PlanCalls      []string
+	ApplyCalls     []string
+
+	EnableOutcome, DisableOutcome, UninstallOutcome, DeployOutcome, ApplyOutcome ActionOutcome
+	PlanView                                                                     SwitchPlanView
+
+	EnableErr, DisableErr, UninstallErr, DeployErr, PlanErr, ApplyErr error
+}
+
+func (r *recordingActions) EnableMod(_ context.Context, item ModItem) (ActionOutcome, error) {
+	r.EnableCalls = append(r.EnableCalls, item)
+	return r.EnableOutcome, r.EnableErr
+}
+
+func (r *recordingActions) DisableMod(_ context.Context, item ModItem) (ActionOutcome, error) {
+	r.DisableCalls = append(r.DisableCalls, item)
+	return r.DisableOutcome, r.DisableErr
+}
+
+func (r *recordingActions) UninstallMod(_ context.Context, item ModItem) (ActionOutcome, error) {
+	r.UninstallCalls = append(r.UninstallCalls, item)
+	return r.UninstallOutcome, r.UninstallErr
+}
+
+func (r *recordingActions) DeployProfile(_ context.Context) (ActionOutcome, error) {
+	r.DeployCalls++
+	return r.DeployOutcome, r.DeployErr
+}
+
+func (r *recordingActions) PlanProfileSwitch(_ context.Context, profile string) (SwitchPlanView, error) {
+	r.PlanCalls = append(r.PlanCalls, profile)
+	return r.PlanView, r.PlanErr
+}
+
+func (r *recordingActions) ApplyProfileSwitch(_ context.Context, profile string) (ActionOutcome, error) {
+	r.ApplyCalls = append(r.ApplyCalls, profile)
+	return r.ApplyOutcome, r.ApplyErr
+}
+
+// failingActions implements ActionProvider with every method returning a
+// fixed error (Err, or a generic one if Err is unset) - for Tasks 6-7 to
+// verify error-path UI (status line rendering, modal dismissal) without
+// per-test stubbing.
+type failingActions struct{ Err error }
+
+func (f failingActions) err() error {
+	if f.Err != nil {
+		return f.Err
+	}
+	return errors.New("failingActions: forced failure")
+}
+
+func (f failingActions) EnableMod(context.Context, ModItem) (ActionOutcome, error) {
+	return ActionOutcome{}, f.err()
+}
+
+func (f failingActions) DisableMod(context.Context, ModItem) (ActionOutcome, error) {
+	return ActionOutcome{}, f.err()
+}
+
+func (f failingActions) UninstallMod(context.Context, ModItem) (ActionOutcome, error) {
+	return ActionOutcome{}, f.err()
+}
+
+func (f failingActions) DeployProfile(context.Context) (ActionOutcome, error) {
+	return ActionOutcome{}, f.err()
+}
+
+func (f failingActions) PlanProfileSwitch(context.Context, string) (SwitchPlanView, error) {
+	return SwitchPlanView{}, f.err()
+}
+
+func (f failingActions) ApplyProfileSwitch(context.Context, string) (ActionOutcome, error) {
+	return ActionOutcome{}, f.err()
+}
+
 func TestRecordingActionsRecordsCallsAndReturnsConfiguredOutcomes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/actions_provider_test.go
+++ b/internal/tui/actions_provider_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
 )
 
 // --- prototypeProvider: ActionProvider ---
@@ -146,6 +148,37 @@ func TestPrototypeProviderActions_PlanProfileSwitch_AlreadyActive(t *testing.T) 
 	assert.True(t, view.AlreadyActive)
 	assert.Equal(t, "survival", view.From)
 	assert.Equal(t, "survival", view.To)
+}
+
+// TestPrototypeProviderActions_PlanProfileSwitch_NeedsDownloadsCannedScenario
+// guards the Task 7 mandated prototype data addition: the one canned
+// profile whose Mods list references an ID absent from InstalledMods
+// (prototype.NeedsDownloadProfileName) must produce a NeedsDownloads plan,
+// unlike every other canned profile (see the "vanilla-plus" test above,
+// which asserts the opposite for the general case).
+func TestPrototypeProviderActions_PlanProfileSwitch_NeedsDownloadsCannedScenario(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	view, err := actions.PlanProfileSwitch(context.Background(), prototype.NeedsDownloadProfileName)
+	require.NoError(t, err)
+	assert.Equal(t, "survival", view.From)
+	assert.Equal(t, prototype.NeedsDownloadProfileName, view.To)
+	assert.False(t, view.AlreadyActive)
+	assert.NotEmpty(t, view.NeedsDownloads)
+}
+
+// TestPrototypeProviderActions_ApplyProfileSwitch_RefusesNeedsDownloadsCannedScenario
+// proves the refusal is enforced at Apply time too, mirroring
+// coreProvider's own NeedsDownloads refusal test.
+func TestPrototypeProviderActions_ApplyProfileSwitch_RefusesNeedsDownloadsCannedScenario(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	_, err := actions.ApplyProfileSwitch(context.Background(), prototype.NeedsDownloadProfileName)
+	require.ErrorIs(t, err, errProfileNeedsDownloads)
 }
 
 func TestPrototypeProviderActions_PlanProfileSwitch_UnknownProfileErrors(t *testing.T) {

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -88,6 +88,40 @@ func TestConfirmKeysDispatchActionAndClearPending(t *testing.T) {
 	}
 }
 
+func TestConfirmClosureMapsProviderErrorToActionFailedMsg(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("provider error: deployment failed")
+	failing := failingActions{Err: sentinel}
+	model := modelWithActions(t, failing)
+	item := ModItem{ID: "skyui", Source: "nexusmods", Name: "SkyUI"}
+
+	// buildAction increments gen and captures it in the closure
+	model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, nil,
+		func(ctx context.Context) (ActionOutcome, error) { return failing.UninstallMod(ctx, item) })
+
+	genAtBuild := model.action.gen
+	model = model.promptAction(pa)
+
+	// Confirm via key, which dispatches pa.confirm() and sets running
+	updated, cmd := model.Update(keyRunes("y"))
+	model = updated.(Model)
+
+	require.Nil(t, model.action.pending, "pending must clear on confirm")
+	require.True(t, model.action.running, "running must be set on confirm")
+	require.NotNil(t, cmd)
+
+	// Run the cmd to trigger the provider call and error path
+	msg := cmd()
+
+	// Assert the error branch maps to actionFailedMsg correctly
+	require.IsType(t, actionFailedMsg{}, msg, "provider error must produce actionFailedMsg")
+	failedMsg := msg.(actionFailedMsg)
+	require.Equal(t, genAtBuild, failedMsg.gen, "actionFailedMsg must carry the gen from buildAction")
+	require.Equal(t, actionUninstall, failedMsg.kind, "actionFailedMsg must carry the action kind")
+	require.Equal(t, sentinel, failedMsg.err, "actionFailedMsg must carry the provider's error")
+}
+
 func TestCancelKeysLeaveStateUntouched(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -1,0 +1,512 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+// modelWithActions builds a fully-loaded Model (data ready) backed by the
+// prototype DataProvider but with actions as its ActionProvider. This
+// isolates action-machinery tests from data-loading concerns, mirroring
+// recordingActions/failingActions' own doc comment on why they exist
+// independent of any specific DataProvider dataset.
+func modelWithActions(t *testing.T, actions ActionProvider) Model {
+	t.Helper()
+	model, err := NewModel(Options{Theme: "wizardry", Provider: NewPrototypeProvider(), Actions: actions})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	return loaded.(Model)
+}
+
+func sizedModelWithActions(t *testing.T, actions ActionProvider, width, height int) Model {
+	t.Helper()
+	model := modelWithActions(t, actions)
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	return updated.(Model)
+}
+
+// --- Rule 1: promptAction shows the modal; nothing mutates before confirm ---
+
+func TestPromptActionShowsModalWithoutMutating(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	item := ModItem{ID: "skyui", Source: "nexusmods", Name: "SkyUI"}
+
+	model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, []string{"Removes SkyUI from the active profile."},
+		func(ctx context.Context) (ActionOutcome, error) { return rec.UninstallMod(ctx, item) })
+	model = model.promptAction(pa)
+
+	require.NotNil(t, model.action.pending)
+	require.Contains(t, model.screenView(), `Uninstall "SkyUI"?`)
+	require.Empty(t, rec.UninstallCalls, "nothing must mutate before confirm")
+}
+
+// --- Rule 2: pending-modal key interception ---
+
+func TestConfirmKeysDispatchActionAndClearPending(t *testing.T) {
+	t.Parallel()
+
+	for _, k := range []string{"y", "enter"} {
+		t.Run(k, func(t *testing.T) {
+			t.Parallel()
+
+			rec := &recordingActions{UninstallOutcome: ActionOutcome{Message: `Uninstalled "SkyUI"`}}
+			model := modelWithActions(t, rec)
+			item := ModItem{ID: "skyui", Source: "nexusmods", Name: "SkyUI"}
+			model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, nil,
+				func(ctx context.Context) (ActionOutcome, error) { return rec.UninstallMod(ctx, item) })
+			model = model.promptAction(pa)
+
+			var updated tea.Model
+			var cmd tea.Cmd
+			if k == "enter" {
+				updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			} else {
+				updated, cmd = model.Update(keyRunes(k))
+			}
+			model = updated.(Model)
+
+			require.Nil(t, model.action.pending, "pending must clear on confirm")
+			require.True(t, model.action.running, "running must be set on confirm")
+			require.NotNil(t, cmd)
+			require.Empty(t, rec.UninstallCalls, "the provider call happens when the returned cmd runs, not synchronously in Update")
+
+			msg := cmd()
+			require.IsType(t, actionDoneMsg{}, msg)
+			require.Len(t, rec.UninstallCalls, 1)
+			require.Equal(t, item, rec.UninstallCalls[0])
+		})
+	}
+}
+
+func TestCancelKeysLeaveStateUntouched(t *testing.T) {
+	t.Parallel()
+
+	for _, k := range []string{"n", "esc"} {
+		t.Run(k, func(t *testing.T) {
+			t.Parallel()
+
+			rec := &recordingActions{}
+			model := modelWithActions(t, rec)
+			model, pa := model.buildAction(actionDeploy, "Deploy?", nil,
+				func(ctx context.Context) (ActionOutcome, error) { return rec.DeployProfile(ctx) })
+			model = model.promptAction(pa)
+			genBefore := model.action.gen
+
+			var updated tea.Model
+			var cmd tea.Cmd
+			if k == "esc" {
+				updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			} else {
+				updated, cmd = model.Update(keyRunes(k))
+			}
+			model = updated.(Model)
+
+			require.Nil(t, model.action.pending)
+			require.False(t, model.action.running)
+			require.Nil(t, cmd)
+			require.Equal(t, genBefore, model.action.gen, "cancel must not touch gen")
+			require.Equal(t, 0, rec.DeployCalls, "cancel must never call the provider")
+		})
+	}
+}
+
+func TestPendingModalIgnoresNavigationButQuitStillQuits(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenDashboard
+	model.selected[ScreenDashboard] = 0
+	model, pa := model.buildAction(actionDeploy, "Deploy?", nil,
+		func(ctx context.Context) (ActionOutcome, error) { return rec.DeployProfile(ctx) })
+	model = model.promptAction(pa)
+
+	updated, cmd := model.Update(keyRunes("j"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.action.pending, "modal must still be shown")
+	require.Equal(t, 0, model.selected[ScreenDashboard], "navigation must not reach the dashboard while the modal is up")
+
+	updated, cmd = model.Update(keyRunes("2"))
+	model = updated.(Model)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, ScreenDashboard, model.CurrentScreen(), "screen must not change while the modal is up")
+
+	_, cmd = model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	require.NotNil(t, cmd)
+	require.Equal(t, tea.Quit(), cmd())
+}
+
+// --- Rule 3: single-flight ---
+
+func TestSingleFlightBlocksNewPromptsWhileRunning(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model, pa := model.buildAction(actionDeploy, "Deploy?", nil,
+		func(ctx context.Context) (ActionOutcome, error) { return rec.DeployProfile(ctx) })
+	model = model.promptAction(pa)
+	updated, cmd := model.Update(keyRunes("y"))
+	model = updated.(Model)
+	require.True(t, model.action.running)
+	require.NotNil(t, cmd)
+	genBefore := model.action.gen
+
+	// A second action attempted while the first is still running must not
+	// disturb the in-flight action's gen or show a modal.
+	model2, pa2 := model.buildAction(actionEnable, "Enable something?", nil,
+		func(ctx context.Context) (ActionOutcome, error) { return rec.EnableMod(ctx, ModItem{}) })
+	model2 = model2.promptAction(pa2)
+	require.Nil(t, model2.action.pending, "single-flight must ignore the new prompt")
+	require.Equal(t, genBefore, model2.action.gen, "buildAction must not bump gen while another action is running")
+
+	// Navigation still works while running.
+	navUpdated, _ := model.Update(keyRunes("2"))
+	require.Equal(t, ScreenInstalledMods, navUpdated.(Model).CurrentScreen())
+
+	// A stray confirm key (pending is already nil) cannot double-dispatch.
+	_, strayCmd := model.Update(keyRunes("y"))
+	require.Nil(t, strayCmd)
+}
+
+// --- Rule 4: actionDoneMsg staleness + refresh ---
+
+func TestStaleActionDoneMsgIsDiscardedEntirely(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 5
+	model.action.running = true
+	model.action.status = ""
+
+	updated, cmd := model.Update(actionDoneMsg{gen: 4, kind: actionEnable, outcome: ActionOutcome{Message: "stale"}})
+	m := updated.(Model)
+	require.Nil(t, cmd, "a stale result must not dispatch a refresh")
+	require.True(t, m.action.running, "stale result must not clear running")
+	require.Empty(t, m.action.status, "stale result must not set status")
+}
+
+func TestFreshActionDoneMsgUpdatesStatusAndRefreshes(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 3
+	model.action.running = true
+
+	updated, cmd := model.Update(actionDoneMsg{gen: 3, kind: actionEnable, outcome: ActionOutcome{Message: `Enabled "SkyUI"`}})
+	m := updated.(Model)
+	require.False(t, m.action.running)
+	require.Equal(t, `Enabled "SkyUI"`, m.action.status)
+	require.False(t, m.action.statusIsError)
+	require.NotNil(t, cmd, "a fresh result must dispatch a data refresh")
+
+	refreshMsg := cmd()
+	require.IsType(t, dataLoadedMsg{}, refreshMsg)
+}
+
+func TestFormatOutcomeStatusWarningSuffix(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "Deployed 3 mod(s)", formatOutcomeStatus(ActionOutcome{Message: "Deployed 3 mod(s)"}))
+	require.Equal(t, "Deployed 3 mod(s) — one broke",
+		formatOutcomeStatus(ActionOutcome{Message: "Deployed 3 mod(s)", Warnings: []string{"one broke"}}))
+	require.Equal(t, "Deployed 3 mod(s) (2 warnings)",
+		formatOutcomeStatus(ActionOutcome{Message: "Deployed 3 mod(s)", Warnings: []string{"a", "b"}}))
+}
+
+// --- Rule 5: actionFailedMsg staleness + partial-mutation contract ---
+
+func TestFreshActionFailedMsgShowsErrorRefreshesAndKeepsScreen(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 2
+	model.action.running = true
+	model.screen = ScreenInstalledMods
+
+	err := fmt.Errorf("deploy failed:\nrollback ok")
+	updated, cmd := model.Update(actionFailedMsg{gen: 2, kind: actionDeploy, err: err})
+	m := updated.(Model)
+
+	require.False(t, m.action.running)
+	require.True(t, m.action.statusIsError)
+	require.NotContains(t, m.action.status, "\n", "status must stay one line")
+	require.Contains(t, m.action.status, "deploy failed")
+	require.Equal(t, ScreenInstalledMods, m.CurrentScreen(), "a failure must not move the user off their screen")
+	require.NotNil(t, cmd, "the partial-mutation contract still refreshes on failure")
+
+	refreshMsg := cmd()
+	require.IsType(t, dataLoadedMsg{}, refreshMsg)
+}
+
+func TestStaleActionFailedMsgIsDiscarded(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 9
+	model.action.running = true
+
+	updated, cmd := model.Update(actionFailedMsg{gen: 1, kind: actionDeploy, err: errors.New("boom")})
+	m := updated.(Model)
+	require.Nil(t, cmd)
+	require.True(t, m.action.running)
+	require.Empty(t, m.action.status)
+}
+
+func TestFailedStatusTruncatesAtRenderTimeNotSetTime(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("x", 300)
+	model := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	model.action.gen = 1
+	model.action.running = true
+	updated, _ := model.Update(actionFailedMsg{gen: 1, kind: actionDeploy, err: errors.New(long)})
+	model = updated.(Model)
+	require.Equal(t, long, model.action.status, "the raw message is stored untruncated")
+
+	wide := model.statusLine()
+	require.LessOrEqual(t, lipgloss.Width(wide), model.availableWidth())
+
+	resized, _ := model.Update(tea.WindowSizeMsg{Width: 40, Height: 30})
+	model = resized.(Model)
+	narrow := model.statusLine()
+	require.LessOrEqual(t, lipgloss.Width(narrow), model.availableWidth())
+	require.Less(t, lipgloss.Width(narrow), lipgloss.Width(wide),
+		"the SAME stored status re-truncates shorter at a narrower width, proving truncation happens at render time")
+}
+
+// --- Rule 6: dataLoadedMsg clamps selections ---
+
+func TestDataLoadedClampsSelectionToShrunkLists(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.selected[ScreenInstalledMods] = 4
+	model.selected[ScreenProfiles] = 3
+
+	updated, _ := model.Update(dataLoadedMsg{
+		summary:  Summary{},
+		mods:     []ModItem{{ID: "a"}, {ID: "b"}},
+		profiles: []ProfileItem{{Name: "solo"}},
+	})
+	m := updated.(Model)
+	require.Equal(t, 1, m.selected[ScreenInstalledMods], "clamped to len(mods)-1")
+	require.Equal(t, 0, m.selected[ScreenProfiles], "clamped to len(profiles)-1")
+}
+
+func TestDataLoadedClampsSelectionToZeroOnEmptyList(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.selected[ScreenInstalledMods] = 4
+
+	updated, _ := model.Update(dataLoadedMsg{summary: Summary{}, mods: nil, profiles: nil})
+	m := updated.(Model)
+	require.Equal(t, 0, m.selected[ScreenInstalledMods])
+}
+
+// --- Rule 7: modal rendering ---
+
+func TestActionModalReplacesContentAreaAndKeepsChrome(t *testing.T) {
+	t.Parallel()
+
+	model := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	model.screen = ScreenInstalledMods
+	model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, []string{"Removes SkyUI."}, func(context.Context) (ActionOutcome, error) {
+		return ActionOutcome{}, nil
+	})
+	model = model.promptAction(pa)
+
+	view := model.View()
+	require.Contains(t, view, "LMM // Linux Mod Manager", "chrome (title) stays")
+	require.Contains(t, view, `Uninstall "SkyUI"?`)
+	require.Contains(t, view, "Removes SkyUI.")
+	require.NotContains(t, view, "SPELLBOOK: INSTALLED MODS", "the modal replaces the underlying screen, not overlays it")
+}
+
+func TestActionModalTruncatesDetailToPanelContentWidth(t *testing.T) {
+	t.Parallel()
+
+	model := sizedModelWithActions(t, &recordingActions{}, 40, 24)
+	long := strings.Repeat("mod-name-", 20)
+	model, pa := model.buildAction(actionUninstall, "Uninstall?", []string{long}, func(context.Context) (ActionOutcome, error) {
+		return ActionOutcome{}, nil
+	})
+	model = model.promptAction(pa)
+
+	for _, line := range strings.Split(model.screenView(), "\n") {
+		require.LessOrEqual(t, lipgloss.Width(line), model.availableWidth())
+	}
+}
+
+func TestActionModalCollapsesLongDetailListWithMoreLine(t *testing.T) {
+	t.Parallel()
+
+	model := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	detail := make([]string, 20)
+	for i := range detail {
+		detail[i] = fmt.Sprintf("mod-%02d", i)
+	}
+	model, pa := model.buildAction(actionSwitch, "Switch profile?", detail, func(context.Context) (ActionOutcome, error) {
+		return ActionOutcome{}, nil
+	})
+	model = model.promptAction(pa)
+
+	view := model.screenView()
+	require.Contains(t, view, "mod-00")
+	require.Contains(t, view, "+", "must summarize the overflow instead of listing all 20")
+	require.NotContains(t, view, "mod-19", "must not render every entry once capped")
+}
+
+func TestActionModalHeightInvariantAt80x24AndWidthFloor40(t *testing.T) {
+	t.Parallel()
+
+	detail := make([]string, 20)
+	for i := range detail {
+		detail[i] = fmt.Sprintf("a very long mod entry name number %02d that could overflow", i)
+	}
+
+	for _, width := range []int{80, 40} {
+		t.Run(fmt.Sprintf("width-%d", width), func(t *testing.T) {
+			t.Parallel()
+			model := sizedModelWithActions(t, &recordingActions{}, width, 24)
+			model, pa := model.buildAction(actionSwitch, "Switch to vanilla-plus?", detail, func(context.Context) (ActionOutcome, error) {
+				return ActionOutcome{}, nil
+			})
+			model = model.promptAction(pa)
+
+			view := model.screenView()
+			require.Equal(t, model.availableContentHeight(), lipgloss.Height(view), "exact-height invariant")
+			require.Equal(t, model.availableWidth(), lipgloss.Width(view), "exact-width invariant")
+		})
+	}
+}
+
+// --- Rule 8: status line height budget + clearing ---
+
+func TestStatusLineOccupiesExactlyOneRowWhenVisible(t *testing.T) {
+	t.Parallel()
+
+	model := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	withoutStatus := model.availableContentHeight()
+	require.Equal(t, 30, lipgloss.Height(model.View()))
+
+	model.action.status = `Enabled "SkyUI"`
+	withStatus := model.availableContentHeight()
+	require.Equal(t, withoutStatus-1, withStatus, "the status row must shrink the content budget by exactly one line")
+	require.Equal(t, 30, lipgloss.Height(model.View()), "total view height must still hit the terminal bounds exactly")
+	require.Contains(t, model.View(), `Enabled "SkyUI"`)
+}
+
+func TestNonModalNonQuitKeypressClearsStatus(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.status = "old status"
+
+	updated, _ := model.Update(keyRunes("j"))
+	require.Empty(t, updated.(Model).action.status)
+}
+
+func TestQuitKeypressDoesNotClearStatus(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.status = "old status"
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	require.NotNil(t, cmd)
+	require.Equal(t, "old status", updated.(Model).action.status)
+}
+
+// --- Rule 9: quit-time context cleanup ---
+
+func TestQuitCancelsInFlightActionContext(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	var capturedCtx context.Context
+	model, pa := model.buildAction(actionDeploy, "Deploy?", nil, func(ctx context.Context) (ActionOutcome, error) {
+		capturedCtx = ctx
+		return ActionOutcome{Message: "ok"}, nil
+	})
+	model = model.promptAction(pa)
+
+	updated, cmd := model.Update(keyRunes("y"))
+	model = updated.(Model)
+	require.NotNil(t, cmd)
+
+	_, quitCmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	require.NotNil(t, quitCmd)
+	require.Equal(t, tea.Quit(), quitCmd())
+
+	// The runtime eventually executes the in-flight command; the context it
+	// hands to the ActionProvider call must already be cancelled.
+	cmd()
+	require.Error(t, capturedCtx.Err())
+	require.ErrorIs(t, capturedCtx.Err(), context.Canceled)
+}
+
+func TestQuitCancelsInFlightSearchContext(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	model.search.cancel = cancel
+
+	_, quitCmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	require.NotNil(t, quitCmd)
+	require.Equal(t, tea.Quit(), quitCmd())
+	require.Error(t, ctx.Err(), "search's cancel must be invoked on quit (#42 lifecycle carry-forward)")
+}
+
+// --- Rule 10: prototype end-to-end wiring ---
+
+func TestPrototypeEndToEndPromptConfirmDoneRefreshChangesOverview(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+	require.NotNil(t, model.actions, "NewPrototypeModel must wire the ActionProvider role")
+
+	before := requireModByID(t, model.mods, "alternate-start")
+	require.Equal(t, "disabled", before.Status)
+
+	actions := model.actions
+	model, pa := model.buildAction(actionEnable, fmt.Sprintf("Enable %q?", before.Name), nil,
+		func(ctx context.Context) (ActionOutcome, error) { return actions.EnableMod(ctx, before) })
+	model = model.promptAction(pa)
+
+	updated, confirmCmd := model.Update(keyRunes("y"))
+	model = updated.(Model)
+	require.NotNil(t, confirmCmd)
+
+	doneMsg := confirmCmd()
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+	updated, refreshCmd := model.Update(doneMsg)
+	model = updated.(Model)
+	require.NotNil(t, refreshCmd)
+	require.Equal(t, `Enabled "Alternate Start"`, model.action.status)
+
+	loadedMsg := refreshCmd()
+	require.IsType(t, dataLoadedMsg{}, loadedMsg)
+	updated, _ = model.Update(loadedMsg)
+	model = updated.(Model)
+
+	after := requireModByID(t, model.mods, "alternate-start")
+	require.NotEqual(t, "disabled", after.Status, "Overview must reflect the action through the SAME prototype instance")
+}

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -453,6 +453,47 @@ func TestNonModalNonQuitKeypressClearsStatus(t *testing.T) {
 	require.Empty(t, updated.(Model).action.status)
 }
 
+// TestRunningActionKeypressDoesNotClearStatus covers a gap rule 8 missed:
+// while an action is in flight (m.action.running == true — set for both a
+// running mutation and an in-flight plan fetch like "Planning switch…", see
+// planProfileSwitch in mutations.go), a navigation keypress must not wipe
+// the in-flight status message. Without an in-flight indicator, the user has
+// no sign that anything is happening until the action resolves.
+func TestRunningActionKeypressDoesNotClearStatus(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.status = "Planning switch…"
+	model.action.running = true
+
+	updated, _ := model.Update(keyRunes("j"))
+	require.Equal(t, "Planning switch…", updated.(Model).action.status,
+		"an in-flight action's status must survive a navigation keypress")
+	require.False(t, updated.(Model).action.statusIsError)
+}
+
+// TestActionDoneRestoresNormalStatusClearing proves the rule-8 clearing
+// behavior resumes as soon as the in-flight action finishes: once
+// actionDoneMsg lands (which sets m.action.running back to false), the next
+// non-modal, non-quit keypress clears the status line exactly as it always
+// has.
+func TestActionDoneRestoresNormalStatusClearing(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.status = "Planning switch…"
+	model.action.running = true
+
+	finished, _ := model.Update(actionDoneMsg{gen: model.action.gen, outcome: ActionOutcome{Message: "Switched to vanilla-plus"}})
+	finishedModel := finished.(Model)
+	require.False(t, finishedModel.action.running)
+	require.Equal(t, "Switched to vanilla-plus", finishedModel.action.status)
+
+	cleared, _ := finishedModel.Update(keyRunes("j"))
+	require.Empty(t, cleared.(Model).action.status,
+		"status must clear normally once the action is no longer running")
+}
+
 func TestQuitKeypressDoesNotClearStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -41,7 +41,7 @@ func TestPromptActionShowsModalWithoutMutating(t *testing.T) {
 	model := modelWithActions(t, rec)
 	item := ModItem{ID: "skyui", Source: "nexusmods", Name: "SkyUI"}
 
-	model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, []string{"Removes SkyUI from the active profile."},
+	model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, []string{"Removes SkyUI from the active profile."}, "",
 		func(ctx context.Context) (ActionOutcome, error) { return rec.UninstallMod(ctx, item) })
 	model = model.promptAction(pa)
 
@@ -62,7 +62,7 @@ func TestConfirmKeysDispatchActionAndClearPending(t *testing.T) {
 			rec := &recordingActions{UninstallOutcome: ActionOutcome{Message: `Uninstalled "SkyUI"`}}
 			model := modelWithActions(t, rec)
 			item := ModItem{ID: "skyui", Source: "nexusmods", Name: "SkyUI"}
-			model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, nil,
+			model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, nil, "",
 				func(ctx context.Context) (ActionOutcome, error) { return rec.UninstallMod(ctx, item) })
 			model = model.promptAction(pa)
 
@@ -97,7 +97,7 @@ func TestConfirmClosureMapsProviderErrorToActionFailedMsg(t *testing.T) {
 	item := ModItem{ID: "skyui", Source: "nexusmods", Name: "SkyUI"}
 
 	// buildAction increments gen and captures it in the closure
-	model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, nil,
+	model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, nil, "",
 		func(ctx context.Context) (ActionOutcome, error) { return failing.UninstallMod(ctx, item) })
 
 	genAtBuild := model.action.gen
@@ -131,7 +131,7 @@ func TestCancelKeysLeaveStateUntouched(t *testing.T) {
 
 			rec := &recordingActions{}
 			model := modelWithActions(t, rec)
-			model, pa := model.buildAction(actionDeploy, "Deploy?", nil,
+			model, pa := model.buildAction(actionDeploy, "Deploy?", nil, "",
 				func(ctx context.Context) (ActionOutcome, error) { return rec.DeployProfile(ctx) })
 			model = model.promptAction(pa)
 			genBefore := model.action.gen
@@ -161,7 +161,7 @@ func TestPendingModalIgnoresNavigationButQuitStillQuits(t *testing.T) {
 	model := modelWithActions(t, rec)
 	model.screen = ScreenDashboard
 	model.selected[ScreenDashboard] = 0
-	model, pa := model.buildAction(actionDeploy, "Deploy?", nil,
+	model, pa := model.buildAction(actionDeploy, "Deploy?", nil, "",
 		func(ctx context.Context) (ActionOutcome, error) { return rec.DeployProfile(ctx) })
 	model = model.promptAction(pa)
 
@@ -188,7 +188,7 @@ func TestSingleFlightBlocksNewPromptsWhileRunning(t *testing.T) {
 
 	rec := &recordingActions{}
 	model := modelWithActions(t, rec)
-	model, pa := model.buildAction(actionDeploy, "Deploy?", nil,
+	model, pa := model.buildAction(actionDeploy, "Deploy?", nil, "",
 		func(ctx context.Context) (ActionOutcome, error) { return rec.DeployProfile(ctx) })
 	model = model.promptAction(pa)
 	updated, cmd := model.Update(keyRunes("y"))
@@ -199,7 +199,7 @@ func TestSingleFlightBlocksNewPromptsWhileRunning(t *testing.T) {
 
 	// A second action attempted while the first is still running must not
 	// disturb the in-flight action's gen or show a modal.
-	model2, pa2 := model.buildAction(actionEnable, "Enable something?", nil,
+	model2, pa2 := model.buildAction(actionEnable, "Enable something?", nil, "",
 		func(ctx context.Context) (ActionOutcome, error) { return rec.EnableMod(ctx, ModItem{}) })
 	model2 = model2.promptAction(pa2)
 	require.Nil(t, model2.action.pending, "single-flight must ignore the new prompt")
@@ -357,7 +357,7 @@ func TestActionModalReplacesContentAreaAndKeepsChrome(t *testing.T) {
 
 	model := sizedModelWithActions(t, &recordingActions{}, 100, 30)
 	model.screen = ScreenInstalledMods
-	model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, []string{"Removes SkyUI."}, func(context.Context) (ActionOutcome, error) {
+	model, pa := model.buildAction(actionUninstall, `Uninstall "SkyUI"?`, []string{"Removes SkyUI."}, "", func(context.Context) (ActionOutcome, error) {
 		return ActionOutcome{}, nil
 	})
 	model = model.promptAction(pa)
@@ -374,7 +374,7 @@ func TestActionModalTruncatesDetailToPanelContentWidth(t *testing.T) {
 
 	model := sizedModelWithActions(t, &recordingActions{}, 40, 24)
 	long := strings.Repeat("mod-name-", 20)
-	model, pa := model.buildAction(actionUninstall, "Uninstall?", []string{long}, func(context.Context) (ActionOutcome, error) {
+	model, pa := model.buildAction(actionUninstall, "Uninstall?", []string{long}, "", func(context.Context) (ActionOutcome, error) {
 		return ActionOutcome{}, nil
 	})
 	model = model.promptAction(pa)
@@ -392,7 +392,7 @@ func TestActionModalCollapsesLongDetailListWithMoreLine(t *testing.T) {
 	for i := range detail {
 		detail[i] = fmt.Sprintf("mod-%02d", i)
 	}
-	model, pa := model.buildAction(actionSwitch, "Switch profile?", detail, func(context.Context) (ActionOutcome, error) {
+	model, pa := model.buildAction(actionSwitch, "Switch profile?", detail, "", func(context.Context) (ActionOutcome, error) {
 		return ActionOutcome{}, nil
 	})
 	model = model.promptAction(pa)
@@ -415,7 +415,7 @@ func TestActionModalHeightInvariantAt80x24AndWidthFloor40(t *testing.T) {
 		t.Run(fmt.Sprintf("width-%d", width), func(t *testing.T) {
 			t.Parallel()
 			model := sizedModelWithActions(t, &recordingActions{}, width, 24)
-			model, pa := model.buildAction(actionSwitch, "Switch to vanilla-plus?", detail, func(context.Context) (ActionOutcome, error) {
+			model, pa := model.buildAction(actionSwitch, "Switch to vanilla-plus?", detail, "", func(context.Context) (ActionOutcome, error) {
 				return ActionOutcome{}, nil
 			})
 			model = model.promptAction(pa)
@@ -471,7 +471,7 @@ func TestQuitCancelsInFlightActionContext(t *testing.T) {
 
 	model := modelWithActions(t, &recordingActions{})
 	var capturedCtx context.Context
-	model, pa := model.buildAction(actionDeploy, "Deploy?", nil, func(ctx context.Context) (ActionOutcome, error) {
+	model, pa := model.buildAction(actionDeploy, "Deploy?", nil, "", func(ctx context.Context) (ActionOutcome, error) {
 		capturedCtx = ctx
 		return ActionOutcome{Message: "ok"}, nil
 	})
@@ -521,7 +521,7 @@ func TestPrototypeEndToEndPromptConfirmDoneRefreshChangesOverview(t *testing.T) 
 	require.Equal(t, "disabled", before.Status)
 
 	actions := model.actions
-	model, pa := model.buildAction(actionEnable, fmt.Sprintf("Enable %q?", before.Name), nil,
+	model, pa := model.buildAction(actionEnable, fmt.Sprintf("Enable %q?", before.Name), nil, "",
 		func(ctx context.Context) (ActionOutcome, error) { return actions.EnableMod(ctx, before) })
 	model = model.promptAction(pa)
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -461,7 +461,7 @@ func (m Model) View() string {
 	if m.showHelp {
 		b.WriteString(m.helpView())
 	} else {
-		b.WriteString(m.theme.Help.Render("?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  e/x/D: mutate  enter: switch  q: quit"))
+		b.WriteString(m.footerLine())
 	}
 
 	app := m.theme.App
@@ -473,6 +473,23 @@ func (m Model) View() string {
 	}
 
 	return app.Render(b.String())
+}
+
+// footerLine renders the bottom key-hint line shown whenever the help
+// overlay isn't. Finding 3 (smoke test): the old "e/x/D: mutate" hint named
+// the keys but never said what they DO, so the mutation hints are spelled
+// out explicitly instead, matching the "·"-separated sub-hint style
+// searchFooterLine already uses. The whole line is hard-truncated
+// (ANSI-safe truncate()) to availableWidth() so a narrower terminal
+// degrades by dropping trailing hints rather than word-wrapping into an
+// extra row - which would silently grow the view past contentChromeHeight's
+// fixed footerHeight == 1 assumption. Per the smoke tester's follow-up
+// guidance, 160 columns (not 80) is the normal case the full wording is
+// designed for; narrower terminals are expected to lose some trailing hints
+// to truncation rather than the wording being shortened to fit them.
+func (m Model) footerLine() string {
+	hint := "?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  e: enable/disable · x: uninstall · D: deploy  enter: switch  q: quit"
+	return truncate(m.theme.Help.Render(hint), m.availableWidth())
 }
 
 // CurrentScreen exposes the selected screen for tests.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -248,6 +248,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.action.status = formatOutcomeStatus(msg.outcome)
 		m.action.statusIsError = false
+		// A fresh switch's target must rebind the session's active-profile
+		// providers BEFORE the refresh below reads them (see rebindProfile
+		// and profileRebinder in actions.go) - otherwise Profiles() keeps
+		// starring the OLD profile forever, and subsequent mutations keep
+		// targeting it too (finding C1).
+		if msg.switchedTo != "" {
+			m.rebindProfile(msg.switchedTo)
+		}
 		return m, m.loadData
 	case actionFailedMsg:
 		if msg.gen != m.action.gen {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -191,20 +191,29 @@ func (m Model) openSelectedMenuEntry() (Model, tea.Cmd) {
 	return m.gotoScreen(items[selected].target)
 }
 
-// gotoScreen switches to the target screen. Every entry path into
-// ScreenSearch — number/tab-cycling navigation, the dashboard menu, and "/"
-// — must leave the user ready to type immediately, so this is the single
-// place that focuses the search input on entry. Esc (the Blur binding) is
-// the only way back out of focus; once blurred, screen-level keys (s, n/p,
-// navigation) reach updateKey's outer switch again. Non-search targets are a
-// no-op beyond the screen assignment: the input is already unfocused in
-// every reachable case, since updateKey's focused-input branch swallows the
-// keys that would otherwise get here while ScreenSearch is still focused.
+// gotoScreen switches to the target screen without touching the search
+// input's focus state. This is the entry path for screen-cycling
+// (NextScreen/PrevScreen), the direct screen-jump bindings (Dashboard,
+// InstalledMods, Profiles, Sources), and dashboard-menu selection
+// (openSelectedMenuEntry) — none of these are an explicit request to search,
+// so landing on ScreenSearch through them must NOT focus the input. A
+// focused input swallows every keystroke (see updateKey's focused-input
+// branch), so auto-focusing here trapped a user cycling through screens with
+// tab/shift-tab/left/right/h/l on Search until they pressed Esc (smoke-test
+// Finding 1). See gotoScreenFocused for the two bindings that DO focus.
 func (m Model) gotoScreen(screen Screen) (Model, tea.Cmd) {
 	m.screen = screen
-	if screen != ScreenSearch {
-		return m, nil
-	}
+	return m, nil
+}
+
+// gotoScreenFocused switches to ScreenSearch and focuses the input
+// immediately. Reserved for the two EXPLICIT "go search" bindings — Search
+// ("/") and SearchScreen ("3") — so pressing either is enough to start
+// typing right away. Esc (the Blur binding) is the only way back out of
+// focus; once blurred, screen-level keys (s, n/p, navigation) reach
+// updateKey's outer switch again.
+func (m Model) gotoScreenFocused(screen Screen) (Model, tea.Cmd) {
+	m, _ = m.gotoScreen(screen)
 	m.search.input.Focus()
 	return m, textinput.Blink
 }
@@ -372,7 +381,7 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.InstalledMods):
 		return m.gotoScreen(ScreenInstalledMods)
 	case key.Matches(msg, m.keys.Search), key.Matches(msg, m.keys.SearchScreen):
-		return m.gotoScreen(ScreenSearch)
+		return m.gotoScreenFocused(ScreenSearch)
 	case key.Matches(msg, m.keys.NextPage):
 		if m.screen == ScreenSearch && m.search.state == searchReady && m.search.hasNextPage() {
 			return m.startSearch(m.search.page.Query, m.search.page.Page+1)
@@ -769,11 +778,12 @@ func (m Model) searchView() string {
 		}
 		return m.searchReadyView(header)
 	default: // searchIdle
-		// Every entry path into ScreenSearch already focuses the input (see
-		// gotoScreen), so the idle hint only needs to mention "/ focus" when
-		// Esc has since blurred it — otherwise it would tell the user to do
-		// something that's already done. While focused, 's' types into the
-		// query (not a source-cycle shortcut), so exclude it from the focused hint.
+		// Only "/" and "3" (gotoScreenFocused) focus the input on entry; every
+		// other path here (cycling, dashboard menu, jump keys) leaves it
+		// unfocused, so the hint always needs to mention "/ focus" unless the
+		// input happens to already be focused. While focused, 's' types into
+		// the query (not a source-cycle shortcut), so exclude it from the
+		// focused hint.
 		hint := "enter search · esc unfocus"
 		if !m.search.input.Focused() {
 			hint = "/ focus · s source"

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -261,6 +261,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.action.status = singleLine(msg.err.Error())
 		m.action.statusIsError = true
 		return m, m.loadData
+	case planResultMsg:
+		if msg.gen != m.action.gen {
+			return m, nil
+		}
+		return m.resolvePlanResult(msg)
+	case planFailedMsg:
+		if msg.gen != m.action.gen {
+			return m, nil
+		}
+		return m.resolvePlanFailure(msg)
 	case loadFailedMsg:
 		m.state = stateFailed
 		m.loadErr = msg.err
@@ -387,7 +397,20 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.moveSelection(1)
 		return m, nil
 	case key.Matches(msg, m.keys.Select):
+		// Select ("enter") is context-dependent: it opens a dashboard menu
+		// entry everywhere except Profiles, where Task 7 repurposes it to
+		// switch to the selected (non-active) profile - see mutations.go's
+		// switchSelectedProfile.
+		if m.screen == ScreenProfiles {
+			return m.switchSelectedProfile()
+		}
 		return m.openSelectedMenuEntry()
+	case key.Matches(msg, m.keys.ToggleEnable):
+		return m.toggleSelectedModEnable()
+	case key.Matches(msg, m.keys.Uninstall):
+		return m.uninstallSelectedMod()
+	case key.Matches(msg, m.keys.Deploy):
+		return m.deployActiveProfile()
 	default:
 		return m, nil
 	}
@@ -415,7 +438,7 @@ func (m Model) View() string {
 	if m.showHelp {
 		b.WriteString(m.helpView())
 	} else {
-		b.WriteString(m.theme.Help.Render("?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit"))
+		b.WriteString(m.theme.Help.Render("?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  e/x/D: mutate  enter: switch  q: quit"))
 	}
 
 	app := m.theme.App
@@ -972,14 +995,15 @@ func (m Model) helpView() string {
 		"tab / shift+tab     cycle top-level screens",
 		"1-5                 jump to a screen (3 focuses search)",
 		"/                   search from anywhere (jumps + focuses input)",
-		"enter               search",
+		"enter               open menu entry / search / switch profile",
 		"esc                 unfocus search input",
 		"n/p                 result pages",
 		"s                   cycle source",
+		"e/x/D               toggle enable/disable / uninstall selected mod / deploy active profile",
 		"?                   toggle this help",
 		"q / ctrl+c           quit",
 		"",
-		"Browsing is read-only. Nothing is installed, updated, or deployed from this screen.",
+		"Enable, disable, uninstall, deploy, and profile switch all confirm through a modal before anything changes.",
 	}, "\n"))
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -329,7 +329,13 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// before this point is ever reached) and isn't quit clears the status
 	// line. isQuitKey (not the bare Quit binding) is used so a "q" that's
 	// actually being typed into the focused search input still clears it.
-	if !m.isQuitKey(msg) {
+	// m.action.running gates this too: it covers both a running mutation and
+	// an in-flight plan fetch (planProfileSwitch in mutations.go sets it
+	// alongside "Planning switch…" before any pendingAction confirmation
+	// exists), so a navigation keypress mid-flight must not wipe the only
+	// sign that work is in progress. actionDoneMsg/actionFailedMsg clear
+	// running when the action settles, restoring normal clearing below.
+	if !m.isQuitKey(msg) && !m.action.running {
 		m.action.status = ""
 		m.action.statusIsError = false
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -179,6 +179,13 @@ func (m Model) dashboardMenuRows() []string {
 	return rows
 }
 
+// openSelectedMenuEntry jumps to the selected dashboard-menu item's target
+// screen. Choosing "Search Archives" by name is an EXPLICIT request to
+// search — the same category as the "/" and SearchScreen ("3") bindings —
+// so that one target routes through gotoScreenFocused; every other menu
+// target (Installed Mods, Profiles, Sources) is a plain screen jump and
+// keeps using gotoScreen. See gotoScreen's doc comment for why passive
+// jumps must never focus.
 func (m Model) openSelectedMenuEntry() (Model, tea.Cmd) {
 	if m.screen != ScreenDashboard {
 		return m, nil
@@ -188,29 +195,34 @@ func (m Model) openSelectedMenuEntry() (Model, tea.Cmd) {
 	if selected >= len(items) || !items[selected].hasTarget {
 		return m, nil
 	}
-	return m.gotoScreen(items[selected].target)
+	target := items[selected].target
+	if target == ScreenSearch {
+		return m.gotoScreenFocused(target)
+	}
+	return m.gotoScreen(target)
 }
 
 // gotoScreen switches to the target screen without touching the search
 // input's focus state. This is the entry path for screen-cycling
-// (NextScreen/PrevScreen), the direct screen-jump bindings (Dashboard,
-// InstalledMods, Profiles, Sources), and dashboard-menu selection
-// (openSelectedMenuEntry) — none of these are an explicit request to search,
-// so landing on ScreenSearch through them must NOT focus the input. A
-// focused input swallows every keystroke (see updateKey's focused-input
-// branch), so auto-focusing here trapped a user cycling through screens with
-// tab/shift-tab/left/right/h/l on Search until they pressed Esc (smoke-test
-// Finding 1). See gotoScreenFocused for the two bindings that DO focus.
+// (NextScreen/PrevScreen) and the direct screen-jump bindings (Dashboard,
+// InstalledMods, Profiles, Sources) — none of these are an explicit request
+// to search, so landing on ScreenSearch through them must NOT focus the
+// input. A focused input swallows every keystroke (see updateKey's
+// focused-input branch), so auto-focusing here trapped a user cycling
+// through screens with tab/shift-tab/left/right/h/l on Search until they
+// pressed Esc (smoke-test Finding 1). See gotoScreenFocused for the bindings
+// that DO focus.
 func (m Model) gotoScreen(screen Screen) (Model, tea.Cmd) {
 	m.screen = screen
 	return m, nil
 }
 
 // gotoScreenFocused switches to ScreenSearch and focuses the input
-// immediately. Reserved for the two EXPLICIT "go search" bindings — Search
-// ("/") and SearchScreen ("3") — so pressing either is enough to start
-// typing right away. Esc (the Blur binding) is the only way back out of
-// focus; once blurred, screen-level keys (s, n/p, navigation) reach
+// immediately. Reserved for EXPLICIT "go search" intent: the Search ("/")
+// and SearchScreen ("3") bindings, and selecting "Search Archives" from the
+// dashboard menu (openSelectedMenuEntry) — picking "search" by name is
+// intent, not passive cycling. Esc (the Blur binding) is the only way back
+// out of focus; once blurred, screen-level keys (s, n/p, navigation) reach
 // updateKey's outer switch again.
 func (m Model) gotoScreenFocused(screen Screen) (Model, tea.Cmd) {
 	m, _ = m.gotoScreen(screen)
@@ -795,8 +807,9 @@ func (m Model) searchView() string {
 		}
 		return m.searchReadyView(header)
 	default: // searchIdle
-		// Only "/" and "3" (gotoScreenFocused) focus the input on entry; every
-		// other path here (cycling, dashboard menu, jump keys) leaves it
+		// Only the EXPLICIT "go search" paths (gotoScreenFocused: "/", "3", and
+		// the dashboard menu's "Search Archives" entry) focus the input on
+		// entry; passive screen-cycling and the other direct jump keys leave it
 		// unfocused, so the hint always needs to mention "/ focus" unless the
 		// input happens to already be focused. While focused, 's' types into
 		// the query (not a source-cycle shortcut), so exclude it from the

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -40,6 +40,11 @@ const (
 type Options struct {
 	Theme    string
 	Provider DataProvider
+	// Actions is the write-side ActionProvider seam (see actions_provider.go).
+	// Optional: a nil Actions means no mutation can be confirmed through
+	// promptAction/buildAction, which is fine for tests that only exercise
+	// the read-only DataProvider surface.
+	Actions ActionProvider
 	// Ctx seeds Model.ctx; see that field for why the context is stored
 	// rather than threaded as a parameter.
 	Ctx context.Context
@@ -51,6 +56,7 @@ type Model struct {
 	layout   Layout
 	keys     KeyMap
 	provider DataProvider
+	actions  ActionProvider
 	// ctx deviates from "don't store contexts in structs": Bubble Tea's
 	// Init/Update/View take no context parameter, so commands (e.g.
 	// startSearch) close over m.ctx to reach it from goroutines.
@@ -64,6 +70,7 @@ type Model struct {
 	profiles []ProfileItem
 	sources  []SourceInfo
 	search   searchModel
+	action   actionModel
 
 	screen   Screen
 	selected map[Screen]int
@@ -110,6 +117,7 @@ func NewModel(options Options) (Model, error) {
 		layout:   layoutForTheme(t.Name),
 		keys:     DefaultKeyMap(),
 		provider: options.Provider,
+		actions:  options.Actions,
 		ctx:      options.Ctx,
 		state:    stateLoading,
 		screen:   ScreenDashboard,
@@ -130,8 +138,16 @@ func NewModel(options Options) (Model, error) {
 }
 
 // NewPrototypeModel creates a side-effect-free TUI model backed by fake data.
+// Provider and Actions are wired from the SAME prototypeProvider instance
+// (see NewPrototypeProvider's doc comment), so actions confirmed through
+// the returned Model are visible in its own subsequent reads — whatever the
+// caller passed in either field is discarded.
 func NewPrototypeModel(options Options) (Model, error) {
-	options.Provider = NewPrototypeProvider()
+	provider := NewPrototypeProvider()
+	options.Provider = provider
+	if actions, ok := provider.(ActionProvider); ok {
+		options.Actions = actions
+	}
 	return NewModel(options)
 }
 
@@ -219,7 +235,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.summary = msg.summary
 		m.mods = msg.mods
 		m.profiles = msg.profiles
+		m.clampSelections()
 		return m, nil
+	case actionDoneMsg:
+		if msg.gen != m.action.gen {
+			return m, nil
+		}
+		m.action.running = false
+		if m.action.cancel != nil {
+			m.action.cancel()
+			m.action.cancel = nil
+		}
+		m.action.status = formatOutcomeStatus(msg.outcome)
+		m.action.statusIsError = false
+		return m, m.loadData
+	case actionFailedMsg:
+		if msg.gen != m.action.gen {
+			return m, nil
+		}
+		m.action.running = false
+		if m.action.cancel != nil {
+			m.action.cancel()
+			m.action.cancel = nil
+		}
+		m.action.status = singleLine(msg.err.Error())
+		m.action.statusIsError = true
+		return m, m.loadData
 	case loadFailedMsg:
 		m.state = stateFailed
 		m.loadErr = msg.err
@@ -262,10 +303,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.action.pending != nil {
+		return m.updatePendingActionKey(msg)
+	}
+
+	// Rule 8: any keypress that isn't a modal response (handled above,
+	// before this point is ever reached) and isn't quit clears the status
+	// line. isQuitKey (not the bare Quit binding) is used so a "q" that's
+	// actually being typed into the focused search input still clears it.
+	if !m.isQuitKey(msg) {
+		m.action.status = ""
+		m.action.statusIsError = false
+	}
+
 	if m.screen == ScreenSearch && m.search.input.Focused() {
 		switch {
-		case key.Matches(msg, m.keys.Quit) && msg.String() == "ctrl+c":
-			return m, tea.Quit
+		case m.isQuitKey(msg): // only ctrl+c while focused — see isQuitKey
+			return m, m.quitCmd()
 		case key.Matches(msg, m.keys.Blur):
 			m.search.input.Blur()
 			return m, nil
@@ -281,7 +335,7 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch {
 	case key.Matches(msg, m.keys.Quit):
-		return m, tea.Quit
+		return m, m.quitCmd()
 	case key.Matches(msg, m.keys.Help):
 		m.showHelp = !m.showHelp
 		return m, nil
@@ -348,6 +402,14 @@ func (m Model) View() string {
 	b.WriteString("\n\n")
 
 	b.WriteString(m.screenView())
+
+	// Exactly one extra line when a status is set (see
+	// contentChromeHeight's matching statusHeight accounting); none when
+	// it's "".
+	if status := m.statusLine(); status != "" {
+		b.WriteString("\n")
+		b.WriteString(status)
+	}
 
 	b.WriteString("\n\n")
 	if m.showHelp {
@@ -442,6 +504,10 @@ func (m Model) nav() string {
 }
 
 func (m Model) screenView() string {
+	if m.action.pending != nil {
+		return m.actionModalView()
+	}
+
 	switch m.state {
 	case stateLoading:
 		return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).
@@ -960,8 +1026,16 @@ func (m Model) contentChromeHeight() int {
 		footerHeight = lipgloss.Height(m.helpView())
 	}
 
+	// The action status line (rule 8) occupies exactly one row above the
+	// footer, and only when set — see statusLine's matching "" ⇒ nothing
+	// rendered contract in View().
+	statusHeight := 0
+	if m.action.status != "" {
+		statusHeight = 1
+	}
+
 	const titleNavAndSpacerHeight = 4 // title, nav, and the spacer lines around content.
-	return titleNavAndSpacerHeight + footerHeight
+	return titleNavAndSpacerHeight + footerHeight + statusHeight
 }
 
 // countLabel renders n, or "?" when n is negative (unknown, e.g. no update

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1001,14 +1001,42 @@ func (m Model) searchFooterLine() string {
 func (m Model) profilesView() string {
 	rows := []string{m.theme.PanelTitle.Render("PROFILE ROSTER")}
 	for i, profile := range m.profiles {
-		active := " "
-		if profile.Active {
-			active = "*"
-		}
-		line := fmt.Sprintf("%s %-22s %3d mods", active, profile.Name, profile.ModCount)
-		rows = append(rows, m.row(i, line))
+		rows = append(rows, m.profileRow(i, m.availableWidth(), profile))
 	}
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
+}
+
+// profileRow renders one Profiles row: active marker / name / mod count.
+// Same defect class modRow was fixed for (see modRow's doc comment): the
+// name column used to be a fixed 22 runes with no truncation
+// ("%s %-22s %3d mods"), so a longer name overflowed it unchecked and
+// shifted the mod-count column out of alignment with shorter rows. The
+// mod-count column gets a proportional (clamped) share of the panel's
+// width and the name column absorbs whatever's left, so it grows with the
+// panel instead of staying a small fixed number. truncate() (ANSI-safe,
+// hard cutoff with an ellipsis) is applied to both fields so an overlong
+// value can never push the mod-count column out of place.
+func (m Model) profileRow(index, width int, profile ProfileItem) string {
+	const prefixWidth = 2 // m.row()'s "> "/"  " selection marker
+	const activeWidth = 1 // "*"/" " active marker
+	const gaps = 2        // separating spaces: marker-name, name-count
+	const minName = 8
+
+	avail := max(width-m.theme.Panel.GetHorizontalFrameSize()-prefixWidth-activeWidth-gaps, minName)
+	countWidth := min(9, max(avail/6, 4)) // "999 mods" is up to 8 runes
+	nameWidth := max(avail-countWidth, minName)
+
+	active := " "
+	if profile.Active {
+		active = "*"
+	}
+	count := fmt.Sprintf("%d mods", profile.ModCount)
+
+	line := fmt.Sprintf("%s %-*s %-*s",
+		active,
+		nameWidth, truncate(profile.Name, nameWidth),
+		countWidth, truncate(count, countWidth))
+	return m.row(index, line)
 }
 
 // sourcesView renders the read-only source registry: every source

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -690,7 +690,7 @@ func (m Model) modsView() string {
 		rows = append(rows, m.theme.MutedText.Render("No mods installed yet. 'lmm install <mod>' begins the quest."))
 	}
 	for i, mod := range m.mods {
-		rows = append(rows, m.modRow(i, mod))
+		rows = append(rows, m.modRow(i, m.availableWidth(), mod))
 	}
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
 }
@@ -1040,8 +1040,33 @@ func (m Model) row(index int, label string) string {
 	return prefix + label
 }
 
-func (m Model) modRow(index int, mod ModItem) string {
-	line := fmt.Sprintf("%-28s %-11s %-16s %7s", mod.Name, mod.Status, mod.Author, mod.Version)
+// modRow renders one Installed Mods row: name / status / author / version.
+// Finding 2 (smoke test): the name column used to be a fixed 28 runes with
+// no truncation, so a longer name overflowed it and shifted every
+// subsequent column to the right, breaking row alignment. Status/author/
+// version get proportional (clamped) shares of the panel's width - the same
+// pattern searchResultsPane already uses - and the name column absorbs
+// whatever's left, so it grows with the panel instead of staying a small
+// fixed number. truncate() (ANSI-safe, hard cutoff with an ellipsis) is
+// applied to every field so an overlong value can never push a later column
+// out of place, matching searchResultsPane's reasoning for why overflow must
+// never reach lipgloss's automatic line-wrap.
+func (m Model) modRow(index, width int, mod ModItem) string {
+	const prefixWidth = 2 // m.row()'s "> "/"  " selection marker
+	const gaps = 3        // separating spaces between the 4 columns
+	const minName = 8
+
+	avail := max(width-m.theme.Panel.GetHorizontalFrameSize()-prefixWidth-gaps, minName)
+	statusWidth := min(11, max(avail/6, 1)) // "disabled"/"deployed" are 8 runes
+	authorWidth := min(16, max(avail/5, 1))
+	versionWidth := min(7, max(avail/8, 1))
+	nameWidth := max(avail-statusWidth-authorWidth-versionWidth, minName)
+
+	line := fmt.Sprintf("%-*s %-*s %-*s %*s",
+		nameWidth, truncate(mod.Name, nameWidth),
+		statusWidth, truncate(mod.Status, statusWidth),
+		authorWidth, truncate(mod.Author, authorWidth),
+		versionWidth, truncate(mod.Version, versionWidth))
 	return m.row(index, line)
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -208,12 +208,19 @@ func TestScreenViewsUseExactAvailableHeightOnLargeTerminals(t *testing.T) {
 func TestViewFitsTerminalBoundsWithHelpVisible(t *testing.T) {
 	t.Parallel()
 
-	model := sizedPrototypeModel(t, "wizardry", 120, 36)
+	// Height bumped 36->37 for Task 7's new e/x/D help line: the party-sheet
+	// dashboard's COMMANDS menu panel already fit height=36's help-visible
+	// content budget with exactly zero slack (6 content lines against a
+	// panelContentHeight of exactly 6), so ANY help-overlay growth needs one
+	// more terminal row here to keep the exact-height invariant this test
+	// guards - see task-7-brief.md's "height/help tests may need justified
+	// adjustment for new hint lines" allowance.
+	model := sizedPrototypeModel(t, "wizardry", 120, 37)
 	model = updateWithRunes(t, model, "?")
 
 	view := model.View()
 	require.Equal(t, 120, lipgloss.Width(view))
-	require.Equal(t, 36, lipgloss.Height(view))
+	require.Equal(t, 37, lipgloss.Height(view))
 }
 
 func TestThemesUseDistinctLayouts(t *testing.T) {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -226,8 +226,14 @@ func TestModRowColumnsAlignRegardlessOfNameLength(t *testing.T) {
 			longIdx := strings.Index(longRow, "disabled")
 			require.Greater(t, shortIdx, 0, "status column must be present in the short-name row")
 			require.Greater(t, longIdx, 0, "status column must be present in the long-name row")
-			require.Equal(t, shortIdx, longIdx,
-				"the Status column must start at the same offset regardless of name length")
+			// Compare DISPLAY columns (lipgloss.Width), not byte offsets: the
+			// truncated long name ends in a multi-byte "…" ellipsis rune, so a
+			// byte-offset comparison would report a false mismatch even though
+			// the row aligns visually - which is the actual bug being fixed.
+			shortCol := lipgloss.Width(shortRow[:shortIdx])
+			longCol := lipgloss.Width(longRow[:longIdx])
+			require.Equal(t, shortCol, longCol,
+				"the Status column must start at the same display column regardless of name length")
 
 			require.LessOrEqual(t, lipgloss.Width(longRow), model.availableWidth(),
 				"an overlong name must be hard-truncated, never overflow the row")

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -259,6 +259,69 @@ func TestModRowNameColumnGrowsWithPanelWidth(t *testing.T) {
 		"a wider terminal must give the name column more room, proportional to the panel width")
 }
 
+// TestProfileRowColumnsAlignRegardlessOfNameLength covers the same defect
+// class the fix wave fixed in modRow (Finding 2) but flagged as out of scope
+// for profilesView: a profile name longer than its allotted space used to
+// overflow the fixed-width name column unchecked (the old
+// "%s %-22s %3d mods" format had no truncation), shifting the mod-count
+// column out of alignment with shorter rows. profileRow must give the name
+// column room proportional to the panel width and hard-truncate any name
+// that still overflows, so the mod-count column starts at the same offset
+// regardless of name length. Run at both a common 80-column size and the
+// wider ~160 columns the smoke test flagged as the normal case.
+func TestProfileRowColumnsAlignRegardlessOfNameLength(t *testing.T) {
+	t.Parallel()
+
+	sizes := []struct{ width, height int }{{80, 24}, {160, 40}}
+	for _, size := range sizes {
+		t.Run(fmt.Sprintf("%dx%d", size.width, size.height), func(t *testing.T) {
+			t.Parallel()
+
+			model := sizedPrototypeModel(t, "wizardry", size.width, size.height)
+			short := ProfileItem{Name: "Short", ModCount: 3}
+			long := ProfileItem{Name: strings.Repeat("VeryLongProfileName", 6), ModCount: 12}
+
+			shortRow := model.profileRow(0, model.availableWidth(), short)
+			longRow := model.profileRow(1, model.availableWidth(), long)
+
+			shortIdx := strings.Index(shortRow, "3 mods")
+			longIdx := strings.Index(longRow, "12 mods")
+			require.Greater(t, shortIdx, 0, "mod-count column must be present in the short-name row")
+			require.Greater(t, longIdx, 0, "mod-count column must be present in the long-name row")
+			// Compare DISPLAY columns (lipgloss.Width), not byte offsets: a
+			// truncated long name ends in a multi-byte "…" ellipsis rune, so a
+			// byte-offset comparison would report a false mismatch even though
+			// the row aligns visually - see modRow's TestModRowColumnsAlign...
+			// for the same pitfall.
+			shortCol := lipgloss.Width(shortRow[:shortIdx])
+			longCol := lipgloss.Width(longRow[:longIdx])
+			require.Equal(t, shortCol, longCol,
+				"the mod-count column must start at the same display column regardless of name length")
+
+			require.LessOrEqual(t, lipgloss.Width(longRow), model.availableWidth(),
+				"an overlong name must be hard-truncated, never overflow the row")
+		})
+	}
+}
+
+// TestProfileRowNameColumnGrowsWithPanelWidth proves the name column is
+// proportional to the panel's width rather than a small fixed column count:
+// a wider terminal must give the whole row - and so the name column - more
+// room, not just a marginally bigger fixed number.
+func TestProfileRowNameColumnGrowsWithPanelWidth(t *testing.T) {
+	t.Parallel()
+
+	narrow := sizedPrototypeModel(t, "wizardry", 80, 24)
+	wide := sizedPrototypeModel(t, "wizardry", 160, 40)
+	profile := ProfileItem{Name: "X", ModCount: 1}
+
+	narrowRow := narrow.profileRow(0, narrow.availableWidth(), profile)
+	wideRow := wide.profileRow(0, wide.availableWidth(), profile)
+
+	require.Greater(t, lipgloss.Width(wideRow), lipgloss.Width(narrowRow),
+		"a wider terminal must give the name column more room, proportional to the panel width")
+}
+
 func TestDashboardLayoutsDoNotOverflowNarrowTerminals(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -62,10 +62,16 @@ func TestTabCyclesScreens(t *testing.T) {
 	require.Equal(t, ScreenDashboard, updated.CurrentScreen())
 }
 
-// TestTabCyclingOntoSearchFocuses covers the tab-cycling entry path into
-// ScreenSearch: like every other entry path (number keys, dashboard menu,
-// "/"), it must focus the input immediately.
-func TestTabCyclingOntoSearchFocuses(t *testing.T) {
+// TestTabCyclingOntoSearchDoesNotFocus covers the tab-cycling entry path into
+// ScreenSearch. Finding 1 (smoke test): auto-focusing here trapped the user,
+// since a focused input swallows every keystroke (see updateKey's
+// focused-input branch) — they couldn't keep cycling past Search without
+// pressing Esc first. Only the two EXPLICIT "go search" bindings, "/" and
+// "3", may focus (see TestSlashFromAnyScreenJumpsAndFocuses and
+// TestNumberThreeJumpsAndFocuses); screen-cycling must land here unfocused,
+// and a further Tab must keep cycling straight through to the next screen
+// instead of being swallowed as literal text — that's the trap repro.
+func TestTabCyclingOntoSearchDoesNotFocus(t *testing.T) {
 	t.Parallel()
 
 	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
@@ -76,7 +82,12 @@ func TestTabCyclingOntoSearchFocuses(t *testing.T) {
 
 	updated = updateWithKeyType(t, updated, tea.KeyTab)
 	require.Equal(t, ScreenSearch, updated.CurrentScreen())
-	require.True(t, updated.search.input.Focused(), "tab-cycling onto search must focus the input")
+	require.False(t, updated.search.input.Focused(), "tab-cycling onto search must NOT focus the input")
+
+	// Trap repro: a further Tab must move on to the next screen, not be
+	// swallowed as literal text by a focused input.
+	updated = updateWithKeyType(t, updated, tea.KeyTab)
+	require.Equal(t, ScreenProfiles, updated.CurrentScreen())
 }
 
 func TestArrowAndVimKeysNavigateScreens(t *testing.T) {
@@ -90,12 +101,18 @@ func TestArrowAndVimKeysNavigateScreens(t *testing.T) {
 
 	model = updateWithRunes(t, model, "l")
 	require.Equal(t, ScreenSearch, model.CurrentScreen())
-	require.True(t, model.search.input.Focused(), "cycling onto search focuses the input")
+	// Finding 1: cycling onto search must NOT focus the input, so the
+	// remaining screen-level arrow/vim keys below keep cycling straight
+	// through — no Esc needed first (that was the trap).
+	require.False(t, model.search.input.Focused(), "cycling onto search must not focus the input")
 
-	// Esc blurs so the remaining screen-level arrow/vim keys reach updateKey's
-	// outer switch instead of moving the cursor inside the now-focused input.
-	model = updateWithKeyType(t, model, tea.KeyEsc)
+	model = updateWithRunes(t, model, "l")
+	require.Equal(t, ScreenProfiles, model.CurrentScreen())
+
 	model = updateWithKeyType(t, model, tea.KeyLeft)
+	require.Equal(t, ScreenSearch, model.CurrentScreen())
+
+	model = updateWithRunes(t, model, "h")
 	require.Equal(t, ScreenInstalledMods, model.CurrentScreen())
 
 	model = updateWithRunes(t, model, "h")
@@ -323,11 +340,13 @@ func TestDashboardEnterOpensSelectedMenuEntry(t *testing.T) {
 	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	require.Equal(t, ScreenInstalledMods, opened.(Model).CurrentScreen())
 
-	// Second entry opens Search, focused like every other entry path.
+	// Second entry opens Search. Per Finding 1, dashboard-menu selection is a
+	// navigation/jump path, not one of the two EXPLICIT "go search" bindings
+	// ("/" and "3"), so it must NOT auto-focus the input either.
 	moved := updateWithRunes(t, model, "j")
 	opened, _ = moved.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	require.Equal(t, ScreenSearch, opened.(Model).CurrentScreen())
-	require.True(t, opened.(Model).search.input.Focused(), "dashboard menu entry into search must focus the input")
+	require.False(t, opened.(Model).search.input.Focused(), "dashboard menu entry into search must not auto-focus")
 }
 
 func TestDashboardEnterOnOracleEntryStaysPut(t *testing.T) {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -402,13 +402,17 @@ func TestDashboardEnterOpensSelectedMenuEntry(t *testing.T) {
 	opened, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	require.Equal(t, ScreenInstalledMods, opened.(Model).CurrentScreen())
 
-	// Second entry opens Search. Per Finding 1, dashboard-menu selection is a
-	// navigation/jump path, not one of the two EXPLICIT "go search" bindings
-	// ("/" and "3"), so it must NOT auto-focus the input either.
+	// Second entry opens Search. Per the reporter's governing principle
+	// (mop-up follow-up to Finding 1): EXPLICIT search intent focuses ("/"
+	// and "3" already do); passive screen-cycling doesn't. Selecting "Search
+	// Archives" from the dashboard menu via Enter IS explicit intent — the
+	// user picked "search" by name — so this path must focus, unlike
+	// NextScreen/PrevScreen/direct-jump cycling landing on Search in
+	// passing (see TestTabCyclingOntoSearchDoesNotFocus).
 	moved := updateWithRunes(t, model, "j")
 	opened, _ = moved.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	require.Equal(t, ScreenSearch, opened.(Model).CurrentScreen())
-	require.False(t, opened.(Model).search.input.Focused(), "dashboard menu entry into search must not auto-focus")
+	require.True(t, opened.(Model).search.input.Focused(), "dashboard menu's explicit Search Archives entry must auto-focus")
 }
 
 func TestDashboardEnterOnOracleEntryStaysPut(t *testing.T) {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -195,6 +197,60 @@ func TestScreenViewsUseAvailableWidth(t *testing.T) {
 		model.screen = screen
 		require.Equal(t, model.availableWidth(), lipgloss.Width(model.screenView()), screen.String())
 	}
+}
+
+// TestModRowColumnsAlignRegardlessOfNameLength covers Finding 2 (smoke
+// test): a mod name longer than its allotted space used to overflow the
+// fixed-width name column unchecked, shifting every subsequent column to
+// the right so rows didn't line up. modRow must give the name column room
+// proportional to the panel width and hard-truncate any name that still
+// overflows, so the Status column starts at the same offset regardless of
+// name length. Run at both a common 80-column size and the wider ~160
+// columns the smoke test flagged as the normal case.
+func TestModRowColumnsAlignRegardlessOfNameLength(t *testing.T) {
+	t.Parallel()
+
+	sizes := []struct{ width, height int }{{80, 24}, {160, 40}}
+	for _, size := range sizes {
+		t.Run(fmt.Sprintf("%dx%d", size.width, size.height), func(t *testing.T) {
+			t.Parallel()
+
+			model := sizedPrototypeModel(t, "wizardry", size.width, size.height)
+			short := ModItem{Name: "Short", Status: "enabled", Author: "Alice", Version: "1.0.0"}
+			long := ModItem{Name: strings.Repeat("VeryLongModName", 6), Status: "disabled", Author: "Bob", Version: "2.1.0"}
+
+			shortRow := model.modRow(0, model.availableWidth(), short)
+			longRow := model.modRow(1, model.availableWidth(), long)
+
+			shortIdx := strings.Index(shortRow, "enabled")
+			longIdx := strings.Index(longRow, "disabled")
+			require.Greater(t, shortIdx, 0, "status column must be present in the short-name row")
+			require.Greater(t, longIdx, 0, "status column must be present in the long-name row")
+			require.Equal(t, shortIdx, longIdx,
+				"the Status column must start at the same offset regardless of name length")
+
+			require.LessOrEqual(t, lipgloss.Width(longRow), model.availableWidth(),
+				"an overlong name must be hard-truncated, never overflow the row")
+		})
+	}
+}
+
+// TestModRowNameColumnGrowsWithPanelWidth proves the name column is
+// proportional to the panel's width (Finding 2) rather than a small fixed
+// column count: a wider terminal must give the whole row - and so the name
+// column - more room, not just a marginally bigger fixed number.
+func TestModRowNameColumnGrowsWithPanelWidth(t *testing.T) {
+	t.Parallel()
+
+	narrow := sizedPrototypeModel(t, "wizardry", 80, 24)
+	wide := sizedPrototypeModel(t, "wizardry", 160, 40)
+	mod := ModItem{Name: "X", Status: "enabled", Author: "Alice", Version: "1.0.0"}
+
+	narrowRow := narrow.modRow(0, narrow.availableWidth(), mod)
+	wideRow := wide.modRow(0, wide.availableWidth(), mod)
+
+	require.Greater(t, lipgloss.Width(wideRow), lipgloss.Width(narrowRow),
+		"a wider terminal must give the name column more room, proportional to the panel width")
 }
 
 func TestDashboardLayoutsDoNotOverflowNarrowTerminals(t *testing.T) {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -22,6 +22,8 @@ type KeyMap struct {
 	NextPage      key.Binding
 	PrevPage      key.Binding
 	CycleSource   key.Binding
+	ConfirmAction key.Binding
+	CancelAction  key.Binding
 }
 
 // DefaultKeyMap returns the shared key bindings shown in help and used by tests.
@@ -98,6 +100,14 @@ func DefaultKeyMap() KeyMap {
 		CycleSource: key.NewBinding(
 			key.WithKeys("s"),
 			key.WithHelp("s", "cycle source"),
+		),
+		ConfirmAction: key.NewBinding(
+			key.WithKeys("y", "enter"),
+			key.WithHelp("y/enter", "confirm"),
+		),
+		CancelAction: key.NewBinding(
+			key.WithKeys("n", "esc"),
+			key.WithHelp("n/esc", "cancel"),
 		),
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -24,6 +24,13 @@ type KeyMap struct {
 	CycleSource   key.Binding
 	ConfirmAction key.Binding
 	CancelAction  key.Binding
+	// ToggleEnable, Uninstall, and Deploy are Phase 5a's Installed
+	// Mods/Dashboard mutation bindings (see mutations.go). Profile switch
+	// deliberately has no binding of its own here - it reuses Select
+	// ("enter"), dispatched by screen in updateKey.
+	ToggleEnable key.Binding
+	Uninstall    key.Binding
+	Deploy       key.Binding
 }
 
 // DefaultKeyMap returns the shared key bindings shown in help and used by tests.
@@ -108,6 +115,18 @@ func DefaultKeyMap() KeyMap {
 		CancelAction: key.NewBinding(
 			key.WithKeys("n", "esc"),
 			key.WithHelp("n/esc", "cancel"),
+		),
+		ToggleEnable: key.NewBinding(
+			key.WithKeys("e"),
+			key.WithHelp("e", "toggle enable/disable"),
+		),
+		Uninstall: key.NewBinding(
+			key.WithKeys("x"),
+			key.WithHelp("x", "uninstall"),
+		),
+		Deploy: key.NewBinding(
+			key.WithKeys("D"),
+			key.WithHelp("D", "deploy profile"),
 		),
 	}
 }

--- a/internal/tui/keys_test.go
+++ b/internal/tui/keys_test.go
@@ -17,3 +17,45 @@ func TestDefaultKeyMapDocumentsPrototypeBindings(t *testing.T) {
 	require.True(t, key.Matches(tea.KeyMsg{Type: tea.KeyTab}, keyMap.NextScreen))
 	require.True(t, key.Matches(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}}, keyMap.Search))
 }
+
+// TestDefaultKeyMapDocumentsMutationBindings guards the Task 7 keybindings:
+// e (toggle enable/disable), x (uninstall), and D (deploy). Profile switch
+// deliberately reuses the existing Select ("enter") binding rather than
+// adding a new one - see mutations.go's switchSelectedProfile.
+func TestDefaultKeyMapDocumentsMutationBindings(t *testing.T) {
+	t.Parallel()
+
+	keyMap := DefaultKeyMap()
+	require.True(t, key.Matches(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}}, keyMap.ToggleEnable))
+	require.True(t, key.Matches(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}}, keyMap.Uninstall))
+	require.True(t, key.Matches(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}}, keyMap.Deploy))
+}
+
+// TestMutationBindingsDoNotCollideWithExistingBindings traces every binding
+// already registered in KeyMap against the three new single-key mutation
+// bindings, guarding task-7-brief.md's "verify no collision" requirement as
+// a standing regression check rather than a one-time manual trace.
+func TestMutationBindingsDoNotCollideWithExistingBindings(t *testing.T) {
+	t.Parallel()
+
+	keyMap := DefaultKeyMap()
+	existing := map[string]key.Binding{
+		"Quit": keyMap.Quit, "Help": keyMap.Help, "NextScreen": keyMap.NextScreen,
+		"PrevScreen": keyMap.PrevScreen, "Up": keyMap.Up, "Down": keyMap.Down,
+		"Search": keyMap.Search, "SearchScreen": keyMap.SearchScreen, "Dashboard": keyMap.Dashboard,
+		"InstalledMods": keyMap.InstalledMods, "Profiles": keyMap.Profiles, "Sources": keyMap.Sources,
+		"Select": keyMap.Select, "Submit": keyMap.Submit, "Blur": keyMap.Blur,
+		"NextPage": keyMap.NextPage, "PrevPage": keyMap.PrevPage, "CycleSource": keyMap.CycleSource,
+		"ConfirmAction": keyMap.ConfirmAction, "CancelAction": keyMap.CancelAction,
+	}
+	mutation := map[string]key.Binding{"ToggleEnable": keyMap.ToggleEnable, "Uninstall": keyMap.Uninstall, "Deploy": keyMap.Deploy}
+
+	for mName, m := range mutation {
+		for eName, e := range existing {
+			for _, k := range m.Keys() {
+				msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)}
+				require.False(t, key.Matches(msg, e), "%s (%q) collides with existing binding %s", mName, k, eName)
+			}
+		}
+	}
+}

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -62,7 +62,7 @@ func (m Model) toggleSelectedModEnable() (Model, tea.Cmd) {
 func (m Model) promptEnable(item ModItem) (Model, tea.Cmd) {
 	title := fmt.Sprintf("Enable %q?", item.Name)
 	detail := m.gameProfileDetail("Files will be deployed to the game directory.")
-	model, pa := m.buildAction(actionEnable, title, detail, func(ctx context.Context) (ActionOutcome, error) {
+	model, pa := m.buildAction(actionEnable, title, detail, "", func(ctx context.Context) (ActionOutcome, error) {
 		return m.actions.EnableMod(ctx, item)
 	})
 	return model.promptAction(pa), nil
@@ -71,7 +71,7 @@ func (m Model) promptEnable(item ModItem) (Model, tea.Cmd) {
 func (m Model) promptDisable(item ModItem) (Model, tea.Cmd) {
 	title := fmt.Sprintf("Disable %q?", item.Name)
 	detail := m.gameProfileDetail("Files will be removed from the game directory (cache kept).")
-	model, pa := m.buildAction(actionDisable, title, detail, func(ctx context.Context) (ActionOutcome, error) {
+	model, pa := m.buildAction(actionDisable, title, detail, "", func(ctx context.Context) (ActionOutcome, error) {
 		return m.actions.DisableMod(ctx, item)
 	})
 	return model.promptAction(pa), nil
@@ -89,7 +89,7 @@ func (m Model) uninstallSelectedMod() (Model, tea.Cmd) {
 	}
 	title := fmt.Sprintf("Uninstall %q?", item.Name)
 	detail := m.gameProfileDetail("Removes deployed files, cache, and profile entry. Uninstall hooks will run.")
-	model, pa := m.buildAction(actionUninstall, title, detail, func(ctx context.Context) (ActionOutcome, error) {
+	model, pa := m.buildAction(actionUninstall, title, detail, "", func(ctx context.Context) (ActionOutcome, error) {
 		return m.actions.UninstallMod(ctx, item)
 	})
 	return model.promptAction(pa), nil
@@ -112,7 +112,7 @@ func (m Model) deployActiveProfile() (Model, tea.Cmd) {
 		fmt.Sprintf("Game: %s", m.summary.GameName),
 		fmt.Sprintf("Mods: %d enabled", m.summary.Enabled),
 	}
-	model, pa := m.buildAction(actionDeploy, title, detail, func(ctx context.Context) (ActionOutcome, error) {
+	model, pa := m.buildAction(actionDeploy, title, detail, "", func(ctx context.Context) (ActionOutcome, error) {
 		return m.actions.DeployProfile(ctx)
 	})
 	return model.promptAction(pa), nil
@@ -216,7 +216,7 @@ func (m Model) resolvePlanResult(msg planResultMsg) (Model, tea.Cmd) {
 		return m, nil
 	default:
 		title := fmt.Sprintf("Switch to %q?", view.To)
-		model, pa := m.buildAction(actionSwitch, title, switchDetailLines(view), func(ctx context.Context) (ActionOutcome, error) {
+		model, pa := m.buildAction(actionSwitch, title, switchDetailLines(view), view.To, func(ctx context.Context) (ActionOutcome, error) {
 			return m.actions.ApplyProfileSwitch(ctx, view.To)
 		})
 		return model.promptAction(pa), nil

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -1,0 +1,259 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// This file wires Task 6's generic confirmation-modal/action machinery
+// (actions.go) to concrete keybindings (keys.go's ToggleEnable/Uninstall/
+// Deploy, and Select reused for profile switch - see updateKey's Select
+// case): what each key builds as a pendingAction, and - for profile switch,
+// which needs an async read before it can even show a modal - the extra
+// plan-fetch state machine. See task-7-brief.md for the exact modal
+// copy/keybindings this implements.
+
+// selectedMod returns the currently-selected Installed Mods row, or false
+// if the selection is out of range (covers both an empty list and the
+// general "selection can't have drifted past clampSelections, but a nil
+// mods slice with a stale selected index is still possible on the very
+// first render before any data has loaded" case).
+func (m Model) selectedMod() (ModItem, bool) {
+	idx := m.selected[ScreenInstalledMods]
+	if idx < 0 || idx >= len(m.mods) {
+		return ModItem{}, false
+	}
+	return m.mods[idx], true
+}
+
+// gameProfileDetail renders the "Game: <name>" / "Profile: <name>" detail
+// lines shared by the Enable/Disable/Uninstall modals, plus one caller-owned
+// trailing line describing the mutation's effect.
+func (m Model) gameProfileDetail(effect string) []string {
+	return []string{
+		fmt.Sprintf("Game: %s", m.summary.GameName),
+		fmt.Sprintf("Profile: %s", m.summary.ProfileName),
+		effect,
+	}
+}
+
+// toggleSelectedModEnable handles 'e' on Installed Mods: the direction
+// comes from the selected item's Status (task-7-brief.md's Keybindings
+// section) - "disabled" enables, anything else (coreProvider's "enabled"/
+// "deployed", or any other in-progress-flavor status a source might report)
+// disables. A no-op on the wrong screen, an empty list, or with no
+// ActionProvider configured.
+func (m Model) toggleSelectedModEnable() (Model, tea.Cmd) {
+	if m.screen != ScreenInstalledMods || m.actions == nil {
+		return m, nil
+	}
+	item, ok := m.selectedMod()
+	if !ok {
+		return m, nil
+	}
+	if item.Status == "disabled" {
+		return m.promptEnable(item)
+	}
+	return m.promptDisable(item)
+}
+
+func (m Model) promptEnable(item ModItem) (Model, tea.Cmd) {
+	title := fmt.Sprintf("Enable %q?", item.Name)
+	detail := m.gameProfileDetail("Files will be deployed to the game directory.")
+	model, pa := m.buildAction(actionEnable, title, detail, func(ctx context.Context) (ActionOutcome, error) {
+		return m.actions.EnableMod(ctx, item)
+	})
+	return model.promptAction(pa), nil
+}
+
+func (m Model) promptDisable(item ModItem) (Model, tea.Cmd) {
+	title := fmt.Sprintf("Disable %q?", item.Name)
+	detail := m.gameProfileDetail("Files will be removed from the game directory (cache kept).")
+	model, pa := m.buildAction(actionDisable, title, detail, func(ctx context.Context) (ActionOutcome, error) {
+		return m.actions.DisableMod(ctx, item)
+	})
+	return model.promptAction(pa), nil
+}
+
+// uninstallSelectedMod handles 'x' on Installed Mods. A no-op on the wrong
+// screen, an empty list, or with no ActionProvider configured.
+func (m Model) uninstallSelectedMod() (Model, tea.Cmd) {
+	if m.screen != ScreenInstalledMods || m.actions == nil {
+		return m, nil
+	}
+	item, ok := m.selectedMod()
+	if !ok {
+		return m, nil
+	}
+	title := fmt.Sprintf("Uninstall %q?", item.Name)
+	detail := m.gameProfileDetail("Removes deployed files, cache, and profile entry. Uninstall hooks will run.")
+	model, pa := m.buildAction(actionUninstall, title, detail, func(ctx context.Context) (ActionOutcome, error) {
+		return m.actions.UninstallMod(ctx, item)
+	})
+	return model.promptAction(pa), nil
+}
+
+// deployActiveProfile handles 'D' on Dashboard or Installed Mods
+// (task-7-brief.md's Keybindings section). Unlike the mod-scoped actions
+// above, deploying doesn't depend on any row selection, so an empty mods
+// list is not a no-op case here - deploying zero enabled mods is a valid
+// (if unusual) outcome the provider itself reports. Link method is omitted
+// from the detail: it isn't exposed anywhere in DataProvider/Summary, and
+// this task's scope keeps DataProvider frozen, so it isn't "cheaply
+// available" per the brief's own qualifier.
+func (m Model) deployActiveProfile() (Model, tea.Cmd) {
+	if (m.screen != ScreenDashboard && m.screen != ScreenInstalledMods) || m.actions == nil {
+		return m, nil
+	}
+	title := fmt.Sprintf("Deploy profile %q?", m.summary.ProfileName)
+	detail := []string{
+		fmt.Sprintf("Game: %s", m.summary.GameName),
+		fmt.Sprintf("Mods: %d", m.summary.Installed),
+	}
+	model, pa := m.buildAction(actionDeploy, title, detail, func(ctx context.Context) (ActionOutcome, error) {
+		return m.actions.DeployProfile(ctx)
+	})
+	return model.promptAction(pa), nil
+}
+
+// planResultMsg carries a successful PlanProfileSwitch result, tagged with
+// the generation established when the fetch was dispatched (see
+// switchSelectedProfile) so a superseded result can be discarded exactly
+// like actionDoneMsg/actionFailedMsg (actions.go).
+type planResultMsg struct {
+	gen  int
+	view SwitchPlanView
+}
+
+// planFailedMsg carries a failed PlanProfileSwitch call, tagged like
+// planResultMsg.
+type planFailedMsg struct {
+	gen int
+	err error
+}
+
+// switchSelectedProfile handles enter on Profiles (task-7-brief.md's
+// profile-switch flow): a no-op on the wrong screen, an empty list, with no
+// ActionProvider, or while another action/plan is already in flight
+// (single-flight, checked explicitly here since this branch runs before any
+// pendingAction exists for buildAction/promptAction's own guard to catch).
+// The active profile resolves synchronously ("Already on profile <name>",
+// no modal - see resolvePlanResult's AlreadyActive branch for the
+// defensive counterpart of this same check); any other profile dispatches
+// an async PlanProfileSwitch, reusing action.gen/action.cancel exactly like
+// buildAction does, so the result is subject to the same staleness
+// discipline before it's allowed to open a modal.
+func (m Model) switchSelectedProfile() (Model, tea.Cmd) {
+	if m.screen != ScreenProfiles || m.actions == nil {
+		return m, nil
+	}
+	if m.action.running || m.action.pending != nil {
+		return m, nil
+	}
+
+	idx := m.selected[ScreenProfiles]
+	if idx < 0 || idx >= len(m.profiles) {
+		return m, nil
+	}
+	profile := m.profiles[idx]
+	if profile.Active {
+		m.action.status = fmt.Sprintf("Already on profile %q", profile.Name)
+		m.action.statusIsError = false
+		return m, nil
+	}
+
+	if m.action.cancel != nil {
+		m.action.cancel()
+	}
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.action.cancel = cancel
+	m.action.gen++
+	gen := m.action.gen
+	m.action.running = true
+	m.action.status = "Planning switch…"
+	m.action.statusIsError = false
+
+	actions := m.actions
+	name := profile.Name
+	return m, func() tea.Msg {
+		view, err := actions.PlanProfileSwitch(ctx, name)
+		if err != nil {
+			return planFailedMsg{gen: gen, err: err}
+		}
+		return planResultMsg{gen: gen, view: view}
+	}
+}
+
+// resolvePlanResult handles a fresh (non-stale - callers check msg.gen
+// first) planResultMsg. AlreadyActive and NeedsDownloads both resolve to a
+// status-line message with no modal (task-7-brief.md's profile-switch
+// flow); AlreadyActive here is defensive only, since switchSelectedProfile
+// already pre-filters the active profile synchronously and never reaches
+// the async fetch for it. Any other plan opens the switch confirmation
+// modal via buildAction, which establishes its OWN fresh gen/cancel for the
+// eventual ApplyProfileSwitch call - running/cancel from the plan fetch are
+// cleared first, so buildAction's single-flight guard passes cleanly.
+func (m Model) resolvePlanResult(msg planResultMsg) (Model, tea.Cmd) {
+	m.action.running = false
+	if m.action.cancel != nil {
+		m.action.cancel()
+		m.action.cancel = nil
+	}
+
+	view := msg.view
+	switch {
+	case view.AlreadyActive:
+		m.action.status = fmt.Sprintf("Already on profile %q", view.To)
+		m.action.statusIsError = false
+		return m, nil
+	case len(view.NeedsDownloads) > 0:
+		// The exact provider-contract refusal message (errProfileNeedsDownloads,
+		// actions_provider.go) - listing which mods is 5b polish per the brief.
+		m.action.status = errProfileNeedsDownloads.Error()
+		m.action.statusIsError = true
+		return m, nil
+	default:
+		title := fmt.Sprintf("Switch to %q?", view.To)
+		model, pa := m.buildAction(actionSwitch, title, switchDetailLines(view), func(ctx context.Context) (ActionOutcome, error) {
+			return m.actions.ApplyProfileSwitch(ctx, view.To)
+		})
+		return model.promptAction(pa), nil
+	}
+}
+
+// resolvePlanFailure handles a fresh planFailedMsg: status line error, no
+// modal, mirroring actionFailedMsg's own rendering (actions.go's
+// singleLine/statusIsError contract).
+func (m Model) resolvePlanFailure(msg planFailedMsg) (Model, tea.Cmd) {
+	m.action.running = false
+	if m.action.cancel != nil {
+		m.action.cancel()
+		m.action.cancel = nil
+	}
+	m.action.status = singleLine(msg.err.Error())
+	m.action.statusIsError = true
+	return m, nil
+}
+
+// switchDetailLines renders a SwitchPlanView as the switch modal's detail
+// lines: "From: <From>", then one "+ <name>" line per mod to enable and one
+// "- <name>" line per mod to disable - the CLI's own +/- convention (see
+// switchPlanView's doc comment in service_core.go) - so the modal's
+// existing "+N more" overflow collapsing (actionModalView) applies per mod
+// instead of truncating one giant joined line. NoChanges plans render a
+// single explanatory line instead, per task-7-brief.md.
+func switchDetailLines(view SwitchPlanView) []string {
+	if view.NoChanges {
+		return []string{fmt.Sprintf("From: %s", view.From), "No mod changes; set as default."}
+	}
+	lines := []string{fmt.Sprintf("From: %s", view.From)}
+	for _, name := range view.Enable {
+		lines = append(lines, fmt.Sprintf("+ %s", name))
+	}
+	for _, name := range view.Disable {
+		lines = append(lines, fmt.Sprintf("- %s", name))
+	}
+	return lines
+}

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -110,7 +110,7 @@ func (m Model) deployActiveProfile() (Model, tea.Cmd) {
 	title := fmt.Sprintf("Deploy profile %q?", m.summary.ProfileName)
 	detail := []string{
 		fmt.Sprintf("Game: %s", m.summary.GameName),
-		fmt.Sprintf("Mods: %d", m.summary.Installed),
+		fmt.Sprintf("Mods: %d enabled", m.summary.Enabled),
 	}
 	model, pa := m.buildAction(actionDeploy, title, detail, func(ctx context.Context) (ActionOutcome, error) {
 		return m.actions.DeployProfile(ctx)

--- a/internal/tui/mutations_test.go
+++ b/internal/tui/mutations_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
@@ -783,12 +784,38 @@ func TestHelpOverlayDocumentsMutationKeysAndDropsStaleReadOnlyClaim(t *testing.T
 		"the help copy must no longer claim the TUI is read-only now that mutations exist")
 }
 
-func TestFooterHintMentionsMutationKeys(t *testing.T) {
+// TestFooterHintNamesEachMutationAction covers Finding 3 (smoke test): the
+// old "e/x/D: mutate" hint named the keys but never said what they DO. The
+// footer must spell out each action explicitly instead. Per the smoke
+// tester's follow-up guidance, 160 columns (not 80) is the normal case to
+// design and assert full clarity against — narrower terminals degrade via
+// truncation (see TestFooterFitsNarrowTerminalViaTruncation) rather than by
+// cramming the wording.
+func TestFooterHintNamesEachMutationAction(t *testing.T) {
 	t.Parallel()
 
-	model := sizedPrototypeModel(t, "wizardry", 120, 36)
+	model := sizedPrototypeModel(t, "wizardry", 160, 40)
 	view := model.View()
 
-	require.Contains(t, view, "e/x/D: mutate")
+	require.Contains(t, view, "e: enable/disable")
+	require.Contains(t, view, "x: uninstall")
+	require.Contains(t, view, "D: deploy")
 	require.Contains(t, view, "enter: switch")
+	require.NotContains(t, view, "mutate",
+		"the terse, unexplained 'mutate' wording must be gone")
+}
+
+// TestFooterFitsNarrowTerminalViaTruncation proves the footer degrades
+// gracefully at a narrower terminal: it must be hard-truncated to the
+// available width rather than left to lipgloss's automatic word-wrap, which
+// would silently grow the view past its fixed-height budget (see
+// contentChromeHeight's footerHeight == 1 assumption).
+func TestFooterFitsNarrowTerminalViaTruncation(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 80, 24)
+	view := model.View()
+
+	require.Equal(t, 80, lipgloss.Width(view))
+	require.Equal(t, 24, lipgloss.Height(view))
 }

--- a/internal/tui/mutations_test.go
+++ b/internal/tui/mutations_test.go
@@ -1,0 +1,671 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
+)
+
+// --- Toggle enable/disable ('e' on Installed Mods) ---
+
+// TestToggleEnableKeyOnDisabledModPromptsEnable covers the full round trip
+// for the enable direction: 'e' on a disabled mod builds+shows the Enable
+// modal (nothing calls the provider yet), 'y' dispatches EnableMod with the
+// SELECTED item, and the resulting actionDoneMsg triggers a refresh.
+func TestToggleEnableKeyOnDisabledModPromptsEnable(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{EnableOutcome: ActionOutcome{Message: `Enabled "Alternate Start"`}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 4 // "Alternate Start", status "disabled"
+	require.Equal(t, "disabled", model.mods[4].Status)
+
+	updated, cmd := model.Update(keyRunes("e"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionEnable, model.action.pending.kind)
+	require.Equal(t, `Enable "Alternate Start"?`, model.action.pending.title)
+	require.Contains(t, model.action.pending.detail, "Game: Skyrim Special Edition")
+	require.Contains(t, model.action.pending.detail, "Profile: survival")
+	require.Contains(t, model.action.pending.detail, "Files will be deployed to the game directory.")
+	require.Empty(t, rec.EnableCalls, "nothing must mutate before confirm")
+
+	confirmed, confirmCmd := model.Update(keyRunes("y"))
+	model = confirmed.(Model)
+	require.Nil(t, model.action.pending)
+	require.NotNil(t, confirmCmd)
+
+	doneMsg := confirmCmd()
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+	require.Len(t, rec.EnableCalls, 1)
+	require.Equal(t, "alternate-start", rec.EnableCalls[0].ID)
+	require.Equal(t, "nexusmods", rec.EnableCalls[0].Source)
+
+	updated, refreshCmd := model.Update(doneMsg)
+	model = updated.(Model)
+	require.NotNil(t, refreshCmd)
+	require.Equal(t, `Enabled "Alternate Start"`, model.action.status)
+	require.IsType(t, dataLoadedMsg{}, refreshCmd())
+}
+
+// TestToggleEnableKeyOnEnabledModPromptsDisable covers the disable
+// direction: any status other than "disabled" toggles to Disable.
+func TestToggleEnableKeyOnEnabledModPromptsDisable(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{DisableOutcome: ActionOutcome{Message: `Disabled "SkyUI"`}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0 // "SkyUI", status "installed"
+	require.NotEqual(t, "disabled", model.mods[0].Status)
+
+	updated, _ := model.Update(keyRunes("e"))
+	model = updated.(Model)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionDisable, model.action.pending.kind)
+	require.Equal(t, `Disable "SkyUI"?`, model.action.pending.title)
+	require.Contains(t, model.action.pending.detail, "Files will be removed from the game directory (cache kept).")
+
+	_, confirmCmd := model.Update(keyRunes("y"))
+	require.NotNil(t, confirmCmd)
+	confirmCmd()
+	require.Len(t, rec.DisableCalls, 1)
+	require.Equal(t, "skyui", rec.DisableCalls[0].ID)
+}
+
+// TestToggleEnableKeyCancelDoesNotCallProvider proves 'n' dismisses the
+// modal without ever touching the provider.
+func TestToggleEnableKeyCancelDoesNotCallProvider(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 4
+
+	updated, _ := model.Update(keyRunes("e"))
+	model = updated.(Model)
+	require.NotNil(t, model.action.pending)
+
+	updated, cmd := model.Update(keyRunes("n"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+	require.Empty(t, rec.EnableCalls)
+	require.Empty(t, rec.DisableCalls)
+}
+
+// TestToggleEnableKeyWrongScreenIsNoop proves 'e' only fires on Installed
+// Mods.
+func TestToggleEnableKeyWrongScreenIsNoop(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenDashboard
+
+	updated, cmd := model.Update(keyRunes("e"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+}
+
+// TestToggleEnableKeyEmptyListIsNoop proves an empty mods list can never
+// crash or open a modal for a nonexistent selection.
+func TestToggleEnableKeyEmptyListIsNoop(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.mods = nil
+	model.selected[ScreenInstalledMods] = 0
+
+	updated, cmd := model.Update(keyRunes("e"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+}
+
+// TestToggleEnableKeyInertWhileRunning proves the single-flight guard: an
+// in-flight action blocks a brand-new prompt, verified via m.action.pending
+// staying nil (buildAction's guard-refusal returns a no-op pendingAction
+// rather than a nil return value - see actions.go's doc comment).
+func TestToggleEnableKeyInertWhileRunning(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 4
+	model.action.running = true
+
+	updated, cmd := model.Update(keyRunes("e"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+	require.Empty(t, rec.EnableCalls)
+}
+
+// TestToggleEnableKeyInertWhileAnotherModalPending proves a DIFFERENT
+// already-pending modal is left completely undisturbed by a second
+// mutation key.
+func TestToggleEnableKeyInertWhileAnotherModalPending(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+
+	updated, _ := model.Update(keyRunes("D")) // opens the Deploy modal
+	model = updated.(Model)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionDeploy, model.action.pending.kind)
+
+	updated, cmd := model.Update(keyRunes("e"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionDeploy, model.action.pending.kind, "the original modal must still be showing")
+	require.Empty(t, rec.EnableCalls)
+	require.Empty(t, rec.DisableCalls)
+}
+
+// TestToggleEnableKeyInertWhileSearchFocused proves 'e' types into the
+// search box instead of triggering a mutation while ScreenSearch is
+// focused - the existing focused-input swallow branch runs before the
+// mutation-key switch, so this is inertness by construction, not a special
+// case.
+func TestToggleEnableKeyInertWhileSearchFocused(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	updated := updateWithRunes(t, model, "3") // jump to search, focused
+	updated = updateWithRunes(t, updated, "e")
+
+	require.True(t, updated.search.input.Focused())
+	require.Contains(t, updated.search.input.Value(), "e")
+	require.Nil(t, updated.action.pending)
+}
+
+// --- Uninstall ('x' on Installed Mods) ---
+
+func TestUninstallKeyPromptsAndConfirmCallsProviderWithSelectedItem(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{UninstallOutcome: ActionOutcome{Message: `Uninstalled "SkyUI"`}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0 // "SkyUI"
+
+	updated, cmd := model.Update(keyRunes("x"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionUninstall, model.action.pending.kind)
+	require.Equal(t, `Uninstall "SkyUI"?`, model.action.pending.title)
+	require.Contains(t, model.action.pending.detail, "Removes deployed files, cache, and profile entry. Uninstall hooks will run.")
+
+	confirmed, confirmCmd := model.Update(keyRunes("y"))
+	model = confirmed.(Model)
+	require.NotNil(t, confirmCmd)
+	doneMsg := confirmCmd()
+	require.Len(t, rec.UninstallCalls, 1)
+	require.Equal(t, "skyui", rec.UninstallCalls[0].ID)
+	require.Equal(t, "nexusmods", rec.UninstallCalls[0].Source)
+
+	updated, refreshCmd := model.Update(doneMsg)
+	require.NotNil(t, refreshCmd)
+	require.Equal(t, `Uninstalled "SkyUI"`, updated.(Model).action.status)
+}
+
+func TestUninstallKeyCancelDoesNotCallProvider(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+
+	updated, _ := model.Update(keyRunes("x"))
+	model = updated.(Model)
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+	require.Empty(t, rec.UninstallCalls)
+}
+
+func TestUninstallKeyWrongScreenIsNoop(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.screen = ScreenProfiles
+
+	updated, cmd := model.Update(keyRunes("x"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+}
+
+func TestUninstallKeyEmptyListIsNoop(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.screen = ScreenInstalledMods
+	model.mods = nil
+
+	updated, cmd := model.Update(keyRunes("x"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+}
+
+func TestUninstallKeyInertWhileRunning(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+	model.action.running = true
+
+	updated, cmd := model.Update(keyRunes("x"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+	require.Empty(t, rec.UninstallCalls)
+}
+
+// --- Deploy ('D' on Dashboard and Installed Mods) ---
+
+func TestDeployKeyFromDashboardPromptsAndConfirmCallsProvider(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{DeployOutcome: ActionOutcome{Message: "Deployed 5 mod(s)"}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenDashboard
+
+	updated, cmd := model.Update(keyRunes("D"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionDeploy, model.action.pending.kind)
+	require.Equal(t, `Deploy profile "survival"?`, model.action.pending.title)
+	require.Contains(t, model.action.pending.detail, "Game: Skyrim Special Edition")
+
+	confirmed, confirmCmd := model.Update(keyRunes("y"))
+	model = confirmed.(Model)
+	require.NotNil(t, confirmCmd)
+	doneMsg := confirmCmd()
+	require.Equal(t, 1, rec.DeployCalls)
+
+	updated, refreshCmd := model.Update(doneMsg)
+	require.NotNil(t, refreshCmd)
+	require.Equal(t, "Deployed 5 mod(s)", updated.(Model).action.status)
+}
+
+func TestDeployKeyFromInstalledModsPrompts(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+
+	updated, _ := model.Update(keyRunes("D"))
+	model = updated.(Model)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionDeploy, model.action.pending.kind)
+}
+
+func TestDeployKeyWrongScreenIsNoop(t *testing.T) {
+	t.Parallel()
+
+	for _, screen := range []Screen{ScreenSearch, ScreenProfiles, ScreenSources} {
+		model := modelWithActions(t, &recordingActions{})
+		model.screen = screen
+
+		updated, cmd := model.Update(keyRunes("D"))
+		model = updated.(Model)
+		require.Nil(t, cmd)
+		require.Nil(t, model.action.pending, "screen %v", screen)
+	}
+}
+
+func TestDeployKeyInertWhileRunning(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenDashboard
+	model.action.running = true
+
+	updated, cmd := model.Update(keyRunes("D"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+	require.Equal(t, 0, rec.DeployCalls)
+}
+
+// --- Profile switch ('enter' on Profiles) ---
+
+func TestSwitchKeyOnActiveProfileSetsStatusNoModal(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	model.selected[ScreenProfiles] = 0 // "survival", active
+	require.True(t, model.profiles[0].Active)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+	require.Equal(t, `Already on profile "survival"`, model.action.status)
+	require.False(t, model.action.statusIsError)
+	require.Empty(t, rec.PlanCalls, "must never call PlanProfileSwitch for the active profile")
+}
+
+func TestSwitchKeyEmptyProfileListIsNoop(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.screen = ScreenProfiles
+	model.profiles = nil
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+}
+
+func TestSwitchKeyWrongScreenIsNoop(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.screen = ScreenInstalledMods
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ScreenInstalledMods, updated.(Model).CurrentScreen())
+	require.Nil(t, cmd)
+}
+
+func TestSwitchKeyInertWhileRunning(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	model.selected[ScreenProfiles] = 1
+	model.action.running = true
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+	require.Empty(t, rec.PlanCalls)
+}
+
+// TestSwitchKeyDispatchesAsyncPlanFetch proves enter on a non-active
+// profile shows a "Planning switch…" status and returns a command instead
+// of synchronously calling the provider.
+func TestSwitchKeyDispatchesAsyncPlanFetch(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{PlanView: SwitchPlanView{From: "survival", To: "vanilla-plus", NoChanges: true}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	model.selected[ScreenProfiles] = 1 // "vanilla-plus"
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.NotNil(t, cmd)
+	require.True(t, model.action.running)
+	require.Equal(t, "Planning switch…", model.action.status)
+	require.False(t, model.action.statusIsError)
+	require.Nil(t, model.action.pending)
+	require.Empty(t, rec.PlanCalls, "the provider call happens when the returned cmd runs, not synchronously")
+
+	msg := cmd()
+	require.IsType(t, planResultMsg{}, msg)
+	require.Equal(t, []string{"vanilla-plus"}, rec.PlanCalls)
+}
+
+// TestSwitchPlanStaleResultDiscarded proves a plan result tagged with an
+// old gen is discarded entirely - no modal, no status change, no running
+// flip - mirroring actionDoneMsg's own staleness contract (rule 4 in
+// actions_test.go).
+func TestSwitchPlanStaleResultDiscarded(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 9
+	model.action.running = true
+	model.action.status = ""
+
+	updated, cmd := model.Update(planResultMsg{gen: 4, view: SwitchPlanView{From: "a", To: "b"}})
+	m := updated.(Model)
+	require.Nil(t, cmd)
+	require.True(t, m.action.running, "stale result must not clear running")
+	require.Nil(t, m.action.pending, "stale result must never open a modal")
+	require.Empty(t, m.action.status)
+}
+
+func TestSwitchPlanStaleFailureDiscarded(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 9
+	model.action.running = true
+
+	updated, cmd := model.Update(planFailedMsg{gen: 1, err: errors.New("boom")})
+	m := updated.(Model)
+	require.Nil(t, cmd)
+	require.True(t, m.action.running)
+	require.Empty(t, m.action.status)
+}
+
+// TestSwitchPlanErrorShowsStatusNoModal covers the plan-error path end to
+// end: enter -> async fetch -> planFailedMsg -> error status, no modal.
+func TestSwitchPlanErrorShowsStatusNoModal(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{PlanErr: errors.New("plan boom")}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	model.selected[ScreenProfiles] = 1
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	require.IsType(t, planFailedMsg{}, msg)
+
+	updated, cmd2 := model.Update(msg)
+	model = updated.(Model)
+	require.Nil(t, cmd2)
+	require.False(t, model.action.running)
+	require.True(t, model.action.statusIsError)
+	require.Contains(t, model.action.status, "plan boom")
+	require.Nil(t, model.action.pending)
+}
+
+// TestSwitchPlanAlreadyActiveDefensive exercises resolvePlanResult's
+// defensive AlreadyActive branch directly (see task-7-brief.md's
+// profile-switch flow: normally pre-filtered by the synchronous active
+// check in the key handler, so this path is otherwise unreachable through
+// a real keypress).
+func TestSwitchPlanAlreadyActiveDefensive(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 1
+	model.action.running = true
+
+	updated, cmd := model.Update(planResultMsg{gen: 1, view: SwitchPlanView{From: "x", To: "x", AlreadyActive: true}})
+	m := updated.(Model)
+	require.Nil(t, cmd)
+	require.False(t, m.action.running)
+	require.Nil(t, m.action.pending)
+	require.Equal(t, `Already on profile "x"`, m.action.status)
+	require.False(t, m.action.statusIsError)
+}
+
+// TestSwitchPlanNeedsDownloadsRefusesNoModal covers the core-fake half of
+// the NeedsDownloads refusal: the exact provider-contract message from
+// errProfileNeedsDownloads must reach the status line, in error styling,
+// with no modal and no ApplyProfileSwitch call.
+func TestSwitchPlanNeedsDownloadsRefusesNoModal(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{PlanView: SwitchPlanView{From: "survival", To: "vanilla-plus", NeedsDownloads: []string{"nexusmods:foo v1.0"}}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	model.selected[ScreenProfiles] = 1
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	msg := cmd()
+
+	updated, cmd2 := model.Update(msg)
+	model = updated.(Model)
+	require.Nil(t, cmd2)
+	require.Nil(t, model.action.pending, "must not open a modal")
+	require.True(t, model.action.statusIsError)
+	require.Equal(t, errProfileNeedsDownloads.Error(), model.action.status)
+	require.Empty(t, rec.ApplyCalls, "must never call ApplyProfileSwitch")
+}
+
+// TestSwitchPlanNoChangesShowsSetAsDefaultModal covers the NoChanges
+// wording mandated by task-7-brief.md.
+func TestSwitchPlanNoChangesShowsSetAsDefaultModal(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{PlanView: SwitchPlanView{From: "survival", To: "vanilla-plus", NoChanges: true}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	model.selected[ScreenProfiles] = 1
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	msg := cmd()
+	updated, _ = model.Update(msg)
+	model = updated.(Model)
+
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionSwitch, model.action.pending.kind)
+	require.Equal(t, `Switch to "vanilla-plus"?`, model.action.pending.title)
+	require.Contains(t, model.action.pending.detail, "From: survival")
+	require.Contains(t, model.action.pending.detail, "No mod changes; set as default.")
+}
+
+// TestSwitchConfirmCallsApplyProfileSwitchWithTargetName covers the full
+// happy path: plan with real Enable/Disable buckets -> modal detail lines
+// -> confirm -> ApplyProfileSwitch(target) -> refresh.
+func TestSwitchConfirmCallsApplyProfileSwitchWithTargetName(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{
+		PlanView:     SwitchPlanView{From: "survival", To: "vanilla-plus", Enable: []string{"Frostfall"}, Disable: []string{"SkyUI"}},
+		ApplyOutcome: ActionOutcome{Message: `Switched to "vanilla-plus"`},
+	}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	model.selected[ScreenProfiles] = 1
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	msg := cmd()
+	updated, _ = model.Update(msg)
+	model = updated.(Model)
+
+	require.NotNil(t, model.action.pending)
+	require.Contains(t, model.action.pending.detail, "+ Frostfall")
+	require.Contains(t, model.action.pending.detail, "- SkyUI")
+
+	confirmed, confirmCmd := model.Update(keyRunes("y"))
+	model = confirmed.(Model)
+	require.NotNil(t, confirmCmd)
+	doneMsg := confirmCmd()
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+	require.Equal(t, []string{"vanilla-plus"}, rec.ApplyCalls)
+
+	updated, refreshCmd := model.Update(doneMsg)
+	model = updated.(Model)
+	require.NotNil(t, refreshCmd)
+	require.Equal(t, `Switched to "vanilla-plus"`, model.action.status)
+}
+
+// TestPrototypeSwitchPlanNeedsDownloadsCannedScenario exercises the
+// mandated prototype demo data addition end to end: a canned profile whose
+// mod list references an ID absent from InstalledMods must drive the exact
+// same refusal path as the core fake above, through the REAL
+// prototypeProvider (not recordingActions).
+func TestPrototypeSwitchPlanNeedsDownloadsCannedScenario(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+	model.screen = ScreenProfiles
+
+	idx := -1
+	for i, p := range model.profiles {
+		if p.Name == prototype.NeedsDownloadProfileName {
+			idx = i
+		}
+	}
+	require.GreaterOrEqualf(t, idx, 0, "canned needs-download profile %q must be present in prototype data", prototype.NeedsDownloadProfileName)
+	model.selected[ScreenProfiles] = idx
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	require.IsType(t, planResultMsg{}, msg, "a needs-downloads plan is a successful plan fetch, not a fetch error")
+
+	updated, cmd2 := model.Update(msg)
+	model = updated.(Model)
+	require.Nil(t, cmd2)
+	require.Nil(t, model.action.pending, "must not open a modal")
+	require.True(t, model.action.statusIsError)
+	require.Equal(t, errProfileNeedsDownloads.Error(), model.action.status)
+}
+
+// --- Help/footer content ---
+
+func TestHelpOverlayDocumentsMutationKeysAndDropsStaleReadOnlyClaim(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 120, 38)
+	model = updateWithRunes(t, model, "?")
+	view := model.View()
+
+	require.Contains(t, view, "toggle enable/disable")
+	require.Contains(t, view, "uninstall selected mod")
+	require.Contains(t, view, "deploy active profile")
+	require.Contains(t, view, "switch profile")
+	require.NotContains(t, view, "Browsing is read-only",
+		"the help copy must no longer claim the TUI is read-only now that mutations exist")
+}
+
+func TestFooterHintMentionsMutationKeys(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 120, 36)
+	view := model.View()
+
+	require.Contains(t, view, "e/x/D: mutate")
+	require.Contains(t, view, "enter: switch")
+}

--- a/internal/tui/mutations_test.go
+++ b/internal/tui/mutations_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -642,6 +643,127 @@ func TestPrototypeSwitchPlanNeedsDownloadsCannedScenario(t *testing.T) {
 	require.Nil(t, model.action.pending, "must not open a modal")
 	require.True(t, model.action.statusIsError)
 	require.Equal(t, errProfileNeedsDownloads.Error(), model.action.status)
+}
+
+// --- Profile rebind after switch (C1) ---
+
+// fakeSwitchableProvider is a minimal DataProvider that also implements the
+// profileRebinder hook (see app.go's rebindProfile), letting these tests
+// simulate coreProvider's per-instance p.profile binding - including the
+// two-SEPARATE-instances wiring cmd/lmm/tui.go actually uses
+// (NewCoreProvider and NewCoreActions each build their own *coreProvider;
+// see their doc comments in service_core.go) - without a real
+// core.Service/SQLite sandbox (that integration is covered directly by
+// service_core_test.go). Profiles()'s Active flag is derived from
+// `current`, which only SetProfile ever changes, so a test can prove
+// app.go's rebindProfile is what moved it, not some other code path.
+type fakeSwitchableProvider struct {
+	names   []string
+	current string
+}
+
+func (f *fakeSwitchableProvider) Overview(context.Context) (Summary, []ModItem, error) {
+	return Summary{GameName: "Game", ProfileName: f.current}, nil, nil
+}
+
+func (f *fakeSwitchableProvider) Sources() []string         { return nil }
+func (f *fakeSwitchableProvider) SourceInfos() []SourceInfo { return nil }
+
+func (f *fakeSwitchableProvider) Search(context.Context, string, string, int) (SearchPage, error) {
+	return SearchPage{}, nil
+}
+
+func (f *fakeSwitchableProvider) Profiles(context.Context) ([]ProfileItem, error) {
+	items := make([]ProfileItem, 0, len(f.names))
+	for _, name := range f.names {
+		items = append(items, ProfileItem{Name: name, Active: name == f.current})
+	}
+	return items, nil
+}
+
+// SetProfile implements app.go's profileRebinder hook.
+func (f *fakeSwitchableProvider) SetProfile(name string) { f.current = name }
+
+// TestSwitchDoneRebindsProviderSoOldActiveProfileReopensPlanModal guards
+// finding C1 end to end at the Model level: a completed switch must rebind
+// which profile the DataProvider reports Active BEFORE the post-action
+// refresh reads it, so Profiles() reflects the target immediately - and a
+// second 'enter' on the now-inactive OLD profile must dispatch a fresh plan
+// fetch instead of hitting switchSelectedProfile's Already-on-profile
+// pre-filter (mutations.go). That pre-filter dead end is exactly what C1
+// reported: without the rebind, the old profile keeps reading Active
+// forever and the user can never switch back to it.
+func TestSwitchDoneRebindsProviderSoOldActiveProfileReopensPlanModal(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeSwitchableProvider{names: []string{"survival", "vanilla-plus"}, current: "survival"}
+	rec := &recordingActions{
+		PlanView:     SwitchPlanView{From: "survival", To: "vanilla-plus", NoChanges: true},
+		ApplyOutcome: ActionOutcome{Message: `Switched to "vanilla-plus"`},
+	}
+	model, err := NewModel(Options{Theme: "wizardry", Provider: provider, Actions: rec})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+	model.screen = ScreenProfiles
+	model.selected[ScreenProfiles] = 1 // "vanilla-plus", not active yet
+	require.False(t, model.profiles[1].Active)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.NotNil(t, cmd)
+	updated, _ = model.Update(cmd())
+	model = updated.(Model)
+	require.NotNil(t, model.action.pending, "a NoChanges plan still opens a confirmation modal")
+
+	confirmed, confirmCmd := model.Update(keyRunes("y"))
+	model = confirmed.(Model)
+	require.NotNil(t, confirmCmd)
+	doneMsg := confirmCmd()
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+
+	updated, refreshCmd := model.Update(doneMsg)
+	model = updated.(Model)
+	require.NotNil(t, refreshCmd)
+	require.Equal(t, "vanilla-plus", provider.current, "the actionDoneMsg handler must rebind the provider before the refresh runs")
+
+	updated, _ = model.Update(refreshCmd())
+	model = updated.(Model)
+	require.True(t, model.profiles[1].Active, "Profiles() must mark the switch target Active after refresh")
+	require.False(t, model.profiles[0].Active, "the old profile must no longer read as active")
+
+	model.selected[ScreenProfiles] = 0 // "survival", the former active profile
+	updated, cmd2 := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.NotNil(t, cmd2, "must dispatch an async plan fetch for the now-inactive old profile, not hit the Already-on-profile dead end")
+	require.NotEqual(t, `Already on profile "survival"`, model.action.status)
+}
+
+// TestStaleSwitchDoneMsgNeverRebindsProfile extends Rule 4's staleness
+// guard (actions_test.go) to the switchedTo field added for C1: a
+// superseded actionDoneMsg must be discarded whole, including its switch
+// target - a stale rebind would silently move the session to a profile the
+// user never actually finished switching to.
+func TestStaleSwitchDoneMsgNeverRebindsProfile(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeSwitchableProvider{names: []string{"survival", "vanilla-plus"}, current: "survival"}
+	model, err := NewModel(Options{Theme: "wizardry", Provider: provider, Actions: &recordingActions{}})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+	model.action.gen = 5
+	model.action.running = true
+
+	updated, cmd := model.Update(actionDoneMsg{
+		gen: 4, kind: actionSwitch,
+		outcome:    ActionOutcome{Message: `Switched to "vanilla-plus"`},
+		switchedTo: "vanilla-plus",
+	})
+	m := updated.(Model)
+	require.Nil(t, cmd, "a stale result must not dispatch a refresh")
+	require.True(t, m.action.running, "stale result must not clear running")
+	require.Equal(t, "survival", provider.current, "a stale switchedTo must never rebind the provider")
 }
 
 // --- Help/footer content ---

--- a/internal/tui/mutations_test.go
+++ b/internal/tui/mutations_test.go
@@ -300,6 +300,7 @@ func TestDeployKeyFromDashboardPromptsAndConfirmCallsProvider(t *testing.T) {
 	require.Equal(t, actionDeploy, model.action.pending.kind)
 	require.Equal(t, `Deploy profile "survival"?`, model.action.pending.title)
 	require.Contains(t, model.action.pending.detail, "Game: Skyrim Special Edition")
+	require.Contains(t, model.action.pending.detail, "Mods: 39 enabled")
 
 	confirmed, confirmCmd := model.Update(keyRunes("y"))
 	model = confirmed.(Model)

--- a/internal/tui/prototype/data.go
+++ b/internal/tui/prototype/data.go
@@ -29,6 +29,7 @@ type Stats struct {
 }
 
 type Mod struct {
+	ID              string // stable, invented demo identifier - addresses the mod alongside Source for action calls
 	Name            string
 	Source          string
 	Author          string
@@ -52,17 +53,17 @@ func Load() Data {
 			Conflicts: 1,
 		},
 		InstalledMods: []Mod{
-			{Name: "SkyUI", Source: "nexusmods", Author: "schlangster", Version: "5.2", Status: "installed", Summary: "Immersive user interface overhaul.", Downloads: 12_500_000, Endorsements: 850_000, HasEndorsements: true},
-			{Name: "USSEP", Source: "nexusmods", Author: "Arthmoor", Version: "4.3", Status: "update", Summary: "Unofficial Skyrim Special Edition Patch.", Downloads: 11_000_000, Endorsements: 420_000, HasEndorsements: true},
-			{Name: "SKSE Address Library", Source: "nexusmods", Author: "meh321", Version: "11", Status: "installed", Summary: "Address library for SKSE plugins.", Downloads: 8_900_000, Endorsements: 150_000, HasEndorsements: true},
-			{Name: "Immersive Armors", Source: "nexusmods", Author: "hothtrooper44", Version: "8.1", Status: "conflict", Summary: "Adds hundreds of new armor variants.", Downloads: 6_700_000, Endorsements: 380_000, HasEndorsements: true},
-			{Name: "Alternate Start", Source: "nexusmods", Author: "Arthmoor", Version: "4.2", Status: "disabled", Summary: "Alternative character start scenarios.", Downloads: 5_200_000, Endorsements: 220_000, HasEndorsements: true},
+			{ID: "skyui", Name: "SkyUI", Source: "nexusmods", Author: "schlangster", Version: "5.2", Status: "installed", Summary: "Immersive user interface overhaul.", Downloads: 12_500_000, Endorsements: 850_000, HasEndorsements: true},
+			{ID: "ussep", Name: "USSEP", Source: "nexusmods", Author: "Arthmoor", Version: "4.3", Status: "update", Summary: "Unofficial Skyrim Special Edition Patch.", Downloads: 11_000_000, Endorsements: 420_000, HasEndorsements: true},
+			{ID: "skse-address-library", Name: "SKSE Address Library", Source: "nexusmods", Author: "meh321", Version: "11", Status: "installed", Summary: "Address library for SKSE plugins.", Downloads: 8_900_000, Endorsements: 150_000, HasEndorsements: true},
+			{ID: "immersive-armors", Name: "Immersive Armors", Source: "nexusmods", Author: "hothtrooper44", Version: "8.1", Status: "conflict", Summary: "Adds hundreds of new armor variants.", Downloads: 6_700_000, Endorsements: 380_000, HasEndorsements: true},
+			{ID: "alternate-start", Name: "Alternate Start", Source: "nexusmods", Author: "Arthmoor", Version: "4.2", Status: "disabled", Summary: "Alternative character start scenarios.", Downloads: 5_200_000, Endorsements: 220_000, HasEndorsements: true},
 		},
 		SearchResults: []Mod{
-			{Name: "Campfire", Source: "nexusmods", Author: "Chesko", Version: "1.12", Status: "available", Summary: "Camping and survival skill system.", Downloads: 4_200_000, Endorsements: 180_000, HasEndorsements: true},
-			{Name: "Frostfall", Source: "nexusmods", Author: "Chesko", Version: "3.4", Status: "available", Summary: "Hypothermia and survival overhaul.", Downloads: 3_800_000, Endorsements: 165_000, HasEndorsements: true},
-			{Name: "Hunterborn", Source: "nexusmods", Author: "unuroboros", Version: "1.6", Status: "available", Summary: "Hunting and harvesting overhaul.", Downloads: 2_900_000, Endorsements: 95_000, HasEndorsements: true},
-			{Name: "Legacy of the Dragonborn", Source: "nexusmods", Author: "icecreamassassin", Version: "6.5", Status: "available", Summary: "Museum and player home museum.", Downloads: 2_100_000, Endorsements: 78_000, HasEndorsements: true},
+			{ID: "campfire", Name: "Campfire", Source: "nexusmods", Author: "Chesko", Version: "1.12", Status: "available", Summary: "Camping and survival skill system.", Downloads: 4_200_000, Endorsements: 180_000, HasEndorsements: true},
+			{ID: "frostfall", Name: "Frostfall", Source: "nexusmods", Author: "Chesko", Version: "3.4", Status: "available", Summary: "Hypothermia and survival overhaul.", Downloads: 3_800_000, Endorsements: 165_000, HasEndorsements: true},
+			{ID: "hunterborn", Name: "Hunterborn", Source: "nexusmods", Author: "unuroboros", Version: "1.6", Status: "available", Summary: "Hunting and harvesting overhaul.", Downloads: 2_900_000, Endorsements: 95_000, HasEndorsements: true},
+			{ID: "legacy-of-the-dragonborn", Name: "Legacy of the Dragonborn", Source: "nexusmods", Author: "icecreamassassin", Version: "6.5", Status: "available", Summary: "Museum and player home museum.", Downloads: 2_100_000, Endorsements: 78_000, HasEndorsements: true},
 		},
 		Profiles: []Profile{
 			{Name: "survival", Active: true, ModCount: 42},

--- a/internal/tui/prototype/data.go
+++ b/internal/tui/prototype/data.go
@@ -19,7 +19,21 @@ type Profile struct {
 	Name     string
 	Active   bool
 	ModCount int
+	// Mods is optional: installed-mod IDs this profile references, used
+	// only to seed PlanProfileSwitch's NeedsDownloads demo scenario (see
+	// NeedsDownloadProfileName below and actions_provider.go's
+	// prototypeProvider.PlanProfileSwitch). Every other canned profile
+	// leaves this nil - the alternating Enable/Disable plan logic never
+	// consults it.
+	Mods []string
 }
+
+// NeedsDownloadProfileName names the one canned profile (see Load) whose
+// Mods list references an ID absent from InstalledMods, so
+// prototypeProvider.PlanProfileSwitch (actions_provider.go) can produce a
+// NeedsDownloads plan and --prototype mode can demo the refusal state
+// without any core.Service.
+const NeedsDownloadProfileName = "requiem-overhaul"
 
 type Stats struct {
 	Installed int
@@ -70,6 +84,10 @@ func Load() Data {
 			{Name: "vanilla-plus", Active: false, ModCount: 18},
 			{Name: "graphics-overkill", Active: false, ModCount: 96},
 			{Name: "testing", Active: false, ModCount: 7},
+			// requiem-legendary is not in InstalledMods above - switching
+			// here always yields a NeedsDownloads plan (see
+			// NeedsDownloadProfileName's doc comment).
+			{Name: NeedsDownloadProfileName, Active: false, ModCount: 2, Mods: []string{"skyui", "requiem-legendary"}},
 		},
 	}
 }

--- a/internal/tui/prototype/data_test.go
+++ b/internal/tui/prototype/data_test.go
@@ -26,3 +26,32 @@ func TestLoadProvidesConsistentDemoData(t *testing.T) {
 
 	require.Equal(t, data.Stats.Installed, data.Profile.ModCount, "dashboard stats should agree with the profile mod count")
 }
+
+// TestLoadAssignsStableUniqueModIDs guards the invented demo IDs every
+// canned Mod must carry so (Source, ID) can address it for ActionProvider
+// calls, mirroring how a real domain.Mod's ID addresses it. IDs must be
+// non-empty, unique within each list, and identical across repeated Load()
+// calls (no randomness) so the prototype demo and its tests are
+// deterministic.
+func TestLoadAssignsStableUniqueModIDs(t *testing.T) {
+	t.Parallel()
+
+	first := Load()
+	second := Load()
+
+	for _, list := range [][]Mod{first.InstalledMods, first.SearchResults} {
+		seen := make(map[string]bool, len(list))
+		for _, mod := range list {
+			require.NotEmpty(t, mod.ID, "mod %q must have a stable ID", mod.Name)
+			require.False(t, seen[mod.ID], "mod ID %q must be unique within its list", mod.ID)
+			seen[mod.ID] = true
+		}
+	}
+
+	for i := range first.InstalledMods {
+		require.Equal(t, first.InstalledMods[i].ID, second.InstalledMods[i].ID, "IDs must be stable across Load() calls")
+	}
+	for i := range first.SearchResults {
+		require.Equal(t, first.SearchResults[i].ID, second.SearchResults[i].ID, "IDs must be stable across Load() calls")
+	}
+}

--- a/internal/tui/prototype/data_test.go
+++ b/internal/tui/prototype/data_test.go
@@ -55,3 +55,42 @@ func TestLoadAssignsStableUniqueModIDs(t *testing.T) {
 		require.Equal(t, first.SearchResults[i].ID, second.SearchResults[i].ID, "IDs must be stable across Load() calls")
 	}
 }
+
+// TestLoadIncludesNeedsDownloadCannedProfile guards the Task 7 demo-data
+// addition: exactly one profile (NeedsDownloadProfileName) must reference a
+// mod ID that is NOT present in InstalledMods, so
+// internal/tui's prototypeProvider.PlanProfileSwitch can compute a
+// NeedsDownloads plan (and --prototype mode can demo the refusal state)
+// without any core.Service. Every other canned profile must be left alone
+// (empty Mods), preserving their existing alternating Enable/Disable demo
+// behavior.
+func TestLoadIncludesNeedsDownloadCannedProfile(t *testing.T) {
+	t.Parallel()
+
+	data := Load()
+
+	installedIDs := make(map[string]bool, len(data.InstalledMods))
+	for _, mod := range data.InstalledMods {
+		installedIDs[mod.ID] = true
+	}
+
+	var target *Profile
+	for i := range data.Profiles {
+		if data.Profiles[i].Name == NeedsDownloadProfileName {
+			target = &data.Profiles[i]
+		} else {
+			require.Empty(t, data.Profiles[i].Mods, "only the needs-download profile should reference Mods")
+		}
+	}
+	require.NotNil(t, target, "NeedsDownloadProfileName must name a profile in Load()'s Profiles list")
+	require.False(t, target.Active, "the needs-download profile must not be the active profile")
+
+	require.NotEmpty(t, target.Mods)
+	missing := 0
+	for _, id := range target.Mods {
+		if !installedIDs[id] {
+			missing++
+		}
+	}
+	require.Greater(t, missing, 0, "at least one referenced mod ID must be absent from InstalledMods")
+}

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -20,8 +20,11 @@ type Summary struct {
 	Conflicts   int // -1 = unknown
 }
 
-// ModItem is one renderable mod row.
+// ModItem is one renderable mod row. ID, together with Source, fully
+// addresses the mod for core mutations keyed on (sourceID, modID) - see
+// ActionProvider.
 type ModItem struct {
+	ID              string
 	Name            string
 	Author          string
 	Version         string
@@ -98,12 +101,17 @@ type prototypeProvider struct {
 }
 
 // NewPrototypeProvider returns the side-effect-free demo DataProvider used
-// by --prototype mode and tests.
+// by --prototype mode and tests. The returned value also implements
+// ActionProvider (see actions_provider.go's prototypeProvider methods): a
+// caller that needs both roles for one demo session should type-assert the
+// single returned value (`provider.(ActionProvider)`) rather than calling
+// this constructor twice, since each call seeds an independent in-memory
+// dataset - two calls would silently diverge instead of sharing state.
 func NewPrototypeProvider() DataProvider {
-	return prototypeProvider{data: prototype.Load()}
+	return &prototypeProvider{data: prototype.Load()}
 }
 
-func (p prototypeProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
+func (p *prototypeProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 	return Summary{
 		GameName:    p.data.Game.Name,
 		ProfileName: p.data.Profile.Name,
@@ -114,11 +122,11 @@ func (p prototypeProvider) Overview(_ context.Context) (Summary, []ModItem, erro
 	}, modItems(p.data.InstalledMods), nil
 }
 
-func (p prototypeProvider) Sources() []string {
+func (p *prototypeProvider) Sources() []string {
 	return []string{"nexusmods"}
 }
 
-func (p prototypeProvider) SourceInfos() []SourceInfo {
+func (p *prototypeProvider) SourceInfos() []SourceInfo {
 	return []SourceInfo{
 		{ID: "curseforge", Name: "CurseForge", Type: "built-in", Auth: "n/a", Capabilities: "search,updates"},
 		{ID: "local-mods", Name: "Local Mods", Type: "directory", Auth: "n/a", Capabilities: "search,updates"},
@@ -126,7 +134,7 @@ func (p prototypeProvider) SourceInfos() []SourceInfo {
 	}
 }
 
-func (p prototypeProvider) Search(_ context.Context, source, query string, _ int) (SearchPage, error) {
+func (p *prototypeProvider) Search(_ context.Context, source, query string, _ int) (SearchPage, error) {
 	all := modItems(p.data.SearchResults)
 	matched := make([]ModItem, 0, len(all))
 	for _, item := range all {
@@ -144,7 +152,7 @@ func (p prototypeProvider) Search(_ context.Context, source, query string, _ int
 	}, nil
 }
 
-func (p prototypeProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
+func (p *prototypeProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
 	items := make([]ProfileItem, 0, len(p.data.Profiles))
 	for _, profile := range p.data.Profiles {
 		items = append(items, ProfileItem{
@@ -160,6 +168,7 @@ func modItems(mods []prototype.Mod) []ModItem {
 	items := make([]ModItem, 0, len(mods))
 	for _, mod := range mods {
 		items = append(items, ModItem{
+			ID:              mod.ID,
 			Name:            mod.Name,
 			Author:          mod.Author,
 			Version:         mod.Version,

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -250,6 +250,22 @@ func (p *coreProvider) modsToItems(mods []domain.Mod, installedKeys map[string]b
 	return items
 }
 
+// SetProfile rebinds the session to a new active profile: after a
+// successful TUI-driven switch, core.Service.ApplyProfileSwitch has already
+// persisted the new default profile (see its own doc comment in flows.go),
+// but THIS instance's p.profile - fixed at NewCoreProvider/NewCoreActions
+// construction time and read by every method on this type - would
+// otherwise never find out, leaving Profiles()/Overview() starring the OLD
+// profile and every mutation still targeting it. Implements app.go's
+// optional profileRebinder hook via a plain method, not part of
+// DataProvider/ActionProvider (both stay frozen at their documented
+// contracts); see rebindProfile there for why both the Provider and Actions
+// instances (cmd/lmm/tui.go wires two SEPARATE *coreProvider values, one
+// per constructor) must each be rebound independently.
+func (p *coreProvider) SetProfile(name string) {
+	p.profile = name
+}
+
 func (p *coreProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
 	profiles, err := p.svc.NewProfileManager().List(p.game.ID)
 	if err != nil {

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -380,9 +380,16 @@ func (p *coreProvider) DeployProfile(ctx context.Context) (ActionOutcome, error)
 	if len(result.Skipped) > 0 {
 		msg += fmt.Sprintf(", %d failed", len(result.Skipped))
 	}
+	// result.Skipped carries one "<mod name>: <reason>" entry per mod that
+	// didn't deploy (see DeployResult.Skipped's doc comment); appended after
+	// the flow Warnings/Notes mergeDiagnostics already composed so the
+	// status line's warning suffix can explain WHY a mod failed, not just
+	// that one did. Appending an empty result.Skipped to a nil merge leaves
+	// Warnings nil, matching every other DataProvider method's "no
+	// diagnostics" convention.
 	return ActionOutcome{
 		Message:  msg,
-		Warnings: mergeDiagnostics(result.Warnings, result.Notes),
+		Warnings: append(mergeDiagnostics(result.Warnings, result.Notes), result.Skipped...),
 	}, nil
 }
 

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 )
 
 // coreProvider adapts *core.Service to the read-only DataProvider boundary.
@@ -21,6 +23,17 @@ type coreProvider struct {
 // NewCoreProvider returns a DataProvider backed by the real app service for
 // one game/profile pair.
 func NewCoreProvider(svc *core.Service, game *domain.Game, profileName string) DataProvider {
+	return &coreProvider{svc: svc, game: game, profile: profileName}
+}
+
+// NewCoreActions returns an ActionProvider backed by the real app service,
+// for the same (svc, game, profileName) triple NewCoreProvider takes. The
+// two constructors are independent (coreProvider carries no in-memory-only
+// state - every mutation goes through svc's DB/filesystem, so two separate
+// instances always observe the same underlying truth), so a caller (Task
+// 6/7's cmd/lmm/tui.go) can call both with the game/profile it already
+// resolved once, without re-deriving anything.
+func NewCoreActions(svc *core.Service, game *domain.Game, profileName string) ActionProvider {
 	return &coreProvider{svc: svc, game: game, profile: profileName}
 }
 
@@ -40,6 +53,7 @@ func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 	items := make([]ModItem, 0, len(mods))
 	for _, mod := range mods {
 		items = append(items, ModItem{
+			ID:      mod.ID,
 			Name:    mod.Name,
 			Author:  mod.Author,
 			Version: mod.Version,
@@ -218,6 +232,7 @@ func (p *coreProvider) modsToItems(mods []domain.Mod, installedKeys map[string]b
 			status = "installed"
 		}
 		item := ModItem{
+			ID:        mod.ID,
 			Name:      mod.Name,
 			Author:    mod.Author,
 			Version:   mod.Version,
@@ -261,4 +276,177 @@ func installedModStatus(mod domain.InstalledMod) string {
 	default:
 		return "disabled"
 	}
+}
+
+// --- ActionProvider ---
+
+// hookRunner returns a HookRunner using the game/profile's configured hook
+// timeout, mirroring cmd/lmm/hooks.go's getHookRunner. The TUI has no
+// --no-hooks equivalent yet (out of scope for this task), so - unlike the
+// CLI helper, which returns nil when --no-hooks is set - this never returns
+// nil: TUI-triggered mutations always run hooks, same as a default CLI
+// invocation.
+func (p *coreProvider) hookRunner() *core.HookRunner {
+	cfg, err := config.Load(p.svc.ConfigDir())
+	timeout := 60 * time.Second // default, matching cmd/lmm/hooks.go
+	if err == nil && cfg.HookTimeout > 0 {
+		timeout = time.Duration(cfg.HookTimeout) * time.Second
+	}
+	return core.NewHookRunner(timeout)
+}
+
+// resolvedHooks resolves game/profile hooks, mirroring cmd/lmm/hooks.go's
+// getResolvedHooks (minus its --no-hooks short-circuit - see hookRunner's
+// doc comment).
+func (p *coreProvider) resolvedHooks() *core.ResolvedHooks {
+	var profile *domain.Profile
+	if p.profile != "" {
+		if pr, err := config.LoadProfile(p.svc.ConfigDir(), p.game.ID, p.profile); err == nil {
+			profile = pr
+		}
+	}
+	return core.ResolveHooks(p.game, profile)
+}
+
+// hookContext mirrors cmd/lmm/hooks.go's makeHookContext.
+func (p *coreProvider) hookContext() core.HookContext {
+	return core.HookContext{
+		GameID:   p.game.ID,
+		GamePath: p.game.InstallPath,
+		ModPath:  p.game.ModPath,
+	}
+}
+
+func (p *coreProvider) EnableMod(ctx context.Context, item ModItem) (ActionOutcome, error) {
+	changed, err := p.svc.EnableMod(ctx, p.game, p.profile, item.Source, item.ID)
+	if err != nil {
+		return ActionOutcome{}, fmt.Errorf("enabling %s: %w", item.Name, err)
+	}
+	if !changed {
+		return ActionOutcome{Message: fmt.Sprintf("%q is already enabled", item.Name)}, nil
+	}
+	return ActionOutcome{Message: fmt.Sprintf("Enabled %q", item.Name)}, nil
+}
+
+func (p *coreProvider) DisableMod(ctx context.Context, item ModItem) (ActionOutcome, error) {
+	changed, err := p.svc.DisableMod(ctx, p.game, p.profile, item.Source, item.ID)
+	if err != nil {
+		return ActionOutcome{}, fmt.Errorf("disabling %s: %w", item.Name, err)
+	}
+	if !changed {
+		return ActionOutcome{Message: fmt.Sprintf("%q is already disabled", item.Name)}, nil
+	}
+	return ActionOutcome{Message: fmt.Sprintf("Disabled %q", item.Name)}, nil
+}
+
+// UninstallMod runs the same hook configuration cmd/lmm/uninstall.go's
+// doUninstall passes to core.UninstallMod (KeepCache=false, Force=false -
+// see hookRunner's doc comment for why hooks are never disabled here).
+func (p *coreProvider) UninstallMod(ctx context.Context, item ModItem) (ActionOutcome, error) {
+	opts := core.UninstallOptions{
+		KeepCache:   false,
+		Hooks:       p.resolvedHooks(),
+		HookRunner:  p.hookRunner(),
+		HookContext: p.hookContext(),
+		Force:       false,
+	}
+	result, err := p.svc.UninstallMod(ctx, p.game, p.profile, item.Source, item.ID, opts)
+	if err != nil {
+		return ActionOutcome{}, fmt.Errorf("uninstalling %s: %w", item.Name, err)
+	}
+	return ActionOutcome{
+		Message:  fmt.Sprintf("Uninstalled %q", item.Name),
+		Warnings: mergeDiagnostics(result.Warnings, result.Notes),
+	}, nil
+}
+
+// DeployProfile deploys with default options (no purge, no link-method
+// override - matching a plain `lmm deploy` with no flags) and the same hook
+// configuration cmd/lmm/deploy.go passes. progress is nil: 5a shows a
+// static "working" state while this call is in flight; 5b streams
+// core.DeployProgress events.
+func (p *coreProvider) DeployProfile(ctx context.Context) (ActionOutcome, error) {
+	opts := core.DeployOptions{
+		Hooks:       p.resolvedHooks(),
+		HookRunner:  p.hookRunner(),
+		HookContext: p.hookContext(),
+		Force:       false,
+	}
+	result, err := p.svc.DeployProfile(ctx, p.game, p.profile, opts, nil)
+	if err != nil {
+		return ActionOutcome{}, fmt.Errorf("deploying profile %s: %w", p.profile, err)
+	}
+	msg := fmt.Sprintf("Deployed %d mod(s)", result.Deployed)
+	if len(result.Skipped) > 0 {
+		msg += fmt.Sprintf(", %d failed", len(result.Skipped))
+	}
+	return ActionOutcome{
+		Message:  msg,
+		Warnings: mergeDiagnostics(result.Warnings, result.Notes),
+	}, nil
+}
+
+func (p *coreProvider) PlanProfileSwitch(ctx context.Context, profileName string) (SwitchPlanView, error) {
+	plan, err := p.svc.PlanProfileSwitch(ctx, p.game, profileName)
+	if err != nil {
+		return SwitchPlanView{}, fmt.Errorf("planning switch to %s: %w", profileName, err)
+	}
+	return switchPlanView(plan), nil
+}
+
+// ApplyProfileSwitch re-plans (PlanProfileSwitch is pure/cheap - see its doc
+// comment - so a fresh plan is always current) and, unless the fresh plan
+// needs downloads, applies it. A plan with NeedsDownloads entries is
+// refused outright (no mutation): 5a's TUI has no install/download path
+// yet (that ships in 5b), so honoring such a plan here would silently do
+// less than the CLI equivalent. AlreadyActive plans are reported without
+// calling ApplyProfileSwitch at all, mirroring cmd/lmm/profile.go's
+// doProfileSwitch, which returns before ever calling it in that case.
+func (p *coreProvider) ApplyProfileSwitch(ctx context.Context, profileName string) (ActionOutcome, error) {
+	plan, err := p.svc.PlanProfileSwitch(ctx, p.game, profileName)
+	if err != nil {
+		return ActionOutcome{}, fmt.Errorf("planning switch to %s: %w", profileName, err)
+	}
+	if plan.AlreadyActive {
+		return ActionOutcome{Message: fmt.Sprintf("Already on profile %q", profileName)}, nil
+	}
+	if len(plan.ToInstall) > 0 {
+		return ActionOutcome{}, errProfileNeedsDownloads
+	}
+
+	result, err := p.svc.ApplyProfileSwitch(ctx, p.game, plan, nil)
+	if err != nil {
+		return ActionOutcome{}, fmt.Errorf("switching to %s: %w", profileName, err)
+	}
+	return ActionOutcome{
+		Message:  fmt.Sprintf("Switched to %q", profileName),
+		Warnings: mergeDiagnostics(nil, result.Notes),
+	}, nil
+}
+
+// switchPlanView maps a core.SwitchPlan to its TUI render model, using the
+// same display strings cmd/lmm/profile.go's doProfileSwitch plan printout
+// uses: ToEnable/ToDisable entries are addressed by Name (the CLI's "  + %s
+// (%s)\n"/"  - %s (%s)\n" lines also show the ID, but SwitchPlanView's
+// Enable/Disable fields are documented as plain mod names). ToInstall
+// entries have no Name yet (they haven't been fetched from source), so
+// NeedsDownloads uses the CLI's own "%s:%s v%s" ref format ("  ↓ %s:%s
+// v%s\n") verbatim - the only display data actually available at plan time.
+func switchPlanView(plan *core.SwitchPlan) SwitchPlanView {
+	view := SwitchPlanView{
+		From:          plan.From,
+		To:            plan.To,
+		NoChanges:     plan.NoChanges,
+		AlreadyActive: plan.AlreadyActive,
+	}
+	for _, im := range plan.ToEnable {
+		view.Enable = append(view.Enable, im.Name)
+	}
+	for _, im := range plan.ToDisable {
+		view.Disable = append(view.Disable, im.Name)
+	}
+	for _, ref := range plan.ToInstall {
+		view.NeedsDownloads = append(view.NeedsDownloads, fmt.Sprintf("%s:%s v%s", ref.SourceID, ref.ModID, ref.Version))
+	}
+	return view
 }

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -2,12 +2,17 @@ package tui_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -129,7 +134,9 @@ func TestCoreProviderOverview(t *testing.T) {
 	require.Equal(t, "deployed", byName["SkyUI"].Status)
 	require.Equal(t, "nexusmods", byName["SkyUI"].Source)
 	require.Equal(t, "5.2", byName["SkyUI"].Version)
+	require.Equal(t, "101", byName["SkyUI"].ID, "ModItem.ID must carry the installed mod's ID")
 	require.Equal(t, "disabled", byName["USSEP"].Status)
+	require.Equal(t, "102", byName["USSEP"].ID)
 }
 
 func TestCoreProviderProfiles(t *testing.T) {
@@ -188,7 +195,9 @@ func TestCoreProviderSearchMarksInstalled(t *testing.T) {
 		byName[r.Name] = r
 	}
 	require.Equal(t, "installed", byName["SkyUI-Stub"].Status)
+	require.Equal(t, "101", byName["SkyUI-Stub"].ID, "ModItem.ID must carry the search result's mod ID")
 	require.Equal(t, "available", byName["NewMod"].Status)
+	require.Equal(t, "999", byName["NewMod"].ID)
 }
 
 func TestCoreProviderSearchDoesNotCrossSourceMarkInstalled(t *testing.T) {
@@ -256,4 +265,386 @@ func TestCoreProviderSearchAllSourcesWarnings(t *testing.T) {
 	require.Len(t, page.Warnings, 1)
 	assert.Contains(t, page.Warnings[0], failingSourceID)
 	assert.NotEmpty(t, page.Results, "good source's results survive the failure")
+}
+
+// --- coreProvider: ActionProvider ---
+
+// newCoreActionsFixture mirrors newCoreProviderFixture, but returns the
+// write-side ActionProvider (tui.NewCoreActions) for the same
+// svc/game/"default"-profile triple, proving both constructors are wireable
+// from the identical already-resolved (svc, game, profileName) values.
+func newCoreActionsFixture(t *testing.T) (tui.ActionProvider, *core.Service, *domain.Game) {
+	t.Helper()
+
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{
+		ID:          "test-game",
+		Name:        "Test Game",
+		InstallPath: t.TempDir(),
+		ModPath:     t.TempDir(),
+		LinkMethod:  domain.LinkSymlink,
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+
+	return tui.NewCoreActions(svc, game, "default"), svc, game
+}
+
+// seedActionMod stores files (if non-nil) in game's cache and saves an
+// InstalledMod DB row for sourceID/modID/version, mirroring
+// internal/core/flows_test.go's seedInstalledMod (unexported there, so
+// duplicated here for this package's tests - see that file's identical
+// helper for the original).
+func seedActionMod(t *testing.T, svc *core.Service, game *domain.Game, sourceID, modID, name, version string, enabled bool, files map[string][]byte) {
+	t.Helper()
+
+	gameCache := svc.GetGameCache(game)
+	for path, content := range files {
+		require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, path, content))
+	}
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       modID,
+			SourceID: sourceID,
+			Name:     name,
+			Version:  version,
+			GameID:   game.ID,
+		},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      enabled,
+	}))
+}
+
+// seedActionProfileMod adds sourceID/modID/version to profileName's YAML,
+// creating the profile first if needed - mirrors
+// internal/core/flows_test.go's seedProfileWithMod (also unexported there).
+func seedActionProfileMod(t *testing.T, svc *core.Service, gameID, profileName, sourceID, modID, version string) {
+	t.Helper()
+	pm := svc.NewProfileManager()
+	if _, err := pm.Get(gameID, profileName); err != nil {
+		require.ErrorIs(t, err, domain.ErrProfileNotFound)
+		_, err := pm.Create(gameID, profileName)
+		require.NoError(t, err)
+	}
+	require.NoError(t, pm.AddMod(gameID, profileName, domain.ModReference{SourceID: sourceID, ModID: modID, Version: version}))
+}
+
+// createActionsTestScript mirrors internal/core's createTestScript
+// (unexported there, so duplicated here).
+func createActionsTestScript(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	scriptPath := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(scriptPath, []byte(content), 0755))
+	return scriptPath
+}
+
+func TestCoreProviderActions_EnableMod_DeploysAndReturnsMessage(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	seedActionMod(t, svc, game, "src", "1", "Test Mod", "1.0", false, map[string][]byte{"plugin.esp": []byte("data")})
+
+	outcome, err := actions.EnableMod(context.Background(), tui.ModItem{ID: "1", Source: "src", Name: "Test Mod"})
+	require.NoError(t, err)
+	assert.Equal(t, `Enabled "Test Mod"`, outcome.Message)
+	assert.Empty(t, outcome.Warnings)
+
+	mod, err := svc.GetInstalledMod("src", "1", game.ID, "default")
+	require.NoError(t, err)
+	assert.True(t, mod.Enabled)
+
+	_, err = os.Lstat(filepath.Join(game.ModPath, "plugin.esp"))
+	assert.NoError(t, err, "EnableMod must actually deploy the mod's files")
+}
+
+func TestCoreProviderActions_EnableMod_AlreadyEnabledMessage(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	seedActionMod(t, svc, game, "src", "1", "Test Mod", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+
+	outcome, err := actions.EnableMod(context.Background(), tui.ModItem{ID: "1", Source: "src", Name: "Test Mod"})
+	require.NoError(t, err)
+	assert.Equal(t, `"Test Mod" is already enabled`, outcome.Message)
+}
+
+func TestCoreProviderActions_EnableMod_UnknownModErrors(t *testing.T) {
+	actions, _, _ := newCoreActionsFixture(t)
+
+	_, err := actions.EnableMod(context.Background(), tui.ModItem{ID: "missing", Source: "src", Name: "Ghost"})
+	require.Error(t, err)
+}
+
+func TestCoreProviderActions_DisableMod_UndeploysAndReturnsMessage(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	seedActionMod(t, svc, game, "src", "1", "Test Mod", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: game.ID}, "default"))
+
+	outcome, err := actions.DisableMod(context.Background(), tui.ModItem{ID: "1", Source: "src", Name: "Test Mod"})
+	require.NoError(t, err)
+	assert.Equal(t, `Disabled "Test Mod"`, outcome.Message)
+
+	mod, err := svc.GetInstalledMod("src", "1", game.ID, "default")
+	require.NoError(t, err)
+	assert.False(t, mod.Enabled)
+
+	_, err = os.Lstat(filepath.Join(game.ModPath, "plugin.esp"))
+	assert.True(t, os.IsNotExist(err), "DisableMod must undeploy the mod's files")
+}
+
+func TestCoreProviderActions_DisableMod_AlreadyDisabledMessage(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	seedActionMod(t, svc, game, "src", "1", "Test Mod", "1.0", false, nil)
+
+	outcome, err := actions.DisableMod(context.Background(), tui.ModItem{ID: "1", Source: "src", Name: "Test Mod"})
+	require.NoError(t, err)
+	assert.Equal(t, `"Test Mod" is already disabled`, outcome.Message)
+}
+
+func TestCoreProviderActions_UninstallMod_RemovesAndReturnsMessage(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	seedActionMod(t, svc, game, "src", "1", "Test Mod", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedActionProfileMod(t, svc, game.ID, "default", "src", "1", "1.0")
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: game.ID}, "default"))
+
+	outcome, err := actions.UninstallMod(context.Background(), tui.ModItem{ID: "1", Source: "src", Name: "Test Mod"})
+	require.NoError(t, err)
+	assert.Equal(t, `Uninstalled "Test Mod"`, outcome.Message)
+	assert.Empty(t, outcome.Warnings)
+
+	_, err = svc.GetInstalledMod("src", "1", game.ID, "default")
+	assert.ErrorIs(t, err, domain.ErrModNotFound)
+}
+
+// TestCoreProviderActions_UninstallMod_RunsUninstallHooksMatchingCLIConfig
+// guards that coreProvider.UninstallMod replicates the CLI's exact hook
+// plumbing (cmd/lmm/uninstall.go's getResolvedHooks/getHookRunner/
+// makeHookContext, traced in the task report): a game-level uninstall hook
+// actually resolves and runs, mirroring
+// internal/core/flows_test.go's TestService_UninstallMod_HookOrder
+// arrangement, one level up.
+func TestCoreProviderActions_UninstallMod_RunsUninstallHooksMatchingCLIConfig(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	scriptsDir := t.TempDir()
+	callLog := filepath.Join(scriptsDir, "calls.log")
+	beforeEachScript := createActionsTestScript(t, scriptsDir, "before_each.sh", `#!/bin/bash
+echo "before_each:$LMM_MOD_ID" >> `+callLog+`
+exit 0`)
+	game.Hooks.Uninstall.BeforeEach = beforeEachScript
+
+	seedActionMod(t, svc, game, "src", "1", "Test Mod", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedActionProfileMod(t, svc, game.ID, "default", "src", "1", "1.0")
+
+	_, err := actions.UninstallMod(context.Background(), tui.ModItem{ID: "1", Source: "src", Name: "Test Mod"})
+	require.NoError(t, err)
+
+	logContent, err := os.ReadFile(callLog)
+	require.NoError(t, err)
+	assert.Equal(t, "before_each:1\n", string(logContent), "coreProvider must resolve and run the game's configured uninstall hooks, same as the CLI")
+}
+
+// TestCoreProviderActions_UninstallMod_WarningsIncludeResultWarningsThenNotes
+// guards the ActionOutcome.Warnings = flow Warnings + Notes contract (in
+// that order) documented on ActionOutcome: an unconditionally-non-fatal
+// after_each hook failure produces a flow Warning, and the mod not being
+// listed in the profile (mirroring
+// internal/core/flows_test.go's TestService_UninstallMod_ProfileDesyncWarnsAndContinues)
+// produces a flow Note - both must appear, Warnings first.
+func TestCoreProviderActions_UninstallMod_WarningsIncludeResultWarningsThenNotes(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	scriptsDir := t.TempDir()
+	failScript := createActionsTestScript(t, scriptsDir, "after_each.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	game.Hooks.Uninstall.AfterEach = failScript
+
+	// No profile seeded with the mod -> profile-removal Note.
+	seedActionMod(t, svc, game, "src", "1", "Test Mod", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+
+	outcome, err := actions.UninstallMod(context.Background(), tui.ModItem{ID: "1", Source: "src", Name: "Test Mod"})
+	require.NoError(t, err)
+	require.Len(t, outcome.Warnings, 2)
+	assert.Contains(t, outcome.Warnings[0], "uninstall.after_each hook failed", "flow Warnings must come first")
+	assert.True(t, strings.HasPrefix(outcome.Warnings[1], "Note: "), "flow Notes must follow, keeping their historical prefix: %q", outcome.Warnings[1])
+}
+
+func TestCoreProviderActions_DeployProfile_DeploysAndReturnsMessage(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	seedActionMod(t, svc, game, "src", "1", "Mod One", "1.0", true, map[string][]byte{"one.esp": []byte("1")})
+	seedActionMod(t, svc, game, "src", "2", "Mod Two", "1.0", true, map[string][]byte{"two.esp": []byte("2")})
+	seedActionProfileMod(t, svc, game.ID, "default", "src", "1", "1.0")
+	seedActionProfileMod(t, svc, game.ID, "default", "src", "2", "1.0")
+
+	outcome, err := actions.DeployProfile(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Deployed 2 mod(s)", outcome.Message)
+	assert.Empty(t, outcome.Warnings)
+
+	_, err = os.Lstat(filepath.Join(game.ModPath, "one.esp"))
+	assert.NoError(t, err)
+	_, err = os.Lstat(filepath.Join(game.ModPath, "two.esp"))
+	assert.NoError(t, err)
+}
+
+// installActionsBlockingTrigger mirrors internal/core/flows_test.go's
+// installBlockingTrigger (unexported there, duplicated here): it opens a
+// second connection to dbPath and installs a trigger that makes any UPDATE
+// touching installed_mods.link_method or installed_mods.deployed fail,
+// deterministically forcing DeployProfile's SetModLinkMethod/SetModDeployed
+// calls to error (and therefore record a Note) without relying on
+// filesystem permissions. Must be called after the owning *core.Service has
+// already run its migrations (so the installed_mods table exists).
+func installActionsBlockingTrigger(t *testing.T, dbPath string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	_, err = conn.Exec(`
+		CREATE TRIGGER block_link_method_and_deployed_updates_actions
+		BEFORE UPDATE OF link_method, deployed ON installed_mods
+		BEGIN
+			SELECT RAISE(ABORT, 'blocked for test');
+		END;
+	`)
+	require.NoError(t, err)
+}
+
+// TestCoreProviderActions_DeployProfile_NotesAppearInWarnings guards the
+// ActionOutcome.Warnings = flow Warnings + Notes contract for DeployProfile,
+// using the SQLite-blocking-trigger technique from
+// internal/core/flows_test.go to force a Note deterministically.
+func TestCoreProviderActions_DeployProfile_NotesAppearInWarnings(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{ID: "g1", Name: "Game", InstallPath: t.TempDir(), ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+	require.NoError(t, svc.AddGame(game))
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+
+	seedActionMod(t, svc, game, "src", "1", "Test Mod", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	seedActionProfileMod(t, svc, game.ID, "default", "src", "1", "1.0")
+
+	dbPath := filepath.Join(dataDir, "lmm.db")
+	installActionsBlockingTrigger(t, dbPath)
+
+	actions := tui.NewCoreActions(svc, game, "default")
+	outcome, err := actions.DeployProfile(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, outcome.Warnings, "the blocked SetModLinkMethod/SetModDeployed updates must surface as Notes in Outcome.Warnings")
+	for _, w := range outcome.Warnings {
+		assert.Contains(t, w, "Warning: ", "DeployProfile's Notes carry a historical prefix")
+	}
+}
+
+func TestCoreProviderActions_PlanProfileSwitch_MapsBucketsToDisplayStrings(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	// modC: enabled under "default", absent from "target" -> Disable.
+	seedActionMod(t, svc, game, "src", "modC", "Mod C", "1.0", true, map[string][]byte{"c.esp": []byte("c")})
+	seedActionProfileMod(t, svc, game.ID, "default", "src", "modC", "1.0")
+
+	// modB: installed (under default) but disabled, cached, referenced by target -> Enable.
+	seedActionMod(t, svc, game, "src", "modB", "Mod B", "1.0", false, map[string][]byte{"b.esp": []byte("b")})
+	seedActionProfileMod(t, svc, game.ID, "target", "src", "modB", "1.0")
+
+	// modD: referenced by target only, no DB row -> NeedsDownloads.
+	seedActionProfileMod(t, svc, game.ID, "target", "src", "modD", "2.0")
+
+	view, err := actions.PlanProfileSwitch(context.Background(), "target")
+	require.NoError(t, err)
+	assert.Equal(t, "default", view.From)
+	assert.Equal(t, "target", view.To)
+	assert.False(t, view.NoChanges)
+	assert.False(t, view.AlreadyActive)
+	assert.Equal(t, []string{"Mod C"}, view.Disable)
+	assert.Equal(t, []string{"Mod B"}, view.Enable)
+	require.Len(t, view.NeedsDownloads, 1)
+	assert.Equal(t, "src:modD v2.0", view.NeedsDownloads[0])
+}
+
+func TestCoreProviderActions_PlanProfileSwitch_AlreadyActive(t *testing.T) {
+	actions, _, _ := newCoreActionsFixture(t)
+
+	view, err := actions.PlanProfileSwitch(context.Background(), "default")
+	require.NoError(t, err)
+	assert.True(t, view.AlreadyActive)
+	assert.Equal(t, "default", view.From)
+	assert.Equal(t, "default", view.To)
+}
+
+func TestCoreProviderActions_PlanProfileSwitch_UnknownProfileErrors(t *testing.T) {
+	actions, _, _ := newCoreActionsFixture(t)
+
+	_, err := actions.PlanProfileSwitch(context.Background(), "does-not-exist")
+	require.Error(t, err)
+}
+
+// TestCoreProviderActions_ApplyProfileSwitch_RefusesWhenNeedsDownloads
+// guards the 5a scope cut: ApplyProfileSwitch must refuse, with the exact
+// error text specified by the task brief, and must not mutate anything -
+// the default profile stays active and the target profile's YAML is
+// untouched - when the freshly-computed plan has NeedsDownloads entries.
+func TestCoreProviderActions_ApplyProfileSwitch_RefusesWhenNeedsDownloads(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "target")
+	require.NoError(t, err)
+	seedActionProfileMod(t, svc, game.ID, "target", "src", "modD", "2.0")
+
+	outcome, err := actions.ApplyProfileSwitch(context.Background(), "target")
+	require.Error(t, err)
+	assert.EqualError(t, err, "profile needs downloads — use 'lmm profile switch' until TUI install ships")
+	assert.Equal(t, tui.ActionOutcome{}, outcome)
+
+	def, err := pm.GetDefault(game.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "default", def.Name, "the refusal must not switch the active profile")
+
+	target, err := pm.Get(game.ID, "target")
+	require.NoError(t, err)
+	assert.Len(t, target.Mods, 1, "the target profile YAML must be untouched by the refused apply")
+}
+
+func TestCoreProviderActions_ApplyProfileSwitch_AppliesAndReturnsMessage(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	seedActionMod(t, svc, game, "src", "modC", "Mod C", "1.0", true, map[string][]byte{"c.esp": []byte("c")})
+	seedActionProfileMod(t, svc, game.ID, "default", "src", "modC", "1.0")
+
+	outcome, err := actions.ApplyProfileSwitch(context.Background(), "target")
+	require.NoError(t, err)
+	assert.Equal(t, `Switched to "target"`, outcome.Message)
+
+	def, err := pm.GetDefault(game.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "target", def.Name)
+
+	mod, err := svc.GetInstalledMod("src", "modC", game.ID, "default")
+	require.NoError(t, err)
+	assert.False(t, mod.Enabled, "modC must have been disabled by the switch")
 }

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -661,6 +661,78 @@ func TestCoreProviderActions_ApplyProfileSwitch_RefusesWhenNeedsDownloads(t *tes
 	assert.Len(t, target.Mods, 1, "the target profile YAML must be untouched by the refused apply")
 }
 
+// --- C1: profile rebind after a TUI-driven switch ---
+
+// TestCoreProviderSetProfile_RebindsWhichProfileProfilesMarksActive guards
+// finding C1's DataProvider half: coreProvider.profile is fixed at
+// NewCoreProvider construction time and, absent a rebind hook, never
+// reflects a later profile switch even though core.Service.
+// ApplyProfileSwitch persists the new default profile via
+// ProfileManager.SetDefault (see ApplyProfileSwitch's own doc comment in
+// internal/core/flows.go). SetProfile is the optional profileRebinder hook
+// app.go's actionDoneMsg handler calls after a successful switch; this test
+// drives it directly against a real coreProvider/temp sandbox, independent
+// of the Model-level wiring covered by mutations_test.go's fakes.
+func TestCoreProviderSetProfile_RebindsWhichProfileProfilesMarksActive(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "hardcore")
+	require.NoError(t, err)
+
+	rebinder, ok := provider.(interface{ SetProfile(string) })
+	require.True(t, ok, "coreProvider must implement the profileRebinder hook (SetProfile(string))")
+	rebinder.SetProfile("hardcore")
+
+	profiles, err := provider.Profiles(context.Background())
+	require.NoError(t, err)
+	byName := map[string]tui.ProfileItem{}
+	for _, p := range profiles {
+		byName[p.Name] = p
+	}
+	require.True(t, byName["hardcore"].Active, "SetProfile must rebind which profile Profiles() marks Active")
+	require.False(t, byName["default"].Active, "the profile bound at construction must no longer read as active")
+}
+
+// TestCoreProviderActions_SetProfile_RebindsSubsequentMutationsToNewProfile
+// guards finding C1's ActionProvider half: after SetProfile retargets the
+// session, EnableMod (and by extension every other ActionProvider method
+// keyed on p.profile) must address the NEW profile's DB row, not the
+// profile bound at NewCoreActions construction time. recordingActions can't
+// catch this class of bug - it never touches a real DB - so this drives the
+// real coreProvider against a temp sandbox, mirroring this file's other
+// ActionProvider tests.
+func TestCoreProviderActions_SetProfile_RebindsSubsequentMutationsToNewProfile(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	// Installed under "target" only - NewCoreActions (via
+	// newCoreActionsFixture) was bound to "default".
+	require.NoError(t, svc.GetGameCache(game).Store(game.ID, "src", "1", "1.0", "plugin.esp", []byte("data")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "1", SourceID: "src", Name: "Test Mod", Version: "1.0", GameID: game.ID},
+		ProfileName:  "target",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      false,
+	}))
+	require.NoError(t, pm.AddMod(game.ID, "target", domain.ModReference{SourceID: "src", ModID: "1", Version: "1.0"}))
+
+	rebinder, ok := actions.(interface{ SetProfile(string) })
+	require.True(t, ok, "coreProvider must implement the profileRebinder hook (SetProfile(string))")
+	rebinder.SetProfile("target")
+
+	_, err = actions.EnableMod(context.Background(), tui.ModItem{ID: "1", Source: "src", Name: "Test Mod"})
+	require.NoError(t, err)
+
+	targetMod, err := svc.GetInstalledMod("src", "1", game.ID, "target")
+	require.NoError(t, err)
+	assert.True(t, targetMod.Enabled, "EnableMod after SetProfile must enable the mod under the TARGET profile")
+
+	_, err = svc.GetInstalledMod("src", "1", game.ID, "default")
+	assert.ErrorIs(t, err, domain.ErrModNotFound, "EnableMod must not fall back to the profile bound at construction time")
+}
+
 func TestCoreProviderActions_ApplyProfileSwitch_AppliesAndReturnsMessage(t *testing.T) {
 	actions, svc, game := newCoreActionsFixture(t)
 	pm := svc.NewProfileManager()

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -562,7 +562,10 @@ func TestCoreProviderActions_DeployProfile_NotesAppearInWarnings(t *testing.T) {
 // and fails - no source is registered for "src", so the GetMod fetch
 // mirrors internal/core/flows_test.go's
 // TestService_DeployProfile_MissingCacheAndFetchFailure_SkipsMod arrangement,
-// one level up - proving the mixed deployed/failed count renders correctly.
+// one level up - proving the mixed deployed/failed count renders correctly,
+// and (Task 7 addition) that the skip reason itself surfaces in
+// Outcome.Warnings so the TUI status line can explain WHY a mod failed
+// rather than just how many did.
 func TestCoreProviderActions_DeployProfile_ReportsFailedCount(t *testing.T) {
 	actions, svc, game := newCoreActionsFixture(t)
 	seedActionMod(t, svc, game, "src", "1", "Mod One", "1.0", true, map[string][]byte{"one.esp": []byte("1")})
@@ -576,7 +579,9 @@ func TestCoreProviderActions_DeployProfile_ReportsFailedCount(t *testing.T) {
 	outcome, err := actions.DeployProfile(context.Background())
 	require.NoError(t, err, "a per-mod fetch failure must not fail the whole deploy")
 	assert.Equal(t, "Deployed 1 mod(s), 1 failed", outcome.Message)
-	assert.Empty(t, outcome.Warnings, "a redownload fetch failure is recorded in DeployResult.Skipped, not Warnings/Notes, so it does not surface in Outcome.Warnings")
+	require.Len(t, outcome.Warnings, 1, "the skip reason (DeployResult.Skipped) must be appended to Outcome.Warnings")
+	assert.Contains(t, outcome.Warnings[0], "Mod Two")
+	assert.Contains(t, outcome.Warnings[0], "failed to fetch")
 
 	_, err = os.Lstat(filepath.Join(game.ModPath, "one.esp"))
 	assert.NoError(t, err, "the mod with an intact cache entry should still deploy")

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -555,6 +555,35 @@ func TestCoreProviderActions_DeployProfile_NotesAppearInWarnings(t *testing.T) {
 	}
 }
 
+// TestCoreProviderActions_DeployProfile_ReportsFailedCount guards the
+// ", %d failed" branch of coreProvider.DeployProfile's Message composition
+// (service_core.go), which had zero coverage: one mod deploys normally, the
+// other's cache entry is deleted so the deploy loop's redownload path runs
+// and fails - no source is registered for "src", so the GetMod fetch
+// mirrors internal/core/flows_test.go's
+// TestService_DeployProfile_MissingCacheAndFetchFailure_SkipsMod arrangement,
+// one level up - proving the mixed deployed/failed count renders correctly.
+func TestCoreProviderActions_DeployProfile_ReportsFailedCount(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	seedActionMod(t, svc, game, "src", "1", "Mod One", "1.0", true, map[string][]byte{"one.esp": []byte("1")})
+	seedActionMod(t, svc, game, "src", "2", "Mod Two", "1.0", true, map[string][]byte{"two.esp": []byte("2")})
+	seedActionProfileMod(t, svc, game.ID, "default", "src", "1", "1.0")
+	seedActionProfileMod(t, svc, game.ID, "default", "src", "2", "1.0")
+
+	require.NoError(t, svc.GetGameCache(game).Delete(game.ID, "src", "2", "1.0"),
+		"deleting mod 2's cache entry forces the redownload path, which fails since no source named \"src\" is registered")
+
+	outcome, err := actions.DeployProfile(context.Background())
+	require.NoError(t, err, "a per-mod fetch failure must not fail the whole deploy")
+	assert.Equal(t, "Deployed 1 mod(s), 1 failed", outcome.Message)
+	assert.Empty(t, outcome.Warnings, "a redownload fetch failure is recorded in DeployResult.Skipped, not Warnings/Notes, so it does not surface in Outcome.Warnings")
+
+	_, err = os.Lstat(filepath.Join(game.ModPath, "one.esp"))
+	assert.NoError(t, err, "the mod with an intact cache entry should still deploy")
+	_, err = os.Lstat(filepath.Join(game.ModPath, "two.esp"))
+	assert.True(t, os.IsNotExist(err), "the mod whose redownload failed must not be deployed")
+}
+
 func TestCoreProviderActions_PlanProfileSwitch_MapsBucketsToDisplayStrings(t *testing.T) {
 	actions, svc, game := newCoreActionsFixture(t)
 	pm := svc.NewProfileManager()

--- a/internal/tui/service_test.go
+++ b/internal/tui/service_test.go
@@ -23,6 +23,31 @@ func TestPrototypeProviderOverviewMirrorsFakeData(t *testing.T) {
 	require.Equal(t, data.Stats.Installed, summary.Installed)
 	require.Len(t, mods, len(data.InstalledMods))
 	require.Equal(t, data.InstalledMods[0].Name, mods[0].Name)
+	require.Equal(t, data.InstalledMods[0].ID, mods[0].ID, "ModItem.ID must carry the canned mod's stable ID")
+}
+
+// TestPrototypeProviderModItemIDsStableAcrossCalls guards the "invent stable
+// IDs" requirement: independently-constructed providers (and repeated calls
+// on the same one) must expose identical, non-empty ModItem.ID values -
+// (Source, ID) must deterministically address the same canned mod every
+// time, not merely within a single provider instance.
+func TestPrototypeProviderModItemIDsStableAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	first := NewPrototypeProvider()
+	second := NewPrototypeProvider()
+
+	_, mods1, err := first.Overview(ctx)
+	require.NoError(t, err)
+	_, mods2, err := second.Overview(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, mods1, len(mods2))
+	for i := range mods1 {
+		require.NotEmpty(t, mods1[i].ID)
+		require.Equal(t, mods1[i].ID, mods2[i].ID, "IDs must be stable across independent provider instances")
+	}
 }
 
 func TestPrototypeProviderSources(t *testing.T) {
@@ -43,6 +68,7 @@ func TestPrototypeProviderSearchFiltersCannedResults(t *testing.T) {
 	require.Equal(t, "nexusmods", page.Source)
 	require.Len(t, page.Results, 1)
 	require.Equal(t, "Frostfall", page.Results[0].Name)
+	require.Equal(t, "frostfall", page.Results[0].ID, "ModItem.ID must carry the canned search result's stable ID")
 	require.Equal(t, 1, page.TotalCount)
 
 	all, err := provider.Search(ctx, "nexusmods", "", 0)


### PR DESCRIPTION
## Summary

TUI Phase 5a: the TUI can now mutate — enable/disable, uninstall, deploy, and profile switch — every action behind an explicit confirmation modal. Closes the first half of the roadmap's Phase 5 (#37); install-from-search and update apply follow in 5b.

### Core: mutation flows extracted (Tasks 1–4)
The CLI's hand-orchestrated mutation logic moved into `internal/core` as reusable flows — `EnableMod`/`DisableMod`, `UninstallMod`, `DeployProfile`, `PlanProfileSwitch` (pure) / `ApplyProfileSwitch` — with the CLI refit on top, **behavior-preserving to the byte**: every task's review byte-diffed CLI output against the pre-refactor code, and the final review ran a 30-command parity matrix against a merge-base build in twin sandboxes. Diagnostics follow a uniform convention (stderr Warnings / verbose stdout Notes, partial results on error, dual-channel progress events with mod attribution).

### TUI: actions behind confirmations (Tasks 5–7)
- `ActionProvider` write-side seam (read-only `DataProvider` unchanged); `ModItem` gained the mod `ID` the Phase 4 review required
- Confirmation modal (`y`/`enter` confirm, `n`/`esc` cancel), single-flight guard, generation-tagged async results, one-row status line, refresh after every action (success or failure), quit now cancels in-flight search/action contexts (#42 lifecycle item)
- Keys: `e` toggle enable/disable + `x` uninstall (Installed Mods), `D` deploy (Installed Mods + Dashboard), `enter` switch with plan preview (Profiles); switches needing downloads are refused with a pointer to the CLI until 5b
- TUI-triggered uninstall/deploy run the same hooks as the CLI (parity traced field-by-field in review)
- `--prototype` demos everything, including a canned needs-downloads refusal scenario
- After a switch, the session rebinds to the new profile (Critical caught and fixed by the final live review)

### The one intentional CLI output change
The purge-phase `before_each` hook-skip diagnostic now prints to stderr with mod attribution (was stdout, unattributed) — documented in the CHANGELOG. Everything else is byte-identical, live-verified.

### Follow-ups filed
#60 (pre-existing switch enable-loop orphaning bug, preserved bug-for-bug), #61 (purge logic triplication), findings comment on #42. 5b carries: result-struct convergence for enable/disable, a provider-field guard for the new profile rebind, hook-config caching.

## Test plan
- Full suite + `-race` green throughout; every task RED→GREEN with per-task spec+quality review
- Final whole-branch review (live): twin-sandbox CLI parity matrix, tmux-driven TUI session with DB-truth probes after each action, `--prototype` walkthrough
- ⏳ **User interactive smoke test gates merge** (TUI-phase convention)

Refs #37, #42. Version v1.11.0 + CHANGELOG included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)