### PR TITLE
fix: profile switch no longer orphans deployments for mods installed under another profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.2] - 2026-07-23
+
+### Fixed
+
+- Profile switch: enabling a mod whose install record lives under a different profile (reachable via `profile export`/`import` or hand-edited profile lists) now creates the record under the target profile, so a later switch away undeploys it — previously the files were deployed but invisible to the target profile, leaving an orphaned deployment and a spurious "failed to update … mod not found" warning (#60)
+
+### Removed
+
+- Dead code: `ProfileManager.Switch` and its rollback helpers — an older, unused second switch implementation superseded by `PlanProfileSwitch`/`ApplyProfileSwitch` (#60)
+
 ## [1.12.1] - 2026-07-23
 
 ### Changed
@@ -795,7 +805,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.1...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.2...HEAD
+[1.12.2]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.1...v1.12.2
 [1.12.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.0...v1.12.1
 [1.12.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.10.0...v1.11.0

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -23,7 +23,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.12.1"
+	version = "1.12.2"
 
 	// Global flags
 	configDir  string

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -1672,11 +1672,24 @@ func (s *Service) ApplyProfileSwitch(ctx context.Context, game *domain.Game, pla
 			continue
 		}
 		if err := s.SetModEnabled(im.SourceID, im.ID, game.ID, plan.To, true); err != nil {
-			msg := fmt.Sprintf("Warning: failed to update %s: %v", im.Name, err)
-			result.Notes = append(result.Notes, msg)
-			evt := base
-			evt.Phase, evt.Detail = SwitchEnableNote, msg
-			emit(evt)
+			if errors.Is(err, domain.ErrModNotFound) {
+				// im's row lives under a different profile (PlanProfileSwitch
+				// admits such mods into ToEnable), so the UPDATE-only
+				// SetModEnabled matched nothing; create the target-profile row
+				// so the deployment we just made isn't orphaned (#60).
+				row := im
+				row.ProfileName = plan.To
+				row.Enabled = true
+				row.Deployed = true
+				err = s.SaveInstalledMod(&row)
+			}
+			if err != nil {
+				msg := fmt.Sprintf("Warning: failed to update %s: %v", im.Name, err)
+				result.Notes = append(result.Notes, msg)
+				evt := base
+				evt.Phase, evt.Detail = SwitchEnableNote, msg
+				emit(evt)
+			}
 		}
 
 		result.Enabled++

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -1449,9 +1449,9 @@ func (s *Service) PurgeProfile(ctx context.Context, game *domain.Game, profileNa
 // cmd/lmm/profile.go's doProfileSwitch's diff computation (through its
 // "Show changes" print block) - see the task report for the exact mapping.
 //
-// CRITICAL: this mirrors the CLI's OWN diff algorithm, which is distinct
-// from (and does not call) ProfileManager.Switch - see the task report for
-// why both exist.
+// CRITICAL: this mirrors the CLI's OWN diff algorithm. (An older, unused
+// ProfileManager.Switch implementation coexisted with it until #60 retired
+// it - this flow is the only switch implementation now.)
 type SwitchPlan struct {
 	GameID, From, To string
 

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -2323,6 +2323,57 @@ func TestService_ApplyProfileSwitch_EnableLoop_SetModEnabledFailureIsNonFatalNot
 	assert.NoError(t, err, "the mod must still have been deployed")
 }
 
+// TestService_ApplyProfileSwitch_EnableLoop_ModInstalledUnderOtherProfile_CreatesTargetRow
+// guards the #60 fix: when the target profile's YAML references a mod whose
+// installed_mods row lives only under a DIFFERENT profile (reachable via
+// profile export/import or hand-edited profile lists), enabling it must
+// create a row under the target profile - otherwise the deployment is
+// orphaned: files on disk and tracked in deployed_files, but invisible to
+// GetInstalledMods(game, target), so a later switch AWAY from the target
+// never undeploys the mod.
+func TestService_ApplyProfileSwitch_EnableLoop_ModInstalledUnderOtherProfile_CreatesTargetRow(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+
+	// Installed+disabled under "default"; referenced by "target"'s YAML
+	// without ever having been installed there.
+	seedInstalledModUnderProfile(t, svc, game, "default", "src", "1", "Test Mod", "1.0", false, map[string][]byte{"plugin.esp": []byte("data")})
+	seedProfileWithMod(t, svc, "g1", "target", "src", "1", "1.0")
+
+	plan, err := svc.PlanProfileSwitch(context.Background(), game, "target")
+	require.NoError(t, err)
+	require.Len(t, plan.ToEnable, 1)
+	require.Equal(t, "default", plan.ToEnable[0].ProfileName,
+		"precondition: the planned mod's row must live under the other profile")
+
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Enabled)
+	assert.Empty(t, result.Notes, "creating the missing target row must not be downgraded to a warning")
+
+	_, err = os.Lstat(filepath.Join(gameDir, "plugin.esp"))
+	assert.NoError(t, err, "the mod must be deployed to the game dir")
+
+	row, err := svc.GetInstalledMod("src", "1", "g1", "target")
+	require.NoError(t, err, "an installed_mods row must exist under the target profile")
+	assert.True(t, row.Enabled)
+	assert.True(t, row.Deployed)
+
+	// The orphan regression: switching back away from "target" must see the
+	// mod as enabled there and schedule it for disable/undeploy.
+	backPlan, err := svc.PlanProfileSwitch(context.Background(), game, "default")
+	require.NoError(t, err)
+	require.Len(t, backPlan.ToDisable, 1, "switching away must undeploy the mod (it was orphaned before #60)")
+	assert.Equal(t, "1", backPlan.ToDisable[0].ID)
+}
+
 // TestService_ApplyProfileSwitch_InstallLoop_FetchFailureSkipsModAndContinuesToNextMod
 // guards the install loop's per-ref isolation: a mod whose source isn't
 // registered (GetMod fails) is skipped via a SwitchInstallError event and

--- a/internal/core/profile.go
+++ b/internal/core/profile.go
@@ -1,33 +1,25 @@
 package core
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"path/filepath"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
-	"github.com/DonovanMods/linux-mod-manager/internal/linker"
-	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/db"
 )
 
-// ProfileManager handles profile CRUD operations and switching
+// ProfileManager handles profile CRUD operations. Profile switching lives in
+// Service.PlanProfileSwitch/ApplyProfileSwitch (internal/core/flows.go).
 type ProfileManager struct {
 	configDir string
 	db        *db.DB
-	cache     *cache.Cache
-	linker    linker.Linker
 }
 
 // NewProfileManager creates a new profile manager
-func NewProfileManager(configDir string, database *db.DB, cache *cache.Cache, lnk linker.Linker) *ProfileManager {
+func NewProfileManager(configDir string, database *db.DB) *ProfileManager {
 	return &ProfileManager{
 		configDir: configDir,
 		db:        database,
-		cache:     cache,
-		linker:    lnk,
 	}
 }
 
@@ -214,207 +206,6 @@ func (pm *ProfileManager) ReorderMods(gameID, profileName string, mods []domain.
 
 	profile.Mods = mods
 	return config.SaveProfile(pm.configDir, profile)
-}
-
-// Switch switches to a different profile, undeploying the current profile's mods
-// and deploying the new profile's mods. It fails fast on any error and rolls back
-// to the previous state (game dir and default profile) so the system is never left
-// in a mixed old/new state.
-func (pm *ProfileManager) Switch(ctx context.Context, game *domain.Game, newProfileName string) error {
-	newProfile, err := config.LoadProfile(pm.configDir, game.ID, newProfileName)
-	if err != nil {
-		return fmt.Errorf("loading new profile: %w", err)
-	}
-
-	currentProfile, err := pm.GetDefault(game.ID)
-	if err != nil && !errors.Is(err, domain.ErrProfileNotFound) {
-		return fmt.Errorf("getting current profile: %w", err)
-	}
-	hadCurrentProfile := currentProfile != nil
-	// Ensure current is never nil so rollbacks can safely use it (no mods/overrides when there was no default).
-	if currentProfile == nil {
-		currentProfile = &domain.Profile{Name: "", GameID: game.ID, Mods: nil, Overrides: nil}
-	}
-
-	// Phase 1: Undeploy current profile (fail-fast). Skip if no default was set, or switching to same profile. On error, rollback by re-deploying undeployed mods.
-	if hadCurrentProfile && currentProfile.Name != newProfileName && len(currentProfile.Mods) > 0 {
-		for i, modRef := range currentProfile.Mods {
-			if err := pm.undeployModRefFailFast(ctx, game, modRef); err != nil {
-				rollbackErr := pm.rollbackRedeploy(ctx, game, currentProfile.Mods[:i+1])
-				return joinSwitchErr(fmt.Errorf("undeploy %s:%s: %w", modRef.SourceID, modRef.ModID, err), rollbackErr)
-			}
-		}
-	}
-
-	// Phase 2: Deploy new profile (fail-fast). On error, rollback: undeploy new mods we deployed, then redeploy old.
-	for i, modRef := range newProfile.Mods {
-		if err := pm.deployMod(ctx, game, modRef); err != nil {
-			rollbackErr := pm.rollbackAfterDeployFailure(ctx, game, currentProfile, newProfile.Mods[:i])
-			return joinSwitchErr(fmt.Errorf("deploy %s:%s: %w", modRef.SourceID, modRef.ModID, err), rollbackErr)
-		}
-	}
-
-	// Phase 3: Apply new profile overrides. On error, rollback: revert to old profile (mods + overrides).
-	if err := ApplyProfileOverrides(game, newProfile); err != nil {
-		rollbackErr := pm.rollbackAfterOverridesFailure(ctx, game, currentProfile, newProfile)
-		return joinSwitchErr(fmt.Errorf("apply overrides: %w", err), rollbackErr)
-	}
-
-	// Phase 4: Set default. On error, rollback full switch so game dir and default stay consistent.
-	if err := pm.SetDefault(game.ID, newProfileName); err != nil {
-		rollbackErr := pm.rollbackAfterOverridesFailure(ctx, game, currentProfile, newProfile)
-		return joinSwitchErr(fmt.Errorf("set default profile: %w", err), rollbackErr)
-	}
-	return nil
-}
-
-func joinSwitchErr(primary, rollback error) error {
-	return &domain.DeployError{Op: "profile switch failed", Primary: primary, Rollback: rollback}
-}
-
-// undeployModRefFailFast removes a mod from the game directory, returning on first file error.
-func (pm *ProfileManager) undeployModRefFailFast(ctx context.Context, game *domain.Game, modRef domain.ModReference) error {
-	files, err := pm.cache.ListFiles(game.ID, modRef.SourceID, modRef.ModID, modRef.Version)
-	if err != nil {
-		return fmt.Errorf("listing cached files: %w", err)
-	}
-	for _, file := range files {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		dstPath := filepath.Join(game.ModPath, file)
-		if err := pm.linker.Undeploy(dstPath); err != nil {
-			return fmt.Errorf("%s: %w", file, err)
-		}
-	}
-	return nil
-}
-
-// rollbackRedeploy re-deploys the given mods (used after undeploy fail-fast).
-func (pm *ProfileManager) rollbackRedeploy(ctx context.Context, game *domain.Game, mods []domain.ModReference) error {
-	var errs []error
-	for _, modRef := range mods {
-		if err := pm.deployMod(ctx, game, modRef); err != nil {
-			errs = append(errs, fmt.Errorf("redeploy %s:%s: %w", modRef.SourceID, modRef.ModID, err))
-		}
-	}
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-	return nil
-}
-
-// rollbackAfterDeployFailure undeploys the new mods we deployed, then redeploys the old profile.
-func (pm *ProfileManager) rollbackAfterDeployFailure(ctx context.Context, game *domain.Game, current *domain.Profile, deployedNew []domain.ModReference) error {
-	var errs []error
-	for _, modRef := range deployedNew {
-		if err := pm.undeployModRef(ctx, game, modRef); err != nil {
-			errs = append(errs, fmt.Errorf("undeploy new %s:%s: %w", modRef.SourceID, modRef.ModID, err))
-		}
-	}
-	if current != nil && len(current.Mods) > 0 {
-		for _, modRef := range current.Mods {
-			if err := pm.deployMod(ctx, game, modRef); err != nil {
-				errs = append(errs, fmt.Errorf("redeploy old %s:%s: %w", modRef.SourceID, modRef.ModID, err))
-			}
-		}
-	}
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-	return nil
-}
-
-// rollbackAfterOverridesFailure restores old profile: undeploy new mods, deploy old mods, apply old overrides.
-func (pm *ProfileManager) rollbackAfterOverridesFailure(ctx context.Context, game *domain.Game, current *domain.Profile, newProfile *domain.Profile) error {
-	var errs []error
-	for _, modRef := range newProfile.Mods {
-		if err := pm.undeployModRef(ctx, game, modRef); err != nil {
-			errs = append(errs, fmt.Errorf("undeploy new %s:%s: %w", modRef.SourceID, modRef.ModID, err))
-		}
-	}
-	if current != nil {
-		for _, modRef := range current.Mods {
-			if err := pm.deployMod(ctx, game, modRef); err != nil {
-				errs = append(errs, fmt.Errorf("redeploy old %s:%s: %w", modRef.SourceID, modRef.ModID, err))
-			}
-		}
-		if len(current.Overrides) > 0 {
-			if err := ApplyProfileOverrides(game, current); err != nil {
-				errs = append(errs, fmt.Errorf("restore old overrides: %w", err))
-			}
-		}
-	}
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-	return nil
-}
-
-// deployMod deploys a single mod to the game directory
-func (pm *ProfileManager) deployMod(ctx context.Context, game *domain.Game, modRef domain.ModReference) error {
-	// Check if mod is cached
-	if !pm.cache.Exists(game.ID, modRef.SourceID, modRef.ModID, modRef.Version) {
-		return fmt.Errorf("mod not cached: %s:%s@%s", modRef.SourceID, modRef.ModID, modRef.Version)
-	}
-
-	// Get list of files
-	files, err := pm.cache.ListFiles(game.ID, modRef.SourceID, modRef.ModID, modRef.Version)
-	if err != nil {
-		return fmt.Errorf("listing cached files: %w", err)
-	}
-
-	var deployed []string
-	// Deploy each file
-	for _, file := range files {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		srcPath := pm.cache.GetFilePath(game.ID, modRef.SourceID, modRef.ModID, modRef.Version, file)
-		dstPath := filepath.Join(game.ModPath, file)
-
-		if err := pm.linker.Deploy(srcPath, dstPath); err != nil {
-			for j := len(deployed) - 1; j >= 0; j-- {
-				_ = pm.linker.Undeploy(filepath.Join(game.ModPath, deployed[j]))
-			}
-			return fmt.Errorf("deploying %s: %w", file, err)
-		}
-		deployed = append(deployed, file)
-	}
-
-	return nil
-}
-
-// undeployModRef removes a mod from the game directory using a ModReference
-func (pm *ProfileManager) undeployModRef(ctx context.Context, game *domain.Game, modRef domain.ModReference) error {
-	// Get list of files
-	files, err := pm.cache.ListFiles(game.ID, modRef.SourceID, modRef.ModID, modRef.Version)
-	if err != nil {
-		return fmt.Errorf("listing cached files: %w", err)
-	}
-
-	var errs []error
-	for _, file := range files {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		dstPath := filepath.Join(game.ModPath, file)
-		if err := pm.linker.Undeploy(dstPath); err != nil {
-			errs = append(errs, fmt.Errorf("%s: %w", file, err))
-		}
-	}
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-	return nil
 }
 
 // Export exports a profile to a portable format

--- a/internal/core/profile_test.go
+++ b/internal/core/profile_test.go
@@ -1,16 +1,10 @@
 package core_test
 
 import (
-	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
-	"github.com/DonovanMods/linux-mod-manager/internal/linker"
-	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
-	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/db"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +19,7 @@ func TestProfileManager_Create(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	pm := core.NewProfileManager(dir, database, cache.New(dir), linker.NewSymlink())
+	pm := core.NewProfileManager(dir, database)
 
 	profile, err := pm.Create("skyrim-se", "survival")
 	require.NoError(t, err)
@@ -41,7 +35,7 @@ func TestProfileManager_Create_DuplicateName(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	pm := core.NewProfileManager(dir, database, cache.New(dir), linker.NewSymlink())
+	pm := core.NewProfileManager(dir, database)
 
 	_, err = pm.Create("skyrim-se", "survival")
 	require.NoError(t, err)
@@ -58,7 +52,7 @@ func TestProfileManager_List(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	pm := core.NewProfileManager(dir, database, cache.New(dir), linker.NewSymlink())
+	pm := core.NewProfileManager(dir, database)
 
 	_, err = pm.Create("skyrim-se", "survival")
 	require.NoError(t, err)
@@ -78,7 +72,7 @@ func TestProfileManager_Get(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	pm := core.NewProfileManager(dir, database, cache.New(dir), linker.NewSymlink())
+	pm := core.NewProfileManager(dir, database)
 
 	_, err = pm.Create("skyrim-se", "survival")
 	require.NoError(t, err)
@@ -96,7 +90,7 @@ func TestProfileManager_Get_NotFound(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	pm := core.NewProfileManager(dir, database, cache.New(dir), linker.NewSymlink())
+	pm := core.NewProfileManager(dir, database)
 
 	_, err = pm.Get("skyrim-se", "nonexistent")
 	assert.ErrorIs(t, err, domain.ErrProfileNotFound)
@@ -110,7 +104,7 @@ func TestProfileManager_Delete(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	pm := core.NewProfileManager(dir, database, cache.New(dir), linker.NewSymlink())
+	pm := core.NewProfileManager(dir, database)
 
 	_, err = pm.Create("skyrim-se", "survival")
 	require.NoError(t, err)
@@ -130,7 +124,7 @@ func TestProfileManager_SetDefault(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	pm := core.NewProfileManager(dir, database, cache.New(dir), linker.NewSymlink())
+	pm := core.NewProfileManager(dir, database)
 
 	_, err = pm.Create("skyrim-se", "profile1")
 	require.NoError(t, err)
@@ -153,7 +147,7 @@ func TestProfileManager_AddMod(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	pm := core.NewProfileManager(dir, database, cache.New(dir), linker.NewSymlink())
+	pm := core.NewProfileManager(dir, database)
 
 	_, err = pm.Create("skyrim-se", "survival")
 	require.NoError(t, err)
@@ -181,7 +175,7 @@ func TestProfileManager_RemoveMod(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	pm := core.NewProfileManager(dir, database, cache.New(dir), linker.NewSymlink())
+	pm := core.NewProfileManager(dir, database)
 
 	_, err = pm.Create("skyrim-se", "survival")
 	require.NoError(t, err)
@@ -202,229 +196,6 @@ func TestProfileManager_RemoveMod(t *testing.T) {
 	assert.Empty(t, profile.Mods)
 }
 
-func TestProfileManager_Switch(t *testing.T) {
-	dir := t.TempDir()
-	modPath := filepath.Join(dir, "game", "mods")
-	require.NoError(t, os.MkdirAll(modPath, 0755))
-
-	database, err := db.New(":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, database.Close())
-	})
-
-	cacheDir := filepath.Join(dir, "cache")
-	modCache := cache.New(cacheDir)
-	lnk := linker.NewSymlink()
-
-	pm := core.NewProfileManager(dir, database, modCache, lnk)
-
-	game := &domain.Game{
-		ID:      "skyrim-se",
-		Name:    "Skyrim SE",
-		ModPath: modPath,
-	}
-
-	// Create two profiles
-	_, err = pm.Create("skyrim-se", "profile1")
-	require.NoError(t, err)
-	_, err = pm.Create("skyrim-se", "profile2")
-	require.NoError(t, err)
-
-	// Add mod to profile1 and cache it
-	modRef := domain.ModReference{SourceID: "nexusmods", ModID: "123", Version: "1.0"}
-	err = pm.AddMod("skyrim-se", "profile1", modRef)
-	require.NoError(t, err)
-
-	// Create cached mod file
-	err = modCache.Store("skyrim-se", "nexusmods", "123", "1.0", "test.esp", []byte("mod data"))
-	require.NoError(t, err)
-
-	// Switch to profile1 should deploy mods
-	err = pm.Switch(context.Background(), game, "profile1")
-	require.NoError(t, err)
-
-	// Verify mod is deployed
-	deployedPath := filepath.Join(modPath, "test.esp")
-	_, err = os.Lstat(deployedPath)
-	require.NoError(t, err)
-
-	// Switch to profile2 should undeploy profile1 mods
-	err = pm.Switch(context.Background(), game, "profile2")
-	require.NoError(t, err)
-
-	// Verify mod is no longer deployed
-	_, err = os.Lstat(deployedPath)
-	assert.True(t, os.IsNotExist(err))
-}
-
-func TestProfileManager_Switch_DeployFailure_Rollback(t *testing.T) {
-	dir := t.TempDir()
-	modPath := filepath.Join(dir, "game", "mods")
-	require.NoError(t, os.MkdirAll(modPath, 0755))
-
-	database, err := db.New(":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, database.Close())
-	})
-
-	cacheDir := filepath.Join(dir, "cache")
-	modCache := cache.New(cacheDir)
-	pm := core.NewProfileManager(dir, database, modCache, linker.NewSymlink())
-
-	game := &domain.Game{ID: "skyrim-se", Name: "Skyrim SE", ModPath: modPath}
-
-	_, err = pm.Create("skyrim-se", "profile1")
-	require.NoError(t, err)
-	_, err = pm.Create("skyrim-se", "profile2")
-	require.NoError(t, err)
-	require.NoError(t, pm.SetDefault("skyrim-se", "profile1"))
-
-	modA := domain.ModReference{SourceID: "nexusmods", ModID: "111", Version: "1.0"}
-	modB := domain.ModReference{SourceID: "nexusmods", ModID: "222", Version: "1.0"}
-	require.NoError(t, pm.AddMod("skyrim-se", "profile1", modA))
-	require.NoError(t, pm.AddMod("skyrim-se", "profile2", modA))
-	require.NoError(t, pm.AddMod("skyrim-se", "profile2", modB))
-
-	require.NoError(t, modCache.Store("skyrim-se", "nexusmods", "111", "1.0", "a.esp", []byte("a")))
-	// mod B is not cached -> deploy will fail when switching to profile2
-
-	require.NoError(t, pm.Switch(context.Background(), game, "profile1"))
-	deployedA := filepath.Join(modPath, "a.esp")
-	_, err = os.Lstat(deployedA)
-	require.NoError(t, err)
-
-	err = pm.Switch(context.Background(), game, "profile2")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "profile switch failed")
-	assert.Contains(t, err.Error(), "deploy nexusmods:222")
-
-	// Rollback: old profile (profile1) restored, default unchanged
-	def, _ := pm.GetDefault("skyrim-se")
-	require.NotNil(t, def)
-	assert.Equal(t, "profile1", def.Name)
-	_, err = os.Lstat(deployedA)
-	require.NoError(t, err)
-}
-
-func TestProfileManager_Switch_UndeployFailure_Rollback(t *testing.T) {
-	dir := t.TempDir()
-	modPath := filepath.Join(dir, "game", "mods")
-	require.NoError(t, os.MkdirAll(modPath, 0755))
-
-	database, err := db.New(":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, database.Close())
-	})
-
-	cacheDir := filepath.Join(dir, "cache")
-	modCache := cache.New(cacheDir)
-	pm := core.NewProfileManager(dir, database, modCache, linker.NewSymlink())
-
-	game := &domain.Game{ID: "skyrim-se", Name: "Skyrim SE", ModPath: modPath}
-
-	_, err = pm.Create("skyrim-se", "profile1")
-	require.NoError(t, err)
-	_, err = pm.Create("skyrim-se", "profile2")
-	require.NoError(t, err)
-	require.NoError(t, pm.SetDefault("skyrim-se", "profile1"))
-
-	modA := domain.ModReference{SourceID: "nexusmods", ModID: "111", Version: "1.0"}
-	modB := domain.ModReference{SourceID: "nexusmods", ModID: "222", Version: "1.0"}
-	require.NoError(t, pm.AddMod("skyrim-se", "profile1", modA))
-	require.NoError(t, pm.AddMod("skyrim-se", "profile1", modB))
-
-	require.NoError(t, modCache.Store("skyrim-se", "nexusmods", "111", "1.0", "a.esp", []byte("a")))
-	require.NoError(t, modCache.Store("skyrim-se", "nexusmods", "222", "1.0", "b.esp", []byte("b")))
-
-	require.NoError(t, pm.Switch(context.Background(), game, "profile1"))
-	deployedA := filepath.Join(modPath, "a.esp")
-	deployedB := filepath.Join(modPath, "b.esp")
-	_, err = os.Lstat(deployedA)
-	require.NoError(t, err)
-	_, err = os.Lstat(deployedB)
-	require.NoError(t, err)
-
-	// Replace B's symlink with a regular file so undeploy fails (symlink linker returns "not a symlink")
-	require.NoError(t, os.Remove(deployedB))
-	require.NoError(t, os.WriteFile(deployedB, []byte("replaced"), 0644))
-
-	err = pm.Switch(context.Background(), game, "profile2")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "profile switch failed")
-	assert.Contains(t, err.Error(), "undeploy nexusmods:222")
-
-	// Rollback must restore the current profile completely, including the mod
-	// whose undeploy failed after partially mutating its files.
-	def, _ := pm.GetDefault("skyrim-se")
-	require.NotNil(t, def)
-	assert.Equal(t, "profile1", def.Name)
-	_, err = os.Lstat(deployedA)
-	require.NoError(t, err, "A should be redeployed")
-	infoB, err := os.Lstat(deployedB)
-	require.NoError(t, err)
-	assert.True(t, infoB.Mode()&os.ModeSymlink != 0, "B should be restored to the original symlink deployment")
-}
-
-func TestProfileManager_Switch_OverridesFailure_Rollback(t *testing.T) {
-	dir := t.TempDir()
-	modPath := filepath.Join(dir, "game", "mods")
-	installPath := filepath.Join(dir, "game")
-	require.NoError(t, os.MkdirAll(modPath, 0755))
-
-	database, err := db.New(":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, database.Close())
-	})
-
-	cacheDir := filepath.Join(dir, "cache")
-	modCache := cache.New(cacheDir)
-	pm := core.NewProfileManager(dir, database, modCache, linker.NewSymlink())
-
-	game := &domain.Game{
-		ID:          "skyrim-se",
-		Name:        "Skyrim SE",
-		ModPath:     modPath,
-		InstallPath: installPath,
-	}
-
-	_, err = pm.Create("skyrim-se", "profile1")
-	require.NoError(t, err)
-	_, err = pm.Create("skyrim-se", "profile2")
-	require.NoError(t, err)
-	require.NoError(t, pm.SetDefault("skyrim-se", "profile1"))
-
-	modRef := domain.ModReference{SourceID: "nexusmods", ModID: "123", Version: "1.0"}
-	require.NoError(t, pm.AddMod("skyrim-se", "profile1", modRef))
-	require.NoError(t, pm.AddMod("skyrim-se", "profile2", modRef))
-	require.NoError(t, modCache.Store("skyrim-se", "nexusmods", "123", "1.0", "mod.esp", []byte("x")))
-
-	require.NoError(t, pm.Switch(context.Background(), game, "profile1"))
-	deployedPath := filepath.Join(modPath, "mod.esp")
-	_, err = os.Lstat(deployedPath)
-	require.NoError(t, err)
-
-	// Give profile2 invalid overrides (path traversal) so ApplyProfileOverrides fails
-	prof, err := config.LoadProfile(dir, "skyrim-se", "profile2")
-	require.NoError(t, err)
-	prof.Overrides = map[string][]byte{"../evil": []byte("x")}
-	require.NoError(t, config.SaveProfile(dir, prof))
-
-	err = pm.Switch(context.Background(), game, "profile2")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "profile switch failed")
-	assert.Contains(t, err.Error(), "apply overrides")
-
-	def, _ := pm.GetDefault("skyrim-se")
-	require.NotNil(t, def)
-	assert.Equal(t, "profile1", def.Name)
-	_, err = os.Lstat(deployedPath)
-	require.NoError(t, err)
-}
-
 func TestProfileManager_ExportImport(t *testing.T) {
 	dir := t.TempDir()
 	database, err := db.New(":memory:")
@@ -433,7 +204,7 @@ func TestProfileManager_ExportImport(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	pm := core.NewProfileManager(dir, database, cache.New(dir), linker.NewSymlink())
+	pm := core.NewProfileManager(dir, database)
 
 	// Create a profile with mods
 	_, err = pm.Create("skyrim-se", "original")
@@ -477,11 +248,7 @@ func TestProfileManager_UpsertMod(t *testing.T) {
 		require.NoError(t, database.Close())
 	})
 
-	cacheDir := filepath.Join(dir, "cache")
-	modCache := cache.New(cacheDir)
-	lnk := linker.NewSymlink()
-
-	pm := core.NewProfileManager(dir, database, modCache, lnk)
+	pm := core.NewProfileManager(dir, database)
 
 	// Create a profile
 	_, err = pm.Create("skyrim-se", "test")

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -579,7 +579,7 @@ func (s *Service) NewInstallerWithLinker(game *domain.Game, lnk linker.Linker) *
 // NewProfileManager returns a ProfileManager wired to this service's storage,
 // so callers do not need direct access to the database or registry.
 func (s *Service) NewProfileManager() *ProfileManager {
-	return NewProfileManager(s.configDir, s.db, s.cache, s.GetLinker(s.config.DefaultLinkMethod))
+	return NewProfileManager(s.configDir, s.db)
 }
 
 // NewUpdater returns an Updater wired to this service's source registry.


### PR DESCRIPTION
Closes #60

## The bug

`ApplyProfileSwitch`'s enable loop called the UPDATE-only `SetModEnabled` with the **target** profile name. When a mod's `installed_mods` row lived under a *different* profile (reachable when a profile's YAML references a mod it never installed — via `profile export`/`import` or hand-edited lists), the UPDATE matched zero rows, the resulting `ErrModNotFound` was downgraded to a warning, and **no row was ever created under the target profile**. Files were deployed and tracked in `deployed_files`, but invisible to `GetInstalledMods(game, target)` — so a later switch *away* from the target never undeployed the mod. Orphaned deployment.

## The fix

On `ErrModNotFound` the enable loop now creates the target-profile row via the existing `SaveInstalledMod` upsert (`Enabled` and `Deployed` true, `FileIDs` preserved). Genuine UPDATE failures on an existing row keep today's warning-note behavior, pinned by the existing `TestService_ApplyProfileSwitch_EnableLoop_SetModEnabledFailureIsNonFatalNote`. The only user-visible change is the bug fix itself: the spurious `Warning: failed to update <name>: mod not found` disappears and switching away now undeploys the mod.

New regression test drives the real `PlanProfileSwitch` → `ApplyProfileSwitch` path and asserts the round-trip (switch back schedules the mod for disable).

## Also: retire dead `ProfileManager.Switch` (per the issue's related question)

An older, second switch implementation with zero production callers — CLI and TUI both go through `PlanProfileSwitch`/`ApplyProfileSwitch`. Deleted with its Switch-only rollback helpers and tests (−460 lines); `ProfileManager` slimmed to the configDir+db its remaining CRUD/export methods use. Same precedent as #61's dead `purgeDeployedMods` removal.

## Verification

- TDD: the new test failed on the exact orphan symptoms before the fix, passes after; full suite green; `gofmt`/`go vet` clean.
- End-to-end CLI smoke in an isolated env: imported a local mod under `default`, disabled it, hand-added its ref to a `target` profile's YAML, `lmm profile switch target` → no warning, target row created (`enabled=1, deployed=1`); `lmm profile switch default` → mod correctly disabled and undeployed (was orphaned pre-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)