### PR TITLE
fix(cli): resolve active profile for flagless commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.2] - 2026-07-23
+
+### Fixed
+
+- Flagless CLI commands now operate on the game's active profile (the one set by `lmm profile switch`) instead of always using the profile literally named "default" (#66). Affected every command that takes `-p/--profile`: `list`, `deploy`, `install`, `uninstall`, `update`, `update rollback`, `mod enable/disable/set-update/files/edit`, `import`, `search`, `conflicts`, `verify`, `purge`, and `profile reorder`. An explicit `-p` still wins, and a fresh setup with no profiles keeps the "default" convention. The TUI already resolved the active profile correctly and now shares the same resolver.
+
+### Changed
+
+- `--profile` flag help text now uniformly reads "(default: active profile)"; several commands previously documented the literal "default" fallback
+
 ## [1.12.1] - 2026-07-23
 
 ### Changed
@@ -795,7 +805,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.1...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.2...HEAD
+[1.12.2]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.1...v1.12.2
 [1.12.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.0...v1.12.1
 [1.12.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.10.0...v1.11.0

--- a/cmd/lmm/conflicts.go
+++ b/cmd/lmm/conflicts.go
@@ -44,7 +44,7 @@ Examples:
 }
 
 func init() {
-	conflictsCmd.Flags().StringVarP(&conflictsProfile, "profile", "p", "", "profile (default: default)")
+	conflictsCmd.Flags().StringVarP(&conflictsProfile, "profile", "p", "", "profile (default: active profile)")
 
 	rootCmd.AddCommand(conflictsCmd)
 }
@@ -56,7 +56,10 @@ func runConflicts(cmd *cobra.Command, args []string) error {
 }
 
 func doConflicts(svc *core.Service, game *domain.Game) error {
-	profileName := profileOrDefault(conflictsProfile)
+	profileName, err := resolveProfile(svc, game.ID, conflictsProfile)
+	if err != nil {
+		return err
+	}
 
 	// Get all installed mods
 	mods, err := svc.GetInstalledMods(game.ID, profileName)

--- a/cmd/lmm/deploy.go
+++ b/cmd/lmm/deploy.go
@@ -65,7 +65,10 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 }
 
 func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, args []string) error {
-	profileName := profileOrDefault(deployProfile)
+	profileName, err := resolveProfile(service, game.ID, deployProfile)
+	if err != nil {
+		return err
+	}
 
 	var linkMethodOverride *domain.LinkMethod
 	if deployMethod != "" {

--- a/cmd/lmm/import.go
+++ b/cmd/lmm/import.go
@@ -44,7 +44,7 @@ Examples:
 }
 
 func init() {
-	importCmd.Flags().StringVarP(&importProfile, "profile", "p", "", "profile to import to (default: default)")
+	importCmd.Flags().StringVarP(&importProfile, "profile", "p", "", "profile to import to (default: active profile)")
 	importCmd.Flags().StringVarP(&importSource, "source", "s", "", "source for update tracking (default: auto-detect or local)")
 	importCmd.Flags().StringVar(&importModID, "id", "", "mod ID for linking to source (defaults to curseforge)")
 	importCmd.Flags().BoolVarP(&importForce, "force", "f", false, "import without conflict prompts")
@@ -61,7 +61,10 @@ func runImport(cmd *cobra.Command, args []string) error {
 }
 
 func doImport(ctx context.Context, cmd *cobra.Command, service *core.Service, game *domain.Game, args []string) error {
-	profileName := profileOrDefault(importProfile)
+	profileName, err := resolveProfile(service, game.ID, importProfile)
+	if err != nil {
+		return err
+	}
 
 	// No args = scan mode
 	if len(args) == 0 {

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -365,7 +365,10 @@ func doInstall(ctx context.Context, service *core.Service, game *domain.Game, ar
 		return err
 	}
 
-	profileName := profileOrDefault(installProfile)
+	profileName, err := resolveProfile(service, game.ID, installProfile)
+	if err != nil {
+		return err
+	}
 
 	// Get the mod to install (by --id or interactive search) - unchanged,
 	// CLI-side.

--- a/cmd/lmm/list.go
+++ b/cmd/lmm/list.go
@@ -64,7 +64,10 @@ func doList(cmd *cobra.Command, service *core.Service, game *domain.Game) error 
 		return runListProfiles(cmd, service, game.ID, game.Name)
 	}
 
-	profileName := profileOrDefault(listProfile)
+	profileName, err := resolveProfile(service, game.ID, listProfile)
+	if err != nil {
+		return err
+	}
 
 	mods, err := service.GetInstalledMods(game.ID, profileName)
 	if err != nil {

--- a/cmd/lmm/mod.go
+++ b/cmd/lmm/mod.go
@@ -157,7 +157,10 @@ func doModSetUpdate(service *core.Service, game *domain.Game, modID string) erro
 		return err
 	}
 
-	profileName := profileOrDefault(modProfile)
+	profileName, err := resolveProfile(service, game.ID, modProfile)
+	if err != nil {
+		return err
+	}
 
 	// Get the mod to verify it exists and get its name
 	mod, err := service.GetInstalledMod(modSource, modID, game.ID, profileName)
@@ -208,7 +211,10 @@ func doModEnable(ctx context.Context, service *core.Service, game *domain.Game, 
 		return err
 	}
 
-	profileName := profileOrDefault(modProfile)
+	profileName, err := resolveProfile(service, game.ID, modProfile)
+	if err != nil {
+		return err
+	}
 
 	// Get the mod to verify it exists and get its name for display
 	mod, err := service.GetInstalledMod(modSource, modID, game.ID, profileName)
@@ -257,7 +263,10 @@ func doModDisable(ctx context.Context, service *core.Service, game *domain.Game,
 		return err
 	}
 
-	profileName := profileOrDefault(modProfile)
+	profileName, err := resolveProfile(service, game.ID, modProfile)
+	if err != nil {
+		return err
+	}
 
 	// Get the mod to verify it exists and get its name for display
 	mod, err := service.GetInstalledMod(modSource, modID, game.ID, profileName)
@@ -317,9 +326,11 @@ func runModFiles(cmd *cobra.Command, args []string) error {
 }
 
 func doModFiles(svc *core.Service, game *domain.Game, modID string) error {
-	profileName := profileOrDefault(modProfile)
+	profileName, err := resolveProfile(svc, game.ID, modProfile)
+	if err != nil {
+		return err
+	}
 
-	var err error
 	modSource, err = resolveSource(game, modSource, false)
 	if err != nil {
 		return err

--- a/cmd/lmm/mod_edit.go
+++ b/cmd/lmm/mod_edit.go
@@ -48,7 +48,7 @@ func init() {
 	modEditCmd.Flags().StringVar(&editAuthor, "author", "", "new author")
 	modEditCmd.Flags().StringVar(&editSource, "source", "", "new source (e.g. curseforge, nexusmods)")
 	modEditCmd.Flags().StringVar(&editID, "source-id", "", "new source-specific mod ID")
-	modEditCmd.Flags().StringVarP(&editProfile, "profile", "p", "", "profile (default: default)")
+	modEditCmd.Flags().StringVarP(&editProfile, "profile", "p", "", "profile (default: active profile)")
 
 	modCmd.AddCommand(modEditCmd)
 }
@@ -60,7 +60,10 @@ func runModEdit(cmd *cobra.Command, args []string) error {
 }
 
 func doModEdit(ctx context.Context, service *core.Service, game *domain.Game, currentID string) error {
-	profileName := profileOrDefault(editProfile)
+	profileName, err := resolveProfile(service, game.ID, editProfile)
+	if err != nil {
+		return err
+	}
 
 	// Find the mod - search all sources
 	var installedMod *domain.InstalledMod

--- a/cmd/lmm/profile.go
+++ b/cmd/lmm/profile.go
@@ -166,7 +166,7 @@ func init() {
 	profileApplyCmd.Flags().BoolVarP(&profileApplyYes, "yes", "y", false, "auto-confirm changes")
 
 	// Reorder flags
-	profileReorderCmd.Flags().StringVarP(&profileReorderProfile, "profile", "p", "", "profile (default: default)")
+	profileReorderCmd.Flags().StringVarP(&profileReorderProfile, "profile", "p", "", "profile (default: active profile)")
 
 	rootCmd.AddCommand(profileCmd)
 }
@@ -809,7 +809,10 @@ func runProfileReorder(cmd *cobra.Command, args []string) error {
 
 func doProfileReorder(service *core.Service, game *domain.Game, args []string) error {
 
-	profileName := profileOrDefault(profileReorderProfile)
+	profileName, err := resolveProfile(service, game.ID, profileReorderProfile)
+	if err != nil {
+		return err
+	}
 	profile, err := config.LoadProfile(service.ConfigDir(), game.ID, profileName)
 	if err != nil {
 		return fmt.Errorf("loading profile: %w", err)

--- a/cmd/lmm/purge.go
+++ b/cmd/lmm/purge.go
@@ -41,7 +41,7 @@ Examples:
 }
 
 func init() {
-	purgeCmd.Flags().StringVarP(&purgeProfile, "profile", "p", "", "profile to purge (default: default profile)")
+	purgeCmd.Flags().StringVarP(&purgeProfile, "profile", "p", "", "profile to purge (default: active profile)")
 	purgeCmd.Flags().BoolVar(&purgeUninstall, "uninstall", false, "also remove mod records from database (like uninstalling each mod)")
 	purgeCmd.Flags().BoolVarP(&purgeYes, "yes", "y", false, "skip confirmation prompt")
 	purgeCmd.Flags().BoolVarP(&purgeForce, "force", "f", false, "continue even if hooks fail")
@@ -56,7 +56,10 @@ func runPurge(cmd *cobra.Command, args []string) error {
 }
 
 func doPurge(ctx context.Context, service *core.Service, game *domain.Game) error {
-	profileName := profileOrDefault(purgeProfile)
+	profileName, err := resolveProfile(service, game.ID, purgeProfile)
+	if err != nil {
+		return err
+	}
 
 	// The mod list is fetched before confirming so the prompt's count is
 	// exactly the set core.PurgeProfile will purge.

--- a/cmd/lmm/resolve_profile_test.go
+++ b/cmd/lmm/resolve_profile_test.go
@@ -14,6 +14,8 @@ import (
 // registered, returning the service (closed via t.Cleanup).
 func newResolveTestService(t *testing.T) *core.Service {
 	t.Helper()
+	prevConfigDir, prevDataDir := configDir, dataDir
+	t.Cleanup(func() { configDir, dataDir = prevConfigDir, prevDataDir })
 	configDir = t.TempDir()
 	dataDir = t.TempDir()
 
@@ -89,9 +91,10 @@ func TestListCmd_UsesActiveProfileAfterSwitch(t *testing.T) {
 	game, err := svc.GetGame("testgame")
 	require.NoError(t, err)
 
+	prevListProfile, prevJSONOutput := listProfile, jsonOutput
+	t.Cleanup(func() { listProfile, jsonOutput = prevListProfile, prevJSONOutput })
 	listProfile = ""
 	jsonOutput = true
-	defer func() { jsonOutput = false }()
 
 	out := captureStdout(t, func() error {
 		return doList(&cobra.Command{}, svc, game)

--- a/cmd/lmm/resolve_profile_test.go
+++ b/cmd/lmm/resolve_profile_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newResolveTestService builds a service against temp dirs with one game
+// registered, returning the service (closed via t.Cleanup).
+func newResolveTestService(t *testing.T) *core.Service {
+	t.Helper()
+	configDir = t.TempDir()
+	dataDir = t.TempDir()
+
+	svc, err := initService()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	require.NoError(t, svc.AddGame(&domain.Game{
+		ID:      "testgame",
+		Name:    "Test Game",
+		ModPath: t.TempDir(),
+	}))
+	return svc
+}
+
+func TestResolveProfile_ExplicitFlagWins(t *testing.T) {
+	svc := newResolveTestService(t)
+	pm := svc.NewProfileManager()
+	_, err := pm.Create("testgame", "active")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault("testgame", "active"))
+
+	got, err := resolveProfile(svc, "testgame", "explicit")
+	require.NoError(t, err)
+	assert.Equal(t, "explicit", got, "an explicit -p value must win over the active profile")
+}
+
+func TestResolveProfile_UsesActiveProfileAfterSwitch(t *testing.T) {
+	svc := newResolveTestService(t)
+	pm := svc.NewProfileManager()
+	for _, name := range []string{"default", "target"} {
+		_, err := pm.Create("testgame", name)
+		require.NoError(t, err)
+	}
+	// Equivalent of `lmm profile switch target` for an empty profile.
+	require.NoError(t, pm.SetDefault("testgame", "target"))
+
+	got, err := resolveProfile(svc, "testgame", "")
+	require.NoError(t, err)
+	assert.Equal(t, "target", got, "flagless commands must operate on the active profile, not the literal \"default\"")
+}
+
+func TestResolveProfile_FallsBackToFirstProfile(t *testing.T) {
+	svc := newResolveTestService(t)
+	pm := svc.NewProfileManager()
+	_, err := pm.Create("testgame", "solo")
+	require.NoError(t, err)
+
+	got, err := resolveProfile(svc, "testgame", "")
+	require.NoError(t, err)
+	assert.Equal(t, "solo", got, "with no IsDefault flag set, GetDefault's first-profile fallback applies")
+}
+
+func TestResolveProfile_NoProfilesFallsBackToDefault(t *testing.T) {
+	svc := newResolveTestService(t)
+
+	got, err := resolveProfile(svc, "testgame", "")
+	require.NoError(t, err)
+	assert.Equal(t, "default", got, "a fresh setup with no profiles keeps the historical \"default\" convention")
+}
+
+// End-to-end repro of the smoke-test failure: after `lmm profile switch
+// target`, a flagless `lmm list` must report the "target" profile.
+func TestListCmd_UsesActiveProfileAfterSwitch(t *testing.T) {
+	svc := newResolveTestService(t)
+	pm := svc.NewProfileManager()
+	for _, name := range []string{"default", "target"} {
+		_, err := pm.Create("testgame", name)
+		require.NoError(t, err)
+	}
+	require.NoError(t, pm.SetDefault("testgame", "target"))
+
+	game, err := svc.GetGame("testgame")
+	require.NoError(t, err)
+
+	listProfile = ""
+	jsonOutput = true
+	defer func() { jsonOutput = false }()
+
+	out := captureStdout(t, func() error {
+		return doList(&cobra.Command{}, svc, game)
+	})
+	assert.Contains(t, out, `"profile": "target"`, "flagless list must use the active profile")
+}

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/curseforge"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/nexusmods"
@@ -274,10 +275,21 @@ func requireGame(cmd *cobra.Command) error {
 	return fmt.Errorf("no game specified; use --game or -g flag, or set a default with 'lmm game set-default <game-id>'")
 }
 
-// profileOrDefault returns the given profile name, or "default" if empty
-func profileOrDefault(profile string) string {
-	if profile == "" {
-		return "default"
+// resolveProfile returns the profile a command should operate on: the explicit
+// -p/--profile value when given, otherwise the game's active profile as
+// resolved by ProfileManager.GetDefault (the IsDefault profile set by
+// `lmm profile switch`, else the first profile). Falls back to "default" when
+// no profiles exist yet so a fresh setup still works.
+func resolveProfile(svc *core.Service, gameID, flagValue string) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
 	}
-	return profile
+	profile, err := svc.NewProfileManager().GetDefault(gameID)
+	if err != nil {
+		if errors.Is(err, domain.ErrProfileNotFound) {
+			return "default", nil
+		}
+		return "", fmt.Errorf("resolving active profile for %s: %w", gameID, err)
+	}
+	return profile.Name, nil
 }

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -24,7 +24,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.12.1"
+	version = "1.12.2"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/search.go
+++ b/cmd/lmm/search.go
@@ -193,7 +193,10 @@ func doSearch(ctx context.Context, service *core.Service, game *domain.Game, arg
 
 	// Get installed mods to mark already-installed ones (source-aware: a mod
 	// ID is only unique within its source, so key on both).
-	profileName := profileOrDefault(searchProfile)
+	profileName, err := resolveProfile(service, game.ID, searchProfile)
+	if err != nil {
+		return err
+	}
 	installedMods, _ := service.GetInstalledMods(game.ID, profileName)
 	installedKeys := make(map[string]bool)
 	for _, im := range installedMods {

--- a/cmd/lmm/tui.go
+++ b/cmd/lmm/tui.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -52,14 +51,9 @@ func runTUI(cmd *cobra.Command, args []string) error {
 	}
 
 	return withGameService(cmd, func(ctx context.Context, svc *core.Service, game *domain.Game) error {
-		// Fall back to the CLI's default-profile convention (cf.
-		// profileOrDefault) when no profile exists yet, so a fresh setup
-		// opens an empty TUI instead of erroring.
-		profileName := "default"
-		if profile, err := svc.NewProfileManager().GetDefault(game.ID); err == nil {
-			profileName = profile.Name
-		} else if !errors.Is(err, domain.ErrProfileNotFound) {
-			return fmt.Errorf("resolving default profile for %s: %w", game.ID, err)
+		profileName, err := resolveProfile(svc, game.ID, "")
+		if err != nil {
+			return err
 		}
 
 		model, err := tui.NewModel(tui.Options{

--- a/cmd/lmm/uninstall.go
+++ b/cmd/lmm/uninstall.go
@@ -50,7 +50,10 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 
 func doUninstall(ctx context.Context, service *core.Service, game *domain.Game, modID string) error {
 	// Determine profile
-	profileName := profileOrDefault(uninstallProfile)
+	profileName, err := resolveProfile(service, game.ID, uninstallProfile)
+	if err != nil {
+		return err
+	}
 
 	if verbose {
 		fmt.Printf("Uninstalling mod %s from %s (profile: %s)...\n", modID, game.Name, profileName)
@@ -58,7 +61,6 @@ func doUninstall(ctx context.Context, service *core.Service, game *domain.Game, 
 
 	// Find the mod - try specified source first, then search all installed mods
 	var installedMod *domain.InstalledMod
-	var err error
 	if uninstallSource != "" {
 		// Source explicitly specified
 		if uninstallSource != domain.SourceLocal {

--- a/cmd/lmm/update.go
+++ b/cmd/lmm/update.go
@@ -98,7 +98,10 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 	}
 
 	// Determine profile
-	profileName := profileOrDefault(updateProfile)
+	profileName, err := resolveProfile(service, game.ID, updateProfile)
+	if err != nil {
+		return err
+	}
 
 	// Get installed mods
 	installed, err := service.GetInstalledMods(game.ID, profileName)
@@ -377,7 +380,10 @@ func doUpdateRollback(ctx context.Context, service *core.Service, game *domain.G
 		return err
 	}
 
-	profileName := profileOrDefault(updateProfile)
+	profileName, err := resolveProfile(service, game.ID, updateProfile)
+	if err != nil {
+		return err
+	}
 
 	// Get the installed mod
 	mod, err := service.GetInstalledMod(updateSource, modID, game.ID, profileName)

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -51,7 +51,7 @@ Examples:
 
 func init() {
 	verifyCmd.Flags().BoolVar(&verifyFix, "fix", false, "Re-download missing files and populate missing checksums by re-downloading")
-	verifyCmd.Flags().StringVarP(&verifyProfile, "profile", "p", "", "profile to verify (default: default)")
+	verifyCmd.Flags().StringVarP(&verifyProfile, "profile", "p", "", "profile to verify (default: active profile)")
 
 	rootCmd.AddCommand(verifyCmd)
 }
@@ -63,7 +63,10 @@ func runVerify(cmd *cobra.Command, args []string) error {
 }
 
 func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []string) error {
-	profile := profileOrDefault(verifyProfile)
+	profile, err := resolveProfile(svc, game.ID, verifyProfile)
+	if err != nil {
+		return err
+	}
 
 	// Get all files with checksums for this game/profile
 	files, err := svc.GetFilesWithChecksums(game.ID, profile)


### PR DESCRIPTION
Fixes #66

## Problem

`profileOrDefault` returned the literal string `"default"` whenever `-p/--profile` was omitted, so every flagless CLI command ignored the active profile set by `lmm profile switch` (`ProfileManager.SetDefault` / the `IsDefault` flag). End-to-end: after `lmm profile switch target`, `lmm list` still listed the profile literally named `default`. Several commands' `--profile` help text already promised "(default: active profile)", so behavior contradicted the docs. The TUI was unaffected — it resolved via `ProfileManager.GetDefault`.

## Fix

- Replace `profileOrDefault` with `resolveProfile(svc, gameID, flagValue)`: an explicit `-p` wins verbatim; otherwise the game's active profile is resolved via `ProfileManager.GetDefault` (the `IsDefault` profile, else the first one), falling back to `"default"` only when no profiles exist yet (fresh-setup convention, same as the TUI).
- Updated all 16 flagless call sites: `list`, `deploy`, `install`, `uninstall`, `update`, `update rollback`, `mod enable/disable/set-update/files/edit`, `import`, `search`, `conflicts`, `verify`, `purge`, `profile reorder`.
- The TUI now shares `resolveProfile` instead of its own inline copy of the same logic.
- Normalized all `--profile` help texts to "(default: active profile)".

## Testing

- TDD: new [cmd/lmm/resolve_profile_test.go](cmd/lmm/resolve_profile_test.go) written first (failed against the old behavior) — unit tests for explicit-flag-wins, active-profile resolution after switch, first-profile fallback, no-profiles fallback, plus an end-to-end repro (`SetDefault("target")` → flagless `list` reports `"profile": "target"`).
- Full suite, `go vet`, `gofmt` clean.
- Manual smoke test with the built binary: seeded a game, created `default` + `target` profiles, `profile switch target`, then flagless `lmm list --json` → `"profile": "target"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)