### PR TITLE
feat(tui): Phase 6a local workflows — purge view, files panel, policy editing, game switcher, profile create/delete, help groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-07-23
+
+### Added
+
+- TUI purge behind a confirmation view (`X` on Dashboard/Installed Mods), streaming per-mod progress via the shared `core.PurgeProfile` flow (#61); an empty profile short-circuits with a "no mods installed" message. The `purge --uninstall` variant deliberately remains CLI-only
+- Per-mod deployed-files panel (`f` on Installed Mods), listing the files a mod has placed in the game directory
+- Update-policy editing (`P` on Installed Mods): a notify/auto/pin picker with the mod's current policy marked
+- In-TUI game switcher (`g`, any screen): pick from configured games to rebind the session (data providers, active profile, sources) and reload; `--prototype` demo mode gets a second canned game to switch to
+- Profile create (`c`) and delete (`d`) on the Profiles screen; delete refuses the active profile, and create validates duplicate names inline
+- Help overlay (`?`) restructured into per-screen key groups, with the current screen's group listed first and a height-capped "+N more" tail; the Dashboard's `enter` action is now documented
+
+### Fixed
+
+- TUI: an in-flight data load racing a game or profile switch could momentarily repopulate the screen with the prior game's or profile's data; loads are now generation-checked so a stale load can no longer overwrite a newer one
+
 ## [1.12.3] - 2026-07-23
 
 ### Fixed
@@ -815,7 +830,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.3...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.13.0...HEAD
+[1.13.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.3...v1.13.0
 [1.12.3]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.2...v1.12.3
 [1.12.2]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.1...v1.12.2
 [1.12.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.0...v1.12.1

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -24,7 +24,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.12.3"
+	version = "1.13.0"
 
 	// Global flags
 	configDir  string

--- a/docs/assets/tui/amber-120x36.ansi
+++ b/docs/assets/tui/amber-120x36.ansi
@@ -1,6 +1,6 @@
                                                                                                                         
   LMM // Linux Mod Manager                                                                                              
-  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles  [5] Sources                                              
                                                                                                                         
   ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮  
   │ BOOT SEQUENCE // MOD GUILD TERMINAL                                                                              │  
@@ -12,8 +12,8 @@
   │ > RUN SPELLBOOK SCAN                                                                                             │  
   │   QUERY ARCHIVE INDEX                                                                                            │  
   │   LOAD PROFILE ROSTER                                                                                            │  
+  │   SCRY SOURCE REGISTRY                                                                                           │  
   │   ASK CONFLICT ORACLE                                                                                            │  
-  │                                                                                                                  │  
   │                                                                                                                  │  
   │                                                                                                                  │  
   │                                                                                                                  │  
@@ -32,5 +32,5 @@
   │                                                                                                                  │  
   ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯  
                                                                                                                         
-  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                                                           
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  i: install  e: enable/disable · x: uninstall · D: deploy · u: c…  
                                                                                                                         

--- a/docs/assets/tui/amber-80x24.ansi
+++ b/docs/assets/tui/amber-80x24.ansi
@@ -1,6 +1,6 @@
                                                                                 
   LMM // Linux Mod Manager                                                      
-  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles  [5] Sources      
                                                                                 
   ╭──────────────────────────────────────────────────────────────────────────╮  
   │ BOOT SEQUENCE // MOD GUILD TERMINAL                                      │  
@@ -12,13 +12,13 @@
   │ > RUN SPELLBOOK SCAN                                                     │  
   │   QUERY ARCHIVE INDEX                                                    │  
   │   LOAD PROFILE ROSTER                                                    │  
+  │   SCRY SOURCE REGISTRY                                                   │  
   │   ASK CONFLICT ORACLE                                                    │  
-  │                                                                          │  
   │                                                                          │  
   │                                                                          │  
   │                                                                          │  
   │                                                                          │  
   ╰──────────────────────────────────────────────────────────────────────────╯  
                                                                                 
-  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                   
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  i: install  e: enable/d…  
                                                                                 

--- a/docs/assets/tui/dos-120x36.ansi
+++ b/docs/assets/tui/dos-120x36.ansi
@@ -1,14 +1,14 @@
                                                                                                                         
   LMM // Linux Mod Manager                                                                                              
-  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles  [5] Sources                                              
                                                                                                                         
   ┌───────────────────────────────────────────────────────┐ ┌────────────────────────────────────────────────────────┐  
   │ ACTIVE PROFILE                                        │ │ OPERATIONS                                             │  
   │ survival                                              │ │ > Installed Mods                                       │  
   │                                                       │ │   Search Archives                                      │  
   │ Game     Skyrim Special Edition                       │ │   Profiles                                             │  
-  │ Enabled  39                                           │ │   Consult Conflict Oracle                              │  
-  │ Updates  3                                            │ │                                                        │  
+  │ Enabled  39                                           │ │   Sources                                              │  
+  │ Updates  3                                            │ │   Consult Conflict Oracle                              │  
   │                                                       │ │                                                        │  
   │                                                       │ │                                                        │  
   │                                                       │ │                                                        │  
@@ -32,5 +32,5 @@
   │                                                       │ │                                                        │  
   └───────────────────────────────────────────────────────┘ └────────────────────────────────────────────────────────┘  
                                                                                                                         
-  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                                                           
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  i: install  e: enable/disable · x: uninstall · D: deploy · u: c…  
                                                                                                                         

--- a/docs/assets/tui/dos-80x24.ansi
+++ b/docs/assets/tui/dos-80x24.ansi
@@ -1,14 +1,14 @@
                                                                                 
   LMM // Linux Mod Manager                                                      
-  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles  [5] Sources      
                                                                                 
   ┌───────────────────────────────────┐ ┌────────────────────────────────────┐  
   │ ACTIVE PROFILE                    │ │ OPERATIONS                         │  
   │ survival                          │ │ > Installed Mods                   │  
   │                                   │ │   Search Archives                  │  
   │ Game     Skyrim Special Edition   │ │   Profiles                         │  
-  │ Enabled  39                       │ │   Consult Conflict Oracle          │  
-  │ Updates  3                        │ │                                    │  
+  │ Enabled  39                       │ │   Sources                          │  
+  │ Updates  3                        │ │   Consult Conflict Oracle          │  
   │                                   │ │                                    │  
   │                                   │ │                                    │  
   │                                   │ │                                    │  
@@ -20,5 +20,5 @@
   │                                   │ │                                    │  
   └───────────────────────────────────┘ └────────────────────────────────────┘  
                                                                                 
-  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                   
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  i: install  e: enable/d…  
                                                                                 

--- a/docs/assets/tui/green-120x36.ansi
+++ b/docs/assets/tui/green-120x36.ansi
@@ -1,6 +1,6 @@
                                                                                                                         
   LMM // Linux Mod Manager                                                                                              
-  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles  [5] Sources                                              
                                                                                                                         
   ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮  
   │ CRT STATUS STACK                                                                                                 │  
@@ -12,8 +12,8 @@
   │ > Installed Mods                                                                                                 │  
   │   Search Archives                                                                                                │  
   │   Profiles                                                                                                       │  
+  │   Sources                                                                                                        │  
   │   Consult Conflict Oracle                                                                                        │  
-  │                                                                                                                  │  
   │                                                                                                                  │  
   │                                                                                                                  │  
   │                                                                                                                  │  
@@ -32,5 +32,5 @@
   │                                                                                                                  │  
   ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯  
                                                                                                                         
-  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                                                           
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  i: install  e: enable/disable · x: uninstall · D: deploy · u: c…  
                                                                                                                         

--- a/docs/assets/tui/green-80x24.ansi
+++ b/docs/assets/tui/green-80x24.ansi
@@ -1,6 +1,6 @@
                                                                                 
   LMM // Linux Mod Manager                                                      
-  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles  [5] Sources      
                                                                                 
   ╭──────────────────────────────────────────────────────────────────────────╮  
   │ CRT STATUS STACK                                                         │  
@@ -12,13 +12,13 @@
   │ > Installed Mods                                                         │  
   │   Search Archives                                                        │  
   │   Profiles                                                               │  
+  │   Sources                                                                │  
   │   Consult Conflict Oracle                                                │  
-  │                                                                          │  
   │                                                                          │  
   │                                                                          │  
   │                                                                          │  
   │                                                                          │  
   ╰──────────────────────────────────────────────────────────────────────────╯  
                                                                                 
-  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                   
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  i: install  e: enable/d…  
                                                                                 

--- a/docs/assets/tui/wizardry-120x36.ansi
+++ b/docs/assets/tui/wizardry-120x36.ansi
@@ -1,6 +1,6 @@
                                                                                                                         
   LMM // Linux Mod Manager                                                                                              
-  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                                                           
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles  [5] Sources                                              
                                                                                                                         
   ╭───────────────────────────────────────────────────────╮ ╭───────────────────────────────────────────────────────╮   
   │ PARTY                                                 │ │ QUEST LOG                                             │   
@@ -21,8 +21,8 @@
   │ > Installed Mods                                                                                                 │  
   │   Search Archives                                                                                                │  
   │   Profiles                                                                                                       │  
+  │   Sources                                                                                                        │  
   │   Consult Conflict Oracle                                                                                        │  
-  │                                                                                                                  │  
   │                                                                                                                  │  
   │                                                                                                                  │  
   │                                                                                                                  │  
@@ -32,5 +32,5 @@
   │                                                                                                                  │  
   ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯  
                                                                                                                         
-  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                                                           
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  i: install  e: enable/disable · x: uninstall · D: deploy · u: c…  
                                                                                                                         

--- a/docs/assets/tui/wizardry-80x24.ansi
+++ b/docs/assets/tui/wizardry-80x24.ansi
@@ -1,6 +1,6 @@
                                                                                 
   LMM // Linux Mod Manager                                                      
-  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles                   
+  [1] Dashboard  [2] Installed Mods  [3] Search  [4] Profiles  [5] Sources      
                                                                                 
   ╭───────────────────────────────────╮ ╭───────────────────────────────────╮   
   │ PARTY                             │ │ QUEST LOG                         │   
@@ -15,10 +15,10 @@
   │ > Installed Mods                                                         │  
   │   Search Archives                                                        │  
   │   Profiles                                                               │  
+  │   Sources                                                                │  
   │   Consult Conflict Oracle                                                │  
-  │                                                                          │  
   │                                                                          │  
   ╰──────────────────────────────────────────────────────────────────────────╯  
                                                                                 
-  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  q: quit                   
+  ?: help  tab/h/l: screens  ↑↓/j/k: move  /: search  i: install  e: enable/d…  
                                                                                 

--- a/docs/plans/2026-07-23-tui-phase6a-workflows-design.md
+++ b/docs/plans/2026-07-23-tui-phase6a-workflows-design.md
@@ -1,0 +1,121 @@
+# TUI Phase 6a — Local Workflows (design)
+
+> Status: **approved design** (2026-07-23). Implementation plan to follow in
+> `2026-07-23-tui-phase6a-workflows-impl.md`. Targets **v1.13.0**.
+>
+> Phase 6 (roadmap `2026-04-28-tui-implementation.md` §Phase 6 + issue #37's
+> additions) is split in two:
+>
+> - **6a (this doc)** — the workflows that ride on Phase 5's existing modal/
+>   action machinery with near-zero core changes.
+> - **6b (later)** — the workflows needing new core extractions: conflict view,
+>   load-order reorder, update rollback + changelogs, profile export/import
+>   entry points.
+
+## Scope
+
+Six items, all local operations (no network, no source capabilities needed):
+
+1. **Purge behind a confirmation view** (`X` on Dashboard/Installed Mods) —
+   consumes `core.PurgeProfile` (#61) exactly as its extraction planned.
+2. **Per-mod deployed-files panel** (`f` on Installed Mods) — read-only
+   overlay over `GetDeployedFilesForMod`.
+3. **Update-policy editing** (`P` on Installed Mods) — notify/auto/pin picker
+   over `SetModUpdatePolicy`. (Decided: lives on Installed Mods now; the 6b
+   update view may add a second entry point later.)
+4. **In-TUI game switcher** (`g`, global) — modal picker; rebinds the session
+   to the chosen game. (Decided: modal on a global key, not a screen or a
+   Dashboard-only entry.)
+5. **Profile create / delete** (`c` / `d` on Profiles) — text-input modal and
+   confirm modal over `ProfileManager.Create`/`Delete`.
+6. **Workflow help overlay** (`?`, global) — expands the existing help binding
+   into a full per-screen key reference.
+
+**Out of scope (deliberate):**
+
+- Everything 6b (conflicts, reorder, rollback, changelogs, export/import).
+- Purge's `--uninstall` variant — the TUI offers only the record-preserving
+  purge; deleting records stays CLI-only.
+- Game add/detect/set-default (CLI-only per the roadmap's parity table);
+  the switcher only switches between already-configured games.
+
+## Keys and UX
+
+| Key | Where | Action |
+| --- | ----- | ------ |
+| `X` | Dashboard, Installed Mods | Purge: confirm modal shows mod count + names (the fetched `GetInstalledMods` list IS the plan — no separate dry-run API), then streaming progress mapped from `DeployBeforeAllForced`/`DeployPurging`/`PurgeModPurged`/`PurgeModSkipped`/`PurgeWarning`/`PurgeNote`/`PurgeComplete`; result on the status line ("Purged N mod(s)", warning count when non-zero) |
+| `f` | Installed Mods | Read-only overlay listing the selected mod's deployed files; `esc` closes; "no files deployed" empty state |
+| `P` | Installed Mods | Three-option picker (notify/auto/pin, current policy marked) → `SetModUpdatePolicy`; `p` remains search paging |
+| `g` | Global (any screen, input blurred) | Game-switcher modal listing configured games, active marked; select rebinds the session; `esc` cancels |
+| `c` | Profiles | Create-profile text-input modal (reuses the search input component); validates non-empty and unique before enabling confirm |
+| `d` | Profiles | Delete-profile confirm modal; refuses the active profile with a status-line error before any modal confirms |
+| `?` | Global | Full help overlay, key groups per screen; `?`/`esc` closes |
+
+Keys `X`, `f`, `P`, `g`, `c`, `d` are currently unbound (verified against
+`keys.go`); `?` is bound but underpowered. Focused-input rule (user law from
+Phase 4/5): a focused search input swallows printable keys, so all new
+printable bindings only fire with the input blurred — same dispatch position
+as `i`/`e`/`x` in `updateKey`.
+
+## Architecture
+
+No new top-level screens — everything is a modal or overlay on existing
+screens, using Phase 5a's machinery unchanged: confirmation modal component,
+single-flight action runner, generation staleness, status line,
+refresh-always-after-mutation, progress pump (single-slot coalescing channel)
+for the purge stream, cancel-then-drain on quit (purge honors ctx between
+mods, per #61).
+
+**New provider surface** (small additions, same DataProvider/ActionProvider
+split as today):
+
+- Data: `DeployedFiles(sourceID, modID) ([]string, error)`,
+  `ListGames() ([]GameInfo, error)` (id, name, active flag).
+- Action: `PurgeProfile(ctx, progress) (*core.PurgeResult, error)`,
+  `SetUpdatePolicy(sourceID, modID, policy) error`,
+  `CreateProfile(name) error`, `DeleteProfile(name) error`.
+
+**Game switcher** is the only structurally new element: on selection it
+constructs a fresh DataProvider/ActionProvider pair bound to the chosen game
+(same constructor path `lmm tui` uses at launch), re-resolves the active
+profile via `ProfileManager.GetDefault`, resets per-screen state (selections,
+search results, update counts back to the `?` sentinel), and triggers a full
+reload. Guard: blocked with a status-line message while an action is in
+flight (single-flight owns this check). The prototype mode gets a canned
+second game so `--prototype` demos the switcher.
+
+**Purge** empty state: zero installed mods short-circuits to a status-line
+message ("No mods installed") without opening a modal, mirroring the CLI's
+early-out.
+
+## Error handling
+
+Existing conventions only: fatal action errors land on the status line named
+by action; partial results surface a warning count (purge's
+`len(result.Skipped)` + `len(result.Warnings)`) consistent with
+deploy/uninstall today; guard paths (active-profile delete, duplicate/empty
+profile name, purge-with-no-mods, switch-while-busy) resolve to status-line
+errors *before* any mutation starts. Errors never leave a modal open on a
+completed action (modal closes, status line reports).
+
+## Testing
+
+Same harness as 5a/5b, TDD throughout:
+
+- **Model tests** (`internal/tui`): key events against the mock provider —
+  modal open/confirm/cancel per feature, guard paths, generation staleness
+  (e.g. a purge completing after a game switch must not paint stale state),
+  focused-input swallowing of the new printable keys.
+- **Provider tests** (`service_core_test.go` pattern): new provider methods
+  against a real temp-dir `core.Service` (in-memory SQLite, `t.TempDir()`).
+- **Snapshot pass**: help overlay and each new modal at 80×24 (exact-height
+  invariant); truncation behavior at the 40-col floor.
+- CLI is untouched this phase — no output-fidelity tests needed.
+
+## Process & release
+
+- Branch `feat/tui-phase6a-workflows`, PRs to protected main (merge commits,
+  Copilot triage rounds incl. post-push, TUI smoke-test merge gate applies).
+- Version **1.13.0** (MINOR — new features), changelog under a new section.
+- On completion: comment on #37 marking the 6a items done; 6b scope stays
+  open there; archive this doc + the impl plan per the plan-doc lifecycle.

--- a/docs/plans/2026-07-23-tui-phase6a-workflows-impl.md
+++ b/docs/plans/2026-07-23-tui-phase6a-workflows-impl.md
@@ -1,0 +1,218 @@
+# TUI Phase 6a — Local Workflows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the six Phase 6a TUI workflows (purge view, files panel, policy editing, game switcher, profile create/delete, expanded help) on Phase 5's modal/action machinery — design in `2026-07-23-tui-phase6a-workflows-design.md`.
+
+**Architecture:** Two new modal primitives (picker, text-input) plus one info overlay join the existing `pendingAction` confirm modal; four new `ActionProvider` methods and two new `DataProvider` methods (plus a `gameRebinder` optional interface mirroring `profileRebinder`) carry the features; no new screens, no CLI changes, no new core flows (everything consumes existing `core.Service`/`ProfileManager` methods, incl. #61's `PurgeProfile`).
+
+**Tech Stack:** Go, Bubble Tea/bubbles (`textinput`), testify; existing tui test harness (prototype provider, `recordingActions`, real-Service provider fixtures).
+
+## Global Constraints
+
+- Branch `feat/tui-phase6a-workflows`; PRs to protected main; merge commits; Copilot triage incl. post-push rounds; TUI smoke-test before merge.
+- TDD: every behavior lands with a failing test first. `gofmt` (tabs), `go vet ./...`, full `go test ./...` green per task; commit per task.
+- Focused-input law: new printable keys (`X f P g c d`) must be swallowed by a focused search input (dispatch AFTER the focused-input branch, `app.go:489-504`).
+- Exact-height invariant: modal/overlay views render via `actionModalView`-style panels; truncate, never wrap (use `truncate`, `availableWidth`, `panelWithHeight` helpers `app.go:1262-1323`).
+- Single-flight: every new mutation path starts via `buildAction` (`actions.go:242`) or is guarded by `m.action.running || m.action.pending != nil`.
+- CLI untouched this phase. Version bump lands ONLY in the final task (1.13.0).
+- New TUI copy is lowercase-terse matching existing footer/help strings.
+
+---
+
+### Task 1: Picker modal primitive
+
+**Files:**
+- Create: `internal/tui/picker.go`, `internal/tui/picker_test.go`
+- Modify: `internal/tui/app.go` (Model field, updateKey intercept, screenView render)
+
+**Interfaces:**
+- Consumes: `Model`, `KeyMap` (Up/Down/Select/CancelAction), panel helpers.
+- Produces: `pendingPicker`, `pickerOption{Label, Note string}`, `Model.picker *pendingPicker`, `(m Model) promptPicker(p pendingPicker) Model` (nil-op when action busy), `(m Model) updatePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)`, `pickerView() string`. Tasks 5 and 7 build on these exact names.
+
+- [ ] **Step 1: Failing tests** — in `picker_test.go` (package `tui`, internal): `TestPickerNavigateAndChoose` (open a 3-option picker via `promptPicker`, send `j`/down twice + `enter`, assert `choose` called with index 2 and `m.picker == nil`), `TestPickerDigitQuickSelect` (send `"2"`, assert choose(1)), `TestPickerEscCancels` (esc → `picker == nil`, choose not called), `TestPickerBlockedWhileActionPending` (set `m.action.pending`, `promptPicker` must not set `m.picker`).
+- [ ] **Step 2: Run** `go test ./internal/tui/ -run TestPicker -v` — expect compile failure (types undefined).
+- [ ] **Step 3: Implement** in `picker.go`:
+
+```go
+type pickerOption struct{ Label, Note string }
+
+type pendingPicker struct {
+	title    string
+	options  []pickerOption
+	selected int
+	choose   func(idx int) tea.Cmd
+}
+```
+
+`promptPicker`: guard `m.action.running || m.action.pending != nil || m.picker != nil`; else set `m.picker = &p`. `updatePickerKey`: Up/Down move selected (clamped); digits `1`-`9` select `int(r-'1')` when in range and immediately choose; `Select` (enter) → clear picker, return `choose(selected)`; `CancelAction`/`Blur` (esc; also plain `n` must NOT cancel — pickers contain text options) → clear picker; Quit keys → `startQuit()`; default swallow. `pickerView`: bordered panel like `actionModalView` (`actions.go:543`), `>` marker on selected row, Note dimmed right of label, hint line `"↑/↓ move · enter choose · esc cancel"`. Wire in `app.go`: `picker *pendingPicker` field on Model; intercept in `updateKey` immediately after the `m.action.pending` intercept (`:470-472`); render in `screenView()` before the per-screen switch (after `actionModalView` branch).
+- [ ] **Step 4: Run** the four tests — PASS; run full `go test ./internal/tui/`.
+- [ ] **Step 5: Commit** `feat(tui): add picker modal primitive (#37)`
+
+---
+
+### Task 2: Text-input modal primitive
+
+**Files:**
+- Create: `internal/tui/input_modal.go`, `internal/tui/input_modal_test.go`
+- Modify: `internal/tui/app.go` (field, intercept, render)
+
+**Interfaces:**
+- Consumes: `textinput` (construction pattern `search.go:91-104`), panel helpers.
+- Produces: `pendingInput`, `Model.inputModal *pendingInput`, `promptInput(p pendingInput) Model`, `updateInputModalKey(msg) (tea.Model, tea.Cmd)`, `inputModalView() string`. Task 6 (profile create) consumes these.
+
+- [ ] **Step 1: Failing tests**: `TestInputModalTypeAndSubmit` (open with validate=ok, type `"survival"`, enter → submit called with "survival", modal nil), `TestInputModalValidationErrorKeepsModalOpen` (validate returns `"name already exists"` → errMsg shown in `View()`, modal still open, submit not called), `TestInputModalEscCancels`, `TestInputModalBlockedWhileActionRunning`.
+- [ ] **Step 2: Run** — compile failure.
+- [ ] **Step 3: Implement**:
+
+```go
+type pendingInput struct {
+	title    string
+	input    textinput.Model
+	errMsg   string
+	validate func(value string) string // "" = ok, else error copy shown in-modal
+	submit   func(value string) tea.Cmd
+}
+```
+
+`promptInput`: same guards as picker (also `m.inputModal != nil`); focus the input (`p.input.Focus()`). `updateInputModalKey`: enter → trim value; empty → `errMsg = "name required"`; else `validate`; non-empty result → set errMsg, stay open; ok → clear modal, return `submit(value)`; esc → clear; ctrl+c → `startQuit()`; default → forward to `p.input.Update(msg)` (swallows everything printable — this is the focused-input law inside the modal). `inputModalView`: panel with title, `input.View()`, errMsg in `DangerText` when set, hint `"enter create · esc cancel"`. Intercept in `updateKey` after the picker intercept; render in `screenView` likewise.
+- [ ] **Step 4: Run** tests — PASS; full package green.
+- [ ] **Step 5: Commit** `feat(tui): add text-input modal primitive (#37)`
+
+---
+
+### Task 3: Info overlay primitive + deployed-files data method
+
+**Files:**
+- Create: `internal/tui/overlay.go`, `internal/tui/overlay_test.go`
+- Modify: `internal/tui/service.go` (DataProvider + prototypeProvider), `internal/tui/service_core.go`, `internal/tui/app.go`, `internal/tui/app_test.go` (`recordingProvider` fake), `internal/tui/service_core_test.go`
+
+**Interfaces:**
+- Consumes: `svc.GetDeployedFilesForMod(gameID, profileName, sourceID, modID)` (`internal/core/service.go:701`), `currentProfile()`.
+- Produces: `DataProvider.DeployedFiles(sourceID, modID string) ([]string, error)` (interface addition — implement on `coreProvider`, `prototypeProvider`, `recordingProvider`); `infoOverlay{title string; lines []string}`, `Model.overlay *infoOverlay`, `updateOverlayKey`, `overlayView`. Task 4 wires the `f` key.
+
+- [ ] **Step 1: Failing tests**: overlay: `TestOverlayEscCloses`, `TestOverlayRendersTitleAndLines` (truncated at width), `TestOverlayCapsLines` (cap at `availableContentHeight`-chrome with `"+N more"` tail — mirror `actionModalMaxDetailLines` mechanics). Provider: `TestCoreProviderDeployedFiles` in `service_core_test.go` — extend `newCoreProviderFixture` usage: `svc.GetInstaller(game).Install(...)` one seeded mod, assert `DeployedFiles("nexusmods","mod-a")` returns the seeded relative paths sorted; `TestCoreProviderDeployedFilesEmpty` returns empty slice, nil error.
+- [ ] **Step 2: Run** — compile failure (interface method missing on fakes → listed compile errors are the point).
+- [ ] **Step 3: Implement**: interface method; `coreProvider.DeployedFiles` = `p.svc.GetDeployedFilesForMod(p.game.ID, p.currentProfile(), sourceID, modID)` (sorted); `prototypeProvider.DeployedFiles` returns canned `[]string{"skse64_loader.exe", "Data/SkyUI.esp"}`-style rows derived from the mod's name for any known mod ID; `recordingProvider` returns configurable `DeployedFilesResult []string` / `DeployedFilesErr error`. Overlay: struct + esc/`f`/`q`-handling (esc and `f` close; quit keys quit), render as titled panel of lines.
+- [ ] **Step 4: Run** — PASS; full suite.
+- [ ] **Step 5: Commit** `feat(tui): info overlay primitive + DeployedFiles provider method (#37)`
+
+---
+
+### Task 4: Files panel feature (`f` on Installed Mods)
+
+**Files:**
+- Modify: `internal/tui/keys.go` (+`Files` binding), `internal/tui/app.go` (updateKey case), `internal/tui/mutations.go` (`showDeployedFiles`), `internal/tui/mutations_test.go`
+
+**Interfaces:**
+- Consumes: Task 3's `DeployedFiles` + `infoOverlay`; selection via `m.selected[ScreenInstalledMods]`/`m.mods`.
+- Produces: `Files key.Binding` (`f`), `(m Model) showDeployedFiles() (tea.Model, tea.Cmd)`.
+
+- [ ] **Step 1: Failing tests**: `TestFilesKeyOpensOverlayWithDeployedFiles` (prototype model, select row 0, send `f`, assert `m.overlay != nil`, title contains mod name, lines non-empty), `TestFilesKeyEmptyStateMessage` (recordingProvider with empty result → overlay shows single line `"no files deployed"`), `TestFilesKeyIgnoredOnOtherScreens`, `TestFilesKeySwallowedByFocusedSearchInput` (focus search input, send `f`, assert input value contains "f" and no overlay), `TestFilesKeyErrorGoesToStatusLine` (provider error → `m.action.status` set, `statusIsError` true, no overlay).
+- [ ] **Step 2: Run** — FAIL (binding/handler undefined).
+- [ ] **Step 3: Implement**: binding `key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "files"))`; `showDeployedFiles` guards screen + valid selection + `provider != nil`; sync call to `DeployedFiles` (local DB read — documented exception to async loads); on error set status; else `m.overlay = &infoOverlay{title: fmt.Sprintf("Files — %s", item.Name), lines: files-or-empty-state}`. Wire `case key.Matches(msg, m.keys.Files)` in updateKey's outer switch.
+- [ ] **Step 4: Run** — PASS; full suite.
+- [ ] **Step 5: Commit** `feat(tui): per-mod deployed-files panel on f (#37)`
+
+---
+
+### Task 5: Update-policy editing (`P` on Installed Mods)
+
+**Files:**
+- Modify: `internal/tui/actions_provider.go` (interface + prototype impl), `internal/tui/service_core.go`, `internal/tui/keys.go` (+`Policy`), `internal/tui/actions.go` (+`actionSetPolicy` kind), `internal/tui/mutations.go` (`editSelectedModPolicy`), `internal/tui/app.go` (key case), tests: `mutations_test.go`, `actions_provider_test.go` (`recordingActions`), `service_core_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's picker; `svc.SetModUpdatePolicy(sourceID, modID, gameID, profileName, policy domain.UpdatePolicy)` (`internal/core/service.go:665`).
+- Produces: `ActionProvider.SetUpdatePolicy(ctx context.Context, item ModItem, policy string) (ActionOutcome, error)` with policy ∈ `"notify"|"auto"|"pin"`; `Policy key.Binding` (`P`); `editSelectedModPolicy()`.
+
+- [ ] **Step 1: Failing tests**: `TestPolicyKeyOpensPickerWithCurrentMarked` (send `P` on Installed Mods; picker has exactly notify/auto/pin options; the item's current policy option Note is `"current"`), `TestPolicyPickerChoiceRunsActionAndRefreshes` (choose "pin" → `recordingActions.SetPolicyCalls == [{modID, "pin"}]`, done → status `"SkyUI update policy: pin"`, refresh cmd is `loadData`), `TestPolicyKeySwallowedByFocusedInput`, provider test `TestCoreProviderActions_SetUpdatePolicy` (real Service fixture: seed installed mod, call with "auto", read back `GetInstalledMod` → `domain.UpdateAuto`; invalid policy string → error).
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement**: interface method; `coreProvider` maps `"notify"→domain.UpdateNotify, "auto"→domain.UpdateAuto, "pin"→domain.UpdatePinned` (unknown → `fmt.Errorf("unknown policy %q", policy)`), calls `SetModUpdatePolicy`, outcome Message `fmt.Sprintf("%s update policy: %s", item.Name, policy)`; prototype impl mutates its canned mod's `UpdatePolicy`. `editSelectedModPolicy`: guard screen/selection/actions; open picker titled `fmt.Sprintf("Update policy — %s", item.Name)`; `choose` closure runs the same `buildAction`-then-confirm-immediately pattern the input modal uses: `mm, pa := m2.buildAction(actionSetPolicy, ...)`; set `mm.action.running = true`; return `pa.confirm()` (no second confirm gate — the pick IS the confirmation). `actionDoneMsg` needs no kind-specific branch (default status+refresh path).
+- [ ] **Step 4: Run** — PASS; full suite.
+- [ ] **Step 5: Commit** `feat(tui): update-policy picker on P (#37)`
+
+---
+
+### Task 6: Profile create (`c`) and delete (`d`) on Profiles screen
+
+**Files:**
+- Modify: `internal/tui/actions_provider.go`, `internal/tui/service_core.go`, `internal/tui/keys.go` (+`CreateProfile`, `DeleteProfile`), `internal/tui/actions.go` (+`actionCreateProfile`, `actionDeleteProfile`), `internal/tui/mutations.go` (`createProfilePrompt`, `deleteSelectedProfile`), `internal/tui/app.go`, tests as Task 5
+
+**Interfaces:**
+- Consumes: Task 2's input modal; existing confirm modal; `ProfileManager.Create/Delete` via `svc.NewProfileManager()`.
+- Produces: `ActionProvider.CreateProfile(ctx context.Context, name string) (ActionOutcome, error)`, `ActionProvider.DeleteProfile(ctx context.Context, name string) (ActionOutcome, error)`; bindings `c`/`d` (Profiles screen only).
+
+- [ ] **Step 1: Failing tests**: `TestCreateProfileKeyOpensInputModal`; `TestCreateProfileDuplicateNameValidatesInModal` (existing name → in-modal error, no action dispatched); `TestCreateProfileSubmitRunsActionAndRefreshes` (submit "survival" → `CreateProfileCalls == ["survival"]`, status `Created profile: survival`); `TestDeleteProfileActiveRefusedOnStatusLine` (select active row, `d` → no modal, status error `"cannot delete the active profile"`); `TestDeleteProfileConfirmFlow` (non-active row → confirm modal titled `Delete profile "combat"?`, `y` → `DeleteProfileCalls == ["combat"]`, refresh); `TestProfileKeysIgnoredOffProfilesScreen`; provider tests against real Service: create then `pm.Get` succeeds; create duplicate → error; delete removes YAML (`pm.Get` → `ErrProfileNotFound`); delete of active profile at provider level returns error too (defense in depth: `if name == p.currentProfile() { return ActionOutcome{}, fmt.Errorf("cannot delete the active profile") }`).
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement**: provider methods (`coreProvider` uses `p.svc.NewProfileManager()`; outcomes `Created profile: <name>` / `Deleted profile: <name>`); prototype impls mutate canned `Profiles` slice. `createProfilePrompt`: input modal, `validate` closure checks against `m.profiles` names (case-sensitive match = `"profile already exists"`); `submit` runs buildAction(actionCreateProfile)+immediate-confirm. `deleteSelectedProfile`: guard active row (status error, per test) then standard `promptAction` confirm; detail line `"mods keep their install records; only the profile list is removed"`.
+- [ ] **Step 4: Run** — PASS; full suite.
+- [ ] **Step 5: Commit** `feat(tui): profile create/delete on Profiles screen (#37)`
+
+---
+
+### Task 7: Purge behind confirmation (`X` on Dashboard/Installed Mods)
+
+**Files:**
+- Modify: `internal/tui/actions_provider.go`, `internal/tui/service_core.go`, `internal/tui/keys.go` (+`Purge`), `internal/tui/actions.go` (+`actionPurge`), `internal/tui/mutations.go` (`purgeProfilePrompt`), `internal/tui/app.go`, tests as Task 5
+
+**Interfaces:**
+- Consumes: `core.PurgeProfile` + `core.PurgeOptions`/`PurgeResult` and phases `DeployBeforeAllForced/DeployPurging/PurgeModPurged/PurgeModSkipped/PurgeWarning/PurgeNote/PurgeComplete` (`internal/core/flows.go:1423`); hook plumbing exactly as `coreProvider.DeployProfile` builds it (cached hooks/runner in `service_core.go`); `mergeDiagnostics`.
+- Produces: `ActionProvider.PurgeProfile(ctx context.Context, progress func(ActionProgress)) (ActionOutcome, error)`; binding `X`.
+
+- [ ] **Step 1: Failing tests**: `TestPurgeKeyPromptsWithModCountAndNames` (modal title `Purge 3 mod(s) from <Game>?`, detail lists mod names from `m.mods`, capped by existing detail cap); `TestPurgeKeyNoModsShortCircuitsToStatus` (empty mods → no modal, status `"no mods installed"`); `TestPurgeConfirmStreamsProgressAndReportsOutcome` (recordingActions replays two `ActionProgress` ticks then outcome `{Message:"Purged 2 mod(s)", Warnings:[...]}` → progress lines seen, final status includes warning count, refresh fires); `TestPurgeKeyWorksFromDashboardToo`; provider test `TestCoreProviderActions_PurgeProfile` (real Service: seed+install 2 mods, run, assert files gone from game dir, both DB rows `Deployed == false`, outcome message `Purged 2 mod(s)`, progress captured a `✓`-line per mod) and `..._SkipAndWarningsSurface` (before_each-failing hook script → Warnings contains `Skipped <name>: uninstall.before_each hook failed: ...`).
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement**: `coreProvider.PurgeProfile`: fetch `mods := p.svc.GetInstalledMods(p.game.ID, p.currentProfile())` (re-fetch at apply — same documented plan-drift stance as `ApplyProfileSwitch`); empty → `ActionOutcome{Message: "no mods installed"}`; else call `p.svc.PurgeProfile` with the same hook block DeployProfile's provider method builds; progress mapping: `DeployPurging→{Line: fmt.Sprintf("purging %d mod(s)…", e.Total), Percent: -1}`, `PurgeModPurged→{Line: fmt.Sprintf("✓ %s (%d/%d)", e.ModName, e.Index, e.Total), Percent: -1}`, `PurgeModSkipped→{Line: "skipped " + e.ModName, Percent: -1}`, other phases not streamed. Outcome: `Message: fmt.Sprintf("Purged %d mod(s)", result.Purged)`; `Warnings: mergeDiagnostics(append(prefixed("Skipped ", result.Skipped), result.Warnings...), result.Notes)`. Errors return partial-result warnings alongside err (mirror `UninstallMod` provider convention). `purgeProfilePrompt` (works on Dashboard + Installed Mods): builds detail from `m.mods` names; standard `buildAction(actionPurge, ...)`+`promptAction`. Prototype impl: clears `Deployed`-ish canned state and returns `Purged N`.
+- [ ] **Step 4: Run** — PASS; full suite.
+- [ ] **Step 5: Commit** `feat(tui): purge behind confirmation view on X (#37)`
+
+---
+
+### Task 8: In-TUI game switcher (`g`)
+
+**Files:**
+- Modify: `internal/tui/service.go` (DataProvider + `GameInfo`), `internal/tui/service_core.go` (impl + `gameMu` + `SetGame`), `internal/tui/actions.go` (`gameRebinder`, `rebindGame`), `internal/tui/mutations.go` (`openGameSwitcher`, `switchGame`), `internal/tui/keys.go` (+`GameSwitch`), `internal/tui/app.go`, `internal/tui/prototype/data.go` + `internal/tui/service.go`/`actions_provider.go` prototype impls, tests: `mutations_test.go`, `service_core_test.go`, `app_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 picker; `svc.ListGames()`/`svc.GetGame(id)` (verify exact names in `internal/core/service.go` at implementation — the CLI's `game list` path shows them), `resolveProfile` semantics (GetDefault → "default" fallback, reimplemented provider-side: `ProfileManager.GetDefault`).
+- Produces: `GameInfo{ID, Name string; Active bool}`; `DataProvider.ListGames() ([]GameInfo, error)`; optional interface `gameRebinder interface{ SetGame(id string) error }` on BOTH coreProvider instances (mirror `profileRebinder`, `actions.go:289-308`); `Model.rebindGame(id string) error`; binding `g`.
+
+- [ ] **Step 1: Failing tests**: `TestGameKeyOpensPickerActiveMarked`; `TestGameSwitchRebindsProvidersResetsAndReloads` (recordingProvider/actions with `SetGameCalls`; choose other game → both providers' `SetGameCalls == ["skyrim"]`, `m.state == stateLoading`, selections zeroed, `summary.Updates == -1` sentinel, sources re-seeded from `SourceInfos()`, in-flight search cancelled, returned cmd chain includes `loadData`); `TestGameSwitchBlockedWhileActionRunning` (running=true → `g` sets status error `"action in progress"`); `TestGameSwitchSameGameIsNoop`; provider tests: `TestCoreProviderListGames` (fixture: two games added → both listed, fixture game `Active`), `TestCoreProviderSetGame` (SetGame to second game; subsequent `Overview`/`Profiles` reflect it; unknown id → error, binding unchanged; hook cache invalidated — assert via the same seam `SetProfile` tests use).
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement**: `coreProvider`: add `gameMu sync.RWMutex` + `currentGame() *domain.Game` accessor; mechanically replace every `p.game` read in `service_core.go` with `currentGame()` (the compiler + `grep -n "p\.game" internal/tui/service_core.go` must come back empty apart from accessor/SetGame). `SetGame(id)`: `svc.GetGame(id)` → error out on unknown; resolve profile via `GetDefault(id)` fallback `"default"`; under locks swap `game`+`profile`, nil `cachedHooks`. `ListGames`: enumerate configured games, `Active = id == currentGame().ID`, sorted by name. Model side: `openGameSwitcher` (any screen; guards busy + picker/input/overlay open) → `ListGames` sync → picker `"Switch game"` with active-marked Note; choose → `switchGame(id)`: no-op when already active; call `rebindGame` (type-assert both provider+actions); cancel in-flight search (reuse the switchedTo-path mechanics, `app.go:309-355` region); reset `summary = Summary{Updates: -1}`, `mods/profiles = nil`, zero all `selected` entries, `m.sources = m.provider.SourceInfos()`, `state = stateLoading`; return `m.loadData`. Prototype: restructure `prototype.Data` minimally — add `AltGame Game` + tiny `AltMods []Mod` canned set; `prototypeProvider.ListGames` returns both; `SetGame` swaps which set backs `Overview` (keep it small — the demo just needs the switcher to visibly work).
+- [ ] **Step 4: Run** — PASS; full suite (race detector run too: `go test -race ./internal/tui/`).
+- [ ] **Step 5: Commit** `feat(tui): in-TUI game switcher on g (#37)`
+
+---
+
+### Task 9: Help overlay expansion + footer copy
+
+**Files:**
+- Modify: `internal/tui/app.go` (`helpView` `:1202-1221`, `footerLine` `:631-634`), `internal/tui/app_test.go`, `internal/tui/snapshot_test.go` run
+
+**Interfaces:** Consumes every binding added in Tasks 4-8. Produces no new API.
+
+- [ ] **Step 1: Failing tests**: `TestHelpViewListsPerScreenGroups` (help output contains group headers `global`, `installed mods`, `profiles`, `search`, `dashboard` and the new hints `f files`, `P policy`, `X purge`, `g game`, `c new profile`, `d delete profile`), `TestFooterMentionsHelpKey` (footer contains `?`).
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement**: restructure `helpView` into per-screen groups (global first, current screen's group highlighted/first after global), still a single truncated panel respecting the height invariant; keep footer terse (`?: help` stays the discovery point — don't stuff new keys into the footer beyond what fits).
+- [ ] **Step 4: Run** — PASS; regenerate snapshots `UPDATE_TUI_SNAPSHOTS=1 go test ./internal/tui/ -run TestGenerateThemeSnapshots` and commit the refreshed `docs/assets/tui/*.ansi`.
+- [ ] **Step 5: Commit** `feat(tui): per-screen help overlay groups (#37)`
+
+---
+
+### Task 10: Release chores + smoke gate
+
+**Files:**
+- Modify: `cmd/lmm/root.go` (version → `1.13.0`), `CHANGELOG.md`, comment on issue #37
+
+- [ ] **Step 1:** Version `1.13.0`; CHANGELOG `[1.13.0]` section (Added: the six workflows, one bullet each, user-visible phrasing; note purge `--uninstall` stays CLI-only) + comparison links.
+- [ ] **Step 2:** `gofmt -l cmd internal` empty; `go vet ./...`; `go test ./...` green; `go test -race ./internal/tui/`.
+- [ ] **Step 3: TUI smoke test (merge gate):** `go build -o lmm ./cmd/lmm && ./lmm tui --prototype` — manually exercise: `X` purge modal+cancel, `f` files overlay, `P` policy pick, `g` game switch (data visibly changes), `c`/`d` on Profiles, `?` overlay on every screen, focused search input swallowing `Xf Pgcd`, 80×24 terminal size. Then against a real throwaway game config (the Task 7/8 provider fixtures' shape, or the smoke-env script pattern from the #60 session) run one real purge.
+- [ ] **Step 4: Commit** `chore: bump version to 1.13.0`; push; PR titled `feat(tui): Phase 6a local workflows (#37)` with design-doc link; Copilot triage rounds; after merge: comment the 6a completion on #37, move design+impl docs to `docs/plans/archive/`.
+
+---
+
+## Self-review notes
+
+- Spec coverage: purge→T7, files→T3+T4, policy→T5, switcher→T8, create/delete→T6, help→T9; primitives T1-T3; release→T10. All design-doc scope items covered; `--uninstall` purge correctly absent.
+- Type consistency: `pendingPicker`/`promptPicker`/`pickerOption` (T1) used verbatim in T5/T8; `pendingInput`/`promptInput` (T2) in T6; `infoOverlay` (T3) in T4; `GameInfo`/`gameRebinder` defined once (T8).
+- Known verify-at-implementation points (flagged, not placeholders): exact core method name for enumerating games (T8) and the hook-block builder name in `service_core.go` (T7) — both located by grep in the named files; the surrounding contracts are fully specified here.

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -31,6 +31,13 @@ const (
 	// actionUpdate is Phase 5b's check/apply-updates action kind (see
 	// mutations.go's checkForUpdates/applyUpdatesSequentially).
 	actionUpdate
+	// actionSetPolicy is Task 5's update-policy picker action kind (see
+	// mutations.go's editSelectedModPolicy/resolvePolicyChoice). No
+	// actionDoneMsg branch needs to name it specifically (app.go) - the
+	// default status+refresh path already covers it, unlike actionInstall
+	// (extra search refresh) and actionUpdate (re-sentinels the Updates
+	// count).
+	actionSetPolicy
 )
 
 // pendingAction is a caller-built (Task 7) description of one mutation

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -329,6 +329,48 @@ func (m Model) rebindProfile(name string) {
 	}
 }
 
+// gameRebinder is implemented by DataProvider/ActionProvider values that
+// carry a per-session active-game binding (currently *coreProvider only -
+// see service_core.go's SetGame), letting a successful TUI-driven game
+// switch rebind the session without reconstructing the provider. Mirrors
+// profileRebinder's own shape/reasoning in full (see that type's doc
+// comment) - it's deliberately NOT part of DataProvider/ActionProvider
+// themselves for the identical reason. prototypeProvider DOES implement
+// this one (unlike profileRebinder, which it deliberately skips - see that
+// type's doc comment for why): Task 8 wants the game switcher to visibly
+// work in --prototype demo mode, and prototypeProvider.SetGame (service.go)
+// is written to tolerate the resulting double-call (see rebindGame below)
+// by being a plain "which one" switch rather than a toggle.
+type gameRebinder interface {
+	SetGame(id string) error
+}
+
+// rebindGame rebinds every provider/actions instance that supports it (see
+// gameRebinder) to id, mirroring rebindProfile's own "both instances,
+// independently, even a shared pointer is a harmless no-op" reasoning in
+// full (see that method's doc comment) - both are attempted unconditionally
+// regardless of whether the first call errored, and the FIRST error either
+// one returns is what's returned here (a second error, if any, is not
+// otherwise surfaced - matching this task's brief, which asks only that
+// both calls happen and the first failure wins). --prototype mode wires
+// m.provider and m.actions from the SAME prototypeProvider instance
+// (NewPrototypeModel), so this calls SetGame on it TWICE for one switch;
+// see gameRebinder's own doc comment for why that's safe.
+func (m Model) rebindGame(id string) error {
+	var firstErr error
+	if rb, ok := m.provider.(gameRebinder); ok {
+		if err := rb.SetGame(id); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if rb, ok := m.actions.(gameRebinder); ok {
+		if err := rb.SetGame(id); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
 // promptAction shows pa as the confirmation modal (rule 1): this is the only
 // method that sets action.pending, and it never calls the ActionProvider
 // itself — nothing mutates until confirm (see updatePendingActionKey).

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -47,6 +47,12 @@ const (
 	// render.
 	actionCreateProfile
 	actionDeleteProfile
+	// actionPurge is Task 7's Dashboard/Installed-Mods purge-behind-
+	// confirmation action kind (see mutations.go's purgeProfilePrompt). No
+	// actionDoneMsg branch needs to name it specifically (app.go) - the
+	// default status+refresh path already covers it, exactly like
+	// actionSetPolicy/actionCreateProfile/actionDeleteProfile above.
+	actionPurge
 )
 
 // pendingAction is a caller-built (Task 7) description of one mutation

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -38,6 +38,15 @@ const (
 	// (extra search refresh) and actionUpdate (re-sentinels the Updates
 	// count).
 	actionSetPolicy
+	// actionCreateProfile and actionDeleteProfile are Task 6's Profiles-screen
+	// create/delete action kinds (see mutations.go's createProfilePrompt/
+	// resolveProfileCreate and deleteSelectedProfile). Neither needs an
+	// actionDoneMsg branch of its own (app.go) - the default status+refresh
+	// path already covers both, exactly like actionSetPolicy above; loadData
+	// re-fetches Profiles, so the new/removed row is visible on the very next
+	// render.
+	actionCreateProfile
+	actionDeleteProfile
 )
 
 // pendingAction is a caller-built (Task 7) description of one mutation

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -60,6 +60,13 @@ type ActionProvider interface {
 	// ApplyUpdate applies one update reported by CheckUpdates. progress may
 	// be nil.
 	ApplyUpdate(ctx context.Context, u UpdateItem, progress func(ActionProgress)) (ActionOutcome, error)
+	// SetUpdatePolicy sets item's update-check policy to policy, one of
+	// "notify" (default: show available updates, require approval), "auto"
+	// (apply automatically), or "pin" (never update) - mapping to
+	// domain.UpdateNotify/UpdateAuto/UpdatePinned respectively for
+	// coreProvider. Unlike CheckUpdates/ApplyUpdate this never touches the
+	// network - a local DB write - so it carries no progress callback.
+	SetUpdatePolicy(ctx context.Context, item ModItem, policy string) (ActionOutcome, error)
 }
 
 // ActionOutcome is what the TUI status line renders after a successful
@@ -514,4 +521,35 @@ func (p *prototypeProvider) ApplyUpdate(_ context.Context, u UpdateItem, progres
 	p.data.InstalledMods[idx].Status = "installed"
 
 	return ActionOutcome{Message: fmt.Sprintf("Updated %q to %s", u.Name, u.ToVersion)}, nil
+}
+
+// isValidUpdatePolicy reports whether policy is one of the three strings
+// SetUpdatePolicy accepts - shared by both providers' validation (see
+// coreProvider's own parseUpdatePolicy in service_core.go, which additionally
+// maps a valid string to its domain.UpdatePolicy constant; the prototype has
+// no such enum to map to, since it stores the policy as a plain string
+// directly on the canned Mod).
+func isValidUpdatePolicy(policy string) bool {
+	switch policy {
+	case "notify", "auto", "pin":
+		return true
+	default:
+		return false
+	}
+}
+
+// SetUpdatePolicy mutates the canned InstalledMods entry's UpdatePolicy
+// field in place - visible in a repeated Overview, mirroring
+// EnableMod/DisableMod/UninstallMod's own "same instance, same session"
+// contract.
+func (p *prototypeProvider) SetUpdatePolicy(_ context.Context, item ModItem, policy string) (ActionOutcome, error) {
+	if !isValidUpdatePolicy(policy) {
+		return ActionOutcome{}, fmt.Errorf("unknown policy %q", policy)
+	}
+	idx := p.findInstalledIndex(item.Source, item.ID)
+	if idx < 0 {
+		return ActionOutcome{}, fmt.Errorf("mod not found: %s", item.ID)
+	}
+	p.data.InstalledMods[idx].UpdatePolicy = policy
+	return ActionOutcome{Message: fmt.Sprintf("%s update policy: %s", item.Name, policy)}, nil
 }

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -94,6 +94,16 @@ type ActionProvider interface {
 	// defense-in-depth, since a stale active-profile row (a refresh landed
 	// between the keypress and confirm) could otherwise let it through.
 	DeleteProfile(ctx context.Context, name string) (ActionOutcome, error)
+
+	// PurgeProfile undeploys every mod currently installed in the active
+	// profile (Task 7's Dashboard/Installed-Mods 'X' binding - see
+	// mutations.go's purgeProfilePrompt): the TUI equivalent of `lmm purge`
+	// with neither --uninstall nor --force. Mod records are preserved, only
+	// marked not-deployed - matching the CLI default (coreProvider never
+	// exposes --uninstall's record-deleting variant; see its own doc
+	// comment). progress may be nil, like every other streaming
+	// ActionProvider method.
+	PurgeProfile(ctx context.Context, progress func(ActionProgress)) (ActionOutcome, error)
 }
 
 // ActionOutcome is what the TUI status line renders after a successful
@@ -610,4 +620,37 @@ func (p *prototypeProvider) SetUpdatePolicy(_ context.Context, item ModItem, pol
 	}
 	p.data.InstalledMods[idx].UpdatePolicy = policy
 	return ActionOutcome{Message: fmt.Sprintf("%s update policy: %s", item.Name, policy)}, nil
+}
+
+// PurgeProfile emits one fake progress tick per canned InstalledMods entry
+// (mirroring purgeProgressLine's real per-mod PurgeModPurged tick in
+// service_core.go, one level up - the prototype has no percentage-based
+// phases to fake, so it ticks by mod rather than by 0/50/100%, unlike
+// fakeProgressTicks' ApplyInstall/ApplyUpdate precedent), then flips every
+// entry to "disabled" - the prototype's own "not deployed" terminal state
+// (see DisableMod above; prototype.Mod has no separate "deployed"/"enabled"
+// distinction the way coreProvider's installedModStatus does - see Mod.Status'
+// doc comment), decrementing Stats.Enabled for whichever entries weren't
+// already disabled. An empty InstalledMods list short-circuits to "no mods
+// installed" with no ticks emitted at all, mirroring coreProvider's own
+// empty-mods short-circuit (see its doc comment).
+func (p *prototypeProvider) PurgeProfile(_ context.Context, progress func(ActionProgress)) (ActionOutcome, error) {
+	if len(p.data.InstalledMods) == 0 {
+		return ActionOutcome{Message: "no mods installed"}, nil
+	}
+
+	purged := 0
+	for i := range p.data.InstalledMods {
+		mod := &p.data.InstalledMods[i]
+		if progress != nil {
+			progress(ActionProgress{Line: fmt.Sprintf("✓ %s", mod.Name), Percent: -1})
+		}
+		if mod.Status != "disabled" {
+			p.data.Stats.Enabled--
+			mod.Status = "disabled"
+		}
+		purged++
+	}
+
+	return ActionOutcome{Message: fmt.Sprintf("Purged %d mod(s)", purged)}, nil
 }

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
@@ -33,6 +34,15 @@ import (
 // the call risks a send-on-closed-channel panic - progress must only be
 // invoked synchronously within the method's own call stack (or from a
 // goroutine fully joined before returning).
+// errCannotDeleteActiveProfile is the shared wording for refusing to delete
+// the currently active profile - the TUI's own status-line refusal
+// (mutations.go's deleteSelectedProfile) and both ActionProvider
+// implementations' defense-in-depth guards (coreProvider.DeleteProfile,
+// prototypeProvider.DeleteProfile below) all use this SAME string, so the
+// three independent checks (self-review finding, Task 6) can never drift out
+// of sync with each other.
+const errCannotDeleteActiveProfile = "cannot delete the active profile"
+
 type ActionProvider interface {
 	EnableMod(ctx context.Context, item ModItem) (ActionOutcome, error)
 	DisableMod(ctx context.Context, item ModItem) (ActionOutcome, error)
@@ -67,6 +77,23 @@ type ActionProvider interface {
 	// coreProvider. Unlike CheckUpdates/ApplyUpdate this never touches the
 	// network - a local DB write - so it carries no progress callback.
 	SetUpdatePolicy(ctx context.Context, item ModItem, policy string) (ActionOutcome, error)
+
+	// CreateProfile creates a new, empty profile named name (Task 6's
+	// Profiles-screen 'c' binding - see mutations.go's createProfilePrompt).
+	// A name colliding with an existing profile is rejected - coreProvider
+	// via ProfileManager.Create's own duplicate check, prototypeProvider
+	// mirroring it defensively even though the TUI's own input-modal
+	// validate closure already refuses a colliding name before this is ever
+	// called.
+	CreateProfile(ctx context.Context, name string) (ActionOutcome, error)
+	// DeleteProfile removes profile name (Task 6's Profiles-screen 'd'
+	// binding - see mutations.go's deleteSelectedProfile). Deleting the
+	// currently active profile is refused - the TUI's own handler already
+	// checks this synchronously before ever reaching here (a status-line
+	// refusal, no modal), but every implementation repeats the guard
+	// defense-in-depth, since a stale active-profile row (a refresh landed
+	// between the keypress and confirm) could otherwise let it through.
+	DeleteProfile(ctx context.Context, name string) (ActionOutcome, error)
 }
 
 // ActionOutcome is what the TUI status line renders after a successful
@@ -411,6 +438,37 @@ func (p *prototypeProvider) ApplyProfileSwitch(ctx context.Context, profileName 
 	p.data.Profile.Name = profileName
 
 	return ActionOutcome{Message: fmt.Sprintf("Switched to %q", profileName)}, nil
+}
+
+// CreateProfile appends a new canned Profile entry to data.Profiles, visible
+// in a repeated Profiles call - mirrors EnableMod/DisableMod's own "same
+// instance, same session" contract. A name colliding with an existing
+// profile is refused, mirroring coreProvider's own ProfileManager.Create
+// precedent (service_core.go) even though this is defense-in-depth here too
+// (see ActionProvider.CreateProfile's doc comment).
+func (p *prototypeProvider) CreateProfile(_ context.Context, name string) (ActionOutcome, error) {
+	if _, ok := p.findProfile(name); ok {
+		return ActionOutcome{}, fmt.Errorf("profile already exists: %s", name)
+	}
+	p.data.Profiles = append(p.data.Profiles, prototype.Profile{Name: name})
+	return ActionOutcome{Message: fmt.Sprintf("Created profile: %s", name)}, nil
+}
+
+// DeleteProfile removes the canned Profiles entry named name, visible in a
+// repeated Profiles call. Refuses to delete the active profile - defense-in-
+// depth mirroring coreProvider's own guard (see ActionProvider.DeleteProfile's
+// doc comment).
+func (p *prototypeProvider) DeleteProfile(_ context.Context, name string) (ActionOutcome, error) {
+	if name == p.activeProfileName() {
+		return ActionOutcome{}, errors.New(errCannotDeleteActiveProfile)
+	}
+	for i, pr := range p.data.Profiles {
+		if pr.Name == name {
+			p.data.Profiles = append(p.data.Profiles[:i], p.data.Profiles[i+1:]...)
+			return ActionOutcome{Message: fmt.Sprintf("Deleted profile: %s", name)}, nil
+		}
+	}
+	return ActionOutcome{}, fmt.Errorf("profile not found: %s", name)
 }
 
 // findSearchResult returns the index of the SearchResults entry matching

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -212,10 +212,12 @@ func mergeDiagnostics(warnings, notes []string) []string {
 // see that method's own doc comment below). Every other canned profile
 // leaves Mods unset and is unaffected.
 
-// findInstalledIndex returns the index of the InstalledMods entry matching
-// (sourceID, id), or -1 if none matches.
+// findInstalledIndex returns the index of the ACTIVE game's installed-mods
+// entry matching (sourceID, id), or -1 if none matches - routed through
+// activeMods (service.go, Copilot PR #69) so every lookup-based operation
+// automatically addresses whichever game the session is bound to.
 func (p *prototypeProvider) findInstalledIndex(sourceID, id string) int {
-	for i, mod := range p.data.InstalledMods {
+	for i, mod := range p.activeMods() {
 		if mod.Source == sourceID && mod.ID == id {
 			return i
 		}
@@ -228,11 +230,12 @@ func (p *prototypeProvider) EnableMod(_ context.Context, item ModItem) (ActionOu
 	if idx < 0 {
 		return ActionOutcome{}, fmt.Errorf("mod not found: %s", item.ID)
 	}
-	if p.data.InstalledMods[idx].Status != "disabled" {
+	mods := p.activeMods()
+	if mods[idx].Status != "disabled" {
 		return ActionOutcome{Message: fmt.Sprintf("%q is already enabled", item.Name)}, nil
 	}
-	p.data.InstalledMods[idx].Status = "installed"
-	p.data.Stats.Enabled++
+	mods[idx].Status = "installed"
+	p.adjustStats(0, 1)
 	return ActionOutcome{Message: fmt.Sprintf("Enabled %q", item.Name)}, nil
 }
 
@@ -241,11 +244,12 @@ func (p *prototypeProvider) DisableMod(_ context.Context, item ModItem) (ActionO
 	if idx < 0 {
 		return ActionOutcome{}, fmt.Errorf("mod not found: %s", item.ID)
 	}
-	if p.data.InstalledMods[idx].Status == "disabled" {
+	mods := p.activeMods()
+	if mods[idx].Status == "disabled" {
 		return ActionOutcome{Message: fmt.Sprintf("%q is already disabled", item.Name)}, nil
 	}
-	p.data.InstalledMods[idx].Status = "disabled"
-	p.data.Stats.Enabled--
+	mods[idx].Status = "disabled"
+	p.adjustStats(0, -1)
 	return ActionOutcome{Message: fmt.Sprintf("Disabled %q", item.Name)}, nil
 }
 
@@ -254,18 +258,20 @@ func (p *prototypeProvider) UninstallMod(_ context.Context, item ModItem) (Actio
 	if idx < 0 {
 		return ActionOutcome{}, fmt.Errorf("mod not found: %s", item.ID)
 	}
-	wasEnabled := p.data.InstalledMods[idx].Status != "disabled"
-	p.data.InstalledMods = append(p.data.InstalledMods[:idx], p.data.InstalledMods[idx+1:]...)
-	p.data.Stats.Installed--
+	mods := p.activeMods()
+	wasEnabled := mods[idx].Status != "disabled"
+	p.setActiveMods(append(mods[:idx], mods[idx+1:]...))
+	enabledDelta := 0
 	if wasEnabled {
-		p.data.Stats.Enabled--
+		enabledDelta = -1
 	}
+	p.adjustStats(-1, enabledDelta)
 	return ActionOutcome{Message: fmt.Sprintf("Uninstalled %q", item.Name)}, nil
 }
 
 func (p *prototypeProvider) DeployProfile(_ context.Context) (ActionOutcome, error) {
 	deployed := 0
-	for _, mod := range p.data.InstalledMods {
+	for _, mod := range p.activeMods() {
 		if mod.Status != "disabled" {
 			deployed++
 		}
@@ -339,7 +345,7 @@ func (p *prototypeProvider) PlanProfileSwitch(_ context.Context, profileName str
 	}
 
 	var enable, disable []string
-	for i, mod := range p.data.InstalledMods {
+	for i, mod := range p.activeMods() {
 		if i%2 == 0 {
 			if mod.Status == "disabled" {
 				enable = append(enable, mod.Name)
@@ -387,10 +393,10 @@ func (p *prototypeProvider) materializeNeedsDownloads(profileName string) {
 		if p.findInstalledIndex("nexusmods", id) >= 0 {
 			continue
 		}
-		p.data.InstalledMods = append(p.data.InstalledMods, prototype.Mod{
+		p.setActiveMods(append(p.activeMods(), prototype.Mod{
 			ID: id, Name: id, Source: "nexusmods", Version: "1.0", Status: "disabled",
-		})
-		p.data.Stats.Installed++
+		}))
+		p.adjustStats(1, 0)
 	}
 }
 
@@ -433,12 +439,13 @@ func (p *prototypeProvider) ApplyProfileSwitch(ctx context.Context, profileName 
 	for _, name := range view.Disable {
 		disable[name] = true
 	}
-	for i := range p.data.InstalledMods {
-		switch name := p.data.InstalledMods[i].Name; {
+	mods := p.activeMods()
+	for i := range mods {
+		switch name := mods[i].Name; {
 		case enable[name]:
-			p.data.InstalledMods[i].Status = "installed"
+			mods[i].Status = "installed"
 		case disable[name]:
-			p.data.InstalledMods[i].Status = "disabled"
+			mods[i].Status = "disabled"
 		}
 	}
 
@@ -539,14 +546,14 @@ func (p *prototypeProvider) ApplyInstall(_ context.Context, item ModItem, progre
 	fakeProgressTicks(progress, fmt.Sprintf("Installing %s", mod.Name))
 
 	if installedIdx := p.findInstalledIndex(item.Source, item.ID); installedIdx >= 0 {
-		p.data.InstalledMods[installedIdx].Status = "installed"
-		p.data.InstalledMods[installedIdx].Version = mod.Version
+		installedMods := p.activeMods()
+		installedMods[installedIdx].Status = "installed"
+		installedMods[installedIdx].Version = mod.Version
 	} else {
 		installed := mod
 		installed.Status = "installed"
-		p.data.InstalledMods = append(p.data.InstalledMods, installed)
-		p.data.Stats.Installed++
-		p.data.Stats.Enabled++
+		p.setActiveMods(append(p.activeMods(), installed))
+		p.adjustStats(1, 1)
 	}
 	p.data.SearchResults[idx].Status = "installed"
 
@@ -560,7 +567,7 @@ func (p *prototypeProvider) ApplyInstall(_ context.Context, item ModItem, progre
 // carries no policy field - see its doc comment).
 func (p *prototypeProvider) CheckUpdates(_ context.Context) (UpdatesView, error) {
 	var view UpdatesView
-	for _, mod := range p.data.InstalledMods {
+	for _, mod := range p.activeMods() {
 		if mod.AvailableVersion == "" {
 			continue
 		}
@@ -584,9 +591,10 @@ func (p *prototypeProvider) ApplyUpdate(_ context.Context, u UpdateItem, progres
 
 	fakeProgressTicks(progress, fmt.Sprintf("Updating %s", u.Name))
 
-	p.data.InstalledMods[idx].Version = u.ToVersion
-	p.data.InstalledMods[idx].AvailableVersion = ""
-	p.data.InstalledMods[idx].Status = "installed"
+	mods := p.activeMods()
+	mods[idx].Version = u.ToVersion
+	mods[idx].AvailableVersion = ""
+	mods[idx].Status = "installed"
 
 	return ActionOutcome{Message: fmt.Sprintf("Updated %q to %s", u.Name, u.ToVersion)}, nil
 }
@@ -618,7 +626,7 @@ func (p *prototypeProvider) SetUpdatePolicy(_ context.Context, item ModItem, pol
 	if idx < 0 {
 		return ActionOutcome{}, fmt.Errorf("mod not found: %s", item.ID)
 	}
-	p.data.InstalledMods[idx].UpdatePolicy = policy
+	p.activeMods()[idx].UpdatePolicy = policy
 	return ActionOutcome{Message: fmt.Sprintf("%s update policy: %s", item.Name, policy)}, nil
 }
 
@@ -635,18 +643,19 @@ func (p *prototypeProvider) SetUpdatePolicy(_ context.Context, item ModItem, pol
 // installed" with no ticks emitted at all, mirroring coreProvider's own
 // empty-mods short-circuit (see its doc comment).
 func (p *prototypeProvider) PurgeProfile(_ context.Context, progress func(ActionProgress)) (ActionOutcome, error) {
-	if len(p.data.InstalledMods) == 0 {
+	mods := p.activeMods()
+	if len(mods) == 0 {
 		return ActionOutcome{Message: "no mods installed"}, nil
 	}
 
 	purged := 0
-	for i := range p.data.InstalledMods {
-		mod := &p.data.InstalledMods[i]
+	for i := range mods {
+		mod := &mods[i]
 		if progress != nil {
 			progress(ActionProgress{Line: fmt.Sprintf("✓ %s", mod.Name), Percent: -1})
 		}
 		if mod.Status != "disabled" {
-			p.data.Stats.Enabled--
+			p.adjustStats(0, -1)
 			mod.Status = "disabled"
 		}
 		purged++

--- a/internal/tui/actions_provider_test.go
+++ b/internal/tui/actions_provider_test.go
@@ -526,27 +526,36 @@ type recordingActions struct {
 	// PlanCalls/ApplyCalls' own single-string-argument shape above.
 	CreateProfileCalls []string
 	DeleteProfileCalls []string
+	// PurgeCalls counts each PurgeProfile call - Task 7's purge wiring tests
+	// assert against this, mirroring DeployCalls/CheckUpdatesCalls' own
+	// no-argument counter shape above (PurgeProfile takes no ModItem/name
+	// argument - it always acts on the whole active profile).
+	PurgeCalls int
 
 	EnableOutcome, DisableOutcome, UninstallOutcome, DeployOutcome, ApplyOutcome ActionOutcome
 	ApplyInstallOutcome, ApplyUpdateOutcome                                      ActionOutcome
 	SetPolicyOutcome                                                             ActionOutcome
 	CreateProfileOutcome, DeleteProfileOutcome                                   ActionOutcome
+	PurgeOutcome                                                                 ActionOutcome
 	PlanView                                                                     SwitchPlanView
 	InstallPlanViewOut                                                           InstallPlanView
 	UpdatesViewOut                                                               UpdatesView
 
-	// ApplySwitchTicks/ApplyInstallTicks/ApplyUpdateTicks, if set, are
-	// replayed through the matching method's progress callback (in order)
-	// whenever it's non-nil - lets a caller assert the pump actually
-	// observes ticks a provider reports (Phase 5b Task 4).
+	// ApplySwitchTicks/ApplyInstallTicks/ApplyUpdateTicks/PurgeTicks, if
+	// set, are replayed through the matching method's progress callback (in
+	// order) whenever it's non-nil - lets a caller assert the pump actually
+	// observes ticks a provider reports (Phase 5b Task 4; PurgeTicks is
+	// Task 7's addition for PurgeProfile).
 	ApplySwitchTicks  []ActionProgress
 	ApplyInstallTicks []ActionProgress
 	ApplyUpdateTicks  []ActionProgress
+	PurgeTicks        []ActionProgress
 
 	EnableErr, DisableErr, UninstallErr, DeployErr, PlanErr, ApplyErr error
 	PlanInstallErr, ApplyInstallErr, CheckUpdatesErr, ApplyUpdateErr  error
 	SetPolicyErr                                                      error
 	CreateProfileErr, DeleteProfileErr                                error
+	PurgeErr                                                          error
 
 	// ApplyUpdateErrByID, if set, overrides ApplyUpdateOutcome/ApplyUpdateErr
 	// for a specific UpdateItem.ID - lets a Task 5 test simulate a
@@ -638,6 +647,16 @@ func (r *recordingActions) DeleteProfile(_ context.Context, name string) (Action
 	return r.DeleteProfileOutcome, r.DeleteProfileErr
 }
 
+func (r *recordingActions) PurgeProfile(_ context.Context, progress func(ActionProgress)) (ActionOutcome, error) {
+	r.PurgeCalls++
+	for _, p := range r.PurgeTicks {
+		if progress != nil {
+			progress(p)
+		}
+	}
+	return r.PurgeOutcome, r.PurgeErr
+}
+
 // failingActions implements ActionProvider with every method returning a
 // fixed error (Err, or a generic one if Err is unset) - for Tasks 6-7 to
 // verify error-path UI (status line rendering, modal dismissal) without
@@ -700,6 +719,10 @@ func (f failingActions) CreateProfile(context.Context, string) (ActionOutcome, e
 }
 
 func (f failingActions) DeleteProfile(context.Context, string) (ActionOutcome, error) {
+	return ActionOutcome{}, f.err()
+}
+
+func (f failingActions) PurgeProfile(context.Context, func(ActionProgress)) (ActionOutcome, error) {
 	return ActionOutcome{}, f.err()
 }
 

--- a/internal/tui/actions_provider_test.go
+++ b/internal/tui/actions_provider_test.go
@@ -531,6 +531,13 @@ type recordingActions struct {
 	// no-argument counter shape above (PurgeProfile takes no ModItem/name
 	// argument - it always acts on the whole active profile).
 	PurgeCalls int
+	// SetGameCalls records each SetGame call's id argument - Task 8's game-
+	// switch wiring tests assert against this, mirroring CreateProfileCalls/
+	// DeleteProfileCalls' own single-string-argument shape above. SetGame
+	// itself is NOT part of ActionProvider (it's the optional gameRebinder
+	// hook, actions.go) - recordingActions implements it anyway so
+	// rebindGame's type assertion succeeds against this fake.
+	SetGameCalls []string
 
 	EnableOutcome, DisableOutcome, UninstallOutcome, DeployOutcome, ApplyOutcome ActionOutcome
 	ApplyInstallOutcome, ApplyUpdateOutcome                                      ActionOutcome
@@ -556,6 +563,7 @@ type recordingActions struct {
 	SetPolicyErr                                                      error
 	CreateProfileErr, DeleteProfileErr                                error
 	PurgeErr                                                          error
+	SetGameErr                                                        error
 
 	// ApplyUpdateErrByID, if set, overrides ApplyUpdateOutcome/ApplyUpdateErr
 	// for a specific UpdateItem.ID - lets a Task 5 test simulate a
@@ -655,6 +663,12 @@ func (r *recordingActions) PurgeProfile(_ context.Context, progress func(ActionP
 		}
 	}
 	return r.PurgeOutcome, r.PurgeErr
+}
+
+// SetGame implements actions.go's optional gameRebinder hook (Task 8).
+func (r *recordingActions) SetGame(id string) error {
+	r.SetGameCalls = append(r.SetGameCalls, id)
+	return r.SetGameErr
 }
 
 // failingActions implements ActionProvider with every method returning a

--- a/internal/tui/actions_provider_test.go
+++ b/internal/tui/actions_provider_test.go
@@ -460,9 +460,15 @@ type recordingActions struct {
 	ApplyInstallCalls []ModItem
 	CheckUpdatesCalls int
 	ApplyUpdateCalls  []UpdateItem
+	// SetPolicyCalls records each SetUpdatePolicy call as {modID, policy} -
+	// Task 5's picker wiring tests assert against this rather than a
+	// []ModItem (mirroring the other *Calls fields) since both the mod
+	// identity and the chosen policy string matter to those tests.
+	SetPolicyCalls []struct{ ModID, Policy string }
 
 	EnableOutcome, DisableOutcome, UninstallOutcome, DeployOutcome, ApplyOutcome ActionOutcome
 	ApplyInstallOutcome, ApplyUpdateOutcome                                      ActionOutcome
+	SetPolicyOutcome                                                             ActionOutcome
 	PlanView                                                                     SwitchPlanView
 	InstallPlanViewOut                                                           InstallPlanView
 	UpdatesViewOut                                                               UpdatesView
@@ -477,6 +483,7 @@ type recordingActions struct {
 
 	EnableErr, DisableErr, UninstallErr, DeployErr, PlanErr, ApplyErr error
 	PlanInstallErr, ApplyInstallErr, CheckUpdatesErr, ApplyUpdateErr  error
+	SetPolicyErr                                                      error
 
 	// ApplyUpdateErrByID, if set, overrides ApplyUpdateOutcome/ApplyUpdateErr
 	// for a specific UpdateItem.ID - lets a Task 5 test simulate a
@@ -553,6 +560,11 @@ func (r *recordingActions) ApplyUpdate(_ context.Context, u UpdateItem, progress
 	return r.ApplyUpdateOutcome, r.ApplyUpdateErr
 }
 
+func (r *recordingActions) SetUpdatePolicy(_ context.Context, item ModItem, policy string) (ActionOutcome, error) {
+	r.SetPolicyCalls = append(r.SetPolicyCalls, struct{ ModID, Policy string }{item.ID, policy})
+	return r.SetPolicyOutcome, r.SetPolicyErr
+}
+
 // failingActions implements ActionProvider with every method returning a
 // fixed error (Err, or a generic one if Err is unset) - for Tasks 6-7 to
 // verify error-path UI (status line rendering, modal dismissal) without
@@ -603,6 +615,10 @@ func (f failingActions) CheckUpdates(context.Context) (UpdatesView, error) {
 }
 
 func (f failingActions) ApplyUpdate(context.Context, UpdateItem, func(ActionProgress)) (ActionOutcome, error) {
+	return ActionOutcome{}, f.err()
+}
+
+func (f failingActions) SetUpdatePolicy(context.Context, ModItem, string) (ActionOutcome, error) {
 	return ActionOutcome{}, f.err()
 }
 

--- a/internal/tui/actions_provider_test.go
+++ b/internal/tui/actions_provider_test.go
@@ -208,6 +208,62 @@ func TestPrototypeProviderActions_ApplyProfileSwitch_DownloadsAndAppliesNeedsDow
 	assert.True(t, byName[prototype.NeedsDownloadProfileName].Active, "the switch must still complete and mark the target active")
 }
 
+// --- prototypeProvider: CreateProfile/DeleteProfile (Task 6) ---
+
+func TestPrototypeProviderActions_CreateProfile_AddsVisibleInRepeatedProfiles(t *testing.T) {
+	t.Parallel()
+
+	provider := NewPrototypeProvider()
+	actions := provider.(ActionProvider)
+
+	outcome, err := actions.CreateProfile(context.Background(), "new-profile")
+	require.NoError(t, err)
+	assert.Equal(t, "Created profile: new-profile", outcome.Message)
+
+	profiles, err := provider.Profiles(context.Background())
+	require.NoError(t, err)
+	byName := map[string]ProfileItem{}
+	for _, p := range profiles {
+		byName[p.Name] = p
+	}
+	require.Contains(t, byName, "new-profile", "the SAME provider instance must reflect the create on a repeated Profiles call")
+}
+
+func TestPrototypeProviderActions_CreateProfile_DuplicateNameErrors(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	_, err := actions.CreateProfile(context.Background(), "survival")
+	assert.Error(t, err)
+}
+
+func TestPrototypeProviderActions_DeleteProfile_RemovesVisibleInRepeatedProfiles(t *testing.T) {
+	t.Parallel()
+
+	provider := NewPrototypeProvider()
+	actions := provider.(ActionProvider)
+
+	outcome, err := actions.DeleteProfile(context.Background(), "vanilla-plus")
+	require.NoError(t, err)
+	assert.Equal(t, "Deleted profile: vanilla-plus", outcome.Message)
+
+	profiles, err := provider.Profiles(context.Background())
+	require.NoError(t, err)
+	for _, p := range profiles {
+		assert.NotEqual(t, "vanilla-plus", p.Name, "a deleted profile must be gone from a repeated Profiles call")
+	}
+}
+
+func TestPrototypeProviderActions_DeleteProfile_ActiveRefused(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	_, err := actions.DeleteProfile(context.Background(), "survival")
+	assert.Error(t, err)
+}
+
 func TestPrototypeProviderActions_PlanProfileSwitch_UnknownProfileErrors(t *testing.T) {
 	t.Parallel()
 
@@ -465,10 +521,16 @@ type recordingActions struct {
 	// []ModItem (mirroring the other *Calls fields) since both the mod
 	// identity and the chosen policy string matter to those tests.
 	SetPolicyCalls []struct{ ModID, Policy string }
+	// CreateProfileCalls/DeleteProfileCalls record each call's name argument
+	// - Task 6's create/delete wiring tests assert against these, mirroring
+	// PlanCalls/ApplyCalls' own single-string-argument shape above.
+	CreateProfileCalls []string
+	DeleteProfileCalls []string
 
 	EnableOutcome, DisableOutcome, UninstallOutcome, DeployOutcome, ApplyOutcome ActionOutcome
 	ApplyInstallOutcome, ApplyUpdateOutcome                                      ActionOutcome
 	SetPolicyOutcome                                                             ActionOutcome
+	CreateProfileOutcome, DeleteProfileOutcome                                   ActionOutcome
 	PlanView                                                                     SwitchPlanView
 	InstallPlanViewOut                                                           InstallPlanView
 	UpdatesViewOut                                                               UpdatesView
@@ -484,6 +546,7 @@ type recordingActions struct {
 	EnableErr, DisableErr, UninstallErr, DeployErr, PlanErr, ApplyErr error
 	PlanInstallErr, ApplyInstallErr, CheckUpdatesErr, ApplyUpdateErr  error
 	SetPolicyErr                                                      error
+	CreateProfileErr, DeleteProfileErr                                error
 
 	// ApplyUpdateErrByID, if set, overrides ApplyUpdateOutcome/ApplyUpdateErr
 	// for a specific UpdateItem.ID - lets a Task 5 test simulate a
@@ -565,6 +628,16 @@ func (r *recordingActions) SetUpdatePolicy(_ context.Context, item ModItem, poli
 	return r.SetPolicyOutcome, r.SetPolicyErr
 }
 
+func (r *recordingActions) CreateProfile(_ context.Context, name string) (ActionOutcome, error) {
+	r.CreateProfileCalls = append(r.CreateProfileCalls, name)
+	return r.CreateProfileOutcome, r.CreateProfileErr
+}
+
+func (r *recordingActions) DeleteProfile(_ context.Context, name string) (ActionOutcome, error) {
+	r.DeleteProfileCalls = append(r.DeleteProfileCalls, name)
+	return r.DeleteProfileOutcome, r.DeleteProfileErr
+}
+
 // failingActions implements ActionProvider with every method returning a
 // fixed error (Err, or a generic one if Err is unset) - for Tasks 6-7 to
 // verify error-path UI (status line rendering, modal dismissal) without
@@ -619,6 +692,14 @@ func (f failingActions) ApplyUpdate(context.Context, UpdateItem, func(ActionProg
 }
 
 func (f failingActions) SetUpdatePolicy(context.Context, ModItem, string) (ActionOutcome, error) {
+	return ActionOutcome{}, f.err()
+}
+
+func (f failingActions) CreateProfile(context.Context, string) (ActionOutcome, error) {
+	return ActionOutcome{}, f.err()
+}
+
+func (f failingActions) DeleteProfile(context.Context, string) (ActionOutcome, error) {
 	return ActionOutcome{}, f.err()
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -438,6 +438,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m.resolveCheckUpdatesFailure(msg)
+	case policyChosenMsg:
+		return m.resolvePolicyChoice(msg)
 	case loadFailedMsg:
 		m.state = stateFailed
 		m.loadErr = msg.err
@@ -602,6 +604,8 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.checkForUpdates()
 	case key.Matches(msg, m.keys.Files):
 		return m.showDeployedFiles()
+	case key.Matches(msg, m.keys.Policy):
+		return m.editSelectedModPolicy()
 	default:
 		return m, nil
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1341,6 +1341,12 @@ func (m Model) helpGroups() []helpGroup {
 	dashboard := helpGroup{
 		name: "dashboard",
 		entries: []string{
+			// Select ("enter") is context-dependent (see updateKey): on
+			// the Dashboard it opens the selected menu entry
+			// (openSelectedMenuEntry), so the description is written out
+			// here rather than reusing keys.go's generic "open" - the same
+			// ad-hoc shape as the profiles group's "switch profile" below.
+			fmt.Sprintf("%-16s %s", m.keys.Select.Help().Key, "open menu entry"),
 			helpEntry(m.keys.Deploy),
 			helpEntry(m.keys.CheckUpdates),
 			helpEntry(m.keys.Purge),
@@ -1452,7 +1458,7 @@ func (m Model) helpView() string {
 		shown := max(budget-1, 0)
 		more := len(body) - shown
 		lines = append(lines, body[:shown]...)
-		lines = append(lines, m.theme.MutedText.Render(fmt.Sprintf("+%d more", more)))
+		lines = append(lines, truncate(m.theme.MutedText.Render(fmt.Sprintf("+%d more", more)), panelContentWidth))
 	} else {
 		lines = append(lines, body...)
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -75,6 +75,10 @@ type Model struct {
 	// Sibling to action.pending: promptPicker/updatePickerKey/pickerView
 	// mirror promptAction/updatePendingActionKey/actionModalView's structure.
 	picker *pendingPicker
+	// inputModal is the pending text-entry modal (see input_modal.go), if
+	// any. Another sibling of action.pending/picker: promptInput/
+	// updateInputModalKey/inputModalView mirror the same structure.
+	inputModal *pendingInput
 
 	screen   Screen
 	selected map[Screen]int
@@ -479,6 +483,10 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.updatePickerKey(msg)
 	}
 
+	if m.inputModal != nil {
+		return m.updateInputModalKey(msg)
+	}
+
 	// Rule 8: any keypress that isn't a modal response (handled above,
 	// before this point is ever reached) and isn't quit clears the status
 	// line. isQuitKey (not the bare Quit binding) is used so a "q" that's
@@ -722,6 +730,10 @@ func (m Model) screenView() string {
 
 	if m.picker != nil {
 		return m.pickerView()
+	}
+
+	if m.inputModal != nil {
+		return m.inputModalView()
 	}
 
 	switch m.state {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -71,6 +71,10 @@ type Model struct {
 	sources  []SourceInfo
 	search   searchModel
 	action   actionModel
+	// picker is the pending list-choice modal (see picker.go), if any.
+	// Sibling to action.pending: promptPicker/updatePickerKey/pickerView
+	// mirror promptAction/updatePendingActionKey/actionModalView's structure.
+	picker *pendingPicker
 
 	screen   Screen
 	selected map[Screen]int
@@ -471,6 +475,10 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.updatePendingActionKey(msg)
 	}
 
+	if m.picker != nil {
+		return m.updatePickerKey(msg)
+	}
+
 	// Rule 8: any keypress that isn't a modal response (handled above,
 	// before this point is ever reached) and isn't quit clears the status
 	// line. isQuitKey (not the bare Quit binding) is used so a "q" that's
@@ -710,6 +718,10 @@ func (m Model) nav() string {
 func (m Model) screenView() string {
 	if m.action.pending != nil {
 		return m.actionModalView()
+	}
+
+	if m.picker != nil {
+		return m.pickerView()
 	}
 
 	switch m.state {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -79,6 +79,11 @@ type Model struct {
 	// any. Another sibling of action.pending/picker: promptInput/
 	// updateInputModalKey/inputModalView mirror the same structure.
 	inputModal *pendingInput
+	// overlay is the pending read-only info panel (see overlay.go), if any.
+	// Another sibling of action.pending/picker/inputModal: promptOverlay/
+	// updateOverlayKey/overlayView mirror the same structure, simplified
+	// (no choose/submit - see infoOverlay's doc comment).
+	overlay *infoOverlay
 
 	screen   Screen
 	selected map[Screen]int
@@ -487,6 +492,10 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.updateInputModalKey(msg)
 	}
 
+	if m.overlay != nil {
+		return m.updateOverlayKey(msg)
+	}
+
 	// Rule 8: any keypress that isn't a modal response (handled above,
 	// before this point is ever reached) and isn't quit clears the status
 	// line. isQuitKey (not the bare Quit binding) is used so a "q" that's
@@ -734,6 +743,10 @@ func (m Model) screenView() string {
 
 	if m.inputModal != nil {
 		return m.inputModalView()
+	}
+
+	if m.overlay != nil {
+		return m.overlayView()
 	}
 
 	switch m.state {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -64,6 +64,19 @@ type Model struct {
 
 	state   loadState
 	loadErr error
+	// loadGen tags every loadData dispatch (dataLoadedMsg/loadFailedMsg
+	// carry the gen current when the cmd was built - loadData's value
+	// receiver captures it), mirroring searchModel.gen's staleness
+	// discipline: Update discards a load message whose gen no longer
+	// matches. Bumped ONLY where an in-flight load is intentionally
+	// invalidated - resolveGameSwitch's session reset (mutations.go) and
+	// actionDoneMsg's profile-switch rebind (both rebind the providers a
+	// still-running load may be reading from, so its eventual result
+	// describes a binding that no longer exists). Ordinary post-action
+	// refreshes deliberately do NOT bump it: concurrent same-binding
+	// refreshes all describe current data, and last-wins (the pre-gen
+	// behavior) remains correct for them.
+	loadGen int
 
 	summary  Summary
 	mods     []ModItem
@@ -101,15 +114,24 @@ const (
 	stateFailed
 )
 
-// dataLoadedMsg carries data successfully loaded through a DataProvider.
+// dataLoadedMsg carries data successfully loaded through a DataProvider,
+// tagged with the load generation current when the fetch was dispatched
+// (see Model.loadGen) so a superseded load - one still in flight when a
+// game switch reset the session - is discarded exactly like a stale
+// searchResultMsg (the mechanism this mirrors).
 type dataLoadedMsg struct {
+	gen      int
 	summary  Summary
 	mods     []ModItem
 	profiles []ProfileItem
 }
 
-// loadFailedMsg carries an error from a failed DataProvider load.
-type loadFailedMsg struct{ err error }
+// loadFailedMsg carries an error from a failed DataProvider load, tagged
+// like dataLoadedMsg.
+type loadFailedMsg struct {
+	gen int
+	err error
+}
 
 // NewModel creates the TUI model backed by the given DataProvider.
 func NewModel(options Options) (Model, error) {
@@ -254,23 +276,34 @@ func (m Model) Init() tea.Cmd {
 }
 
 // loadData fetches all dashboard data through the configured DataProvider.
-// It runs as a Bubble Tea command, off the update loop.
+// It runs as a Bubble Tea command, off the update loop. The value receiver
+// captures m.loadGen as of dispatch time, so the message this eventually
+// produces is tagged with the generation the load was issued under (see
+// Model.loadGen) - a caller that bumps loadGen and THEN returns m.loadData
+// (resolveGameSwitch) stamps the fresh gen, while a load already in flight
+// keeps its old one and is discarded on arrival.
 func (m Model) loadData() tea.Msg {
 	summary, mods, err := m.provider.Overview(m.ctx)
 	if err != nil {
-		return loadFailedMsg{err: err}
+		return loadFailedMsg{gen: m.loadGen, err: err}
 	}
 	profiles, err := m.provider.Profiles(m.ctx)
 	if err != nil {
-		return loadFailedMsg{err: err}
+		return loadFailedMsg{gen: m.loadGen, err: err}
 	}
 
-	return dataLoadedMsg{summary: summary, mods: mods, profiles: profiles}
+	return dataLoadedMsg{gen: m.loadGen, summary: summary, mods: mods, profiles: profiles}
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case dataLoadedMsg:
+		// Stale gen: a load dispatched before a game/profile switch reset
+		// the session (see Model.loadGen) - discarded whole, exactly like a
+		// stale searchResultMsg below.
+		if msg.gen != m.loadGen {
+			return m, nil
+		}
 		m.state = stateReady
 		summary := msg.summary
 		// Updates is the model's own in-memory count once a check has
@@ -337,6 +370,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.search.gen++
 			m.search.state = searchIdle
+			// Same invalidation for any in-flight DATA load (see
+			// Model.loadGen): it was dispatched against the OLD profile's
+			// binding, so its eventual rows/summary go stale the instant
+			// the rebind above lands - and, if it completed after the
+			// fresh refresh dispatched below, would silently overwrite the
+			// NEW profile's data. Bumped BEFORE the cmds slice below is
+			// built, so the refresh's own m.loadData captures the fresh
+			// gen (loadData's value receiver - see its doc comment).
+			m.loadGen++
 		}
 		// A completed update-apply batch invalidates the just-checked
 		// Updates count: applying updates changes how many are left, and
@@ -445,6 +487,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case gameChosenMsg:
 		return m.resolveGameSwitch(msg)
 	case loadFailedMsg:
+		// Stale gen: mirrors dataLoadedMsg's discard above - a superseded
+		// load's failure must not flip the fresh session into stateFailed.
+		if msg.gen != m.loadGen {
+			return m, nil
+		}
 		m.state = stateFailed
 		m.loadErr = msg.err
 		return m, nil

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -440,6 +440,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.resolveCheckUpdatesFailure(msg)
 	case policyChosenMsg:
 		return m.resolvePolicyChoice(msg)
+	case profileCreateSubmittedMsg:
+		return m.resolveProfileCreate(msg)
 	case loadFailedMsg:
 		m.state = stateFailed
 		m.loadErr = msg.err
@@ -606,6 +608,10 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.showDeployedFiles()
 	case key.Matches(msg, m.keys.Policy):
 		return m.editSelectedModPolicy()
+	case key.Matches(msg, m.keys.CreateProfile):
+		return m.createProfilePrompt()
+	case key.Matches(msg, m.keys.DeleteProfile):
+		return m.deleteSelectedProfile()
 	default:
 		return m, nil
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1301,25 +1301,163 @@ func (m Model) sourcesView() string {
 	return m.panelWithHeight(m.availableWidth(), m.availableContentHeight()).Render(strings.Join(rows, "\n"))
 }
 
+// helpGroup is one labeled section of the help panel: a screen name (or
+// "global") plus the key entries that apply to it. Group labels are
+// lowercase per Task 9's copy convention (see helpGroups).
+type helpGroup struct {
+	name    string
+	entries []string
+}
+
+// helpEntry formats one keybinding as a help-panel row, reusing the
+// binding's own key.WithHelp key/description from keys.go rather than
+// restating it - the single source of truth for "what does this key do"
+// stays in DefaultKeyMap.
+func helpEntry(kb key.Binding) string {
+	h := kb.Help()
+	return fmt.Sprintf("%-16s %s", h.Key, h.Desc)
+}
+
+// helpGroups builds the full, ordered set of help groups: "global" always
+// first, then every screen group that has entries, in a fixed order
+// (dashboard, installed mods, search, profiles - sources has no bindings
+// beyond plain navigation, so it's omitted entirely), with the CURRENT
+// screen's group promoted to immediately follow global. Each screen's list
+// mirrors updateKey's dispatch guards in mutations.go (e.g. Files/Policy/
+// Purge all gate on ScreenInstalledMods too, alongside Deploy/CheckUpdates).
+func (m Model) helpGroups() []helpGroup {
+	global := helpGroup{
+		name: "global",
+		entries: []string{
+			helpEntry(m.keys.Quit),
+			helpEntry(m.keys.Help),
+			helpEntry(m.keys.NextScreen),
+			helpEntry(m.keys.PrevScreen),
+			fmt.Sprintf("%-16s %s", "1-5", "jump to a screen"),
+			helpEntry(m.keys.GameSwitch),
+		},
+	}
+
+	dashboard := helpGroup{
+		name: "dashboard",
+		entries: []string{
+			helpEntry(m.keys.Deploy),
+			helpEntry(m.keys.CheckUpdates),
+			helpEntry(m.keys.Purge),
+		},
+	}
+
+	installedMods := helpGroup{
+		name: "installed mods",
+		entries: []string{
+			helpEntry(m.keys.ToggleEnable),
+			helpEntry(m.keys.Uninstall),
+			helpEntry(m.keys.Deploy),
+			helpEntry(m.keys.CheckUpdates),
+			helpEntry(m.keys.Files),
+			helpEntry(m.keys.Policy),
+			helpEntry(m.keys.Purge),
+		},
+	}
+
+	search := helpGroup{
+		name: "search",
+		entries: []string{
+			helpEntry(m.keys.Search),
+			helpEntry(m.keys.Submit),
+			helpEntry(m.keys.Blur),
+			helpEntry(m.keys.NextPage),
+			helpEntry(m.keys.PrevPage),
+			helpEntry(m.keys.CycleSource),
+			helpEntry(m.keys.Install),
+		},
+	}
+
+	profiles := helpGroup{
+		name: "profiles",
+		entries: []string{
+			// Select ("enter") is context-dependent (see updateKey): on
+			// Profiles it switches, not "open" like keys.go's generic
+			// Select.Help() says elsewhere - so this one entry is written
+			// out rather than reusing helpEntry, matching the actual
+			// behavior on this screen.
+			fmt.Sprintf("%-16s %s", m.keys.Select.Help().Key, "switch profile"),
+			helpEntry(m.keys.CreateProfile),
+			helpEntry(m.keys.DeleteProfile),
+		},
+	}
+
+	fixed := []helpGroup{dashboard, installedMods, search, profiles}
+	screenGroupName := map[Screen]string{
+		ScreenDashboard:     dashboard.name,
+		ScreenInstalledMods: installedMods.name,
+		ScreenSearch:        search.name,
+		ScreenProfiles:      profiles.name,
+	}
+	if name, ok := screenGroupName[m.screen]; ok {
+		for i, g := range fixed {
+			if g.name == name {
+				promoted := append([]helpGroup{g}, fixed[:i]...)
+				fixed = append(promoted, fixed[i+1:]...)
+				break
+			}
+		}
+	}
+
+	return append([]helpGroup{global}, fixed...)
+}
+
+// helpBodyBudget bounds how many content rows the help panel's group list
+// may use, so a long grouped list can't crowd screenView down past its own
+// floor (matching availableContentHeight's own max(...,8)) - the same
+// "+N more" cap overlayView uses, sized so the two floors agree exactly:
+// when the list is capped, screenView gets precisely its floor of 8; when
+// it isn't, screenView gets whatever room the (smaller) natural list left,
+// same as before Task 9.
+func (m Model) helpBodyBudget() int {
+	if m.height == 0 {
+		return 40
+	}
+	status := 0
+	if m.hasVisibleStatus() {
+		status = 1
+	}
+	const (
+		titleNavSpacerHeight = 4 // matches contentChromeHeight's own constant
+		screenViewFloor      = 8 // matches availableContentHeight's own floor
+		fixedHelpLines       = 2 // "HELP" title + blank separator
+	)
+	total := m.height - m.theme.App.GetVerticalFrameSize() - titleNavSpacerHeight - status
+	return max(total-screenViewFloor-m.theme.Panel.GetVerticalBorderSize()-fixedHelpLines, 1)
+}
+
 func (m Model) helpView() string {
-	return m.panel(m.availableWidth()).Render(strings.Join([]string{
-		m.theme.PanelTitle.Render("HELP"),
-		"arrows / hjkl       move or switch screens",
-		"tab / shift+tab     cycle top-level screens",
-		"1-5                 jump to a screen (3 focuses search)",
-		"/                   search from anywhere (jumps + focuses input)",
-		"i                   install the selected search result (Search, unfocused)",
-		"enter               open menu entry / search / switch profile",
-		"esc                 unfocus search input",
-		"n/p                 result pages",
-		"s                   cycle source",
-		"e/x/D               toggle enable/disable / uninstall selected mod / deploy active profile",
-		"u                   check for updates (Dashboard/Installed Mods)",
-		"?                   toggle this help",
-		"q / ctrl+c           quit",
-		"",
-		"Enable, disable, uninstall, deploy, install, apply updates, and profile switch all confirm through a modal before anything changes.",
-	}, "\n"))
+	width := m.availableWidth()
+	panelContentWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
+
+	var body []string
+	for i, g := range m.helpGroups() {
+		if i > 0 {
+			body = append(body, "")
+		}
+		body = append(body, truncate(m.theme.PanelTitle.Render(g.name), panelContentWidth))
+		for _, e := range g.entries {
+			body = append(body, truncate(e, panelContentWidth))
+		}
+	}
+
+	lines := []string{truncate(m.theme.PanelTitle.Render("HELP"), panelContentWidth), ""}
+	budget := m.helpBodyBudget()
+	if len(body) > budget {
+		shown := max(budget-1, 0)
+		more := len(body) - shown
+		lines = append(lines, body[:shown]...)
+		lines = append(lines, m.theme.MutedText.Render(fmt.Sprintf("+%d more", more)))
+	} else {
+		lines = append(lines, body...)
+	}
+
+	return m.panel(width).Render(strings.Join(lines, "\n"))
 }
 
 func (m Model) row(index int, label string) string {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -612,6 +612,8 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.createProfilePrompt()
 	case key.Matches(msg, m.keys.DeleteProfile):
 		return m.deleteSelectedProfile()
+	case key.Matches(msg, m.keys.Purge):
+		return m.purgeProfilePrompt()
 	default:
 		return m, nil
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -600,6 +600,8 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.installSelectedSearchResult()
 	case key.Matches(msg, m.keys.CheckUpdates):
 		return m.checkForUpdates()
+	case key.Matches(msg, m.keys.Files):
+		return m.showDeployedFiles()
 	default:
 		return m, nil
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -442,6 +442,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.resolvePolicyChoice(msg)
 	case profileCreateSubmittedMsg:
 		return m.resolveProfileCreate(msg)
+	case gameChosenMsg:
+		return m.resolveGameSwitch(msg)
 	case loadFailedMsg:
 		m.state = stateFailed
 		m.loadErr = msg.err
@@ -614,6 +616,8 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.deleteSelectedProfile()
 	case key.Matches(msg, m.keys.Purge):
 		return m.purgeProfilePrompt()
+	case key.Matches(msg, m.keys.GameSwitch):
+		return m.openGameSwitcher()
 	default:
 		return m, nil
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -526,7 +526,7 @@ func (f failingProvider) Search(context.Context, string, string, int) (SearchPag
 	return SearchPage{}, f.err
 }
 func (f failingProvider) DeployedFiles(string, string) ([]string, error) { return nil, f.err }
-func (f failingProvider) ListGames() ([]GameInfo, error)                 { return nil, nil }
+func (f failingProvider) ListGames() ([]GameInfo, error)                 { return nil, f.err }
 
 func TestModelShowsLoadingBeforeDataArrives(t *testing.T) {
 	t.Parallel()

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -350,29 +350,30 @@ func TestScreenViewsUseExactAvailableHeightOnLargeTerminals(t *testing.T) {
 func TestViewFitsTerminalBoundsWithHelpVisible(t *testing.T) {
 	t.Parallel()
 
-	// Height bumped 37->39->40 across Phase 5b Task 5's two new help lines
-	// ("i" install, added first; "u" check-updates, added second - see
-	// helpView). Verified empirically at each step (scratch probes sweeping
-	// a height range, since removed) the same way 5a proved its own 36->37
-	// bump: below the fitting height, the rendered view consistently comes
-	// out one row taller than the requested terminal height (lipgloss pads
-	// SHORT content but never clips content taller than the requested
-	// budget) - the party-sheet dashboard's split-panel math
-	// (partyDashboardView's topHeight/menuHeight, both integer divisions of
-	// availableContentHeight) hits its natural minimum before the requested
-	// budget does. Height=40 is the first value where the requested content
-	// budget (with BOTH new help lines present) finally reaches that same
-	// natural minimum, so the view fits with exactly zero slack (41 and
-	// above, the content grows to fill the larger budget instead). This
-	// pins the current zero-slack floor - see task-5-brief.md's "prove
+	// Height bumped 37->39->40->60 over time (37->39->40 across Phase 5b
+	// Task 5's two new help lines; 40->60 in Task 9, when helpView grew from
+	// a flat ~15-line list into per-screen groups covering every Tasks
+	// 4-8 binding - see helpGroups/helpBodyBudget). Verified empirically
+	// each time (scratch probes sweeping a height range, since removed) the
+	// same way 5a proved its own 36->37 bump: below the fitting height, the
+	// rendered view consistently comes out one row taller than the
+	// requested terminal height (lipgloss pads SHORT content but never
+	// clips content taller than the requested budget) - the party-sheet
+	// dashboard's split-panel math (partyDashboardView's topHeight/
+	// menuHeight, both integer divisions of availableContentHeight) hits
+	// its natural minimum before the requested budget does. Height=60 is
+	// the first value where the requested content budget finally reaches
+	// that same natural minimum, so the view fits with exactly zero slack
+	// (61 and above, the content grows to fill the larger budget instead).
+	// This pins the current zero-slack floor - see task-5-brief.md's "prove
 	// pre-existing saturation... like 5a did" allowance for justified
 	// height adjustments.
-	model := sizedPrototypeModel(t, "wizardry", 120, 40)
+	model := sizedPrototypeModel(t, "wizardry", 120, 60)
 	model = updateWithRunes(t, model, "?")
 
 	view := model.View()
 	require.Equal(t, 120, lipgloss.Width(view))
-	require.Equal(t, 40, lipgloss.Height(view))
+	require.Equal(t, 60, lipgloss.Height(view))
 }
 
 func TestThemesUseDistinctLayouts(t *testing.T) {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -526,6 +526,7 @@ func (f failingProvider) Search(context.Context, string, string, int) (SearchPag
 	return SearchPage{}, f.err
 }
 func (f failingProvider) DeployedFiles(string, string) ([]string, error) { return nil, f.err }
+func (f failingProvider) ListGames() ([]GameInfo, error)                 { return nil, nil }
 
 func TestModelShowsLoadingBeforeDataArrives(t *testing.T) {
 	t.Parallel()
@@ -583,6 +584,7 @@ func (emptyProvider) Search(context.Context, string, string, int) (SearchPage, e
 	return SearchPage{}, nil
 }
 func (emptyProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
+func (emptyProvider) ListGames() ([]GameInfo, error)                 { return nil, nil }
 
 func TestEmptyStatesRenderHonestCopy(t *testing.T) {
 	t.Parallel()
@@ -618,6 +620,7 @@ func (sentinelUpdatesProvider) Search(context.Context, string, string, int) (Sea
 	return SearchPage{}, nil
 }
 func (sentinelUpdatesProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
+func (sentinelUpdatesProvider) ListGames() ([]GameInfo, error)                 { return nil, nil }
 
 // TestFirstLoadHonorsProviderUpdatesSentinel guards the dataLoadedMsg
 // preserve behavior (see mutations_test.go's
@@ -644,39 +647,71 @@ func TestFirstLoadHonorsProviderUpdatesSentinel(t *testing.T) {
 // DeployedFilesErr configure DeployedFiles directly (no delegate call, no
 // recording) - simple canned-return fields, since no test using this fake
 // needs to observe DeployedFiles' arguments the way onOverview observes
-// Overview's context.
+// Overview's context. ListGamesResult/ListGamesErr/SetGameCalls/SetGameErr
+// are Task 8's game-switch additions, mirroring DeployedFiles' own
+// canned-return shape for ListGames and recordingActions' own *Calls-slice
+// convention (actions_provider_test.go) for SetGame; AltSourceInfos/
+// AltSources, once set, become what SourceInfos()/Sources() return after
+// the FIRST SetGame call - letting a test prove the post-switch source
+// re-seed (mutations.go's resolveGameSwitch) actually reads a fresh call
+// rather than a value cached from before the switch. Now a POINTER receiver
+// throughout (Task 8): SetGameCalls must accumulate visibly to the caller's
+// own variable, which a value-receiver method can never do.
 type recordingProvider struct {
 	delegate            DataProvider
 	onOverview          func(context.Context)
 	DeployedFilesResult []string
 	DeployedFilesErr    error
+
+	ListGamesResult []GameInfo
+	ListGamesErr    error
+	SetGameCalls    []string
+	SetGameErr      error
+	AltSourceInfos  []SourceInfo
+	AltSources      []string
 }
 
-func (r recordingProvider) Overview(ctx context.Context) (Summary, []ModItem, error) {
+func (r *recordingProvider) Overview(ctx context.Context) (Summary, []ModItem, error) {
 	if r.onOverview != nil {
 		r.onOverview(ctx)
 	}
 	return r.delegate.Overview(ctx)
 }
 
-func (r recordingProvider) Profiles(ctx context.Context) ([]ProfileItem, error) {
+func (r *recordingProvider) Profiles(ctx context.Context) ([]ProfileItem, error) {
 	return r.delegate.Profiles(ctx)
 }
 
-func (r recordingProvider) Sources() []string {
+func (r *recordingProvider) Sources() []string {
+	if len(r.SetGameCalls) > 0 && r.AltSources != nil {
+		return r.AltSources
+	}
 	return r.delegate.Sources()
 }
 
-func (r recordingProvider) SourceInfos() []SourceInfo {
+func (r *recordingProvider) SourceInfos() []SourceInfo {
+	if len(r.SetGameCalls) > 0 && r.AltSourceInfos != nil {
+		return r.AltSourceInfos
+	}
 	return r.delegate.SourceInfos()
 }
 
-func (r recordingProvider) Search(ctx context.Context, source, query string, page int) (SearchPage, error) {
+func (r *recordingProvider) Search(ctx context.Context, source, query string, page int) (SearchPage, error) {
 	return r.delegate.Search(ctx, source, query, page)
 }
 
-func (r recordingProvider) DeployedFiles(sourceID, modID string) ([]string, error) {
+func (r *recordingProvider) DeployedFiles(sourceID, modID string) ([]string, error) {
 	return r.DeployedFilesResult, r.DeployedFilesErr
+}
+
+func (r *recordingProvider) ListGames() ([]GameInfo, error) {
+	return r.ListGamesResult, r.ListGamesErr
+}
+
+// SetGame implements actions.go's optional gameRebinder hook.
+func (r *recordingProvider) SetGame(id string) error {
+	r.SetGameCalls = append(r.SetGameCalls, id)
+	return r.SetGameErr
 }
 
 func TestModelUsesProvidedContext(t *testing.T) {
@@ -686,7 +721,7 @@ func TestModelUsesProvidedContext(t *testing.T) {
 	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
 
 	var seen context.Context
-	provider := recordingProvider{
+	provider := &recordingProvider{
 		delegate:   NewPrototypeProvider(),
 		onOverview: func(c context.Context) { seen = c },
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -350,10 +350,11 @@ func TestScreenViewsUseExactAvailableHeightOnLargeTerminals(t *testing.T) {
 func TestViewFitsTerminalBoundsWithHelpVisible(t *testing.T) {
 	t.Parallel()
 
-	// Height bumped 37->39->40->60 over time (37->39->40 across Phase 5b
-	// Task 5's two new help lines; 40->60 in Task 9, when helpView grew from
-	// a flat ~15-line list into per-screen groups covering every Tasks
-	// 4-8 binding - see helpGroups/helpBodyBudget). Verified empirically
+	// Height bumped 37->39->40->60->61 over time (37->39->40 across Phase
+	// 5b Task 5's two new help lines; 40->60 in Task 9, when helpView grew
+	// from a flat ~15-line list into per-screen groups covering every Tasks
+	// 4-8 binding - see helpGroups/helpBodyBudget; 60->61 for the dashboard
+	// group's "enter open menu entry" line). Verified empirically
 	// each time (scratch probes sweeping a height range, since removed) the
 	// same way 5a proved its own 36->37 bump: below the fitting height, the
 	// rendered view consistently comes out one row taller than the
@@ -361,19 +362,19 @@ func TestViewFitsTerminalBoundsWithHelpVisible(t *testing.T) {
 	// clips content taller than the requested budget) - the party-sheet
 	// dashboard's split-panel math (partyDashboardView's topHeight/
 	// menuHeight, both integer divisions of availableContentHeight) hits
-	// its natural minimum before the requested budget does. Height=60 is
+	// its natural minimum before the requested budget does. Height=61 is
 	// the first value where the requested content budget finally reaches
 	// that same natural minimum, so the view fits with exactly zero slack
-	// (61 and above, the content grows to fill the larger budget instead).
+	// (62 and above, the content grows to fill the larger budget instead).
 	// This pins the current zero-slack floor - see task-5-brief.md's "prove
 	// pre-existing saturation... like 5a did" allowance for justified
 	// height adjustments.
-	model := sizedPrototypeModel(t, "wizardry", 120, 60)
+	model := sizedPrototypeModel(t, "wizardry", 120, 61)
 	model = updateWithRunes(t, model, "?")
 
 	view := model.View()
 	require.Equal(t, 120, lipgloss.Width(view))
-	require.Equal(t, 60, lipgloss.Height(view))
+	require.Equal(t, 61, lipgloss.Height(view))
 }
 
 func TestThemesUseDistinctLayouts(t *testing.T) {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -525,6 +525,7 @@ func (f failingProvider) SourceInfos() []SourceInfo                       { retu
 func (f failingProvider) Search(context.Context, string, string, int) (SearchPage, error) {
 	return SearchPage{}, f.err
 }
+func (f failingProvider) DeployedFiles(string, string) ([]string, error) { return nil, f.err }
 
 func TestModelShowsLoadingBeforeDataArrives(t *testing.T) {
 	t.Parallel()
@@ -581,6 +582,7 @@ func (emptyProvider) SourceInfos() []SourceInfo                       { return n
 func (emptyProvider) Search(context.Context, string, string, int) (SearchPage, error) {
 	return SearchPage{}, nil
 }
+func (emptyProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
 
 func TestEmptyStatesRenderHonestCopy(t *testing.T) {
 	t.Parallel()
@@ -615,6 +617,7 @@ func (sentinelUpdatesProvider) SourceInfos() []SourceInfo                       
 func (sentinelUpdatesProvider) Search(context.Context, string, string, int) (SearchPage, error) {
 	return SearchPage{}, nil
 }
+func (sentinelUpdatesProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
 
 // TestFirstLoadHonorsProviderUpdatesSentinel guards the dataLoadedMsg
 // preserve behavior (see mutations_test.go's
@@ -637,10 +640,16 @@ func TestFirstLoadHonorsProviderUpdatesSentinel(t *testing.T) {
 }
 
 // recordingProvider wraps a delegate DataProvider and records the context
-// passed to Overview for test verification.
+// passed to Overview for test verification. DeployedFilesResult/
+// DeployedFilesErr configure DeployedFiles directly (no delegate call, no
+// recording) - simple canned-return fields, since no test using this fake
+// needs to observe DeployedFiles' arguments the way onOverview observes
+// Overview's context.
 type recordingProvider struct {
-	delegate   DataProvider
-	onOverview func(context.Context)
+	delegate            DataProvider
+	onOverview          func(context.Context)
+	DeployedFilesResult []string
+	DeployedFilesErr    error
 }
 
 func (r recordingProvider) Overview(ctx context.Context) (Summary, []ModItem, error) {
@@ -664,6 +673,10 @@ func (r recordingProvider) SourceInfos() []SourceInfo {
 
 func (r recordingProvider) Search(ctx context.Context, source, query string, page int) (SearchPage, error) {
 	return r.delegate.Search(ctx, source, query, page)
+}
+
+func (r recordingProvider) DeployedFiles(sourceID, modID string) ([]string, error) {
+	return r.DeployedFilesResult, r.DeployedFilesErr
 }
 
 func TestModelUsesProvidedContext(t *testing.T) {

--- a/internal/tui/game_switch_test.go
+++ b/internal/tui/game_switch_test.go
@@ -8,6 +8,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
 )
 
 // --- Task 8: in-TUI game switcher ('g' from any screen) ---
@@ -445,4 +447,107 @@ func TestPrototypeGameSwitchFlipsData(t *testing.T) {
 		names = append(names, mod.Name)
 	}
 	require.Contains(t, names, "Fallout 4 Script Extender")
+}
+
+// --- Prototype mutations after a game switch (Copilot PR #69) ---
+//
+// Every prototypeProvider mutation/read used to address p.data.InstalledMods
+// and p.data.Stats directly, ignoring the altActive binding Task 8's
+// Overview flip introduced: after a --prototype game switch, an operation
+// either failed "mod not found" (the target lives in AltMods) or silently
+// mutated the WRONG game's dataset and corrupted the primary game's canned
+// Stats. These tests drive the provider through its own SetGame seam (the
+// exact call rebindGame makes) and assert each operation targets the ACTIVE
+// game's mods, leaving the primary dataset and Stats untouched.
+
+// prototypeProviderOnAltGame returns a prototypeProvider already switched to
+// the alt canned game, plus deep-ish copies of the primary dataset taken
+// BEFORE the switch so tests can prove it stayed untouched.
+func prototypeProviderOnAltGame(t *testing.T) (*prototypeProvider, []prototype.Mod, prototype.Stats) {
+	t.Helper()
+	p := NewPrototypeProvider().(*prototypeProvider)
+	primaryBefore := make([]prototype.Mod, len(p.data.InstalledMods))
+	copy(primaryBefore, p.data.InstalledMods)
+	statsBefore := p.data.Stats
+	require.NoError(t, p.SetGame(p.data.AltGame.ID))
+	return p, primaryBefore, statsBefore
+}
+
+func TestPrototypePolicyEditAfterGameSwitchTargetsActiveGame(t *testing.T) {
+	t.Parallel()
+
+	p, primaryBefore, _ := prototypeProviderOnAltGame(t)
+
+	_, err := p.SetUpdatePolicy(context.Background(), ModItem{ID: "f4se", Source: "nexusmods", Name: "Fallout 4 Script Extender"}, "pin")
+	require.NoError(t, err, "the alt game's own mod must be addressable after the switch")
+	require.Equal(t, "pin", p.data.AltMods[0].UpdatePolicy, "the ACTIVE game's row must carry the new policy")
+	require.Equal(t, primaryBefore, p.data.InstalledMods, "the primary game's rows must be untouched")
+}
+
+func TestPrototypePurgeAfterGameSwitchTargetsActiveGame(t *testing.T) {
+	t.Parallel()
+
+	p, primaryBefore, statsBefore := prototypeProviderOnAltGame(t)
+
+	outcome, err := p.PurgeProfile(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, "Purged 2 mod(s)", outcome.Message, "must purge the ACTIVE game's 2 mods, not the primary's 5")
+	for _, mod := range p.data.AltMods {
+		require.Equal(t, "disabled", mod.Status)
+	}
+	require.Equal(t, primaryBefore, p.data.InstalledMods, "the primary game's rows must be untouched")
+	require.Equal(t, statsBefore, p.data.Stats, "the primary game's canned Stats must not be corrupted")
+}
+
+func TestPrototypeUninstallAfterGameSwitchTargetsActiveGame(t *testing.T) {
+	t.Parallel()
+
+	p, primaryBefore, statsBefore := prototypeProviderOnAltGame(t)
+
+	_, err := p.UninstallMod(context.Background(), ModItem{ID: "f4se", Source: "nexusmods", Name: "Fallout 4 Script Extender"})
+	require.NoError(t, err)
+	require.Len(t, p.data.AltMods, 1, "the ACTIVE game's list must shrink")
+	require.Equal(t, primaryBefore, p.data.InstalledMods, "the primary game's rows must be untouched")
+	require.Equal(t, statsBefore, p.data.Stats, "the primary game's canned Stats must not be corrupted")
+}
+
+func TestPrototypeEnableAfterGameSwitchLeavesPrimaryStats(t *testing.T) {
+	t.Parallel()
+
+	p, primaryBefore, statsBefore := prototypeProviderOnAltGame(t)
+
+	// "unofficial-patch" is canned disabled (see prototype.Load's AltMods).
+	_, err := p.EnableMod(context.Background(), ModItem{ID: "unofficial-patch", Source: "nexusmods", Name: "Unofficial Fallout 4 Patch"})
+	require.NoError(t, err)
+	require.Equal(t, "installed", p.data.AltMods[1].Status, "the ACTIVE game's row must flip")
+	require.Equal(t, primaryBefore, p.data.InstalledMods, "the primary game's rows must be untouched")
+	require.Equal(t, statsBefore, p.data.Stats,
+		"the alt game derives its counts live from AltMods - the primary's canned Stats must not move")
+}
+
+func TestPrototypeCheckUpdatesAfterGameSwitchUsesActiveMods(t *testing.T) {
+	t.Parallel()
+
+	p, _, _ := prototypeProviderOnAltGame(t)
+
+	view, err := p.CheckUpdates(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, view.Updates,
+		"AltMods carry no AvailableVersion entries - reporting the PRIMARY game's canned updates after the switch is the bug")
+}
+
+func TestPrototypeDeployedFilesAfterGameSwitchUsesActiveMods(t *testing.T) {
+	t.Parallel()
+
+	p, _, _ := prototypeProviderOnAltGame(t)
+
+	files, err := p.DeployedFiles("nexusmods", "f4se")
+	require.NoError(t, err)
+	require.Contains(t, files, "Fallout 4 Script Extender.esp",
+		"the display-name lookup must resolve against the ACTIVE game's mods, not fall back to the raw mod ID")
+
+	outcome, err := p.DeployProfile(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Deployed 1 mod(s)", outcome.Message,
+		"deploy must count the ACTIVE game's enabled mods (1 of 2), not the primary's")
 }

--- a/internal/tui/game_switch_test.go
+++ b/internal/tui/game_switch_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"testing"
 
@@ -256,6 +257,95 @@ func TestGameSwitchCancelsInFlightSearchAndDiscardsLateResult(t *testing.T) {
 	updated, _ = model.Update(msg)
 	model = updated.(Model)
 	require.NotEqual(t, searchReady, model.search.state, "a late, now-stale search result must not be applied")
+}
+
+// TestGameSwitchDropsStaleInFlightLoad guards the review's Important
+// finding: dataLoadedMsg used to be applied unconditionally, so a load
+// dispatched BEFORE a game switch (game A's Overview/Profiles, possibly
+// even read mid-rebind) could land AFTER resolveGameSwitch's reset and
+// repopulate the model with the old game's rows while the providers are
+// already bound to game B. The fix mirrors the search-gen mechanism
+// (searchResultMsg/searchFailedMsg): loads are stamped with m.loadGen at
+// dispatch, resolveGameSwitch bumps it, and Update discards a stale-gen
+// dataLoadedMsg/loadFailedMsg entirely.
+func TestGameSwitchDropsStaleInFlightLoad(t *testing.T) {
+	t.Parallel()
+
+	games := []GameInfo{
+		{ID: "gameA", Name: "Game A", Active: true},
+		{ID: "gameB", Name: "Game B", Active: false},
+	}
+	provider := &recordingProvider{delegate: NewPrototypeProvider(), ListGamesResult: games}
+	model, err := NewModel(Options{Theme: "wizardry", Provider: provider, Actions: &recordingActions{}})
+	require.NoError(t, err)
+
+	// Capture (but do not deliver) the initial load's message - this is the
+	// in-flight load-A whose result must go stale the moment the switch
+	// resets the session.
+	staleLoadMsg := model.Init()()
+	require.IsType(t, dataLoadedMsg{}, staleLoadMsg)
+
+	updated, _ := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.NotNil(t, model.picker)
+	updated, chooseCmd := model.Update(keyRunes("2")) // "Game B", not active
+	model = updated.(Model)
+	require.NotNil(t, chooseCmd)
+
+	updated, loadCmd := model.Update(chooseCmd())
+	model = updated.(Model)
+	require.Equal(t, stateLoading, model.state)
+	require.NotNil(t, loadCmd)
+
+	// The OLD load's message lands after the reset: it must be discarded
+	// whole - no state transition, no repopulated rows.
+	updated, _ = model.Update(staleLoadMsg)
+	model = updated.(Model)
+	require.Equal(t, stateLoading, model.state, "a stale in-flight load must not resolve the post-switch loading state")
+	require.Nil(t, model.mods, "a stale in-flight load must not repopulate the old game's rows")
+
+	// The NEW load (dispatched by the switch itself, stamped with the
+	// bumped gen) still applies normally.
+	updated, _ = model.Update(loadCmd())
+	model = updated.(Model)
+	require.Equal(t, stateReady, model.state)
+}
+
+// TestGameSwitcherListGamesErrorGoesToStatusLine covers openGameSwitcher's
+// ListGames-failure branch: the error renders on the status line
+// (statusIsError set) and no picker opens - mirroring
+// TestFilesKeyErrorGoesToStatusLine's shape for the other synchronous
+// provider read.
+func TestGameSwitcherListGamesErrorGoesToStatusLine(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{delegate: NewPrototypeProvider(), ListGamesErr: errors.New("games.yaml unreadable")}
+	model := modelWithProvider(t, provider)
+
+	updated, cmd := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.picker)
+	require.True(t, model.action.statusIsError)
+	require.Equal(t, singleLine("games.yaml unreadable"), model.action.status)
+}
+
+// TestGameSwitchNoGamesConfiguredStatus covers ListGames returning ZERO
+// entries (unreachable via coreProvider, whose session is always bound to
+// a configured game, but the message must not lie): "no games configured",
+// not "only one game configured".
+func TestGameSwitchNoGamesConfiguredStatus(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{delegate: NewPrototypeProvider(), ListGamesResult: nil}
+	model := modelWithProvider(t, provider)
+
+	updated, cmd := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.picker)
+	require.Equal(t, "no games configured", model.action.status)
+	require.False(t, model.action.statusIsError)
 }
 
 // --- Prototype demo ---

--- a/internal/tui/game_switch_test.go
+++ b/internal/tui/game_switch_test.go
@@ -348,6 +348,53 @@ func TestGameSwitchNoGamesConfiguredStatus(t *testing.T) {
 	require.False(t, model.action.statusIsError)
 }
 
+// TestGameSwitchResetClosesOpenModals guards the final-review pre-merge
+// finding: a deferred gameChosenMsg resolves on the tick AFTER the pick,
+// and type-ahead widens that window - another modal (e.g. 'c' on Profiles
+// opening the "new profile" input modal) can be up by the time the switch
+// resolves. resolveGameSwitch's reset must close it: a modal built against
+// the OLD game's data (the input modal's validate closure captured the old
+// profile list) operating over reset state bound to the NEW game is
+// exactly the stale-capture class the reset exists to prevent.
+func TestGameSwitchResetClosesOpenModals(t *testing.T) {
+	t.Parallel()
+
+	games := []GameInfo{
+		{ID: "gameA", Name: "Game A", Active: true},
+		{ID: "gameB", Name: "Game B", Active: false},
+	}
+	provider := &recordingProvider{delegate: NewPrototypeProvider(), ListGamesResult: games}
+	model, err := NewModel(Options{Theme: "wizardry", Provider: provider, Actions: &recordingActions{}})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+
+	// Pick the non-active game; hold its gameChosenMsg undelivered - this
+	// is the pick→resolution window.
+	updated, _ := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.NotNil(t, model.picker)
+	updated, chooseCmd := model.Update(keyRunes("2"))
+	model = updated.(Model)
+	require.NotNil(t, chooseCmd)
+	pendingMsg := chooseCmd()
+
+	// Type-ahead: open the "new profile" input modal before the switch
+	// resolves (its validate closure captured the OLD game's profile list).
+	model.screen = ScreenProfiles
+	updated, _ = model.Update(keyRunes("c"))
+	model = updated.(Model)
+	require.NotNil(t, model.inputModal, "arrange: the input modal must be up when the switch resolves")
+
+	updated, loadCmd := model.Update(pendingMsg)
+	model = updated.(Model)
+	require.Equal(t, stateLoading, model.state)
+	require.NotNil(t, loadCmd)
+	require.Nil(t, model.inputModal, "the reset must close a modal captured against the old game's data")
+	require.Nil(t, model.picker)
+	require.Nil(t, model.overlay)
+}
+
 // --- Prototype demo ---
 
 // TestPrototypeGameSwitchFlipsData proves the switcher visibly works in

--- a/internal/tui/game_switch_test.go
+++ b/internal/tui/game_switch_test.go
@@ -1,0 +1,311 @@
+package tui
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Task 8: in-TUI game switcher ('g' from any screen) ---
+
+// TestGameKeyOpensPickerActiveMarked covers 'g' opening the switcher: the
+// picker's title, every configured game's name as an option, and the
+// active game's option carrying the "active" Note (mirroring
+// editSelectedModPolicy's own "current" Note convention for the
+// update-policy picker).
+func TestGameKeyOpensPickerActiveMarked(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{
+		delegate: NewPrototypeProvider(),
+		ListGamesResult: []GameInfo{
+			{ID: "skyrim", Name: "Skyrim", Active: false},
+			{ID: "fallout4", Name: "Fallout 4", Active: true},
+		},
+	}
+	model := modelWithProvider(t, provider)
+
+	updated, cmd := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.picker)
+	require.Equal(t, "switch game", model.picker.title)
+	require.Len(t, model.picker.options, 2)
+	require.Equal(t, "Skyrim", model.picker.options[0].Label)
+	require.Empty(t, model.picker.options[0].Note)
+	require.Equal(t, "Fallout 4", model.picker.options[1].Label)
+	require.Equal(t, "active", model.picker.options[1].Note)
+	require.Equal(t, 1, model.picker.selected, "the active game must start selected")
+}
+
+// TestGameSwitchRebindsProvidersResetsAndReloads is the end-to-end happy
+// path: choosing a non-active game rebinds BOTH m.provider and m.actions
+// (rebindGame, actions.go), resets the session's data-derived state to its
+// "nothing loaded yet" shape, re-seeds sources from the NEW game, and
+// returns a cmd chain that resolves to a fresh dataLoadedMsg.
+func TestGameSwitchRebindsProvidersResetsAndReloads(t *testing.T) {
+	t.Parallel()
+
+	games := []GameInfo{
+		{ID: "fallout4", Name: "Fallout 4", Active: true},
+		{ID: "skyrim", Name: "Skyrim", Active: false},
+	}
+	provider := &recordingProvider{
+		delegate:        NewPrototypeProvider(),
+		ListGamesResult: games,
+		AltSourceInfos:  []SourceInfo{{ID: "alt-source", Name: "Alt Source", Type: "built-in"}},
+		AltSources:      []string{"alt-source"},
+	}
+	actions := &recordingActions{}
+	model, err := NewModel(Options{Theme: "wizardry", Provider: provider, Actions: actions})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+
+	// Dirty the state a real switch must reset, so zeroing/clearing is
+	// actually observable rather than trivially already-true.
+	model.selected[ScreenInstalledMods] = 1
+	model.selected[ScreenSearch] = 2
+	model.summary.Updates = 7
+
+	updated, cmd := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.picker)
+
+	// Option 1 ("Skyrim") is the non-active game; digit quick-select chooses
+	// it directly (picker.go's digitQuickSelect is 1-based).
+	updated, chooseCmd := model.Update(keyRunes("2"))
+	model = updated.(Model)
+	require.Nil(t, model.picker, "choosing an option must clear the picker")
+	require.NotNil(t, chooseCmd)
+
+	gameMsg := chooseCmd()
+	require.IsType(t, gameChosenMsg{}, gameMsg)
+	require.Equal(t, "skyrim", gameMsg.(gameChosenMsg).id)
+
+	updated, loadCmd := model.Update(gameMsg)
+	model = updated.(Model)
+
+	require.Equal(t, []string{"skyrim"}, provider.SetGameCalls)
+	require.Equal(t, []string{"skyrim"}, actions.SetGameCalls)
+
+	require.Equal(t, stateLoading, model.state)
+	require.Nil(t, model.mods)
+	require.Nil(t, model.profiles)
+	require.Equal(t, -1, model.summary.Updates)
+	require.Equal(t, -1, model.summary.Conflicts)
+	require.Equal(t, 0, model.selected[ScreenInstalledMods])
+	require.Equal(t, 0, model.selected[ScreenSearch])
+
+	require.Equal(t, provider.AltSourceInfos, model.sources, "sources must re-seed from the NEW game's SourceInfos()")
+	require.Equal(t, []string{"", "alt-source"}, model.search.sources, "search sources must re-seed from the NEW game's Sources()")
+
+	require.NotNil(t, loadCmd)
+	dataMsg := loadCmd()
+	require.IsType(t, dataLoadedMsg{}, dataMsg)
+
+	updated, _ = model.Update(dataMsg)
+	model = updated.(Model)
+	require.Equal(t, stateReady, model.state)
+}
+
+// TestGameSwitchBlockedWhileActionRunning covers the single-flight guard:
+// while an action is running, 'g' refuses synchronously with an explicit
+// "action in progress" status (unlike promptPicker's own silent no-op -
+// see openGameSwitcher's doc comment for why this task's own test demands
+// an explicit message) and opens no picker at all.
+func TestGameSwitchBlockedWhileActionRunning(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.running = true
+
+	updated, cmd := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.picker)
+	require.Equal(t, "action in progress", model.action.status)
+	require.True(t, model.action.statusIsError)
+}
+
+// TestGameSwitchSameGameIsNoop covers choosing the ALREADY-active game:
+// openGameSwitcher's picker closure returns a nil cmd for that option (see
+// its own doc comment), so no gameChosenMsg is ever produced - no SetGame
+// call on either provider or actions, and no session reset.
+func TestGameSwitchSameGameIsNoop(t *testing.T) {
+	t.Parallel()
+
+	games := []GameInfo{
+		{ID: "fallout4", Name: "Fallout 4", Active: true},
+		{ID: "skyrim", Name: "Skyrim", Active: false},
+	}
+	provider := &recordingProvider{delegate: NewPrototypeProvider(), ListGamesResult: games}
+	actions := &recordingActions{}
+	model, err := NewModel(Options{Theme: "wizardry", Provider: provider, Actions: actions})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+	stateBefore := model.state
+
+	updated, _ := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.NotNil(t, model.picker)
+	require.Equal(t, 0, model.picker.selected, "the active game (index 0) must start selected")
+
+	// Select (enter) chooses whatever's currently selected - the active
+	// game itself, with no navigation first.
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.Nil(t, model.picker, "choosing must still clear the picker")
+	require.Nil(t, cmd, "choosing the active game must dispatch no cmd at all")
+
+	require.Empty(t, provider.SetGameCalls)
+	require.Empty(t, actions.SetGameCalls)
+	require.Equal(t, stateBefore, model.state, "nothing about the session's data must reset")
+}
+
+// TestGameKeySwallowedByFocusedSearchInput proves 'g' types into the search
+// box instead of opening the switcher while ScreenSearch is focused - the
+// existing focused-input swallow branch (updateKey, app.go) runs before the
+// mutation-key switch this is dispatched from, mirroring every other
+// single-letter mutation key's own test of the same guard (e.g.
+// TestFilesKeySwallowedByFocusedSearchInput).
+func TestGameKeySwallowedByFocusedSearchInput(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	updated := updateWithRunes(t, model, "3") // jump to search, focused
+	updated = updateWithRunes(t, updated, "g")
+
+	require.True(t, updated.search.input.Focused())
+	require.Contains(t, updated.search.input.Value(), "g")
+	require.Nil(t, updated.picker)
+}
+
+// TestGameSwitchOnlyOneGameConfiguredStatus covers ListGames returning
+// exactly one entry: a status line ("only one game configured", not an
+// error) instead of an empty/single-option picker, per task-8-brief.md's
+// own framing ("nicer than an empty pick").
+func TestGameSwitchOnlyOneGameConfiguredStatus(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{
+		delegate:        NewPrototypeProvider(),
+		ListGamesResult: []GameInfo{{ID: "only", Name: "Only Game", Active: true}},
+	}
+	model := modelWithProvider(t, provider)
+
+	updated, cmd := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.picker)
+	require.Equal(t, "only one game configured", model.action.status)
+	require.False(t, model.action.statusIsError)
+}
+
+// TestGameSwitchCancelsInFlightSearchAndDiscardsLateResult mirrors
+// TestSwitchDoneCancelsInFlightSearchAndDiscardsLateResult (the
+// profile-switch precedent for this exact mechanism, immediately above in
+// this file): a fresh game switch must cancel any in-flight search's
+// context and bump search.gen, so a late result computed against the
+// NOW-STALE old game's installed-marks/sources is discarded by the ordinary
+// stale-gen check (searchResultMsg's case in app.go) rather than applied.
+func TestGameSwitchCancelsInFlightSearchAndDiscardsLateResult(t *testing.T) {
+	t.Parallel()
+
+	provider := &searchCancelProvider{listGames: []GameInfo{
+		{ID: "current", Name: "Current Game", Active: true},
+		{ID: "other", Name: "Other Game", Active: false},
+	}}
+	model, err := NewModel(Options{Theme: "wizardry", Provider: provider, Actions: &recordingActions{}})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+
+	model, searchCmd := model.startSearch("skyui", 0)
+	require.NotNil(t, searchCmd, "startSearch must dispatch a query given a real configured source")
+	gen1 := model.search.gen
+	require.NotNil(t, model.search.cancel)
+
+	msg := searchCmd() // runs provider.Search, capturing its ctx
+	require.NotNil(t, provider.capturedCtx)
+	require.NoError(t, provider.capturedCtx.Err(), "search's ctx must not be cancelled yet")
+
+	updated, _ := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.NotNil(t, model.picker)
+
+	updated, chooseCmd := model.Update(keyRunes("2")) // "Other Game", not active
+	model = updated.(Model)
+	require.NotNil(t, chooseCmd)
+	gameMsg := chooseCmd()
+
+	updated, _ = model.Update(gameMsg)
+	model = updated.(Model)
+
+	require.Error(t, provider.capturedCtx.Err(), "game switch must cancel the in-flight search's context")
+	require.ErrorIs(t, provider.capturedCtx.Err(), context.Canceled)
+	require.NotEqual(t, gen1, model.search.gen, "game switch must bump the search generation")
+
+	// The late result (tagged with the now-stale gen1) must be discarded,
+	// exactly like any other superseded search result.
+	updated, _ = model.Update(msg)
+	model = updated.(Model)
+	require.NotEqual(t, searchReady, model.search.state, "a late, now-stale search result must not be applied")
+}
+
+// --- Prototype demo ---
+
+// TestPrototypeGameSwitchFlipsData proves the switcher visibly works in
+// --prototype mode end to end: picking the alt canned game (Data.AltGame)
+// flips Overview to report it, with AltMods' own names showing up as the
+// Installed Mods list. NewPrototypeModel wires m.provider and m.actions
+// from the SAME prototypeProvider instance (see that constructor's doc
+// comment), so this also exercises rebindGame's documented double-call onto
+// one instance (gameRebinder's own doc comment, actions.go).
+func TestPrototypeGameSwitchFlipsData(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+
+	updated, _ := model.Update(keyRunes("g"))
+	model = updated.(Model)
+	require.NotNil(t, model.picker)
+
+	targetIdx := -1
+	for i, opt := range model.picker.options {
+		if opt.Note != "active" {
+			targetIdx = i
+		}
+	}
+	require.GreaterOrEqual(t, targetIdx, 0, "exactly one option must be the non-active alt game")
+
+	updated, chooseCmd := model.Update(keyRunes(strconv.Itoa(targetIdx + 1)))
+	model = updated.(Model)
+	require.NotNil(t, chooseCmd)
+	gameMsg := chooseCmd()
+
+	updated, loadCmd := model.Update(gameMsg)
+	model = updated.(Model)
+	require.Equal(t, stateLoading, model.state)
+	require.NotNil(t, loadCmd)
+
+	dataMsg := loadCmd()
+	updated, _ = model.Update(dataMsg)
+	model = updated.(Model)
+
+	require.Equal(t, "Fallout 4", model.summary.GameName)
+	require.NotEmpty(t, model.mods)
+	names := make([]string, 0, len(model.mods))
+	for _, mod := range model.mods {
+		names = append(names, mod.Name)
+	}
+	require.Contains(t, names, "Fallout 4 Script Extender")
+}

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,6 +59,35 @@ func TestHelpViewCurrentScreenGroupFirst(t *testing.T) {
 	require.NotEqual(t, -1, installedIdx, "installed mods header missing")
 	require.NotEqual(t, -1, profilesIdx, "profiles header missing")
 	require.Less(t, installedIdx, profilesIdx, "installed mods group should render before profiles when on Installed Mods")
+}
+
+// TestHelpViewCapsWithMoreTailAtSmallHeight exercises the height-capped
+// path the other help tests never reach (their budgets exceed the full
+// grouped list by construction): at 80x24 helpBodyBudget is far below the
+// body's natural size, so helpView must cap the list with a dimmed
+// "+N more" tail AND the whole View() must still occupy the terminal
+// bounds exactly - the same invariant TestViewFitsTerminalBoundsWithHelpVisible
+// pins at its uncapped zero-slack height. ScreenProfiles is used because
+// its screen view genuinely shrinks to availableContentHeight's 8-row
+// floor (the floor helpBodyBudget reserves); the party-sheet Dashboard and
+// a populated Installed Mods list have natural minimums above that floor
+// and overflow at this size with or without the help panel open - a
+// pre-existing limitation, not the cap's.
+//
+// Negative control (recorded in task-9-report.md): temporarily inflating
+// helpBodyBudget by +10 makes this test FAIL (view grows past 24 rows),
+// proving it guards the cap arithmetic, not just the tail copy.
+func TestHelpViewCapsWithMoreTailAtSmallHeight(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 80, 24)
+	model.screen = ScreenProfiles
+	model = updateWithRunes(t, model, "?")
+
+	view := model.View()
+	require.Regexp(t, `\+\d+ more`, view, "capped help must end in a '+N more' tail")
+	require.Equal(t, 80, lipgloss.Width(view))
+	require.Equal(t, 24, lipgloss.Height(view))
 }
 
 // TestFooterMentionsHelpKey pins "?" as the discovery point for help: the

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -1,0 +1,72 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHelpViewListsPerScreenGroups proves Task 9's restructure: the help
+// panel documents every binding added across Tasks 4-8 (files, policy,
+// purge, game switch, profile create/delete) grouped by the screen each
+// applies to, with "global" first. Zero-size model (no WindowSizeMsg) keeps
+// helpBodyBudget() at its generous unsized default so the full group list
+// renders uncapped - this test is about content, not the height invariant
+// (see TestViewFitsTerminalBoundsWithHelpVisible for that).
+func TestHelpViewListsPerScreenGroups(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+	model.showHelp = true
+	view := model.helpView()
+
+	for _, want := range []string{
+		"global", "dashboard", "installed mods", "search", "profiles",
+		"files", "policy", "purge", "game", "new profile", "delete profile",
+	} {
+		require.Contains(t, view, want, "missing %q", want)
+	}
+}
+
+// TestHelpViewCurrentScreenGroupFirst proves the current screen's group is
+// promoted to immediately after "global", while the rest keep their fixed
+// relative order - so a Profiles-screen user sees their own bindings first,
+// not buried after Installed Mods' longer list.
+func TestHelpViewCurrentScreenGroupFirst(t *testing.T) {
+	t.Parallel()
+
+	onProfiles, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+	onProfiles.screen = ScreenProfiles
+	onProfiles.showHelp = true
+	profilesView := onProfiles.helpView()
+	profilesIdx := strings.Index(profilesView, "profiles")
+	installedIdx := strings.Index(profilesView, "installed mods")
+	require.NotEqual(t, -1, profilesIdx, "profiles header missing")
+	require.NotEqual(t, -1, installedIdx, "installed mods header missing")
+	require.Less(t, profilesIdx, installedIdx, "profiles group should render before installed mods when on Profiles")
+
+	onInstalled, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+	onInstalled.screen = ScreenInstalledMods
+	onInstalled.showHelp = true
+	installedView := onInstalled.helpView()
+	installedIdx = strings.Index(installedView, "installed mods")
+	profilesIdx = strings.Index(installedView, "profiles")
+	require.NotEqual(t, -1, installedIdx, "installed mods header missing")
+	require.NotEqual(t, -1, profilesIdx, "profiles header missing")
+	require.Less(t, installedIdx, profilesIdx, "installed mods group should render before profiles when on Installed Mods")
+}
+
+// TestFooterMentionsHelpKey pins "?" as the discovery point for help: the
+// footer must always name it, even as the panel it opens grows with new
+// bindings.
+func TestFooterMentionsHelpKey(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+	require.Contains(t, model.footerLine(), "?: help")
+}

--- a/internal/tui/input_modal.go
+++ b/internal/tui/input_modal.go
@@ -1,0 +1,138 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// pendingInput is a caller-built description of a text-entry modal awaiting
+// a value, mirroring pendingPicker's role for the list-choice modal (see
+// picker.go) and pendingAction's for the confirm modal (see actions.go).
+// validate is consulted only for a non-empty trimmed value (the empty case
+// is handled directly by updateInputModalKey's own "name required" check,
+// so callers need not special-case it); "" means the value is acceptable,
+// any other string is shown in-modal as the error and keeps the modal open.
+// submit is invoked exactly once, when the value passes both checks - never
+// on cancel, and never while an error is showing.
+type pendingInput struct {
+	title    string
+	input    textinput.Model
+	errMsg   string
+	validate func(value string) string // "" = ok, else error copy shown in-modal
+	submit   func(value string) tea.Cmd
+}
+
+// newInputModalTextInput builds a textinput.Model configured for use inside
+// a pendingInput, following the same construction pattern newSearchModel
+// uses (search.go): CharLimit 64 (shorter than search's 120 - modal inputs
+// are short values like a profile name, not a free-text query) and Width
+// derived from the current available width via searchInputWidthFor, so a
+// value near the viewport width scrolls horizontally instead of word-wrapping
+// inside the width-set modal panel.
+func newInputModalTextInput(placeholder string, availableWidth, panelHorizontalFrameSize int) textinput.Model {
+	input := textinput.New()
+	input.Placeholder = placeholder
+	input.CharLimit = 64
+	input.Width = searchInputWidthFor(availableWidth, panelHorizontalFrameSize)
+	return input
+}
+
+// promptInput shows p as the text-input modal: this is the only method that
+// sets Model.inputModal, and it never calls submit itself - only
+// updateInputModalKey does, on a successful validated submission. Guarded
+// like promptPicker/promptAction (single-flight): while an action is
+// running or pending, a picker is up, or an input modal is already up, the
+// request is a no-op. The input is focused immediately, matching
+// gotoScreenFocused's search-input focus (app.go) - a modal is only ever
+// shown because the user asked for it, so it should be ready to type into
+// without an extra keypress.
+func (m Model) promptInput(p pendingInput) Model {
+	if m.action.running || m.action.pending != nil || m.picker != nil || m.inputModal != nil {
+		return m
+	}
+	p.input.Focus()
+	m.inputModal = &p
+	return m
+}
+
+// updateInputModalKey handles every key while the input modal is shown, and
+// is the focused-input law applied to a modal: Select (enter) attempts a
+// submission - trim the value, "name required" if empty, else validate(value)
+// (a non-empty result becomes errMsg and the modal stays open, exactly like
+// an empty value), and on success clear the modal and return submit(value);
+// Blur (esc) clears the modal without calling submit; ctrl+c quits (matched
+// directly by string, NOT via m.keys.Quit, whose bound keys also include a
+// plain "q" that must be typeable here - see the doc comment on isQuitKey's
+// focused-search-input case in app.go, which this mirrors); every other key -
+// including "q" - forwards to p.input.Update(msg), so the modal is a focused
+// input in every sense: nothing typed here can leak through to a binding
+// behind it.
+func (m Model) updateInputModalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	p := m.inputModal
+
+	switch {
+	case msg.String() == "ctrl+c":
+		return m.startQuit()
+	case key.Matches(msg, m.keys.Blur):
+		m.inputModal = nil
+		return m, nil
+	case key.Matches(msg, m.keys.Select):
+		return m.submitInputModal(p)
+	default:
+		var cmd tea.Cmd
+		p.input, cmd = p.input.Update(msg)
+		return m, cmd
+	}
+}
+
+// submitInputModal runs p's validation chain against its current input
+// value and either keeps the modal open with an errMsg (empty value, or a
+// non-empty validate result) or clears the modal and dispatches p.submit -
+// the single point updateInputModalKey's Select branch routes through, so
+// "validate, then submit exactly once" stays true regardless of which key
+// triggered it (mirroring choosePickerOption's role for the picker modal).
+func (m Model) submitInputModal(p *pendingInput) (tea.Model, tea.Cmd) {
+	value := strings.TrimSpace(p.input.Value())
+	if value == "" {
+		p.errMsg = "name required"
+		return m, nil
+	}
+	if errMsg := p.validate(value); errMsg != "" {
+		p.errMsg = errMsg
+		return m, nil
+	}
+	m.inputModal = nil
+	return m, p.submit(value)
+}
+
+// inputModalView renders the pending input as a bordered panel that
+// REPLACES the screen content, mirroring pickerView/actionModalView's
+// approach (see actionModalView's doc comment for why). Unlike those two,
+// this modal's line count never varies with caller-supplied data (no
+// option/detail list to budget for): title, input, an optional errMsg, a
+// blank separator, and the hint is at most 5 lines, always. That fits with
+// room to spare even at the smallest terminal this ever renders at:
+// availableContentHeight's floor is 8, and panelWithHeight subtracts the
+// panel's vertical border size (2, top+bottom) from whatever height it's
+// given, leaving a content floor of 6 - so no scroll/clip handling is
+// needed the way pickerView's option list requires.
+func (m Model) inputModalView() string {
+	width := m.availableWidth()
+	height := m.availableContentHeight()
+	panelContentWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
+
+	p := m.inputModal
+	lines := []string{
+		truncate(m.theme.PanelTitle.Render(p.title), panelContentWidth),
+		truncate(p.input.View(), panelContentWidth),
+	}
+	if p.errMsg != "" {
+		lines = append(lines, truncate(m.theme.DangerText.Render(p.errMsg), panelContentWidth))
+	}
+	lines = append(lines, "", m.theme.MutedText.Render("enter create · esc cancel"))
+
+	return m.panelWithHeight(width, height).Render(strings.Join(lines, "\n"))
+}

--- a/internal/tui/input_modal_test.go
+++ b/internal/tui/input_modal_test.go
@@ -1,0 +1,140 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// inputModalTestModel builds a fully-loaded, sized prototype Model with no
+// pending action/picker/input modal - the common starting point for every
+// test below.
+func inputModalTestModel(t *testing.T) Model {
+	t.Helper()
+	return sizedPrototypeModel(t, "wizardry", 100, 30)
+}
+
+// promptTestInput attaches an input modal to model via promptInput, using
+// validate as the validation func and recording every submit(value) call in
+// *submitted (appended, so a test can assert both "was it called" and "with
+// what value").
+func promptTestInput(model Model, validate func(value string) string, submitted *[]string) Model {
+	input := newInputModalTextInput("profile name", model.availableWidth(), model.theme.Panel.GetHorizontalFrameSize())
+	return model.promptInput(pendingInput{
+		title:    "Create Profile",
+		input:    input,
+		validate: validate,
+		submit: func(value string) tea.Cmd {
+			*submitted = append(*submitted, value)
+			return nil
+		},
+	})
+}
+
+// typeString sends model one KeyMsg per rune of s, matching how the rest of
+// the package's tests drive textinput.Model (see search_test.go).
+func typeString(t *testing.T, model Model, s string) Model {
+	t.Helper()
+	for _, r := range s {
+		model = updateWithRunes(t, model, string(r))
+	}
+	return model
+}
+
+func alwaysValid(string) string { return "" }
+
+func TestInputModalTypeAndSubmit(t *testing.T) {
+	t.Parallel()
+
+	var submitted []string
+	model := promptTestInput(inputModalTestModel(t), alwaysValid, &submitted)
+	require.NotNil(t, model.inputModal)
+	require.True(t, model.inputModal.input.Focused(), "promptInput must focus the input")
+
+	model = typeString(t, model, "survival")
+	model = updateWithKeyType(t, model, tea.KeyEnter)
+
+	require.Equal(t, []string{"survival"}, submitted)
+	require.Nil(t, model.inputModal)
+}
+
+// TestInputModalValidationErrorKeepsModalOpen covers a non-empty value that
+// fails caller validation (e.g. a name collision): the error is shown
+// in-modal, the modal stays open, and submit is never called.
+func TestInputModalValidationErrorKeepsModalOpen(t *testing.T) {
+	t.Parallel()
+
+	var submitted []string
+	model := promptTestInput(inputModalTestModel(t), func(string) string {
+		return "name already exists"
+	}, &submitted)
+
+	model = typeString(t, model, "duplicate")
+	model = updateWithKeyType(t, model, tea.KeyEnter)
+
+	require.Empty(t, submitted, "submit must not be called on a validation error")
+	require.NotNil(t, model.inputModal, "modal must stay open on a validation error")
+	require.Contains(t, model.View(), "name already exists")
+}
+
+func TestInputModalEscCancels(t *testing.T) {
+	t.Parallel()
+
+	var submitted []string
+	model := promptTestInput(inputModalTestModel(t), alwaysValid, &submitted)
+
+	model = typeString(t, model, "abc")
+	model = updateWithKeyType(t, model, tea.KeyEsc)
+
+	require.Empty(t, submitted)
+	require.Nil(t, model.inputModal)
+}
+
+func TestInputModalBlockedWhileActionRunning(t *testing.T) {
+	t.Parallel()
+
+	var submitted []string
+	model := inputModalTestModel(t)
+	model.action.running = true
+
+	model = promptTestInput(model, alwaysValid, &submitted)
+
+	require.Nil(t, model.inputModal, "promptInput must be a no-op while an action is running")
+}
+
+// TestInputModalQKeyTypesInsteadOfQuitting locks in the modal's departure
+// from the Quit binding's usual "q" behavior (see updateInputModalKey's doc
+// comment): "q" must be typeable like any other character, and only ctrl+c
+// actually quits while the modal is open.
+func TestInputModalQKeyTypesInsteadOfQuitting(t *testing.T) {
+	t.Parallel()
+
+	var submitted []string
+	model := promptTestInput(inputModalTestModel(t), alwaysValid, &submitted)
+
+	model = updateWithRunes(t, model, "q")
+
+	require.NotNil(t, model.inputModal, "plain q must not quit the modal")
+	require.Contains(t, model.inputModal.input.Value(), "q")
+
+	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	require.NotNil(t, cmd)
+	require.Equal(t, tea.Quit(), cmd(), "ctrl+c must still quit while the modal is open")
+}
+
+// TestInputModalEmptySubmitShowsNameRequired covers submitting with no
+// value typed at all: validate is never even consulted (empty is checked
+// first - see updateInputModalKey's doc comment), and the modal stays open.
+func TestInputModalEmptySubmitShowsNameRequired(t *testing.T) {
+	t.Parallel()
+
+	var submitted []string
+	model := promptTestInput(inputModalTestModel(t), alwaysValid, &submitted)
+
+	model = updateWithKeyType(t, model, tea.KeyEnter)
+
+	require.Empty(t, submitted)
+	require.NotNil(t, model.inputModal)
+	require.Contains(t, model.View(), "name required")
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -47,6 +47,11 @@ type KeyMap struct {
 	// "f" to CLOSE the overlay once open, so this key doubles as an open/
 	// close toggle.
 	Files key.Binding
+	// Policy is Task 5's update-policy picker binding (see mutations.go's
+	// editSelectedModPolicy): fires on ScreenInstalledMods with a mod
+	// selected, opening a notify/auto/pin picker whose selection dispatches
+	// immediately (no separate confirm modal).
+	Policy key.Binding
 }
 
 // DefaultKeyMap returns the shared key bindings shown in help and used by tests.
@@ -155,6 +160,10 @@ func DefaultKeyMap() KeyMap {
 		Files: key.NewBinding(
 			key.WithKeys("f"),
 			key.WithHelp("f", "files"),
+		),
+		Policy: key.NewBinding(
+			key.WithKeys("P"),
+			key.WithHelp("P", "policy"),
 		),
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -61,6 +61,13 @@ type KeyMap struct {
 	// synchronously on the status line for the active one.
 	CreateProfile key.Binding
 	DeleteProfile key.Binding
+	// Purge is Task 7's Dashboard/Installed-Mods purge-behind-confirmation
+	// binding (see mutations.go's purgeProfilePrompt): undeploys every mod
+	// currently installed in the active profile, behind the standard y/n
+	// confirmation modal - the TUI equivalent of `lmm purge`. Capital "X"
+	// (distinct from lowercase "x"/Uninstall) since purge acts on the WHOLE
+	// profile, not the selected mod.
+	Purge key.Binding
 }
 
 // DefaultKeyMap returns the shared key bindings shown in help and used by tests.
@@ -181,6 +188,10 @@ func DefaultKeyMap() KeyMap {
 		DeleteProfile: key.NewBinding(
 			key.WithKeys("d"),
 			key.WithHelp("d", "delete profile"),
+		),
+		Purge: key.NewBinding(
+			key.WithKeys("X"),
+			key.WithHelp("X", "purge"),
 		),
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -52,6 +52,15 @@ type KeyMap struct {
 	// selected, opening a notify/auto/pin picker whose selection dispatches
 	// immediately (no separate confirm modal).
 	Policy key.Binding
+	// CreateProfile and DeleteProfile are Task 6's Profiles-screen bindings
+	// (see mutations.go's createProfilePrompt/deleteSelectedProfile).
+	// CreateProfile opens the "new profile" input modal, whose submit
+	// dispatches immediately (no separate confirm modal - mirroring Policy's
+	// own "the choice IS the confirmation" shape). DeleteProfile opens the
+	// standard y/n confirmation modal for a non-active row, or refuses
+	// synchronously on the status line for the active one.
+	CreateProfile key.Binding
+	DeleteProfile key.Binding
 }
 
 // DefaultKeyMap returns the shared key bindings shown in help and used by tests.
@@ -164,6 +173,14 @@ func DefaultKeyMap() KeyMap {
 		Policy: key.NewBinding(
 			key.WithKeys("P"),
 			key.WithHelp("P", "policy"),
+		),
+		CreateProfile: key.NewBinding(
+			key.WithKeys("c"),
+			key.WithHelp("c", "new profile"),
+		),
+		DeleteProfile: key.NewBinding(
+			key.WithKeys("d"),
+			key.WithHelp("d", "delete profile"),
 		),
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -41,6 +41,12 @@ type KeyMap struct {
 	// mutations.go's checkForUpdates): fires on ScreenDashboard and
 	// ScreenInstalledMods.
 	CheckUpdates key.Binding
+	// Files is Task 4's deployed-files-overlay binding (see mutations.go's
+	// showDeployedFiles): fires on ScreenInstalledMods with a mod selected.
+	// "f" is overloaded - overlay.go's updateOverlayKey also matches a plain
+	// "f" to CLOSE the overlay once open, so this key doubles as an open/
+	// close toggle.
+	Files key.Binding
 }
 
 // DefaultKeyMap returns the shared key bindings shown in help and used by tests.
@@ -145,6 +151,10 @@ func DefaultKeyMap() KeyMap {
 		CheckUpdates: key.NewBinding(
 			key.WithKeys("u"),
 			key.WithHelp("u", "check for updates"),
+		),
+		Files: key.NewBinding(
+			key.WithKeys("f"),
+			key.WithHelp("f", "files"),
 		),
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -68,6 +68,13 @@ type KeyMap struct {
 	// (distinct from lowercase "x"/Uninstall) since purge acts on the WHOLE
 	// profile, not the selected mod.
 	Purge key.Binding
+	// GameSwitch is Task 8's in-TUI game switcher binding (see mutations.go's
+	// openGameSwitcher): fires on ANY screen (unlike every other mutation
+	// binding above, which is scoped to specific screens), opening a picker
+	// of every configured game with the active one marked - picking one
+	// dispatches immediately (no separate confirm modal, mirroring Policy's
+	// own "the choice IS the confirmation" shape).
+	GameSwitch key.Binding
 }
 
 // DefaultKeyMap returns the shared key bindings shown in help and used by tests.
@@ -192,6 +199,10 @@ func DefaultKeyMap() KeyMap {
 		Purge: key.NewBinding(
 			key.WithKeys("X"),
 			key.WithHelp("X", "purge"),
+		),
+		GameSwitch: key.NewBinding(
+			key.WithKeys("g"),
+			key.WithHelp("g", "game"),
 		),
 	}
 }

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -874,3 +874,120 @@ func applyUpdatesSequentially(ctx context.Context, actions ActionProvider, updat
 		Warnings: warnings,
 	}, nil
 }
+
+// --- Profile create/delete ('c'/'d' on Profiles) ---
+
+// profileCreateSubmittedMsg carries the name the user typed and confirmed in
+// the "new profile" input modal (see createProfilePrompt), routed through
+// Update() to resolveProfileCreate exactly like policyChosenMsg is routed to
+// resolvePolicyChoice - and for the identical reason (see policyChosenMsg's
+// own doc comment, which this mirrors in full): pendingInput's submit
+// closure has signature `func(value string) tea.Cmd` (input_modal.go), so it
+// cannot hand back a mutated Model itself - it can only return a Cmd that,
+// on the next tick, delivers this message to Update(), which runs the
+// actual buildAction call against the LIVE model. This message type is the
+// corrected mechanic for Task 6: the brief's own text describes create's
+// submit as running buildAction directly inside the modal closure, which
+// Task 5 already proved cannot work - see policyChosenMsg's doc comment for
+// the full explanation of why (stranded Model writes, a permanently wedged
+// single-flight guard on a refused buildAction).
+type profileCreateSubmittedMsg struct {
+	name string
+}
+
+// createProfilePrompt handles 'c' on Profiles (task-6-brief.md's profile
+// create flow): a no-op on the wrong screen or with no ActionProvider
+// configured - mirrors editSelectedModPolicy/uninstallSelectedMod's own
+// guard shape, minus a selection requirement, since creating a profile needs
+// no row selected. Opens the input modal with validate rejecting only an
+// EXACT (case-sensitive) match against a name already in m.profiles - the
+// input modal's own "name required" handling already covers the empty case
+// (see pendingInput's doc comment), so validate here never needs to.
+// submit dispatches profileCreateSubmittedMsg on the next tick rather than
+// calling buildAction directly - see that message's own doc comment for why.
+func (m Model) createProfilePrompt() (Model, tea.Cmd) {
+	if m.screen != ScreenProfiles || m.actions == nil {
+		return m, nil
+	}
+
+	existing := make(map[string]bool, len(m.profiles))
+	for _, p := range m.profiles {
+		existing[p.Name] = true
+	}
+
+	input := newInputModalTextInput("profile name", m.availableWidth(), m.theme.Panel.GetHorizontalFrameSize())
+	pi := pendingInput{
+		title: "new profile",
+		input: input,
+		validate: func(value string) string {
+			if existing[value] {
+				return "profile already exists"
+			}
+			return ""
+		},
+		submit: func(value string) tea.Cmd {
+			return func() tea.Msg { return profileCreateSubmittedMsg{name: value} }
+		},
+	}
+	return m.promptInput(pi), nil
+}
+
+// resolveProfileCreate handles a profileCreateSubmittedMsg: dispatches
+// actionCreateProfile and confirms immediately - the modal's own submit WAS
+// the user's confirmation (task-6-brief.md: no second confirm gate),
+// mirroring resolvePolicyChoice's identical "no pendingAction, set running
+// directly" shape. The single-flight guard is checked HERE, not left to
+// buildAction's own guard, for the exact reason resolvePolicyChoice's doc
+// comment gives: the window between promptInput's submit clearing the modal
+// (running still false) and this resolution running is real, and relying on
+// buildAction's own refusal alone would leave this method setting
+// running=true below for an action that never actually started, sticking
+// the single-flight guard with nothing to ever clear it.
+func (m Model) resolveProfileCreate(msg profileCreateSubmittedMsg) (Model, tea.Cmd) {
+	if m.action.running || m.action.pending != nil {
+		return m, nil
+	}
+	name := msg.name
+	actions := m.actions
+	title := fmt.Sprintf("Create profile %q?", name)
+	model, pa := m.buildAction(actionCreateProfile, title, nil, "", func(ctx context.Context, _ func(ActionProgress)) (ActionOutcome, error) {
+		return actions.CreateProfile(ctx, name)
+	})
+	model.action.running = true
+	return model, pa.confirm()
+}
+
+// deleteSelectedProfile handles 'd' on Profiles (task-6-brief.md's profile
+// delete flow): a no-op on the wrong screen, an empty list, or with no
+// ActionProvider configured - mirrors switchSelectedProfile's guard/
+// selection shape. The active profile is refused SYNCHRONOUSLY, on the
+// status line, with no modal at all: deleting the profile the session is
+// currently on would leave the TUI's own state (and a real coreProvider's
+// currentProfile) pointing at a profile that no longer exists, so this is
+// checked before ever building a confirmation - the ActionProvider's own
+// DeleteProfile repeats the same guard defense-in-depth (see its doc
+// comment), but the TUI-level check is what keeps this a clean status-line
+// refusal instead of a modal the user could still confirm into an error.
+func (m Model) deleteSelectedProfile() (Model, tea.Cmd) {
+	if m.screen != ScreenProfiles || m.actions == nil {
+		return m, nil
+	}
+	idx := m.selected[ScreenProfiles]
+	if idx < 0 || idx >= len(m.profiles) {
+		return m, nil
+	}
+	profile := m.profiles[idx]
+	if profile.Active {
+		m.action.status = singleLine(errCannotDeleteActiveProfile)
+		m.action.statusIsError = true
+		return m, nil
+	}
+
+	title := fmt.Sprintf("Delete profile %q?", profile.Name)
+	detail := []string{"mods keep their install records; only the profile list is removed"}
+	name := profile.Name
+	model, pa := m.buildAction(actionDeleteProfile, title, detail, "", func(ctx context.Context, _ func(ActionProgress)) (ActionOutcome, error) {
+		return m.actions.DeleteProfile(ctx, name)
+	})
+	return model.promptAction(pa), nil
+}

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -1216,6 +1216,15 @@ func (m Model) resolveGameSwitch(msg gameChosenMsg) (Model, tea.Cmd) {
 	// receiver captures the new gen and its own message still applies.
 	m.loadGen++
 
+	// Modals are session state too: type-ahead in the pick→resolution window
+	// can open one (e.g. 'c' → the "new profile" input modal, whose validate
+	// closure captured the OLD game's profile list) before this deferred
+	// message resolves - left standing, it would operate over the reset
+	// state below while bound to the new game's providers.
+	m.picker = nil
+	m.inputModal = nil
+	m.overlay = nil
+
 	m.summary = Summary{Updates: -1, Conflicts: -1}
 	m.mods = nil
 	m.profiles = nil

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -1104,7 +1104,16 @@ func (m Model) openGameSwitcher() (Model, tea.Cmd) {
 		m.action.statusIsError = true
 		return m, nil
 	}
-	if len(games) <= 1 {
+	// Zero games is unreachable via coreProvider (its session is always
+	// bound to a configured game, so ListGames returns at least that one),
+	// but a message claiming "only one" when there are NONE would lie -
+	// guarded separately (review finding).
+	if len(games) == 0 {
+		m.action.status = "no games configured"
+		m.action.statusIsError = false
+		return m, nil
+	}
+	if len(games) == 1 {
 		m.action.status = "only one game configured"
 		m.action.statusIsError = false
 		return m, nil
@@ -1197,6 +1206,15 @@ func (m Model) resolveGameSwitch(msg gameChosenMsg) (Model, tea.Cmd) {
 	}
 	m.search.gen++
 	m.search.state = searchIdle
+
+	// Invalidate any in-flight DATA load the same way (see Model.loadGen's
+	// doc comment, app.go): a load dispatched before this reset was reading
+	// the OLD game's binding - without the bump, its message could land
+	// after this reset (even after the fresh load below) and repopulate the
+	// old game's rows while the providers are already bound to the new one.
+	// Bumped before the m.loadData return below, so the fresh load's value
+	// receiver captures the new gen and its own message still applies.
+	m.loadGen++
 
 	m.summary = Summary{Updates: -1, Conflicts: -1}
 	m.mods = nil

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -119,6 +119,52 @@ func (m Model) deployActiveProfile() (Model, tea.Cmd) {
 	return model.promptAction(pa), nil
 }
 
+// --- Deployed files ('f' on Installed Mods) ---
+
+// showDeployedFiles handles 'f' on Installed Mods (task-4-brief.md): opens a
+// read-only overlay listing the selected mod's deployed file paths. A no-op
+// on the wrong screen, an empty list, or with no DataProvider configured -
+// mirrors uninstallSelectedMod's guard/selection shape, using m.provider
+// instead of m.actions since this is a read, not a mutation.
+//
+// Unlike every other handler in this file, the DeployedFiles call below is
+// made SYNCHRONOUSLY rather than dispatched as an async tea.Cmd: it's a
+// local DB read (coreProvider.DeployedFiles, service_core.go), not a network
+// call, so the async-dispatch discipline installSelectedSearchResult/
+// switchSelectedProfile/checkForUpdates follow (status line + tea.Cmd +
+// staleness-checked result message) doesn't apply here - this is the one
+// documented exception.
+//
+// No extra single-flight/other-modal guard is needed here: updateKey only
+// ever reaches the outer switch this is dispatched from when
+// m.action.pending, m.picker, m.inputModal, and m.overlay are ALL already
+// nil, so promptOverlay's own guard (overlay.go) can never actually refuse
+// on this path - it's kept anyway for defense-in-depth, exactly like every
+// other promptX call in this file.
+func (m Model) showDeployedFiles() (tea.Model, tea.Cmd) {
+	if m.screen != ScreenInstalledMods || m.provider == nil {
+		return m, nil
+	}
+	item, ok := m.selectedMod()
+	if !ok {
+		return m, nil
+	}
+
+	files, err := m.provider.DeployedFiles(item.Source, item.ID)
+	if err != nil {
+		m.action.status = singleLine(err.Error())
+		m.action.statusIsError = true
+		return m, nil
+	}
+
+	lines := files
+	if len(lines) == 0 {
+		lines = []string{"no files deployed"}
+	}
+	m = m.promptOverlay(infoOverlay{title: fmt.Sprintf("Files — %s", item.Name), lines: lines})
+	return m, nil
+}
+
 // planResultMsg carries a successful PlanProfileSwitch result, tagged with
 // the generation established when the fetch was dispatched (see
 // switchSelectedProfile) so a superseded result can be discarded exactly

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -991,3 +991,52 @@ func (m Model) deleteSelectedProfile() (Model, tea.Cmd) {
 	})
 	return model.promptAction(pa), nil
 }
+
+// --- Purge ('X' on Dashboard and Installed Mods) ---
+
+// purgeProfilePrompt handles 'X' on Dashboard/Installed Mods (task-7-brief.md's
+// purge flow): a no-op on the wrong screen or with no ActionProvider
+// configured - mirrors deployActiveProfile's guard shape (both fire on the
+// same two screens, and neither depends on a row selection - purging, like
+// deploying, acts on the WHOLE active profile, not a single mod).
+//
+// An empty m.mods resolves SYNCHRONOUSLY to a status-line message with no
+// modal, unlike deployActiveProfile (which lets a zero-enabled-mods deploy
+// through as a valid, if unusual, outcome the provider itself reports):
+// purging zero installed mods has nothing to confirm and nothing for the
+// provider to do - coreProvider.PurgeProfile short-circuits identically
+// (see its own doc comment in service_core.go) - so this mirrors that
+// provider-side short-circuit at the TUI layer too, sparing a pointless
+// confirm-then-no-op round trip. statusIsError is explicitly false: this is
+// a benign "nothing to do" outcome, not a refusal (contrast
+// deleteSelectedProfile's active-profile guard, which IS an error).
+//
+// The modal title names the game (task-7-brief.md's own example: "Purge 3
+// mod(s) from <Game>?"): m.summary.GameName is already populated by the
+// same Overview call that fills m.mods (see coreProvider.Overview), so it's
+// cheaply available here exactly like deployActiveProfile's own detail
+// lines already assume. detail lists every mod's name - the existing
+// confirmation-modal "+N more" overflow cap (actionModalView,
+// actionModalMaxDetailLines) handles a long list without this needing to
+// truncate itself.
+func (m Model) purgeProfilePrompt() (Model, tea.Cmd) {
+	if (m.screen != ScreenDashboard && m.screen != ScreenInstalledMods) || m.actions == nil {
+		return m, nil
+	}
+	if len(m.mods) == 0 {
+		m.action.status = "no mods installed"
+		m.action.statusIsError = false
+		return m, nil
+	}
+
+	detail := make([]string, 0, len(m.mods))
+	for _, mod := range m.mods {
+		detail = append(detail, mod.Name)
+	}
+
+	title := fmt.Sprintf("Purge %d mod(s) from %s?", len(m.mods), m.summary.GameName)
+	model, pa := m.buildAction(actionPurge, title, detail, "", func(ctx context.Context, progress func(ActionProgress)) (ActionOutcome, error) {
+		return m.actions.PurgeProfile(ctx, progress)
+	})
+	return model.promptAction(pa), nil
+}

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -165,6 +165,116 @@ func (m Model) showDeployedFiles() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// --- Update policy ('P' on Installed Mods) ---
+
+// updatePolicyOptions is the fixed notify/auto/pin option order the policy
+// picker always shows (task-5-brief.md's Keybindings section), independent
+// of the selected mod's actual current policy - which only decides which
+// option starts pre-selected and marked "current" (see
+// editSelectedModPolicy).
+var updatePolicyOptions = []string{"notify", "auto", "pin"}
+
+// policyChosenMsg carries the option the user picked in the update-policy
+// picker (see editSelectedModPolicy), naming both the ModItem the picker was
+// opened for and the chosen policy string.
+//
+// Unlike planResultMsg/installPlanResultMsg/checkUpdatesResultMsg below
+// (which resolve an ASYNC network fetch dispatched earlier, tagged with a
+// gen for staleness), this message exists purely so the actual buildAction
+// call - which must run against the LIVE Model, not a value captured by the
+// picker's own choose closure - happens from inside Update(), the same way
+// updatePendingActionKey's ConfirmAction branch runs buildAction's result
+// against the live model when the user presses y/enter. Bubble Tea models
+// are values: a closure built when editSelectedModPolicy opened the picker
+// closes over the Model as it was AT THAT MOMENT, but pendingPicker.choose's
+// signature is `func(idx int) tea.Cmd` - it cannot hand back a mutated
+// Model, only a Cmd. If buildAction ran directly inside that closure, the
+// gen/cancel/progressCh bookkeeping it computes would be stamped onto a
+// Model copy nothing ever adopts, while choosePickerOption (picker.go)
+// separately returns the UNMODIFIED live model (with only .picker cleared)
+// as the new current Model - so the eventual actionDoneMsg's gen would never
+// match live m.action.gen and would be silently discarded as stale. Routing
+// through this message instead means choose's Cmd carries no I/O at all: it
+// fires on the very next Bubble Tea tick, and resolvePolicyChoice - which
+// DOES receive the live Model as its method receiver - does the actual
+// buildAction call there, exactly like the confirm-modal path does.
+type policyChosenMsg struct {
+	item   ModItem
+	policy string
+}
+
+// editSelectedModPolicy handles 'P' on Installed Mods (task-5-brief.md's
+// update-policy flow): a no-op on the wrong screen, an empty list, or with
+// no ActionProvider configured - mirrors uninstallSelectedMod/
+// showDeployedFiles' guard/selection shape. Opens a 3-option (notify/auto/
+// pin) picker with the selected mod's CURRENT policy (item.UpdatePolicy -
+// populated by coreProvider's Overview mapping / prototypeProvider's canned
+// data, see ModItem's doc comment) pre-selected and labeled "current"; a
+// mod whose UpdatePolicy doesn't match any of the three options (e.g. the
+// zero value "") simply leaves the picker on its default selection (index
+// 0, "notify") with no option marked "current" - it never guesses.
+//
+// Picking an option dispatches the action immediately - task-5-brief.md: "no
+// second confirm gate, the pick IS the confirmation" - via policyChosenMsg/
+// resolvePolicyChoice; see policyChosenMsg's own doc comment for why that
+// indirection is required rather than calling buildAction directly inside
+// choose.
+func (m Model) editSelectedModPolicy() (Model, tea.Cmd) {
+	if m.screen != ScreenInstalledMods || m.actions == nil {
+		return m, nil
+	}
+	item, ok := m.selectedMod()
+	if !ok {
+		return m, nil
+	}
+
+	options := make([]pickerOption, len(updatePolicyOptions))
+	selected := 0
+	for i, policy := range updatePolicyOptions {
+		options[i] = pickerOption{Label: policy}
+		if policy == item.UpdatePolicy {
+			options[i].Note = "current"
+			selected = i
+		}
+	}
+
+	picker := pendingPicker{
+		title:    fmt.Sprintf("Update policy — %s", item.Name),
+		options:  options,
+		selected: selected,
+		choose: func(idx int) tea.Cmd {
+			policy := updatePolicyOptions[idx]
+			return func() tea.Msg { return policyChosenMsg{item: item, policy: policy} }
+		},
+	}
+	return m.promptPicker(picker), nil
+}
+
+// resolvePolicyChoice handles a policyChosenMsg: builds the actionSetPolicy
+// action for msg.item/msg.policy and confirms it immediately, mirroring
+// updatePendingActionKey's ConfirmAction branch (actions.go) - buildAction
+// runs here, against m (this method's receiver, the CURRENT live Model), so
+// its gen/cancel/progressCh bookkeeping stays consistent with whatever
+// actionDoneMsg/actionProgressMsg eventually arrives (see policyChosenMsg's
+// doc comment for why this can't happen inside the picker's choose closure
+// itself). No pendingAction/confirmation modal is ever shown - the picker
+// selection already WAS the user's confirmation (task-5-brief.md) - so this
+// sets action.running directly instead of calling promptAction.
+// buildAction's own single-flight guard (running/pending) still applies
+// defensively, on the vanishingly unlikely chance something else started an
+// action in the gap between the picker closing and this message arriving.
+func (m Model) resolvePolicyChoice(msg policyChosenMsg) (Model, tea.Cmd) {
+	item := msg.item
+	policy := msg.policy
+	title := fmt.Sprintf("Update policy — %s", item.Name)
+	actions := m.actions
+	model, pa := m.buildAction(actionSetPolicy, title, nil, "", func(ctx context.Context, _ func(ActionProgress)) (ActionOutcome, error) {
+		return actions.SetUpdatePolicy(ctx, item, policy)
+	})
+	model.action.running = true
+	return model, pa.confirm()
+}
+
 // planResultMsg carries a successful PlanProfileSwitch result, tagged with
 // the generation established when the fetch was dispatched (see
 // switchSelectedProfile) so a superseded result can be discarded exactly

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -1040,3 +1040,175 @@ func (m Model) purgeProfilePrompt() (Model, tea.Cmd) {
 	})
 	return model.promptAction(pa), nil
 }
+
+// --- Game switch ('g' from any screen) ---
+
+// gameChosenMsg carries the game ID the user picked in the game-switcher
+// picker (see openGameSwitcher), routed through Update() to
+// resolveGameSwitch exactly like policyChosenMsg/profileCreateSubmittedMsg
+// are routed to their own resolvers - and for the identical reason (see
+// policyChosenMsg's own doc comment for the full explanation): the picker's
+// choose closure (pendingPicker.choose, picker.go) can only return a
+// tea.Cmd, never a mutated Model, so the actual rebind-and-reset must run
+// inside Update(), against the LIVE model, not a Model captured when the
+// picker was built.
+//
+// Unlike policyChosenMsg/profileCreateSubmittedMsg, a game switch is NOT a
+// buildAction-built ActionProvider mutation at all - see resolveGameSwitch's
+// own doc comment - so this message carries only the chosen id, nothing
+// else buildAction's machinery would need.
+type gameChosenMsg struct{ id string }
+
+// openGameSwitcher handles 'g' from ANY screen (task-8-brief.md's in-TUI
+// game switcher): unlike every other mutation handler in this file, it has
+// no screen guard at all - switching games is meaningful regardless of
+// which screen the user is currently looking at.
+//
+// A running action refuses synchronously, on the status line ("action in
+// progress"), BEFORE promptPicker is ever called: promptPicker's own guard
+// (picker.go) already refuses while running/pending/a picker is already up,
+// but it does so SILENTLY (a plain no-op) - task-8-brief.md's own test
+// (TestGameSwitchBlockedWhileActionRunning) requires an explicit status
+// message here, mirroring switchSelectedProfile/checkForUpdates/
+// installSelectedSearchResult's own explicit single-flight checks elsewhere
+// in this file (rather than leaning on buildAction/promptAction's silent
+// refusal the way editSelectedModPolicy/createProfilePrompt do - those are
+// followed by a picker/input modal whose OWN "no second confirm needed"
+// framing makes a silent refusal acceptable; a "why did nothing happen"
+// keypress on ANY screen deserves better here).
+//
+// The inputModal/overlay check below is defense-in-depth, not a reachable
+// guard: updateKey (app.go) only ever reaches the outer switch this is
+// dispatched from when m.action.pending, m.picker, m.inputModal, AND
+// m.overlay are all already nil - mirroring showDeployedFiles' own doc
+// comment on the identical situation for that handler. It's kept anyway,
+// same as every other promptX call in this file, in case that call-site
+// invariant is ever weakened.
+func (m Model) openGameSwitcher() (Model, tea.Cmd) {
+	if m.action.running {
+		m.action.status = "action in progress"
+		m.action.statusIsError = true
+		return m, nil
+	}
+	if m.inputModal != nil || m.overlay != nil {
+		return m, nil
+	}
+
+	// Synchronous, mirroring showDeployedFiles' documented exception
+	// (this file's own doc comment on that method): ListGames is a local
+	// games.yaml/config read, not network I/O, for both coreProvider and
+	// prototypeProvider.
+	games, err := m.provider.ListGames()
+	if err != nil {
+		m.action.status = singleLine(err.Error())
+		m.action.statusIsError = true
+		return m, nil
+	}
+	if len(games) <= 1 {
+		m.action.status = "only one game configured"
+		m.action.statusIsError = false
+		return m, nil
+	}
+
+	options := make([]pickerOption, len(games))
+	ids := make([]string, len(games))
+	selected := 0
+	activeID := ""
+	for i, g := range games {
+		options[i] = pickerOption{Label: g.Name}
+		ids[i] = g.ID
+		if g.Active {
+			options[i].Note = "active"
+			selected = i
+			activeID = g.ID
+		}
+	}
+
+	picker := pendingPicker{
+		title:    "switch game",
+		options:  options,
+		selected: selected,
+		// Choosing the already-active game is a no-op: returning a nil
+		// tea.Cmd here means choosePickerOption (picker.go) just clears the
+		// picker and dispatches nothing - no gameChosenMsg is ever produced,
+		// so resolveGameSwitch never runs, matching
+		// TestGameSwitchSameGameIsNoop's "no SetGame calls, no reset"
+		// expectation without needing its own guard in resolveGameSwitch.
+		choose: func(idx int) tea.Cmd {
+			id := ids[idx]
+			if id == activeID {
+				return nil
+			}
+			return func() tea.Msg { return gameChosenMsg{id: id} }
+		},
+	}
+	return m.promptPicker(picker), nil
+}
+
+// resolveGameSwitch handles a gameChosenMsg: guards single-flight
+// (running/pending), mirroring resolvePolicyChoice/resolveProfileCreate's
+// own "the window between the pick and this resolution is real" reasoning
+// (see either's doc comment in full) - a second 'g' press in that window
+// opens a second picker, and a mutation key opens a confirm modal.
+//
+// Unlike every OTHER resolve* handler in this file, this is not a
+// buildAction-built ActionProvider mutation at all: switching games is a
+// direct, synchronous Model rebind (task-8-brief.md's own framing) - no
+// confirm modal, no progress stream, no actionDoneMsg round trip. rebindGame
+// (actions.go) rebinds every provider/actions instance that supports it; an
+// error there (e.g. coreProvider.SetGame's own unknown-id guard, unreachable
+// in practice since msg.id always comes from a ListGames-derived option,
+// but checked anyway) renders on the status line and leaves every other
+// piece of session state completely untouched - nothing about the OLD
+// game's data is wrong just because the rebind itself failed.
+//
+// A successful rebind resets the session's data-derived state to the exact
+// shape Init()/NewModel's zero state uses, mirroring actionDoneMsg's own
+// switchedTo handling in app.go (the profile-switch analog of this reset,
+// one layer down):
+//   - any in-flight search is cancelled and its generation bumped (a search
+//     built against the OLD game's sources/installed-marks is meaningless
+//     for the new one - mirrors actionDoneMsg's identical search-cancel)
+//   - summary/mods/profiles revert to "nothing loaded yet"; every screen's
+//     selection zeroes (a stale selected row surviving into totally
+//     different data is exactly the class of bug clampSelections exists to
+//     prevent elsewhere, but the OLD list is about to be replaced wholesale
+//     here, not just resized, so this resets rather than clamps)
+//   - sources/search.sources re-seed from the NEW game's SourceInfos()/
+//     Sources() - a different game can have an entirely different set of
+//     configured/registered sources
+//
+// state = stateLoading + returning m.loadData re-fetches Overview/Profiles
+// for the new game, mirroring Init()'s own first-load shape exactly.
+func (m Model) resolveGameSwitch(msg gameChosenMsg) (Model, tea.Cmd) {
+	if m.action.running || m.action.pending != nil {
+		return m, nil
+	}
+
+	if err := m.rebindGame(msg.id); err != nil {
+		m.action.status = singleLine(err.Error())
+		m.action.statusIsError = true
+		return m, nil
+	}
+
+	if m.search.cancel != nil {
+		m.search.cancel()
+		m.search.cancel = nil
+	}
+	m.search.gen++
+	m.search.state = searchIdle
+
+	m.summary = Summary{Updates: -1, Conflicts: -1}
+	m.mods = nil
+	m.profiles = nil
+	for screen := range m.selected {
+		m.selected[screen] = 0
+	}
+
+	m.sources = m.provider.SourceInfos()
+	m.search.sources = append([]string{""}, m.provider.Sources()...)
+	m.search.sourceIdx = 0
+
+	m.state = stateLoading
+	return m, m.loadData
+}

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -260,10 +260,21 @@ func (m Model) editSelectedModPolicy() (Model, tea.Cmd) {
 // itself). No pendingAction/confirmation modal is ever shown - the picker
 // selection already WAS the user's confirmation (task-5-brief.md) - so this
 // sets action.running directly instead of calling promptAction.
-// buildAction's own single-flight guard (running/pending) still applies
-// defensively, on the vanishingly unlikely chance something else started an
-// action in the gap between the picker closing and this message arriving.
+// Single-flight is checked HERE, not left to buildAction's own guard: a
+// policyChosenMsg is an in-flight message, and the window between the pick
+// (picker cleared, running still false) and this resolution is real - a
+// second 'P' press there opens a second picker and yields a second
+// policyChosenMsg, and a 'D' press opens a confirm modal. A message
+// arriving while an action is already running or a confirmation is already
+// pending is dropped entirely - mirroring the stale-gen discards the
+// resolve* family's callers perform (app.go) - because relying on
+// buildAction's refusal alone would leave this method setting
+// running=true below for an action that never actually started, sticking
+// the single-flight guard with nothing to ever clear it.
 func (m Model) resolvePolicyChoice(msg policyChosenMsg) (Model, tea.Cmd) {
+	if m.action.running || m.action.pending != nil {
+		return m, nil
+	}
 	item := msg.item
 	policy := msg.policy
 	title := fmt.Sprintf("Update policy — %s", item.Name)

--- a/internal/tui/mutations_test.go
+++ b/internal/tui/mutations_test.go
@@ -2505,3 +2505,109 @@ func TestFooterHintNamesCheckUpdatesAction(t *testing.T) {
 
 	require.Contains(t, view, "u: check updates")
 }
+
+// --- Deployed files ('f' on Installed Mods) ---
+
+// modelWithProvider builds a fully-loaded Model (data ready) backed by the
+// given DataProvider and no ActionProvider - mirrors modelWithActions'
+// shape but for tests exercising a read-only DataProvider seam (showDeployedFiles
+// only needs m.provider, never m.actions).
+func modelWithProvider(t *testing.T, provider DataProvider) Model {
+	t.Helper()
+	model, err := NewModel(Options{Theme: "wizardry", Provider: provider})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	return loaded.(Model)
+}
+
+// TestFilesKeyOpensOverlayWithDeployedFiles covers the happy path against
+// the prototype provider (real, non-empty canned DeployedFiles rows for a
+// known installed mod - see prototypeProvider.DeployedFiles): 'f' on row 0
+// opens the overlay with a title naming the mod and a non-empty file list.
+func TestFilesKeyOpensOverlayWithDeployedFiles(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+	name := model.mods[0].Name
+
+	updated, cmd := model.Update(keyRunes("f"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.overlay)
+	require.Contains(t, model.overlay.title, name)
+	require.NotEmpty(t, model.overlay.lines)
+}
+
+// TestFilesKeyEmptyStateMessage covers a mod with nothing currently
+// deployed: DeployedFiles' documented empty-but-no-error contract (an empty
+// slice, nil error - see DataProvider.DeployedFiles' doc comment) renders as
+// a single explanatory line, never a blank overlay.
+func TestFilesKeyEmptyStateMessage(t *testing.T) {
+	t.Parallel()
+
+	provider := recordingProvider{delegate: NewPrototypeProvider()}
+	model := modelWithProvider(t, provider)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+
+	updated, cmd := model.Update(keyRunes("f"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.overlay)
+	require.Equal(t, []string{"no files deployed"}, model.overlay.lines)
+}
+
+// TestFilesKeyIgnoredOnOtherScreens proves 'f' only fires on Installed Mods.
+func TestFilesKeyIgnoredOnOtherScreens(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.screen = ScreenDashboard
+
+	updated, cmd := model.Update(keyRunes("f"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.overlay)
+}
+
+// TestFilesKeySwallowedByFocusedSearchInput proves 'f' types into the search
+// box instead of opening the overlay while ScreenSearch is focused - the
+// existing focused-input swallow branch (updateKey, app.go) runs before the
+// mutation-key switch this is dispatched from, so this is inertness by
+// construction, matching every other single-letter mutation key's own test
+// of the same guard (e.g. TestToggleEnableKeyInertWhileSearchFocused).
+func TestFilesKeySwallowedByFocusedSearchInput(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	updated := updateWithRunes(t, model, "3") // jump to search, focused
+	updated = updateWithRunes(t, updated, "f")
+
+	require.True(t, updated.search.input.Focused())
+	require.Contains(t, updated.search.input.Value(), "f")
+	require.Nil(t, updated.overlay)
+}
+
+// TestFilesKeyErrorGoesToStatusLine covers a DeployedFiles failure (e.g. a
+// DB read error): the status line renders the error and statusIsError
+// flips, mirroring every other synchronous/async failure path's rendering
+// (singleLine(err.Error()) + statusIsError = true - see resolvePlanFailure/
+// resolveInstallPlanFailure/resolveCheckUpdatesFailure for the async
+// precedent this mirrors) - no overlay opens.
+func TestFilesKeyErrorGoesToStatusLine(t *testing.T) {
+	t.Parallel()
+
+	provider := recordingProvider{delegate: NewPrototypeProvider(), DeployedFilesErr: errors.New("db read failed")}
+	model := modelWithProvider(t, provider)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+
+	updated, cmd := model.Update(keyRunes("f"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.overlay)
+	require.True(t, model.action.statusIsError)
+	require.Equal(t, singleLine("db read failed"), model.action.status)
+}

--- a/internal/tui/mutations_test.go
+++ b/internal/tui/mutations_test.go
@@ -937,6 +937,7 @@ func (f *fakeSwitchableProvider) Search(context.Context, string, string, int) (S
 }
 
 func (f *fakeSwitchableProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
+func (f *fakeSwitchableProvider) ListGames() ([]GameInfo, error)                 { return nil, nil }
 
 func (f *fakeSwitchableProvider) Profiles(context.Context) ([]ProfileItem, error) {
 	items := make([]ProfileItem, 0, len(f.names))
@@ -1037,8 +1038,15 @@ func TestStaleSwitchDoneMsgNeverRebindsProfile(t *testing.T) {
 // fakeSwitchableProvider since this test needs a real Sources() list (so
 // startSearch doesn't hit the "no sources configured" guard) but no
 // profileRebinder behavior at all.
+// listGames/SetGameCalls are Task 8's addition, letting
+// TestGameSwitchCancelsInFlightSearchAndDiscardsLateResult below drive a
+// real game-switch picker choice through this same minimal double, mirroring
+// this type's existing profile-switch precedent (the test right above this
+// one) for the game-switch case.
 type searchCancelProvider struct {
-	capturedCtx context.Context
+	capturedCtx  context.Context
+	listGames    []GameInfo
+	SetGameCalls []string
 }
 
 func (p *searchCancelProvider) Overview(context.Context) (Summary, []ModItem, error) {
@@ -1052,6 +1060,13 @@ func (p *searchCancelProvider) Search(ctx context.Context, _, _ string, _ int) (
 	return SearchPage{Results: []ModItem{{ID: "x", Name: "X"}}}, nil
 }
 func (p *searchCancelProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
+func (p *searchCancelProvider) ListGames() ([]GameInfo, error)                 { return p.listGames, nil }
+
+// SetGame implements actions.go's optional gameRebinder hook.
+func (p *searchCancelProvider) SetGame(id string) error {
+	p.SetGameCalls = append(p.SetGameCalls, id)
+	return nil
+}
 
 // TestSwitchDoneCancelsInFlightSearchAndDiscardsLateResult guards Task 6
 // item b's second belt (the 5a review's UX-correctness recommendation,
@@ -2547,7 +2562,7 @@ func TestFilesKeyOpensOverlayWithDeployedFiles(t *testing.T) {
 func TestFilesKeyEmptyStateMessage(t *testing.T) {
 	t.Parallel()
 
-	provider := recordingProvider{delegate: NewPrototypeProvider()}
+	provider := &recordingProvider{delegate: NewPrototypeProvider()}
 	model := modelWithProvider(t, provider)
 	model.screen = ScreenInstalledMods
 	model.selected[ScreenInstalledMods] = 0
@@ -2599,7 +2614,7 @@ func TestFilesKeySwallowedByFocusedSearchInput(t *testing.T) {
 func TestFilesKeyErrorGoesToStatusLine(t *testing.T) {
 	t.Parallel()
 
-	provider := recordingProvider{delegate: NewPrototypeProvider(), DeployedFilesErr: errors.New("db read failed")}
+	provider := &recordingProvider{delegate: NewPrototypeProvider(), DeployedFilesErr: errors.New("db read failed")}
 	model := modelWithProvider(t, provider)
 	model.screen = ScreenInstalledMods
 	model.selected[ScreenInstalledMods] = 0

--- a/internal/tui/mutations_test.go
+++ b/internal/tui/mutations_test.go
@@ -936,6 +936,8 @@ func (f *fakeSwitchableProvider) Search(context.Context, string, string, int) (S
 	return SearchPage{}, nil
 }
 
+func (f *fakeSwitchableProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
+
 func (f *fakeSwitchableProvider) Profiles(context.Context) ([]ProfileItem, error) {
 	items := make([]ProfileItem, 0, len(f.names))
 	for _, name := range f.names {
@@ -1049,6 +1051,7 @@ func (p *searchCancelProvider) Search(ctx context.Context, _, _ string, _ int) (
 	p.capturedCtx = ctx
 	return SearchPage{Results: []ModItem{{ID: "x", Name: "X"}}}, nil
 }
+func (p *searchCancelProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
 
 // TestSwitchDoneCancelsInFlightSearchAndDiscardsLateResult guards Task 6
 // item b's second belt (the 5a review's UX-correctness recommendation,

--- a/internal/tui/mutations_test.go
+++ b/internal/tui/mutations_test.go
@@ -1116,13 +1116,20 @@ func TestSwitchDoneCancelsInFlightSearchAndDiscardsLateResult(t *testing.T) {
 func TestHelpOverlayDocumentsMutationKeysAndDropsStaleReadOnlyClaim(t *testing.T) {
 	t.Parallel()
 
-	model := sizedPrototypeModel(t, "wizardry", 120, 38)
+	// Height 60 keeps every help group uncapped (see
+	// TestViewFitsTerminalBoundsWithHelpVisible's helpBodyBudget note), so
+	// this doesn't depend on which screen's group happens to render first.
+	model := sizedPrototypeModel(t, "wizardry", 120, 60)
 	model = updateWithRunes(t, model, "?")
 	view := model.View()
 
+	// Task 9 restructured helpView into per-screen groups whose entries
+	// reuse each binding's own key.WithHelp copy from keys.go (helpEntry)
+	// instead of the old flat list's bespoke prose - so the wording here is
+	// terser than the pre-Task-9 assertions were.
 	require.Contains(t, view, "toggle enable/disable")
-	require.Contains(t, view, "uninstall selected mod")
-	require.Contains(t, view, "deploy active profile")
+	require.Contains(t, view, "uninstall")
+	require.Contains(t, view, "deploy profile")
 	require.Contains(t, view, "switch profile")
 	require.NotContains(t, view, "Browsing is read-only",
 		"the help copy must no longer claim the TUI is read-only now that mutations exist")
@@ -1834,11 +1841,16 @@ func TestPrototypeInstallPlanReinstallForSkyUI(t *testing.T) {
 func TestHelpOverlayDocumentsInstallKey(t *testing.T) {
 	t.Parallel()
 
-	model := sizedPrototypeModel(t, "wizardry", 160, 40)
+	// Height 60 keeps every help group uncapped, same as
+	// TestHelpOverlayDocumentsMutationKeysAndDropsStaleReadOnlyClaim - the
+	// "search" group (which documents Install) isn't promoted to the front
+	// on the default Dashboard screen, so it needs enough budget to render
+	// at all.
+	model := sizedPrototypeModel(t, "wizardry", 160, 60)
 	model = updateWithRunes(t, model, "?")
 	view := model.View()
 
-	require.Contains(t, view, "install the selected search result")
+	require.Contains(t, view, "install selected result")
 }
 
 func TestFooterHintNamesInstallAction(t *testing.T) {

--- a/internal/tui/overlay.go
+++ b/internal/tui/overlay.go
@@ -1,0 +1,102 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// infoOverlay is a caller-built description of a read-only info panel
+// awaiting dismissal, mirroring pendingPicker/pendingInput's role for their
+// own modals (see picker.go/input_modal.go) - simpler than either: there is
+// no choose/submit callback, since there's nothing for the user to choose
+// or submit, only to read and close. lines are plain display rows;
+// truncation happens at render time against the current width (see
+// overlayView), not here, matching every other modal's convention.
+type infoOverlay struct {
+	title string
+	lines []string
+}
+
+// promptOverlay shows o as the info overlay: this is the only method that
+// sets Model.overlay. Guarded like promptPicker/promptInput (single-flight):
+// while a confirmation modal, picker, input modal, or another overlay is
+// already up, the request is a no-op. Unlike promptPicker/promptInput, this
+// deliberately does NOT check m.action.running - the overlay is read-only,
+// so it's safe to open even while a mutation is still in flight.
+func (m Model) promptOverlay(o infoOverlay) Model {
+	if m.action.pending != nil || m.picker != nil || m.inputModal != nil || m.overlay != nil {
+		return m
+	}
+	m.overlay = &o
+	return m
+}
+
+// updateOverlayKey handles every key while the info overlay is shown: esc
+// (Blur) or a plain "f" closes it - two close keys because Task 4 also
+// binds "f" to OPEN the overlay from a list screen, and closing on the same
+// key it opened with is the expected toggle feel; quit keys still quit, via
+// isQuitKey (actions.go) - unlike updateInputModalKey, which matches only
+// "ctrl+c" so a plain "q" stays typeable in its text field, the overlay has
+// no text entry at all, so a plain "q" quitting (isQuitKey's ordinary,
+// non-focused-search-input behavior) matches every other list screen; every
+// other key is swallowed so nothing behind the overlay can react to it.
+func (m Model) updateOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case m.isQuitKey(msg):
+		return m.startQuit()
+	case key.Matches(msg, m.keys.Blur):
+		m.overlay = nil
+		return m, nil
+	case msg.String() == "f":
+		m.overlay = nil
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+
+// overlayView renders the pending info overlay as a bordered panel that
+// REPLACES the screen content, mirroring pickerView/inputModalView's
+// approach (see actionModalView's doc comment for why: it preserves the
+// exact-height render invariant every screen holds without an overlay
+// needing its own height bookkeeping). Unlike pickerView's scroll-follow-
+// selection option list, the overlay is read-only and, deliberately
+// (YAGNI - file lists are typically short), not scrollable: when o.lines
+// overflows the panel's budget, it is capped exactly like actionModalView's
+// detail lines - the first N-1 lines that fit, plus a dimmed "+N more" tail
+// line naming the overflow.
+func (m Model) overlayView() string {
+	width := m.availableWidth()
+	height := m.availableContentHeight()
+	panelContentWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
+	panelContentHeight := max(height-m.theme.Panel.GetVerticalBorderSize(), 1)
+
+	o := m.overlay
+	lines := []string{truncate(m.theme.PanelTitle.Render(o.title), panelContentWidth)}
+
+	// Fixed lines: title, blank separator, hint (3 total) - the same
+	// accounting pickerView/actionModalView use. Whatever vertical room
+	// remains is the budget for o.lines.
+	const fixedLines = 3
+	budget := max(panelContentHeight-fixedLines, 1)
+
+	if len(o.lines) > budget {
+		shown := max(budget-1, 0)
+		more := len(o.lines) - shown
+		for _, line := range o.lines[:shown] {
+			lines = append(lines, truncate(line, panelContentWidth))
+		}
+		lines = append(lines, m.theme.MutedText.Render(fmt.Sprintf("+%d more", more)))
+	} else {
+		for _, line := range o.lines {
+			lines = append(lines, truncate(line, panelContentWidth))
+		}
+	}
+
+	lines = append(lines, "", m.theme.MutedText.Render("esc close"))
+
+	return m.panelWithHeight(width, height).Render(strings.Join(lines, "\n"))
+}

--- a/internal/tui/overlay.go
+++ b/internal/tui/overlay.go
@@ -35,9 +35,12 @@ func (m Model) promptOverlay(o infoOverlay) Model {
 }
 
 // updateOverlayKey handles every key while the info overlay is shown: esc
-// (Blur) or a plain "f" closes it - two close keys because Task 4 also
-// binds "f" to OPEN the overlay from a list screen, and closing on the same
-// key it opened with is the expected toggle feel; quit keys still quit, via
+// (Blur) or the Files binding closes it - two close keys because Task 4
+// also binds Files ("f") to OPEN the overlay from a list screen, and
+// closing on the same key it opened with is the expected toggle feel; the
+// close side matches m.keys.Files rather than a hard-coded "f" (Copilot PR
+// #69 finding) so a custom KeyMap remapping Files can never desync the
+// toggle's open and close halves; quit keys still quit, via
 // isQuitKey (actions.go) - unlike updateInputModalKey, which matches only
 // "ctrl+c" so a plain "q" stays typeable in its text field, the overlay has
 // no text entry at all, so a plain "q" quitting (isQuitKey's ordinary,
@@ -55,7 +58,7 @@ func (m Model) updateOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Blur):
 		m.overlay = nil
 		return m, nil
-	case msg.String() == "f":
+	case key.Matches(msg, m.keys.Files):
 		m.overlay = nil
 		return m, nil
 	default:

--- a/internal/tui/overlay.go
+++ b/internal/tui/overlay.go
@@ -43,6 +43,11 @@ func (m Model) promptOverlay(o infoOverlay) Model {
 // no text entry at all, so a plain "q" quitting (isQuitKey's ordinary,
 // non-focused-search-input behavior) matches every other list screen; every
 // other key is swallowed so nothing behind the overlay can react to it.
+// Invariant this relies on: the overlay is only ever opened from Installed
+// Mods (Task 4's showDeployedFiles, mutations.go, guards on m.screen ==
+// ScreenInstalledMods) - the search input only ever focuses on ScreenSearch
+// (gotoScreenFocused) - so it can never be focused while the overlay is up,
+// meaning a plain "q" here always quits reliably, never types into a field.
 func (m Model) updateOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch {
 	case m.isQuitKey(msg):

--- a/internal/tui/overlay_test.go
+++ b/internal/tui/overlay_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
@@ -47,6 +48,31 @@ func TestOverlayFKeyCloses(t *testing.T) {
 	model = updateWithRunes(t, model, "f")
 
 	require.Nil(t, model.overlay)
+}
+
+// TestOverlayClosesOnRemappedFilesKey guards Copilot PR #69's finding on
+// updateOverlayKey: the close side used to hard-code msg.String() == "f"
+// while the OPEN side matches m.keys.Files - a custom KeyMap remapping
+// Files would desync the toggle (the new key opens, only the old literal
+// closes). Both sides must consult the same binding.
+func TestOverlayClosesOnRemappedFilesKey(t *testing.T) {
+	t.Parallel()
+
+	model := overlayTestModel(t)
+	model.keys.Files = key.NewBinding(key.WithKeys("F"), key.WithHelp("F", "files"))
+	model = model.promptOverlay(infoOverlay{
+		title: "Deployed Files",
+		lines: []string{"Data/SkyUI.esp"},
+	})
+	require.NotNil(t, model.overlay)
+
+	// The now-unbound old literal must NOT close it...
+	model = updateWithRunes(t, model, "f")
+	require.NotNil(t, model.overlay, "an unbound key must be swallowed, not treated as the Files toggle")
+
+	// ...and the remapped binding must.
+	model = updateWithRunes(t, model, "F")
+	require.Nil(t, model.overlay, "the remapped Files binding must close the overlay it opens")
 }
 
 // TestOverlayQuitKeyQuits locks in that, unlike the input modal (which must

--- a/internal/tui/overlay_test.go
+++ b/internal/tui/overlay_test.go
@@ -1,0 +1,120 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+// overlayTestModel builds a fully-loaded, sized prototype Model with no
+// pending action/picker/input modal/overlay - the common starting point for
+// every test below.
+func overlayTestModel(t *testing.T) Model {
+	t.Helper()
+	return sizedPrototypeModel(t, "wizardry", 100, 30)
+}
+
+func TestOverlayEscCloses(t *testing.T) {
+	t.Parallel()
+
+	model := overlayTestModel(t).promptOverlay(infoOverlay{
+		title: "Deployed Files",
+		lines: []string{"Data/SkyUI.esp"},
+	})
+	require.NotNil(t, model.overlay)
+
+	model = updateWithKeyType(t, model, tea.KeyEsc)
+
+	require.Nil(t, model.overlay)
+}
+
+// TestOverlayFKeyCloses locks in the second documented close key: unlike
+// esc (Blur), "f" is overlay-specific - it must also dismiss the overlay,
+// not just open it (Task 4 wires the open side).
+func TestOverlayFKeyCloses(t *testing.T) {
+	t.Parallel()
+
+	model := overlayTestModel(t).promptOverlay(infoOverlay{
+		title: "Deployed Files",
+		lines: []string{"Data/SkyUI.esp"},
+	})
+	require.NotNil(t, model.overlay)
+
+	model = updateWithRunes(t, model, "f")
+
+	require.Nil(t, model.overlay)
+}
+
+// TestOverlayQuitKeyQuits locks in that, unlike the input modal (which must
+// let a plain "q" be typed), the overlay has no text entry, so a plain "q"
+// still quits - matching list-screen behavior.
+func TestOverlayQuitKeyQuits(t *testing.T) {
+	t.Parallel()
+
+	model := overlayTestModel(t).promptOverlay(infoOverlay{
+		title: "Deployed Files",
+		lines: []string{"Data/SkyUI.esp"},
+	})
+	require.NotNil(t, model.overlay)
+
+	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	require.NotNil(t, cmd)
+	require.Equal(t, tea.Quit(), cmd(), "plain q must quit while the overlay is open")
+}
+
+// TestOverlayBlockedWhileAnotherModalOpen locks in the single-flight guard
+// promptOverlay's doc comment describes: a picker/input modal/action modal
+// already up refuses a second overlay.
+func TestOverlayBlockedWhileAnotherModalOpen(t *testing.T) {
+	t.Parallel()
+
+	model := overlayTestModel(t)
+	model.action.pending = &pendingAction{title: "Some action"}
+
+	model = model.promptOverlay(infoOverlay{title: "Deployed Files", lines: []string{"a"}})
+
+	require.Nil(t, model.overlay)
+}
+
+func TestOverlayRendersTitleAndLines(t *testing.T) {
+	t.Parallel()
+
+	longLine := strings.Repeat("x", 200)
+	model := sizedPrototypeModel(t, "wizardry", 40, 30).promptOverlay(infoOverlay{
+		title: "Deployed Files",
+		lines: []string{"Data/SkyUI.esp", longLine},
+	})
+
+	view := model.overlayView()
+
+	require.Contains(t, view, "Deployed Files")
+	require.Contains(t, view, "Data/SkyUI.esp")
+	require.Contains(t, view, "esc close")
+	require.NotContains(t, view, longLine, "a line wider than the panel must be truncated, not wrapped")
+}
+
+// TestOverlayCapsLines pins the exact-height render invariant for an
+// overlay taller than the panel: it is not scrollable (YAGNI), so overflow
+// collapses into a single dimmed "+N more" tail line, mirroring
+// actionModalView's cap style - never the scroll-follow-selection window
+// pickerView uses (there's no selection to follow).
+func TestOverlayCapsLines(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 100, 12) // forces the 8-line content floor
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("file-%02d.esp", i+1)
+	}
+	model = model.promptOverlay(infoOverlay{title: "Deployed Files", lines: lines})
+	require.NotNil(t, model.overlay)
+
+	view := model.overlayView()
+	require.LessOrEqual(t, lipgloss.Height(view), model.availableContentHeight(),
+		"overlay must never render taller than the content budget")
+	require.Contains(t, view, "more", "clipped lines are named by an indicator line")
+}

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -105,16 +106,33 @@ func digitQuickSelect(msg tea.KeyMsg, n int) (int, bool) {
 // the screen content, mirroring actionModalView's approach (see that
 // method's doc comment for why: it preserves the exact-height render
 // invariant every screen holds without an overlay needing its own height
-// bookkeeping).
+// bookkeeping). Unlike actionModalView's detail lines (informational, so
+// overflow collapses into a single "+N more"), every picker option must
+// stay reachable and selectable, so an option list taller than the panel's
+// budget is clipped to a scroll-follow-selection window instead (see
+// pickerWindow), with dimmed "↑ N more"/"↓ N more" indicator lines naming
+// whatever is clipped above/below.
 func (m Model) pickerView() string {
 	width := m.availableWidth()
 	height := m.availableContentHeight()
 	panelContentWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
+	panelContentHeight := max(height-m.theme.Panel.GetVerticalBorderSize(), 1)
 
 	p := m.picker
 	lines := []string{truncate(m.theme.PanelTitle.Render(p.title), panelContentWidth)}
 
-	for i, opt := range p.options {
+	// Fixed lines: title, blank separator, hint (3 total) — the same
+	// accounting actionModalView uses. Whatever vertical room remains is
+	// the budget for option rows plus any indicator lines.
+	const fixedLines = 3
+	budget := max(panelContentHeight-fixedLines, 1)
+	start, windowSize := pickerWindow(len(p.options), p.selected, budget)
+
+	if start > 0 {
+		lines = append(lines, m.theme.MutedText.Render(fmt.Sprintf("↑ %d more", start)))
+	}
+	for i := start; i < start+windowSize; i++ {
+		opt := p.options[i]
 		marker := "  "
 		if i == p.selected {
 			marker = "> "
@@ -129,8 +147,34 @@ func (m Model) pickerView() string {
 		}
 		lines = append(lines, row)
 	}
+	if below := len(p.options) - (start + windowSize); below > 0 {
+		lines = append(lines, m.theme.MutedText.Render(fmt.Sprintf("↓ %d more", below)))
+	}
 
 	lines = append(lines, "", m.theme.MutedText.Render("↑/↓ move · enter choose · esc cancel"))
 
 	return m.panelWithHeight(width, height).Render(strings.Join(lines, "\n"))
+}
+
+// pickerWindow computes the contiguous [start, start+windowSize) slice of an
+// n-option list to render given the selected index and the row budget
+// (option rows + indicator lines together must fit in budget). When
+// everything fits, the window is the whole list and no indicators are
+// needed. Otherwise two rows are reserved for the "↑/↓ N more" indicators —
+// unconditionally, so the window size (and therefore total rendered lines)
+// can never exceed budget regardless of which edge the window touches; a
+// window at an edge simply renders one fewer line — and the window is
+// centered on the selection, clamped to the list bounds, so the selected
+// row is always visible (scroll-follow-selection). budget is always >= 3 in
+// practice: availableContentHeight's 8-line floor minus the panel border
+// minus the 3 fixed lines (see pickerView) leaves at least 3.
+func pickerWindow(n, selected, budget int) (start, windowSize int) {
+	if n <= budget {
+		return 0, n
+	}
+	windowSize = max(budget-2, 1)
+	start = selected - (windowSize-1)/2
+	start = min(start, n-windowSize)
+	start = max(start, 0)
+	return start, windowSize
 }

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -1,0 +1,136 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// pickerOption is one selectable row in a pendingPicker: Label is the
+// primary text, Note is optional dimmed detail rendered to its right (e.g.
+// a policy's current value, or a profile's mod count).
+type pickerOption struct{ Label, Note string }
+
+// pendingPicker is a caller-built description of a list-choice modal
+// awaiting a selection, mirroring pendingAction's role for the confirm
+// modal (see actions.go). choose is invoked exactly once, when the user
+// selects a row (Select/enter or a digit quick-select) - never on cancel.
+type pendingPicker struct {
+	title    string
+	options  []pickerOption
+	selected int
+	choose   func(idx int) tea.Cmd
+}
+
+// promptPicker shows p as the picker modal: this is the only method that
+// sets Model.picker, and it never calls choose itself - only
+// updatePickerKey does, on selection. Guarded like promptAction/buildAction
+// (single-flight): while an action is running or a confirmation modal is
+// already pending, or a picker is already up, the request is a no-op.
+func (m Model) promptPicker(p pendingPicker) Model {
+	if m.action.running || m.action.pending != nil || m.picker != nil {
+		return m
+	}
+	m.picker = &p
+	return m
+}
+
+// updatePickerKey handles every key while the picker modal is shown:
+// Up/Down move the selection (clamped to the option list); a digit 1-9
+// immediately selects and chooses that option (when in range); Select
+// (enter) chooses the currently-selected row; Blur (esc) - matched
+// directly rather than via CancelAction, whose bound keys include a plain
+// "n" that a picker's option labels may legitimately start with -
+// cancels without choosing; quit keys still quit (via startQuit); every
+// other key is swallowed so nothing behind the modal can react to it.
+func (m Model) updatePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	p := m.picker
+
+	switch {
+	case key.Matches(msg, m.keys.Quit):
+		return m.startQuit()
+	case key.Matches(msg, m.keys.Up):
+		if p.selected > 0 {
+			p.selected--
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.Down):
+		if p.selected < len(p.options)-1 {
+			p.selected++
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.Select):
+		return m.choosePickerOption(p.selected)
+	case key.Matches(msg, m.keys.Blur):
+		m.picker = nil
+		return m, nil
+	default:
+		if idx, ok := digitQuickSelect(msg, len(p.options)); ok {
+			return m.choosePickerOption(idx)
+		}
+		return m, nil
+	}
+}
+
+// choosePickerOption clears the picker and invokes its choose callback with
+// idx - the single point both Select and a digit quick-select route
+// through, so "choose exactly once, then close" stays true regardless of
+// which key triggered it.
+func (m Model) choosePickerOption(idx int) (tea.Model, tea.Cmd) {
+	p := m.picker
+	m.picker = nil
+	return m, p.choose(idx)
+}
+
+// digitQuickSelect reports whether msg is a single digit "1"-"9" naming a
+// valid index (0-based) into an option list of length n, for updatePickerKey's
+// quick-select branch.
+func digitQuickSelect(msg tea.KeyMsg, n int) (int, bool) {
+	if msg.Type != tea.KeyRunes || len(msg.Runes) != 1 {
+		return 0, false
+	}
+	r := msg.Runes[0]
+	if r < '1' || r > '9' {
+		return 0, false
+	}
+	idx := int(r - '1')
+	if idx >= n {
+		return 0, false
+	}
+	return idx, true
+}
+
+// pickerView renders the pending picker as a bordered panel that REPLACES
+// the screen content, mirroring actionModalView's approach (see that
+// method's doc comment for why: it preserves the exact-height render
+// invariant every screen holds without an overlay needing its own height
+// bookkeeping).
+func (m Model) pickerView() string {
+	width := m.availableWidth()
+	height := m.availableContentHeight()
+	panelContentWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
+
+	p := m.picker
+	lines := []string{truncate(m.theme.PanelTitle.Render(p.title), panelContentWidth)}
+
+	for i, opt := range p.options {
+		marker := "  "
+		if i == p.selected {
+			marker = "> "
+		}
+		row := marker + opt.Label
+		if opt.Note != "" {
+			row += "  " + m.theme.MutedText.Render(opt.Note)
+		}
+		row = truncate(row, panelContentWidth)
+		if i == p.selected {
+			row = m.theme.Selected.Render(row)
+		}
+		lines = append(lines, row)
+	}
+
+	lines = append(lines, "", m.theme.MutedText.Render("↑/↓ move · enter choose · esc cancel"))
+
+	return m.panelWithHeight(width, height).Render(strings.Join(lines, "\n"))
+}

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"fmt"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,4 +83,60 @@ func TestPickerBlockedWhileActionPending(t *testing.T) {
 	model = promptTestPicker(model, &chosen)
 
 	require.Nil(t, model.picker)
+}
+
+// TestPickerPlainNDoesNotCancel locks in the Blur-not-CancelAction matching
+// choice (see updatePickerKey's doc comment): CancelAction's bound keys
+// include a plain "n", which a picker's option labels may legitimately
+// start with, so pressing it must neither cancel the picker nor choose
+// anything.
+func TestPickerPlainNDoesNotCancel(t *testing.T) {
+	t.Parallel()
+
+	var chosen []int
+	model := promptTestPicker(pickerTestModel(t), &chosen)
+
+	model = updateWithRunes(t, model, "n")
+
+	require.NotNil(t, model.picker, "plain n must not cancel the picker")
+	require.Empty(t, chosen, "plain n must not choose anything")
+}
+
+// TestPickerHeightCappedWithScrollWindow pins the exact-height render
+// invariant for pickers taller than the panel: the rendered modal never
+// exceeds availableContentHeight() (a small terminal forces the 8-line
+// content floor here), and moving the selection below the visible window
+// scrolls it into view rather than clipping it away.
+func TestPickerHeightCappedWithScrollWindow(t *testing.T) {
+	t.Parallel()
+
+	model := sizedPrototypeModel(t, "wizardry", 100, 12) // forces the 8-line content floor
+	options := make([]pickerOption, 20)
+	for i := range options {
+		options[i] = pickerOption{Label: fmt.Sprintf("alpha-%02d", i+1)}
+	}
+	model = model.promptPicker(pendingPicker{
+		title:   "Pick one",
+		options: options,
+		choose:  func(int) tea.Cmd { return nil },
+	})
+	require.NotNil(t, model.picker)
+
+	view := model.pickerView()
+	require.LessOrEqual(t, lipgloss.Height(view), model.availableContentHeight(),
+		"picker must never render taller than the content budget")
+	require.Contains(t, view, "alpha-01", "window starts at the selection")
+	require.NotContains(t, view, "alpha-20", "options past the window are clipped")
+	require.Contains(t, view, "more", "clipped rows are named by an indicator line")
+
+	for range len(options) - 1 {
+		model = updateWithRunes(t, model, "j")
+	}
+	require.Equal(t, len(options)-1, model.picker.selected)
+
+	view = model.pickerView()
+	require.LessOrEqual(t, lipgloss.Height(view), model.availableContentHeight(),
+		"scrolled picker must never render taller than the content budget")
+	require.Contains(t, view, "alpha-20", "moving below the window scrolls the selection into view")
+	require.NotContains(t, view, "alpha-01", "options scrolled above the window are clipped")
 }

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// pickerTestModel builds a fully-loaded, sized prototype Model with no
+// pending action/picker - the common starting point for every test below.
+func pickerTestModel(t *testing.T) Model {
+	t.Helper()
+	return sizedPrototypeModel(t, "wizardry", 100, 30)
+}
+
+// promptTestPicker attaches a 3-option picker to model via promptPicker,
+// recording every choose(idx) call in *chosen (appended, so a test can
+// assert both "was it called" and "with what index").
+func promptTestPicker(model Model, chosen *[]int) Model {
+	return model.promptPicker(pendingPicker{
+		title: "Pick one",
+		options: []pickerOption{
+			{Label: "First", Note: "one"},
+			{Label: "Second", Note: "two"},
+			{Label: "Third", Note: "three"},
+		},
+		choose: func(idx int) tea.Cmd {
+			*chosen = append(*chosen, idx)
+			return nil
+		},
+	})
+}
+
+func TestPickerNavigateAndChoose(t *testing.T) {
+	t.Parallel()
+
+	var chosen []int
+	model := promptTestPicker(pickerTestModel(t), &chosen)
+	require.NotNil(t, model.picker)
+
+	model = updateWithRunes(t, model, "j")
+	model = updateWithRunes(t, model, "j")
+	model = updateWithKeyType(t, model, tea.KeyEnter)
+
+	require.Equal(t, []int{2}, chosen)
+	require.Nil(t, model.picker)
+}
+
+func TestPickerDigitQuickSelect(t *testing.T) {
+	t.Parallel()
+
+	var chosen []int
+	model := promptTestPicker(pickerTestModel(t), &chosen)
+
+	model = updateWithRunes(t, model, "2")
+
+	require.Equal(t, []int{1}, chosen)
+	require.Nil(t, model.picker)
+}
+
+func TestPickerEscCancels(t *testing.T) {
+	t.Parallel()
+
+	var chosen []int
+	model := promptTestPicker(pickerTestModel(t), &chosen)
+
+	model = updateWithKeyType(t, model, tea.KeyEsc)
+
+	require.Empty(t, chosen)
+	require.Nil(t, model.picker)
+}
+
+func TestPickerBlockedWhileActionPending(t *testing.T) {
+	t.Parallel()
+
+	var chosen []int
+	model := pickerTestModel(t)
+	model.action.pending = &pendingAction{title: "Some action"}
+
+	model = promptTestPicker(model, &chosen)
+
+	require.Nil(t, model.picker)
+}

--- a/internal/tui/policy_test.go
+++ b/internal/tui/policy_test.go
@@ -1,0 +1,238 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- Update policy ('P' on Installed Mods) ---
+
+// TestPolicyKeyOpensPickerWithCurrentMarked covers editSelectedModPolicy's
+// core contract: pressing 'P' on a selected mod opens a picker with exactly
+// the three notify/auto/pin options, in that order, and the option matching
+// the mod's current ModItem.UpdatePolicy is both labeled "current" and
+// pre-selected.
+func TestPolicyKeyOpensPickerWithCurrentMarked(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0 // "SkyUI" - canned UpdatePolicy "auto"
+	require.Equal(t, "SkyUI", model.mods[0].Name)
+	require.Equal(t, "auto", model.mods[0].UpdatePolicy)
+
+	updated, cmd := model.Update(keyRunes("P"))
+	model = updated.(Model)
+	require.Nil(t, cmd, "opening the picker is synchronous - no cmd yet")
+	require.NotNil(t, model.picker)
+	require.Contains(t, model.picker.title, "SkyUI")
+
+	require.Len(t, model.picker.options, 3)
+	wantLabels := []string{"notify", "auto", "pin"}
+	for i, opt := range model.picker.options {
+		require.Equal(t, wantLabels[i], opt.Label)
+	}
+
+	require.Equal(t, "current", model.picker.options[1].Note, `"auto" must be marked current`)
+	require.Empty(t, model.picker.options[0].Note)
+	require.Empty(t, model.picker.options[2].Note)
+	require.Equal(t, 1, model.picker.selected, `"auto" (index 1) must start pre-selected`)
+}
+
+// TestPolicyKeyOpensPickerNotifyCurrentByDefault covers the other canned
+// policy value (USSEP's "notify") so the "current" marking isn't hardcoded
+// to whatever index the first test happens to use.
+func TestPolicyKeyOpensPickerNotifyCurrentByDefault(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 1 // "USSEP" - canned UpdatePolicy "notify"
+	require.Equal(t, "notify", model.mods[1].UpdatePolicy)
+
+	updated, _ := model.Update(keyRunes("P"))
+	model = updated.(Model)
+	require.NotNil(t, model.picker)
+	require.Equal(t, "current", model.picker.options[0].Note)
+	require.Equal(t, 0, model.picker.selected)
+}
+
+// TestPolicyPickerChoiceRunsActionAndRefreshes drives the full round trip:
+// 'P' opens the picker, choosing "pin" (digit quick-select 3) immediately
+// dispatches SetUpdatePolicy - no second confirm gate - and the resulting
+// actionDoneMsg updates the status line and triggers a data refresh.
+func TestPolicyPickerChoiceRunsActionAndRefreshes(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{SetPolicyOutcome: ActionOutcome{Message: `SkyUI update policy: pin`}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0 // "SkyUI", ID "skyui"
+
+	updated, cmd := model.Update(keyRunes("P"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.picker)
+
+	// Digit quick-select "3" chooses index 2 ("pin").
+	updated, chooseCmd := model.Update(keyRunes("3"))
+	model = updated.(Model)
+	require.Nil(t, model.picker, "choosing must clear the picker")
+	require.NotNil(t, chooseCmd, "choosing must return the deferred dispatch cmd")
+	require.Empty(t, rec.SetPolicyCalls, "nothing must mutate before the deferred cmd runs")
+
+	msg := chooseCmd()
+	require.IsType(t, policyChosenMsg{}, msg)
+	picked := msg.(policyChosenMsg)
+	require.Equal(t, "pin", picked.policy)
+	require.Equal(t, "skyui", picked.item.ID)
+
+	updated, actionCmd := model.Update(msg)
+	model = updated.(Model)
+	require.True(t, model.action.running, "resolving the choice must mark the action running")
+	require.NotNil(t, actionCmd)
+
+	doneMsg := runActionCmd(t, actionCmd)
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+	require.Len(t, rec.SetPolicyCalls, 1)
+	require.Equal(t, "skyui", rec.SetPolicyCalls[0].ModID)
+	require.Equal(t, "pin", rec.SetPolicyCalls[0].Policy)
+
+	updated, refreshCmd := model.Update(doneMsg)
+	model = updated.(Model)
+	require.NotNil(t, refreshCmd)
+	require.Equal(t, `SkyUI update policy: pin`, model.action.status)
+	require.False(t, model.action.statusIsError)
+
+	loadedMsg := refreshCmd()
+	require.IsType(t, dataLoadedMsg{}, loadedMsg)
+}
+
+// TestPolicyKeySwallowedByFocusedInput proves 'P' types into the search box
+// instead of opening the picker while ScreenSearch is focused - the existing
+// focused-input swallow branch (updateKey, app.go) runs before the
+// mutation-key switch this is dispatched from, matching every other
+// single-letter mutation key's own test of the same guard (e.g.
+// TestFilesKeySwallowedByFocusedSearchInput).
+func TestPolicyKeySwallowedByFocusedInput(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	updated := updateWithRunes(t, model, "3") // jump to search, focused
+	updated = updateWithRunes(t, updated, "P")
+
+	require.True(t, updated.search.input.Focused())
+	require.Contains(t, updated.search.input.Value(), "P")
+	require.Nil(t, updated.picker)
+}
+
+// TestPolicyKeyIgnoredOffInstalledMods proves 'P' only fires on Installed
+// Mods.
+func TestPolicyKeyIgnoredOffInstalledMods(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenDashboard
+
+	updated, cmd := model.Update(keyRunes("P"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.picker)
+}
+
+// TestPolicyKeyEmptyListIsNoop proves an empty mods list can never crash or
+// open a picker for a nonexistent selection.
+func TestPolicyKeyEmptyListIsNoop(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.mods = nil
+	model.selected[ScreenInstalledMods] = 0
+
+	updated, cmd := model.Update(keyRunes("P"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.picker)
+}
+
+// TestPolicyKeyInertWhileAnotherModalPending proves a DIFFERENT already-
+// pending confirmation modal is left completely undisturbed by 'P'.
+func TestPolicyKeyInertWhileAnotherModalPending(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+
+	updated, _ := model.Update(keyRunes("D")) // opens the Deploy modal
+	model = updated.(Model)
+	require.NotNil(t, model.action.pending)
+
+	updated, cmd := model.Update(keyRunes("P"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.action.pending, "the original modal must still be showing")
+	require.Equal(t, actionDeploy, model.action.pending.kind)
+	require.Nil(t, model.picker, "P must not open a picker behind the confirm modal")
+}
+
+// TestPolicyKeyNoActionProviderIsNoop proves 'P' is inert with no
+// ActionProvider configured, mirroring uninstallSelectedMod/
+// toggleSelectedModEnable's own guard.
+func TestPolicyKeyNoActionProviderIsNoop(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(Options{Theme: "wizardry", Provider: NewPrototypeProvider()})
+	require.NoError(t, err)
+	loaded, _ := model.Update(model.Init()())
+	model = loaded.(Model)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+
+	updated, cmd := model.Update(keyRunes("P"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.picker)
+}
+
+// TestPolicyChoiceMapsProviderErrorToActionFailedMsg proves an error from
+// SetUpdatePolicy (e.g. an unknown-policy rejection from a real
+// coreProvider) surfaces as an actionFailedMsg through the SAME immediate-
+// dispatch path, mirroring TestConfirmClosureMapsProviderErrorToActionFailedMsg
+// for the two-step confirm modal.
+func TestPolicyChoiceMapsProviderErrorToActionFailedMsg(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("unknown policy")
+	rec := &recordingActions{SetPolicyErr: sentinel}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+
+	updated, _ := model.Update(keyRunes("P"))
+	model = updated.(Model)
+	updated, chooseCmd := model.Update(keyRunes("1"))
+	model = updated.(Model)
+	msg := chooseCmd()
+
+	updated, actionCmd := model.Update(msg)
+	model = updated.(Model)
+	require.True(t, model.action.running)
+
+	doneMsg := runActionCmd(t, actionCmd)
+	require.IsType(t, actionFailedMsg{}, doneMsg)
+
+	updated, refreshCmd := model.Update(doneMsg)
+	model = updated.(Model)
+	require.True(t, model.action.statusIsError)
+	require.Contains(t, model.action.status, sentinel.Error())
+	require.NotNil(t, refreshCmd, "the partial-mutation contract still refreshes on failure")
+}

--- a/internal/tui/policy_test.go
+++ b/internal/tui/policy_test.go
@@ -236,3 +236,95 @@ func TestPolicyChoiceMapsProviderErrorToActionFailedMsg(t *testing.T) {
 	require.Contains(t, model.action.status, sentinel.Error())
 	require.NotNil(t, refreshCmd, "the partial-mutation contract still refreshes on failure")
 }
+
+// TestPolicyChoiceSecondPickInFlightIsDropped guards the in-flight-message
+// window between a pick and its resolution: after choosePickerOption clears
+// the picker, action.running stays false until resolvePolicyChoice runs, so
+// a second 'P' press in that window opens a second picker and yields a
+// SECOND policyChosenMsg before the first has resolved. Resolving both must
+// dispatch exactly ONE SetUpdatePolicy call - the second message is dropped
+// by resolvePolicyChoice's own single-flight guard once the first
+// resolution has set running=true - and the second resolution must leave
+// the action state (gen, running, status) untouched.
+func TestPolicyChoiceSecondPickInFlightIsDropped(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{SetPolicyOutcome: ActionOutcome{Message: `SkyUI update policy: pin`}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+
+	// First pick: P → picker → "3" chooses "pin"; the deferred msg exists
+	// but has NOT resolved yet.
+	updated, _ := model.Update(keyRunes("P"))
+	model = updated.(Model)
+	updated, chooseCmd1 := model.Update(keyRunes("3"))
+	model = updated.(Model)
+	msg1 := chooseCmd1()
+
+	// Second pick in the window: the picker re-opens (running is still
+	// false) and a second deferred msg is produced.
+	updated, _ = model.Update(keyRunes("P"))
+	model = updated.(Model)
+	require.NotNil(t, model.picker, "the window is real: a second picker can open before the first pick resolves")
+	updated, chooseCmd2 := model.Update(keyRunes("2"))
+	model = updated.(Model)
+	msg2 := chooseCmd2()
+
+	// First resolution dispatches normally.
+	updated, actionCmd1 := model.Update(msg1)
+	model = updated.(Model)
+	require.True(t, model.action.running)
+	require.NotNil(t, actionCmd1)
+	genAfterFirst := model.action.gen
+
+	// Second resolution, arriving while the first action is in flight, must
+	// be a no-op: no second dispatch, no state disturbance.
+	updated, actionCmd2 := model.Update(msg2)
+	model = updated.(Model)
+	require.Nil(t, actionCmd2, "the dropped second pick must not dispatch anything")
+	require.Equal(t, genAfterFirst, model.action.gen, "the dropped pick must not bump gen")
+	require.True(t, model.action.running, "the FIRST action stays in flight")
+
+	doneMsg := runActionCmd(t, actionCmd1)
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+	require.Len(t, rec.SetPolicyCalls, 1, "exactly one SetUpdatePolicy dispatch for two back-to-back picks")
+	require.Equal(t, "pin", rec.SetPolicyCalls[0].Policy, "the FIRST pick wins")
+}
+
+// TestPolicyChoiceDroppedWhileConfirmModalPending covers the other edge of
+// the same window: a pendingAction confirm modal opened between the pick and
+// its resolution (e.g. 'D' pressed in the gap). Without
+// resolvePolicyChoice's guard, buildAction's own refusal leaves the model
+// untouched but resolvePolicyChoice then set running=true anyway - sticking
+// the single-flight guard permanently (no action is actually running, so no
+// actionDoneMsg/actionFailedMsg would ever clear it). The stray message
+// must be dropped entirely: running stays false, the modal stays up, no
+// dispatch.
+func TestPolicyChoiceDroppedWhileConfirmModalPending(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.selected[ScreenInstalledMods] = 0
+
+	updated, _ := model.Update(keyRunes("P"))
+	model = updated.(Model)
+	updated, chooseCmd := model.Update(keyRunes("3"))
+	model = updated.(Model)
+	msg := chooseCmd()
+
+	// A confirm modal opens in the window before the pick resolves.
+	updated, _ = model.Update(keyRunes("D"))
+	model = updated.(Model)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionDeploy, model.action.pending.kind)
+
+	updated, cmd := model.Update(msg)
+	model = updated.(Model)
+	require.Nil(t, cmd, "the dropped pick must not dispatch anything")
+	require.False(t, model.action.running, "a dropped pick must never set running - nothing would ever clear it")
+	require.NotNil(t, model.action.pending, "the confirm modal must stay up, undisturbed")
+	require.Empty(t, rec.SetPolicyCalls)
+}

--- a/internal/tui/profile_mgmt_test.go
+++ b/internal/tui/profile_mgmt_test.go
@@ -1,0 +1,263 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Profile create ('c' on Profiles) ---
+
+// TestCreateProfileKeyOpensInputModal covers createProfilePrompt's core
+// contract: pressing 'c' on Profiles opens the input modal titled "new
+// profile", synchronously (no cmd yet - the modal itself is the only
+// state change until a value is submitted).
+func TestCreateProfileKeyOpensInputModal(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+
+	updated, cmd := model.Update(keyRunes("c"))
+	model = updated.(Model)
+	require.Nil(t, cmd, "opening the input modal is synchronous - no cmd yet")
+	require.NotNil(t, model.inputModal)
+	require.Equal(t, "new profile", model.inputModal.title)
+	require.True(t, model.inputModal.input.Focused())
+}
+
+// TestCreateProfileDuplicateNameValidatesInModal covers the validate
+// closure's case-sensitive match against the currently-loaded m.profiles:
+// typing an existing profile's name and pressing enter keeps the modal open
+// with the "profile already exists" error, and never dispatches.
+func TestCreateProfileDuplicateNameValidatesInModal(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	require.NotEmpty(t, model.profiles)
+	existing := model.profiles[0].Name // "survival", the canned active profile
+
+	updated, _ := model.Update(keyRunes("c"))
+	model = updated.(Model)
+	model = typeString(t, model, existing)
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+
+	require.Nil(t, cmd, "a validation error must not dispatch anything")
+	require.NotNil(t, model.inputModal, "modal must stay open on a validation error")
+	require.Equal(t, "profile already exists", model.inputModal.errMsg)
+	require.Empty(t, rec.CreateProfileCalls)
+}
+
+// TestCreateProfileSubmitRunsActionAndRefreshes drives the full round trip:
+// 'c' opens the modal, typing a new name and pressing enter dispatches a
+// deferred profileCreateSubmittedMsg (the closure-over-stale-Model problem
+// policyChosenMsg's doc comment describes - a pendingInput.submit closure
+// can only return a Cmd, not a mutated Model), which Update() routes to
+// resolveProfileCreate against the LIVE model - runs CreateProfile and
+// confirms immediately (no second confirm gate), and the resulting
+// actionDoneMsg updates the status line and triggers a data refresh.
+func TestCreateProfileSubmitRunsActionAndRefreshes(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{CreateProfileOutcome: ActionOutcome{Message: "Created profile: survival"}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	// The prototype's own canned Profiles list already contains "survival"
+	// (the active profile) - cleared here so submitting that same name below
+	// exercises the SUCCESS path, not the duplicate-name validation covered
+	// separately by TestCreateProfileDuplicateNameValidatesInModal.
+	model.profiles = nil
+
+	updated, _ := model.Update(keyRunes("c"))
+	model = updated.(Model)
+	model = typeString(t, model, "survival")
+	updated, submitCmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	require.Nil(t, model.inputModal, "successful submit clears the modal")
+	require.NotNil(t, submitCmd)
+	require.Empty(t, rec.CreateProfileCalls, "nothing must mutate before the deferred cmd runs")
+
+	msg := submitCmd()
+	require.IsType(t, profileCreateSubmittedMsg{}, msg)
+	require.Equal(t, "survival", msg.(profileCreateSubmittedMsg).name)
+
+	updated, actionCmd := model.Update(msg)
+	model = updated.(Model)
+	require.True(t, model.action.running, "resolving the submission must mark the action running")
+	require.NotNil(t, actionCmd)
+
+	doneMsg := runActionCmd(t, actionCmd)
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+	require.Equal(t, []string{"survival"}, rec.CreateProfileCalls)
+
+	updated, refreshCmd := model.Update(doneMsg)
+	model = updated.(Model)
+	require.NotNil(t, refreshCmd)
+	require.Equal(t, "Created profile: survival", model.action.status)
+	require.False(t, model.action.statusIsError)
+
+	loadedMsg := refreshCmd()
+	require.IsType(t, dataLoadedMsg{}, loadedMsg)
+}
+
+// TestCreateProfileResolveDroppedWhileBusy mirrors
+// TestPolicyChoiceSecondPickInFlightIsDropped's shape for the profile-create
+// resolver: the window between a submit clearing the input modal (running
+// still false) and resolveProfileCreate actually running is real, so a
+// second 'c'/submit in that window must be dropped by resolveProfileCreate's
+// own single-flight guard once the first resolution has set running=true.
+func TestCreateProfileResolveDroppedWhileBusy(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{CreateProfileOutcome: ActionOutcome{Message: "Created profile: alpha"}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	model.profiles = nil
+
+	// First submit: 'c' -> modal -> "alpha" -> enter; the deferred msg exists
+	// but has NOT resolved yet.
+	updated, _ := model.Update(keyRunes("c"))
+	model = updated.(Model)
+	model = typeString(t, model, "alpha")
+	updated, submitCmd1 := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	msg1 := submitCmd1()
+
+	// Second submit in the window: the modal re-opens (running is still
+	// false) and a second deferred msg is produced.
+	updated, _ = model.Update(keyRunes("c"))
+	model = updated.(Model)
+	require.NotNil(t, model.inputModal, "the window is real: a second modal can open before the first submit resolves")
+	model = typeString(t, model, "beta")
+	updated, submitCmd2 := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	msg2 := submitCmd2()
+
+	// First resolution dispatches normally.
+	updated, actionCmd1 := model.Update(msg1)
+	model = updated.(Model)
+	require.True(t, model.action.running)
+	require.NotNil(t, actionCmd1)
+	genAfterFirst := model.action.gen
+
+	// Second resolution, arriving while the first action is in flight, must
+	// be a no-op: no second dispatch, no state disturbance.
+	updated, actionCmd2 := model.Update(msg2)
+	model = updated.(Model)
+	require.Nil(t, actionCmd2, "the dropped second submit must not dispatch anything")
+	require.Equal(t, genAfterFirst, model.action.gen, "the dropped submit must not bump gen")
+	require.True(t, model.action.running, "the FIRST action stays in flight")
+
+	doneMsg := runActionCmd(t, actionCmd1)
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+	require.Equal(t, []string{"alpha"}, rec.CreateProfileCalls, "exactly one CreateProfile dispatch for two back-to-back submits")
+}
+
+// --- Profile delete ('d' on Profiles) ---
+
+// TestDeleteProfileActiveRefusedOnStatusLine covers deleteSelectedProfile's
+// active-row guard: selecting the active profile and pressing 'd' never
+// opens a confirmation modal - it's refused synchronously on the status
+// line.
+func TestDeleteProfileActiveRefusedOnStatusLine(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	model.selected[ScreenProfiles] = 0 // "survival", the canned active profile
+	require.True(t, model.profiles[0].Active)
+
+	updated, cmd := model.Update(keyRunes("d"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending, "no modal for the active profile")
+	require.Equal(t, "cannot delete the active profile", model.action.status)
+	require.True(t, model.action.statusIsError)
+	require.Empty(t, rec.DeleteProfileCalls)
+}
+
+// TestDeleteProfileConfirmFlow covers the standard confirm-modal path for a
+// non-active row: 'd' opens a modal naming the profile, 'y' confirms,
+// DeleteProfile is called with that name, and the resulting actionDoneMsg
+// updates the status line and triggers a data refresh.
+func TestDeleteProfileConfirmFlow(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{DeleteProfileOutcome: ActionOutcome{Message: "Deleted profile: vanilla-plus"}}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenProfiles
+	model.selected[ScreenProfiles] = 1 // "vanilla-plus", not active
+	require.Equal(t, "vanilla-plus", model.profiles[1].Name)
+	require.False(t, model.profiles[1].Active)
+
+	updated, cmd := model.Update(keyRunes("d"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.action.pending)
+	require.Contains(t, model.action.pending.title, "vanilla-plus")
+	require.Empty(t, rec.DeleteProfileCalls, "nothing must mutate before confirm")
+
+	updated, confirmCmd := model.Update(keyRunes("y"))
+	model = updated.(Model)
+	require.True(t, model.action.running)
+	require.NotNil(t, confirmCmd)
+
+	doneMsg := runActionCmd(t, confirmCmd)
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+	require.Equal(t, []string{"vanilla-plus"}, rec.DeleteProfileCalls)
+
+	updated, refreshCmd := model.Update(doneMsg)
+	model = updated.(Model)
+	require.NotNil(t, refreshCmd)
+	require.Equal(t, "Deleted profile: vanilla-plus", model.action.status)
+	require.False(t, model.action.statusIsError)
+
+	loadedMsg := refreshCmd()
+	require.IsType(t, dataLoadedMsg{}, loadedMsg)
+}
+
+// --- Screen/focus guards, shared by both keys ---
+
+// TestProfileKeysIgnoredOffProfilesScreen proves 'c'/'d' only fire on the
+// Profiles screen, mirroring TestPolicyKeyIgnoredOffInstalledMods.
+func TestProfileKeysIgnoredOffProfilesScreen(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenDashboard
+
+	updated, cmd := model.Update(keyRunes("c"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.inputModal)
+
+	updated, cmd = model.Update(keyRunes("d"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+}
+
+// TestProfileKeysSwallowedByFocusedSearchInput proves 'c'/'d' type into the
+// search box instead of triggering create/delete while ScreenSearch is
+// focused, mirroring TestPolicyKeySwallowedByFocusedInput.
+func TestProfileKeysSwallowedByFocusedSearchInput(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	updated := updateWithRunes(t, model, "3") // jump to search, focused
+	updated = updateWithRunes(t, updated, "c")
+	updated = updateWithRunes(t, updated, "d")
+
+	require.True(t, updated.search.input.Focused())
+	require.Contains(t, updated.search.input.Value(), "c")
+	require.Contains(t, updated.search.input.Value(), "d")
+	require.Nil(t, updated.inputModal)
+	require.Nil(t, updated.action.pending)
+}

--- a/internal/tui/prototype/data.go
+++ b/internal/tui/prototype/data.go
@@ -8,6 +8,14 @@ type Data struct {
 	InstalledMods []Mod
 	SearchResults []Mod
 	Profiles      []Profile
+	// AltGame/AltMods are Task 8's second canned game, letting --prototype
+	// mode demo the in-TUI game switcher ('g') end to end: AltMods is
+	// deliberately tiny (1-2 entries) - the demo only needs the switch to
+	// visibly work, not a second full dataset. See
+	// prototypeProvider.ListGames/SetGame (service.go/actions_provider.go)
+	// for how these back the switcher.
+	AltGame Game
+	AltMods []Mod
 }
 
 type Game struct {
@@ -80,6 +88,11 @@ type Mod struct {
 func Load() Data {
 	return Data{
 		Game:    Game{ID: "skyrim-se", Name: "Skyrim Special Edition"},
+		AltGame: Game{ID: "fallout4", Name: "Fallout 4"},
+		AltMods: []Mod{
+			{ID: "f4se", Name: "Fallout 4 Script Extender", Source: "nexusmods", Author: "behippo", Version: "0.6.23", Status: "installed", Summary: "Script extender required by most other mods.", Downloads: 9_100_000, Endorsements: 310_000, HasEndorsements: true},
+			{ID: "unofficial-patch", Name: "Unofficial Fallout 4 Patch", Source: "nexusmods", Author: "Arthmoor", Version: "2.1.3", Status: "disabled", Summary: "Community bug-fix compilation.", Downloads: 4_400_000, Endorsements: 190_000, HasEndorsements: true},
+		},
 		Profile: Profile{Name: "survival", Active: true, ModCount: 42},
 		Stats: Stats{
 			Installed: 42,

--- a/internal/tui/purge_test.go
+++ b/internal/tui/purge_test.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+// Task 7: purge behind confirmation ('X' on Dashboard/Installed Mods) -
+// mutations.go's purgeProfilePrompt, wired onto ActionProvider.PurgeProfile.
+// Mirrors deployActiveProfile's own test shape (mutations_test.go's "---
+// Deploy ('D' on Dashboard and Installed Mods) ---" section): same two
+// screens, no row selection required, ordinary confirm-modal flow (not the
+// deferred plan-fetch pattern install/switch/updates use).
+
+func TestPurgeKeyPromptsWithModCountAndNames(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	require.Len(t, model.mods, 5, "sanity: the prototype fixture's canned InstalledMods count")
+
+	updated, cmd := model.Update(keyRunes("X"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionPurge, model.action.pending.kind)
+	require.Equal(t, `Purge 5 mod(s) from Skyrim Special Edition?`, model.action.pending.title)
+	for _, mod := range model.mods {
+		require.Contains(t, model.action.pending.detail, mod.Name)
+	}
+	require.Zero(t, rec.PurgeCalls, "nothing must mutate before confirm")
+}
+
+func TestPurgeKeyNoModsShortCircuitsToStatus(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+	model.mods = nil
+
+	updated, cmd := model.Update(keyRunes("X"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending, "an empty mods list must never open a confirmation modal")
+	require.Equal(t, "no mods installed", model.action.status)
+	require.False(t, model.action.statusIsError, "nothing to purge is a benign outcome, not a refusal")
+	require.Zero(t, rec.PurgeCalls)
+}
+
+// TestPurgeConfirmStreamsProgressAndReportsOutcome drives the full pump
+// pipeline (mirroring TestInstallProgressStreamsIntoStatusLine/
+// TestActionProgressStreamsWhileRunningThenActionDoneClearsIt in
+// mutations_test.go/actions_test.go): confirming replays the provider's
+// progress ticks through the SAME single-slot channel every other streaming
+// action uses (sendActionProgress's documented "last value wins"
+// coalescing - see actions.go), so only the LAST of the two configured
+// ticks survives to the listener by the time it's read; the completed
+// outcome's two warnings then drive formatOutcomeStatus's "(N warnings)"
+// count-suffix branch, and the done message triggers the standard refresh.
+func TestPurgeConfirmStreamsProgressAndReportsOutcome(t *testing.T) {
+	t.Parallel()
+
+	outcome := ActionOutcome{
+		Message: "Purged 2 mod(s)",
+		Warnings: []string{
+			"Skipped USSEP: uninstall.before_each hook failed: boom",
+			"uninstall.after_each hook failed for SkyUI: boom",
+		},
+	}
+	rec := &recordingActions{
+		PurgeTicks: []ActionProgress{
+			{Line: "purging 2 mod(s)…", Percent: -1},
+			{Line: "✓ SkyUI (1/2)", Percent: -1},
+		},
+		PurgeOutcome: outcome,
+	}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenInstalledMods
+
+	updated, cmd := model.Update(keyRunes("X"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.action.pending)
+
+	confirmed, confirmCmd := model.Update(keyRunes("y"))
+	model = confirmed.(Model)
+	require.NotNil(t, confirmCmd)
+
+	batchMsg := confirmCmd()
+	batch, ok := batchMsg.(tea.BatchMsg)
+	require.True(t, ok, "confirm must return tea.Batch(actionCmd, listenerCmd)")
+	require.Len(t, batch, 2)
+
+	actionMsg := batch[0]()
+	require.IsType(t, actionDoneMsg{}, actionMsg)
+	require.Equal(t, 1, rec.PurgeCalls)
+
+	progressMsg := batch[1]()
+	updated, _ = model.Update(progressMsg)
+	model = updated.(Model)
+	require.Contains(t, model.statusLine(), "✓ SkyUI (1/2)",
+		"the pump must observe the freshest tick the provider reported")
+
+	updated, refreshCmd := model.Update(actionMsg)
+	model = updated.(Model)
+	require.NotNil(t, refreshCmd, "a completed purge must trigger the standard refresh")
+	require.Equal(t, formatOutcomeStatus(outcome), model.action.status)
+	require.Contains(t, model.action.status, "(2 warnings)", "the final status must surface the warning count")
+	require.False(t, model.action.statusIsError)
+	require.IsType(t, dataLoadedMsg{}, refreshCmd())
+}
+
+func TestPurgeKeyWorksFromDashboardToo(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenDashboard
+
+	updated, cmd := model.Update(keyRunes("X"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.NotNil(t, model.action.pending)
+	require.Equal(t, actionPurge, model.action.pending.kind)
+}
+
+// TestPurgeKeySwallowedByFocusedSearchInput proves 'X' types into the search
+// box instead of triggering purge while ScreenSearch is focused - mirrors
+// TestToggleEnableKeyInertWhileSearchFocused's identical shape (the
+// focused-input branch in updateKey runs before the mutation-key switch, so
+// this is inertness by construction, not a special case this handler needs
+// to implement itself).
+func TestPurgeKeySwallowedByFocusedSearchInput(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	updated := updateWithRunes(t, model, "3") // jump to search, focused
+	updated = updateWithRunes(t, updated, "X")
+
+	require.True(t, updated.search.input.Focused())
+	require.Contains(t, updated.search.input.Value(), "X")
+	require.Nil(t, updated.action.pending)
+}
+
+// --- Extra coverage mirroring Deploy's own sibling tests ---
+
+func TestPurgeKeyWrongScreenIsNoop(t *testing.T) {
+	t.Parallel()
+
+	for _, screen := range []Screen{ScreenSearch, ScreenProfiles, ScreenSources} {
+		model := modelWithActions(t, &recordingActions{})
+		model.screen = screen
+
+		updated, cmd := model.Update(keyRunes("X"))
+		model = updated.(Model)
+		require.Nil(t, cmd)
+		require.Nil(t, model.action.pending, "screen %v", screen)
+	}
+}
+
+func TestPurgeKeyInertWhileRunning(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	model := modelWithActions(t, rec)
+	model.screen = ScreenDashboard
+	model.action.running = true
+
+	updated, cmd := model.Update(keyRunes("X"))
+	model = updated.(Model)
+	require.Nil(t, cmd)
+	require.Nil(t, model.action.pending)
+	require.Zero(t, rec.PurgeCalls)
+}

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -361,6 +361,7 @@ func (noSourcesProvider) SourceInfos() []SourceInfo                       { retu
 func (noSourcesProvider) Search(context.Context, string, string, int) (SearchPage, error) {
 	return SearchPage{}, nil
 }
+func (noSourcesProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
 
 func TestZeroRealSourcesShowsConfiguredSourcesDiagnosticOnConstruction(t *testing.T) {
 	t.Parallel()

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -362,6 +362,7 @@ func (noSourcesProvider) Search(context.Context, string, string, int) (SearchPag
 	return SearchPage{}, nil
 }
 func (noSourcesProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
+func (noSourcesProvider) ListGames() ([]GameInfo, error)                 { return nil, nil }
 
 func TestZeroRealSourcesShowsConfiguredSourcesDiagnosticOnConstruction(t *testing.T) {
 	t.Parallel()

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/tui/prototype"
@@ -92,6 +94,11 @@ type DataProvider interface {
 	// Search queries one source, or every one of the game's configured
 	// sources when source is "" (the documented all-sources sentinel).
 	Search(ctx context.Context, source, query string, page int) (SearchPage, error)
+	// DeployedFiles lists the relative paths a specific installed mod has
+	// deployed into the game directory, sorted, for the read-only files
+	// overlay (Task 4). An empty slice with a nil error means the mod is
+	// known but has nothing currently deployed (e.g. disabled).
+	DeployedFiles(sourceID, modID string) ([]string, error)
 }
 
 // prototypeProvider serves the static demo data set. It must never touch
@@ -150,6 +157,30 @@ func (p *prototypeProvider) Search(_ context.Context, source, query string, _ in
 		PageSize:   SearchPageSize,
 		TotalCount: len(matched),
 	}, nil
+}
+
+// DeployedFiles returns 2-3 plausible canned rows derived from item's name
+// (falling back to the raw modID when it isn't one of the canned
+// InstalledMods/SearchResults entries - see findInstalledIndex/
+// findSearchResult in actions_provider.go): deterministic, no randomness,
+// and never errors, matching this type's "never touch disk/network"
+// contract. Sorted, matching the interface's documented contract (coreProvider
+// gets this for free from its query's ORDER BY - see that type's own
+// DeployedFiles).
+func (p *prototypeProvider) DeployedFiles(sourceID, modID string) ([]string, error) {
+	name := modID
+	if idx := p.findInstalledIndex(sourceID, modID); idx >= 0 {
+		name = p.data.InstalledMods[idx].Name
+	} else if idx := p.findSearchResult(sourceID, modID); idx >= 0 {
+		name = p.data.SearchResults[idx].Name
+	}
+	files := []string{
+		fmt.Sprintf("%s.esp", name),
+		fmt.Sprintf("Data/%s.bsa", name),
+		fmt.Sprintf("textures/%s/main.dds", modID),
+	}
+	sort.Strings(files)
+	return files, nil
 }
 
 func (p *prototypeProvider) Profiles(_ context.Context) ([]ProfileItem, error) {

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -36,6 +36,15 @@ type ModItem struct {
 	Downloads       int64
 	Endorsements    int64
 	HasEndorsements bool
+	// UpdatePolicy is the mod's current update-check policy - "notify",
+	// "auto", or "pin" (see ActionProvider.SetUpdatePolicy's doc comment for
+	// what each means) - populated by coreProvider's Overview mapping
+	// (stringified from domain.InstalledMod.UpdatePolicy) and
+	// prototypeProvider's canned Mod.UpdatePolicy field. Empty for a
+	// Search-derived ModItem (search results aren't installed, so they have
+	// no policy of their own) - only Overview/the Installed Mods screen ever
+	// populates it.
+	UpdatePolicy string
 }
 
 // SourceInfo is one renderable source-registry row, mirroring the columns of
@@ -209,6 +218,7 @@ func modItems(mods []prototype.Mod) []ModItem {
 			Downloads:       mod.Downloads,
 			Endorsements:    mod.Endorsements,
 			HasEndorsements: mod.HasEndorsements,
+			UpdatePolicy:    mod.UpdatePolicy,
 		})
 	}
 	return items

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -155,13 +155,47 @@ func (p *prototypeProvider) activeGame() prototype.Game {
 	return p.data.Game
 }
 
-// activeMods returns the canned InstalledMods this session is currently
-// bound to (see altActive's doc comment).
+// activeMods returns the canned installed-mods slice this session is
+// currently bound to (see altActive's doc comment). Every prototypeProvider
+// method that reads OR mutates installed mods must go through this (or
+// setActiveMods below) instead of touching p.data.InstalledMods directly -
+// Copilot PR #69 caught SetUpdatePolicy/PurgeProfile (and an audit found
+// every other mutation) addressing the primary slice regardless of which
+// game was active, silently mutating the WRONG game's dataset after a
+// --prototype game switch. In-place element writes through the returned
+// slice value share the backing array and are visible in later reads;
+// append/remove must write the new header back via setActiveMods.
 func (p *prototypeProvider) activeMods() []prototype.Mod {
 	if p.altActive {
 		return p.data.AltMods
 	}
 	return p.data.InstalledMods
+}
+
+// setActiveMods replaces the ACTIVE game's installed-mods slice - the
+// write-back half of activeMods (see its doc comment), needed by the
+// operations that grow or shrink the list (UninstallMod, ApplyInstall,
+// materializeNeedsDownloads) rather than mutating elements in place.
+func (p *prototypeProvider) setActiveMods(mods []prototype.Mod) {
+	if p.altActive {
+		p.data.AltMods = mods
+		return
+	}
+	p.data.InstalledMods = mods
+}
+
+// adjustStats applies installed/enabled deltas to the PRIMARY game's canned
+// Stats counters - a deliberate no-op while the alt game is active: the alt
+// game has no canned Stats at all (its Overview derives Installed/Enabled
+// live from AltMods - see Overview's doc comment), so mutating the shared
+// Stats there would silently corrupt the PRIMARY game's counters (the
+// Copilot PR #69 PurgeProfile finding, generalized to every mutation).
+func (p *prototypeProvider) adjustStats(installedDelta, enabledDelta int) {
+	if p.altActive {
+		return
+	}
+	p.data.Stats.Installed += installedDelta
+	p.data.Stats.Enabled += enabledDelta
 }
 
 func (p *prototypeProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
@@ -270,17 +304,17 @@ func (p *prototypeProvider) Search(_ context.Context, source, query string, _ in
 }
 
 // DeployedFiles returns 2-3 plausible canned rows derived from item's name
-// (falling back to the raw modID when it isn't one of the canned
-// InstalledMods/SearchResults entries - see findInstalledIndex/
-// findSearchResult in actions_provider.go): deterministic, no randomness,
-// and never errors, matching this type's "never touch disk/network"
-// contract. Sorted, matching the interface's documented contract (coreProvider
-// gets this for free from its query's ORDER BY - see that type's own
-// DeployedFiles).
+// (falling back to the raw modID when it isn't one of the ACTIVE game's
+// installed mods or the canned SearchResults entries - see
+// findInstalledIndex/findSearchResult in actions_provider.go):
+// deterministic, no randomness, and never errors, matching this type's
+// "never touch disk/network" contract. Sorted, matching the interface's
+// documented contract (coreProvider gets this for free from its query's
+// ORDER BY - see that type's own DeployedFiles).
 func (p *prototypeProvider) DeployedFiles(sourceID, modID string) ([]string, error) {
 	name := modID
 	if idx := p.findInstalledIndex(sourceID, modID); idx >= 0 {
-		name = p.data.InstalledMods[idx].Name
+		name = p.activeMods()[idx].Name
 	} else if idx := p.findSearchResult(sourceID, modID); idx >= 0 {
 		name = p.data.SearchResults[idx].Name
 	}

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -68,6 +68,15 @@ type ProfileItem struct {
 	ModCount int
 }
 
+// GameInfo is one renderable configured-game row for the in-TUI game
+// switcher (Task 8's 'g' binding - see mutations.go's openGameSwitcher).
+// Mirrors ProfileItem's shape: just enough to render a picker option and
+// mark which one is currently bound to the session.
+type GameInfo struct {
+	ID, Name string
+	Active   bool
+}
+
 // SearchPage is one page of search results for one source/query.
 type SearchPage struct {
 	Results    []ModItem
@@ -108,12 +117,22 @@ type DataProvider interface {
 	// overlay (Task 4). An empty slice with a nil error means the mod is
 	// known but has nothing currently deployed (e.g. disabled).
 	DeployedFiles(sourceID, modID string) ([]string, error)
+	// ListGames lists every game configured for this session's underlying
+	// app data, sorted by Name, for the in-TUI game switcher (Task 8's 'g'
+	// binding - see mutations.go's openGameSwitcher). Exactly one entry has
+	// Active set: the game this session is currently bound to.
+	ListGames() ([]GameInfo, error)
 }
 
 // prototypeProvider serves the static demo data set. It must never touch
 // disk, network, DB, or APIs.
 type prototypeProvider struct {
 	data prototype.Data
+	// altActive is Task 8's game-switch flag: false (the zero value) means
+	// the session is bound to data.Game/data.InstalledMods, true means it's
+	// bound to data.AltGame/data.AltMods - see currentGameID/Overview/
+	// SetGame below and ListGames/SetGame in actions_provider.go.
+	altActive bool
 }
 
 // NewPrototypeProvider returns the side-effect-free demo DataProvider used
@@ -127,15 +146,97 @@ func NewPrototypeProvider() DataProvider {
 	return &prototypeProvider{data: prototype.Load()}
 }
 
+// activeGame returns the canned Game this session is currently bound to
+// (see altActive's doc comment).
+func (p *prototypeProvider) activeGame() prototype.Game {
+	if p.altActive {
+		return p.data.AltGame
+	}
+	return p.data.Game
+}
+
+// activeMods returns the canned InstalledMods this session is currently
+// bound to (see altActive's doc comment).
+func (p *prototypeProvider) activeMods() []prototype.Mod {
+	if p.altActive {
+		return p.data.AltMods
+	}
+	return p.data.InstalledMods
+}
+
 func (p *prototypeProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
+	mods := p.activeMods()
+	if !p.altActive {
+		// The primary game keeps its own canned Stats (installed/enabled
+		// counts don't necessarily match InstalledMods' own length/status
+		// mix - see prototype.Stats' doc comment) - Updates/Conflicts are
+		// deliberately fictional there. AltMods has no such canned Stats
+		// (it's a minimal 1-2 mod demo set, see Data.AltMods' doc comment),
+		// so the alt branch below derives Installed/Enabled directly from
+		// it and leaves Updates/Conflicts at the "unknown" sentinel, same
+		// as coreProvider.Overview's real convention.
+		return Summary{
+			GameName:    p.activeGame().Name,
+			ProfileName: p.data.Profile.Name,
+			Installed:   p.data.Stats.Installed,
+			Enabled:     p.data.Stats.Enabled,
+			Updates:     p.data.Stats.Updates,
+			Conflicts:   p.data.Stats.Conflicts,
+		}, modItems(mods), nil
+	}
+
+	enabled := 0
+	for _, mod := range mods {
+		if mod.Status != "disabled" {
+			enabled++
+		}
+	}
 	return Summary{
-		GameName:    p.data.Game.Name,
+		GameName:    p.activeGame().Name,
 		ProfileName: p.data.Profile.Name,
-		Installed:   p.data.Stats.Installed,
-		Enabled:     p.data.Stats.Enabled,
-		Updates:     p.data.Stats.Updates,
-		Conflicts:   p.data.Stats.Conflicts,
-	}, modItems(p.data.InstalledMods), nil
+		Installed:   len(mods),
+		Enabled:     enabled,
+		Updates:     -1,
+		Conflicts:   -1,
+	}, modItems(mods), nil
+}
+
+// ListGames returns the two canned games (see Data.AltGame's doc comment),
+// sorted by Name like coreProvider.ListGames - deterministic even though a
+// 2-entry list has nothing to actually jitter.
+func (p *prototypeProvider) ListGames() ([]GameInfo, error) {
+	games := []GameInfo{
+		{ID: p.data.Game.ID, Name: p.data.Game.Name, Active: !p.altActive},
+		{ID: p.data.AltGame.ID, Name: p.data.AltGame.Name, Active: p.altActive},
+	}
+	sort.Slice(games, func(i, j int) bool { return games[i].Name < games[j].Name })
+	return games, nil
+}
+
+// SetGame implements actions.go's optional gameRebinder hook: id must name
+// one of the two canned games (Data.Game/Data.AltGame), flipping altActive
+// to match. Unlike coreProvider.SetGame (service_core.go), which always
+// WRITES p.game/p.profile even on a same-id rebind (cheap, no correctness
+// concern there), this is written as a plain "which one" switch rather than
+// a toggle specifically so a REPEAT call with the SAME id is a no-op: Model.
+// rebindGame (actions.go) calls SetGame on both m.provider and m.actions,
+// and --prototype mode wires both from the SAME prototypeProvider instance
+// (NewPrototypeModel) - a toggle-based flip would double-apply and switch
+// back to the ORIGINAL game on the second call. Mirrors why prototypeProvider
+// deliberately does not implement SetProfile at all (profileRebinder's own
+// doc comment) - this hook can't opt out the same way (Task 8 wants the
+// switcher to visibly work in --prototype demo mode), so it's made
+// idempotent instead.
+func (p *prototypeProvider) SetGame(id string) error {
+	switch id {
+	case p.data.Game.ID:
+		p.altActive = false
+	case p.data.AltGame.ID:
+		p.altActive = true
+	default:
+		return fmt.Errorf("game not found: %s", id)
+	}
+	return nil
 }
 
 func (p *prototypeProvider) Sources() []string {

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -105,12 +105,13 @@ func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 	items := make([]ModItem, 0, len(mods))
 	for _, mod := range mods {
 		items = append(items, ModItem{
-			ID:      mod.ID,
-			Name:    mod.Name,
-			Author:  mod.Author,
-			Version: mod.Version,
-			Source:  mod.SourceID,
-			Status:  installedModStatus(mod),
+			ID:           mod.ID,
+			Name:         mod.Name,
+			Author:       mod.Author,
+			Version:      mod.Version,
+			Source:       mod.SourceID,
+			Status:       installedModStatus(mod),
+			UpdatePolicy: policyToString(mod.UpdatePolicy),
 		})
 	}
 
@@ -384,6 +385,43 @@ func installedModStatus(mod domain.InstalledMod) string {
 		return "enabled"
 	default:
 		return "disabled"
+	}
+}
+
+// policyToString renders a domain.UpdatePolicy as ModItem.UpdatePolicy's
+// documented "notify"/"auto"/"pin" wire strings - the inverse of
+// parseUpdatePolicy below. Deliberately NOT shared with cmd/lmm/update.go's
+// own policyToString (whose "pinned" spelling differs and which internal/tui
+// cannot import - see customSourceType's doc comment for why CLI-only
+// helpers are duplicated rather than shared): the TUI's ActionProvider
+// contract fixes "pin" as the wire string (see SetUpdatePolicy's doc
+// comment), so this must NOT reuse the CLI's "pinned".
+func policyToString(policy domain.UpdatePolicy) string {
+	switch policy {
+	case domain.UpdateAuto:
+		return "auto"
+	case domain.UpdatePinned:
+		return "pin"
+	default:
+		return "notify"
+	}
+}
+
+// parseUpdatePolicy maps SetUpdatePolicy's policy argument to its
+// domain.UpdatePolicy constant, the inverse of policyToString - an unknown
+// string (anything but "notify"/"auto"/"pin") is rejected rather than
+// silently defaulting to UpdateNotify, so a caller typo never quietly pins
+// nothing.
+func parseUpdatePolicy(policy string) (domain.UpdatePolicy, error) {
+	switch policy {
+	case "notify":
+		return domain.UpdateNotify, nil
+	case "auto":
+		return domain.UpdateAuto, nil
+	case "pin":
+		return domain.UpdatePinned, nil
+	default:
+		return 0, fmt.Errorf("unknown policy %q", policy)
 	}
 }
 
@@ -979,6 +1017,20 @@ func (p *coreProvider) ApplyUpdate(ctx context.Context, u UpdateItem, progress f
 		Message:  fmt.Sprintf("Updated %q to %s", u.Name, upd.NewVersion),
 		Warnings: mergeDiagnostics(result.Warnings, result.Notes),
 	}, nil
+}
+
+// SetUpdatePolicy validates and maps policy (see parseUpdatePolicy) and
+// persists it via svc.SetModUpdatePolicy - a local DB write with no network
+// call and no hooks, unlike every other mutation in this file.
+func (p *coreProvider) SetUpdatePolicy(_ context.Context, item ModItem, policy string) (ActionOutcome, error) {
+	mapped, err := parseUpdatePolicy(policy)
+	if err != nil {
+		return ActionOutcome{}, err
+	}
+	if err := p.svc.SetModUpdatePolicy(item.Source, item.ID, p.game.ID, p.currentProfile(), mapped); err != nil {
+		return ActionOutcome{}, fmt.Errorf("setting update policy for %s: %w", item.Name, err)
+	}
+	return ActionOutcome{Message: fmt.Sprintf("%s update policy: %s", item.Name, policy)}, nil
 }
 
 // switchPlanView maps a core.SwitchPlan to its TUI render model, using the

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -18,6 +18,20 @@ import (
 
 // coreProvider adapts *core.Service to the read-only DataProvider boundary.
 //
+// gameMu guards game (Task 8): SetGame (called from the Bubble Tea Update
+// goroutine when a game-switch picker choice resolves - see mutations.go's
+// resolveGameSwitch / actions.go's rebindGame) writes it, while a
+// still-in-flight Search call may read it concurrently - the exact same
+// race profileMu (below) already guards against for p.profile, see its own
+// doc comment for the full reasoning (TestCoreProviderProfileFieldRaceGuard
+// mirrors this for p.game too). Every read goes through currentGame();
+// every write through SetGame - never read/write p.game directly elsewhere
+// in this file. A SEPARATE mutex from profileMu and hooksMu, deliberately,
+// for the same non-reentrancy reason those two are already separate from
+// each other (sync.RWMutex/sync.Mutex are not reentrant) - SetGame takes
+// all three sequentially (gameMu, then profileMu, then hooksMu), NEVER
+// nested, so no critical section here ever blocks waiting on itself.
+//
 // profileMu guards profile (Task 6 item b): SetProfile (called from the
 // Bubble Tea Update goroutine when a profile-switch action completes - see
 // app.go's actionDoneMsg handler / rebindProfile) writes it, while a
@@ -40,8 +54,10 @@ import (
 // actions.go's buildAction) so it needs the same mutex discipline as
 // profileMu, just not the SAME mutex.
 type coreProvider struct {
-	svc  *core.Service
-	game *domain.Game
+	svc *core.Service
+
+	gameMu sync.RWMutex
+	game   *domain.Game
 
 	profileMu sync.RWMutex
 	profile   string
@@ -90,9 +106,9 @@ func NewCoreActions(svc *core.Service, game *domain.Game, profileName string) Ac
 
 func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 	profile := p.currentProfile()
-	mods, err := p.svc.GetInstalledMods(p.game.ID, profile)
+	mods, err := p.svc.GetInstalledMods(p.currentGame().ID, profile)
 	if err != nil {
-		return Summary{}, nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, profile, err)
+		return Summary{}, nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.currentGame().ID, profile, err)
 	}
 
 	enabled := 0
@@ -116,7 +132,7 @@ func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 	}
 
 	return Summary{
-		GameName:    p.game.Name,
+		GameName:    p.currentGame().Name,
 		ProfileName: profile,
 		Installed:   len(mods),
 		Enabled:     enabled,
@@ -126,8 +142,8 @@ func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 }
 
 func (p *coreProvider) Sources() []string {
-	sources := make([]string, 0, len(p.game.SourceIDs))
-	for id := range p.game.SourceIDs {
+	sources := make([]string, 0, len(p.currentGame().SourceIDs))
+	for id := range p.currentGame().SourceIDs {
 		sources = append(sources, id)
 	}
 	sort.Strings(sources)
@@ -215,7 +231,7 @@ func sourceCapabilitySummary(c source.Capabilities) string {
 // already installed in the active profile.
 func (p *coreProvider) Search(ctx context.Context, sourceID, query string, page int) (SearchPage, error) {
 	if sourceID == "" {
-		agg, err := p.svc.SearchAllSources(ctx, p.game.ID, query, "", nil, page, SearchPageSize)
+		agg, err := p.svc.SearchAllSources(ctx, p.currentGame().ID, query, "", nil, page, SearchPageSize)
 		if err != nil {
 			return SearchPage{}, fmt.Errorf("searching all sources for %q: %w", query, err)
 		}
@@ -241,7 +257,7 @@ func (p *coreProvider) Search(ctx context.Context, sourceID, query string, page 
 		}, nil
 	}
 
-	result, err := p.svc.SearchMods(ctx, sourceID, p.game.ID, query, "", nil, page, SearchPageSize)
+	result, err := p.svc.SearchMods(ctx, sourceID, p.currentGame().ID, query, "", nil, page, SearchPageSize)
 	if err != nil {
 		return SearchPage{}, fmt.Errorf("searching %s for %q: %w", sourceID, query, err)
 	}
@@ -265,9 +281,9 @@ func (p *coreProvider) Search(ctx context.Context, sourceID, query string, page 
 // installed in the active profile, used to mark search results as installed.
 func (p *coreProvider) installedModKeys() (map[string]bool, error) {
 	profile := p.currentProfile()
-	installed, err := p.svc.GetInstalledMods(p.game.ID, profile)
+	installed, err := p.svc.GetInstalledMods(p.currentGame().ID, profile)
 	if err != nil {
-		return nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, profile, err)
+		return nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.currentGame().ID, profile, err)
 	}
 	keys := make(map[string]bool, len(installed))
 	for _, mod := range installed {
@@ -302,6 +318,87 @@ func (p *coreProvider) modsToItems(mods []domain.Mod, installedKeys map[string]b
 		items = append(items, item)
 	}
 	return items
+}
+
+// currentGame returns the session's current active game, guarded by gameMu
+// (Task 8, mirroring currentProfile below) - the single read path every
+// method on this type must use instead of touching p.game directly.
+func (p *coreProvider) currentGame() *domain.Game {
+	p.gameMu.RLock()
+	defer p.gameMu.RUnlock()
+	return p.game
+}
+
+// ListGames enumerates every game configured for the underlying service
+// (Task 8's 'g' binding - see mutations.go's openGameSwitcher), sorted by
+// Name - the same "Go map iteration order is randomized" concern
+// SourceInfos already documents, since svc.ListGames ranges over its own
+// internal map.
+func (p *coreProvider) ListGames() ([]GameInfo, error) {
+	games := p.svc.ListGames()
+	current := p.currentGame().ID
+
+	infos := make([]GameInfo, 0, len(games))
+	for _, g := range games {
+		infos = append(infos, GameInfo{ID: g.ID, Name: g.Name, Active: g.ID == current})
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
+	return infos, nil
+}
+
+// resolveDefaultProfile mirrors cmd/lmm/root.go's resolveProfile fallback
+// semantics (SetGame's own doc comment): the target game's default profile
+// when one resolves cleanly, "default" on any error (most commonly
+// domain.ErrProfileNotFound for a freshly-added game with no profiles yet -
+// but any other resolution failure falls back the same way, matching the
+// brief's own "on error fall back to 'default'" wording precisely rather
+// than special-casing just the not-found error).
+func resolveDefaultProfile(pm *core.ProfileManager, gameID string) string {
+	profile, err := pm.GetDefault(gameID)
+	if err != nil {
+		return "default"
+	}
+	return profile.Name
+}
+
+// SetGame rebinds the session to a different configured game: id must name
+// a game svc.GetGame resolves (an unknown id is refused, and the current
+// binding is left completely untouched - no partial rebind). Implements
+// actions.go's optional gameRebinder hook, mirroring SetProfile's own
+// "plain method, not part of DataProvider/ActionProvider" shape - see that
+// method's doc comment - except a game switch also picks a FRESH profile
+// (resolveDefaultProfile above), since the profile bound at construction
+// time (or from whatever game was previously active) has no reason to exist
+// under the new game at all.
+//
+// Lock ordering (gameMu's own doc comment on the struct): gameMu, then
+// profileMu, then hooksMu, taken and released SEQUENTIALLY - never nested -
+// exactly like SetProfile already takes profileMu then hooksMu below.
+// cachedHooks is invalidated for the same reason SetProfile invalidates it
+// (a different game's hooks.yaml/games.yaml Hooks entirely supersede the
+// old game's); cachedRunner deliberately survives (mirrors SetProfile - see
+// the struct's own doc comment: HookTimeout is a single global config.yaml
+// setting, not game- or profile-specific).
+func (p *coreProvider) SetGame(id string) error {
+	game, err := p.svc.GetGame(id)
+	if err != nil {
+		return fmt.Errorf("switching to game %s: %w", id, err)
+	}
+	profileName := resolveDefaultProfile(p.svc.NewProfileManager(), id)
+
+	p.gameMu.Lock()
+	p.game = game
+	p.gameMu.Unlock()
+
+	p.profileMu.Lock()
+	p.profile = profileName
+	p.profileMu.Unlock()
+
+	p.hooksMu.Lock()
+	p.cachedHooks = nil
+	p.hooksMu.Unlock()
+
+	return nil
 }
 
 // currentProfile returns the session's current active profile, guarded by
@@ -347,9 +444,9 @@ func (p *coreProvider) SetProfile(name string) {
 
 func (p *coreProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
 	activeProfile := p.currentProfile()
-	profiles, err := p.svc.NewProfileManager().List(p.game.ID)
+	profiles, err := p.svc.NewProfileManager().List(p.currentGame().ID)
 	if err != nil {
-		return nil, fmt.Errorf("listing profiles for %s: %w", p.game.ID, err)
+		return nil, fmt.Errorf("listing profiles for %s: %w", p.currentGame().ID, err)
 	}
 
 	items := make([]ProfileItem, 0, len(profiles))
@@ -370,7 +467,7 @@ func (p *coreProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
 // because their underlying iteration order (a Go map) is genuinely
 // unordered.
 func (p *coreProvider) DeployedFiles(sourceID, modID string) ([]string, error) {
-	paths, err := p.svc.GetDeployedFilesForMod(p.game.ID, p.currentProfile(), sourceID, modID)
+	paths, err := p.svc.GetDeployedFilesForMod(p.currentGame().ID, p.currentProfile(), sourceID, modID)
 	if err != nil {
 		return nil, fmt.Errorf("loading deployed files for %s:%s: %w", sourceID, modID, err)
 	}
@@ -474,25 +571,25 @@ func (p *coreProvider) resolvedHooks(activeProfile string) *core.ResolvedHooks {
 
 	var profile *domain.Profile
 	if activeProfile != "" {
-		if pr, err := config.LoadProfile(p.svc.ConfigDir(), p.game.ID, activeProfile); err == nil {
+		if pr, err := config.LoadProfile(p.svc.ConfigDir(), p.currentGame().ID, activeProfile); err == nil {
 			profile = pr
 		}
 	}
-	p.cachedHooks = core.ResolveHooks(p.game, profile)
+	p.cachedHooks = core.ResolveHooks(p.currentGame(), profile)
 	return p.cachedHooks
 }
 
 // hookContext mirrors cmd/lmm/hooks.go's makeHookContext.
 func (p *coreProvider) hookContext() core.HookContext {
 	return core.HookContext{
-		GameID:   p.game.ID,
-		GamePath: p.game.InstallPath,
-		ModPath:  p.game.ModPath,
+		GameID:   p.currentGame().ID,
+		GamePath: p.currentGame().InstallPath,
+		ModPath:  p.currentGame().ModPath,
 	}
 }
 
 func (p *coreProvider) EnableMod(ctx context.Context, item ModItem) (ActionOutcome, error) {
-	result, err := p.svc.EnableMod(ctx, p.game, p.currentProfile(), item.Source, item.ID)
+	result, err := p.svc.EnableMod(ctx, p.currentGame(), p.currentProfile(), item.Source, item.ID)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("enabling %s: %w", item.Name, err)
 	}
@@ -503,7 +600,7 @@ func (p *coreProvider) EnableMod(ctx context.Context, item ModItem) (ActionOutco
 }
 
 func (p *coreProvider) DisableMod(ctx context.Context, item ModItem) (ActionOutcome, error) {
-	result, err := p.svc.DisableMod(ctx, p.game, p.currentProfile(), item.Source, item.ID)
+	result, err := p.svc.DisableMod(ctx, p.currentGame(), p.currentProfile(), item.Source, item.ID)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("disabling %s: %w", item.Name, err)
 	}
@@ -525,7 +622,7 @@ func (p *coreProvider) UninstallMod(ctx context.Context, item ModItem) (ActionOu
 		HookContext: p.hookContext(),
 		Force:       false,
 	}
-	result, err := p.svc.UninstallMod(ctx, p.game, profile, item.Source, item.ID, opts)
+	result, err := p.svc.UninstallMod(ctx, p.currentGame(), profile, item.Source, item.ID, opts)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("uninstalling %s: %w", item.Name, err)
 	}
@@ -548,7 +645,7 @@ func (p *coreProvider) DeployProfile(ctx context.Context) (ActionOutcome, error)
 		HookContext: p.hookContext(),
 		Force:       false,
 	}
-	result, err := p.svc.DeployProfile(ctx, p.game, profile, opts, nil)
+	result, err := p.svc.DeployProfile(ctx, p.currentGame(), profile, opts, nil)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("deploying profile %s: %w", profile, err)
 	}
@@ -641,9 +738,9 @@ func purgeProgressLine(p core.DeployProgress) (ActionProgress, bool) {
 // returning before anything in the result is populated anyway.
 func (p *coreProvider) PurgeProfile(ctx context.Context, progress func(ActionProgress)) (ActionOutcome, error) {
 	profile := p.currentProfile()
-	mods, err := p.svc.GetInstalledMods(p.game.ID, profile)
+	mods, err := p.svc.GetInstalledMods(p.currentGame().ID, profile)
 	if err != nil {
-		return ActionOutcome{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, profile, err)
+		return ActionOutcome{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.currentGame().ID, profile, err)
 	}
 	if len(mods) == 0 {
 		return ActionOutcome{Message: "no mods installed"}, nil
@@ -658,7 +755,7 @@ func (p *coreProvider) PurgeProfile(ctx context.Context, progress func(ActionPro
 	}
 
 	adapter := deployProgressAdapter(progress, purgeProgressLine)
-	result, err := p.svc.PurgeProfile(ctx, p.game, profile, mods, opts, adapter)
+	result, err := p.svc.PurgeProfile(ctx, p.currentGame(), profile, mods, opts, adapter)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("purging profile %s: %w", profile, err)
 	}
@@ -671,7 +768,7 @@ func (p *coreProvider) PurgeProfile(ctx context.Context, progress func(ActionPro
 }
 
 func (p *coreProvider) PlanProfileSwitch(ctx context.Context, profileName string) (SwitchPlanView, error) {
-	plan, err := p.svc.PlanProfileSwitch(ctx, p.game, profileName)
+	plan, err := p.svc.PlanProfileSwitch(ctx, p.currentGame(), profileName)
 	if err != nil {
 		return SwitchPlanView{}, fmt.Errorf("planning switch to %s: %w", profileName, err)
 	}
@@ -722,7 +819,7 @@ func (p *coreProvider) PlanProfileSwitch(ctx context.Context, profileName string
 // caller applying a switch with progress=nil, e.g. a "fire and check the
 // outcome" caller, must still see the failure in Warnings).
 func (p *coreProvider) ApplyProfileSwitch(ctx context.Context, profileName string, progress func(ActionProgress)) (ActionOutcome, error) {
-	plan, err := p.svc.PlanProfileSwitch(ctx, p.game, profileName)
+	plan, err := p.svc.PlanProfileSwitch(ctx, p.currentGame(), profileName)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("planning switch to %s: %w", profileName, err)
 	}
@@ -759,7 +856,7 @@ func (p *coreProvider) ApplyProfileSwitch(ctx context.Context, profileName strin
 		}
 	}
 
-	result, err := p.svc.ApplyProfileSwitch(ctx, p.game, plan, onProgress)
+	result, err := p.svc.ApplyProfileSwitch(ctx, p.currentGame(), plan, onProgress)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("switching to %s: %w", profileName, err)
 	}
@@ -956,7 +1053,7 @@ func installPlanView(plan *core.InstallPlan) InstallPlanView {
 // yet - matching the CLI's own non-interactive default when that flag is
 // omitted).
 func (p *coreProvider) PlanInstall(ctx context.Context, item ModItem) (InstallPlanView, error) {
-	plan, err := p.svc.PlanInstall(ctx, p.game, p.currentProfile(), item.Source, item.ID, false)
+	plan, err := p.svc.PlanInstall(ctx, p.currentGame(), p.currentProfile(), item.Source, item.ID, false)
 	if err != nil {
 		return InstallPlanView{}, mapInstallNetworkError(fmt.Sprintf("planning install of %s", item.Name), item.Source, err)
 	}
@@ -981,7 +1078,7 @@ func (p *coreProvider) PlanInstall(ctx context.Context, item ModItem) (InstallPl
 // in internal/core/flows.go) rather than the CLI's blocking one.
 func (p *coreProvider) ApplyInstall(ctx context.Context, item ModItem, progress func(ActionProgress)) (ActionOutcome, error) {
 	profile := p.currentProfile()
-	plan, err := p.svc.PlanInstall(ctx, p.game, profile, item.Source, item.ID, false)
+	plan, err := p.svc.PlanInstall(ctx, p.currentGame(), profile, item.Source, item.ID, false)
 	if err != nil {
 		return ActionOutcome{}, mapInstallNetworkError(fmt.Sprintf("planning install of %s", item.Name), item.Source, err)
 	}
@@ -1004,7 +1101,7 @@ func (p *coreProvider) ApplyInstall(ctx context.Context, item ModItem, progress 
 	adapter := deployProgressAdapter(progress, func(p core.DeployProgress) (ActionProgress, bool) {
 		return installProgressLine(item.Name, p)
 	})
-	result, err := p.svc.ApplyInstall(ctx, p.game, plan, opts, adapter)
+	result, err := p.svc.ApplyInstall(ctx, p.currentGame(), plan, opts, adapter)
 	if err != nil {
 		return ActionOutcome{}, mapInstallNetworkError(fmt.Sprintf("installing %s", item.Name), item.Source, err)
 	}
@@ -1052,12 +1149,12 @@ func (p *coreProvider) ApplyInstall(ctx context.Context, item ModItem, progress 
 // "source %s: %w" text this doesn't discard.
 func (p *coreProvider) CheckUpdates(ctx context.Context) (UpdatesView, error) {
 	profile := p.currentProfile()
-	installed, err := p.svc.GetInstalledMods(p.game.ID, profile)
+	installed, err := p.svc.GetInstalledMods(p.currentGame().ID, profile)
 	if err != nil {
-		return UpdatesView{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, profile, err)
+		return UpdatesView{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.currentGame().ID, profile, err)
 	}
 
-	updates, checkErr := p.svc.NewUpdater().CheckUpdates(ctx, p.game, installed)
+	updates, checkErr := p.svc.NewUpdater().CheckUpdates(ctx, p.currentGame(), installed)
 	var view UpdatesView
 	for _, u := range updates {
 		view.Updates = append(view.Updates, UpdateItem{
@@ -1086,12 +1183,12 @@ func (p *coreProvider) CheckUpdates(ctx context.Context) (UpdatesView, error) {
 // correctly; only a fresh CheckUpdates call can supply it.
 func (p *coreProvider) ApplyUpdate(ctx context.Context, u UpdateItem, progress func(ActionProgress)) (ActionOutcome, error) {
 	profile := p.currentProfile()
-	mod, err := p.svc.GetInstalledMod(u.Source, u.ID, p.game.ID, profile)
+	mod, err := p.svc.GetInstalledMod(u.Source, u.ID, p.currentGame().ID, profile)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("getting installed mod %s: %w", u.Name, err)
 	}
 
-	updates, err := p.svc.NewUpdater().CheckUpdates(ctx, p.game, []domain.InstalledMod{*mod})
+	updates, err := p.svc.NewUpdater().CheckUpdates(ctx, p.currentGame(), []domain.InstalledMod{*mod})
 	if err != nil {
 		return ActionOutcome{}, mapUpdateNetworkError(fmt.Sprintf("checking update for %s", u.Name), u.Source, err)
 	}
@@ -1110,7 +1207,7 @@ func (p *coreProvider) ApplyUpdate(ctx context.Context, u UpdateItem, progress f
 	adapter := deployProgressAdapter(progress, func(p core.DeployProgress) (ActionProgress, bool) {
 		return updateProgressLine(u.Name, p)
 	})
-	result, err := p.svc.ApplyUpdate(ctx, p.game, profile, upd, opts, adapter)
+	result, err := p.svc.ApplyUpdate(ctx, p.currentGame(), profile, upd, opts, adapter)
 	if err != nil {
 		return ActionOutcome{}, mapUpdateNetworkError(fmt.Sprintf("updating %s", u.Name), u.Source, err)
 	}
@@ -1128,7 +1225,7 @@ func (p *coreProvider) SetUpdatePolicy(_ context.Context, item ModItem, policy s
 	if err != nil {
 		return ActionOutcome{}, err
 	}
-	if err := p.svc.SetModUpdatePolicy(item.Source, item.ID, p.game.ID, p.currentProfile(), mapped); err != nil {
+	if err := p.svc.SetModUpdatePolicy(item.Source, item.ID, p.currentGame().ID, p.currentProfile(), mapped); err != nil {
 		return ActionOutcome{}, fmt.Errorf("setting update policy for %s: %w", item.Name, err)
 	}
 	return ActionOutcome{Message: fmt.Sprintf("%s update policy: %s", item.Name, policy)}, nil
@@ -1140,7 +1237,7 @@ func (p *coreProvider) SetUpdatePolicy(_ context.Context, item ModItem, policy s
 // rejects a colliding name ("profile already exists: <name>") - see
 // internal/core/profile.go - so no separate check is needed here.
 func (p *coreProvider) CreateProfile(_ context.Context, name string) (ActionOutcome, error) {
-	if _, err := p.svc.NewProfileManager().Create(p.game.ID, name); err != nil {
+	if _, err := p.svc.NewProfileManager().Create(p.currentGame().ID, name); err != nil {
 		return ActionOutcome{}, fmt.Errorf("creating profile %s: %w", name, err)
 	}
 	return ActionOutcome{Message: fmt.Sprintf("Created profile: %s", name)}, nil
@@ -1155,7 +1252,7 @@ func (p *coreProvider) DeleteProfile(_ context.Context, name string) (ActionOutc
 	if name == p.currentProfile() {
 		return ActionOutcome{}, errors.New(errCannotDeleteActiveProfile)
 	}
-	if err := p.svc.NewProfileManager().Delete(p.game.ID, name); err != nil {
+	if err := p.svc.NewProfileManager().Delete(p.currentGame().ID, name); err != nil {
 		return ActionOutcome{}, fmt.Errorf("deleting profile %s: %w", name, err)
 	}
 	return ActionOutcome{Message: fmt.Sprintf("Deleted profile: %s", name)}, nil

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -1033,6 +1033,33 @@ func (p *coreProvider) SetUpdatePolicy(_ context.Context, item ModItem, policy s
 	return ActionOutcome{Message: fmt.Sprintf("%s update policy: %s", item.Name, policy)}, nil
 }
 
+// CreateProfile creates a new, empty profile via ProfileManager.Create - a
+// local YAML write, no network call, no hooks (mirroring SetUpdatePolicy's
+// own "local DB/config write" shape above). ProfileManager.Create already
+// rejects a colliding name ("profile already exists: <name>") - see
+// internal/core/profile.go - so no separate check is needed here.
+func (p *coreProvider) CreateProfile(_ context.Context, name string) (ActionOutcome, error) {
+	if _, err := p.svc.NewProfileManager().Create(p.game.ID, name); err != nil {
+		return ActionOutcome{}, fmt.Errorf("creating profile %s: %w", name, err)
+	}
+	return ActionOutcome{Message: fmt.Sprintf("Created profile: %s", name)}, nil
+}
+
+// DeleteProfile removes profile name via ProfileManager.Delete. Refuses to
+// delete the currently active profile - defense-in-depth backing the TUI's
+// own active-row guard (mutations.go's deleteSelectedProfile), in case a
+// stale selection ever reaches this call with the session's actual current
+// profile (see ActionProvider.DeleteProfile's doc comment).
+func (p *coreProvider) DeleteProfile(_ context.Context, name string) (ActionOutcome, error) {
+	if name == p.currentProfile() {
+		return ActionOutcome{}, errors.New(errCannotDeleteActiveProfile)
+	}
+	if err := p.svc.NewProfileManager().Delete(p.game.ID, name); err != nil {
+		return ActionOutcome{}, fmt.Errorf("deleting profile %s: %w", name, err)
+	}
+	return ActionOutcome{Message: fmt.Sprintf("Deleted profile: %s", name)}, nil
+}
+
 // switchPlanView maps a core.SwitchPlan to its TUI render model, using the
 // same display strings cmd/lmm/profile.go's doProfileSwitch plan printout
 // uses: ToEnable/ToDisable entries are addressed by Name (the CLI's "  + %s

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -362,6 +362,20 @@ func (p *coreProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
 	return items, nil
 }
 
+// DeployedFiles lists the relative paths sourceID/modID has deployed in the
+// active profile. p.svc.GetDeployedFilesForMod's own query already ORDER
+// BYs relative_path (internal/storage/db/files.go), so no defensive
+// sort.Strings is needed here - unlike Sources()/SourceInfos(), which sort
+// because their underlying iteration order (a Go map) is genuinely
+// unordered.
+func (p *coreProvider) DeployedFiles(sourceID, modID string) ([]string, error) {
+	paths, err := p.svc.GetDeployedFilesForMod(p.game.ID, p.currentProfile(), sourceID, modID)
+	if err != nil {
+		return nil, fmt.Errorf("loading deployed files for %s:%s: %w", sourceID, modID, err)
+	}
+	return paths, nil
+}
+
 func installedModStatus(mod domain.InstalledMod) string {
 	switch {
 	case mod.Enabled && mod.Deployed:

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -569,6 +569,107 @@ func (p *coreProvider) DeployProfile(ctx context.Context) (ActionOutcome, error)
 	}, nil
 }
 
+// prefixSkipped maps each core.PurgeResult.Skipped entry ("<name>: <reason>"
+// - see that field's own doc comment) to "Skipped <name>: <reason>" for
+// ActionOutcome.Warnings. Unlike DeployResult.Skipped, which
+// coreProvider.DeployProfile appends bare (its message already leads with
+// "Deployed N, M failed"), PurgeProfile's outcome message never mentions a
+// skip count at all - so each entry needs its own "Skipped " lead-in to read
+// as a diagnostic rather than an unlabeled fragment on the status line.
+func prefixSkipped(skipped []string) []string {
+	if len(skipped) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(skipped))
+	for _, s := range skipped {
+		out = append(out, "Skipped "+s)
+	}
+	return out
+}
+
+// purgeProgressLine composes an ActionProgress from one core.DeployProgress
+// event during PurgeProfile - only the three phases task-7-brief.md calls
+// out for the TUI status line: DeployPurging's header (Total mods about to
+// purge), and each mod's own PurgeModPurged/PurgeModSkipped. Every other
+// phase PurgeProfile can emit (DeployBeforeAllForced, PurgeWarning,
+// PurgeNote, PurgeComplete) is deliberately NOT streamed - those already
+// reach the user through the completed outcome's Warnings (see
+// coreProvider.PurgeProfile below), and streaming them too would just
+// duplicate the same text on the status line a moment earlier.
+func purgeProgressLine(p core.DeployProgress) (ActionProgress, bool) {
+	switch p.Phase {
+	case core.DeployPurging:
+		return ActionProgress{Line: fmt.Sprintf("purging %d mod(s)…", p.Total), Percent: -1}, true
+	case core.PurgeModPurged:
+		return ActionProgress{Line: fmt.Sprintf("✓ %s (%d/%d)", p.ModName, p.Index, p.Total), Percent: -1}, true
+	case core.PurgeModSkipped:
+		return ActionProgress{Line: "skipped " + p.ModName, Percent: -1}, true
+	default:
+		return ActionProgress{}, false
+	}
+}
+
+// PurgeProfile undeploys every mod currently installed in the active
+// profile - the TUI's 'X' binding (Task 7, mutations.go's
+// purgeProfilePrompt), wired onto core.PurgeProfile (#61's extraction built
+// specifically for this consumer). mods is re-fetched here via
+// GetInstalledMods rather than reused from whatever list the confirmation
+// modal was built from - the same documented plan-drift stance as
+// ApplyProfileSwitch's own re-plan-at-apply precedent (see that method's
+// doc comment): the set actually purged can differ from what the modal
+// showed if something changed between the keypress and the confirm. An
+// empty list short-circuits to a plain "no mods installed" outcome with no
+// core call, no hooks, and no progress ticks at all - mirroring the CLI's
+// own "No mods installed" short-circuit (cmd/lmm/purge.go's doPurge) and
+// core.PurgeProfile's own documented empty-mods no-op.
+//
+// Uninstall is always false (the TUI has no --uninstall equivalent - purged
+// mods keep their DB record, matching a plain `lmm purge`) and Force is
+// always false (matching every other coreProvider mutation's hook
+// defaults - see hookRunner's doc comment), same as DeployProfile/
+// UninstallMod above.
+//
+// On error, coreProvider follows the SAME convention every other mutation
+// in this file already does (DeployProfile/UninstallMod/ApplyInstall/
+// ApplyUpdate/ApplyProfileSwitch): the wrapped error is returned with an
+// empty ActionOutcome{}, not core.PurgeProfile's own partial result -
+// buildAction's actionFailedMsg (actions.go) only ever carries the error
+// text, never an outcome, so a partial result's Warnings/Skipped would
+// never reach the status line regardless of whether this method populated
+// them. The only PurgeProfile error path reachable with Force=false is an
+// uninstall.before_all hook failure, which core.PurgeProfile documents as
+// returning before anything in the result is populated anyway.
+func (p *coreProvider) PurgeProfile(ctx context.Context, progress func(ActionProgress)) (ActionOutcome, error) {
+	profile := p.currentProfile()
+	mods, err := p.svc.GetInstalledMods(p.game.ID, profile)
+	if err != nil {
+		return ActionOutcome{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.game.ID, profile, err)
+	}
+	if len(mods) == 0 {
+		return ActionOutcome{Message: "no mods installed"}, nil
+	}
+
+	opts := core.PurgeOptions{
+		Uninstall:   false,
+		Hooks:       p.resolvedHooks(profile),
+		HookRunner:  p.hookRunner(),
+		HookContext: p.hookContext(),
+		Force:       false,
+	}
+
+	adapter := deployProgressAdapter(progress, purgeProgressLine)
+	result, err := p.svc.PurgeProfile(ctx, p.game, profile, mods, opts, adapter)
+	if err != nil {
+		return ActionOutcome{}, fmt.Errorf("purging profile %s: %w", profile, err)
+	}
+
+	warnings := mergeDiagnostics(append(prefixSkipped(result.Skipped), result.Warnings...), result.Notes)
+	return ActionOutcome{
+		Message:  fmt.Sprintf("Purged %d mod(s)", result.Purged),
+		Warnings: warnings,
+	}, nil
+}
+
 func (p *coreProvider) PlanProfileSwitch(ctx context.Context, profileName string) (SwitchPlanView, error) {
 	plan, err := p.svc.PlanProfileSwitch(ctx, p.game, profileName)
 	if err != nil {

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -31,6 +31,15 @@ import (
 // each other (sync.RWMutex/sync.Mutex are not reentrant) - SetGame takes
 // all three sequentially (gameMu, then profileMu, then hooksMu), NEVER
 // nested, so no critical section here ever blocks waiting on itself.
+// resolvedHooks/hookContext take the already-snapshotted *domain.Game as a
+// parameter - never calling currentGame() themselves - precisely so
+// gameMu.RLock is never acquired inside hooksMu's critical section (the
+// same snapshot-then-lock discipline resolvedHooks has always applied to
+// the profile, see its doc comment). Relatedly (Task 8 review's TOCTOU
+// finding): any method that uses the game more than once per logical
+// operation snapshots it ONCE up front (`game := p.currentGame()`,
+// mirroring the existing `profile := p.currentProfile()` convention) so a
+// concurrent SetGame can never split one operation across two games.
 //
 // profileMu guards profile (Task 6 item b): SetProfile (called from the
 // Bubble Tea Update goroutine when a profile-switch action completes - see
@@ -105,10 +114,11 @@ func NewCoreActions(svc *core.Service, game *domain.Game, profileName string) Ac
 }
 
 func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
+	game := p.currentGame()
 	profile := p.currentProfile()
-	mods, err := p.svc.GetInstalledMods(p.currentGame().ID, profile)
+	mods, err := p.svc.GetInstalledMods(game.ID, profile)
 	if err != nil {
-		return Summary{}, nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.currentGame().ID, profile, err)
+		return Summary{}, nil, fmt.Errorf("loading installed mods for %s/%s: %w", game.ID, profile, err)
 	}
 
 	enabled := 0
@@ -132,7 +142,7 @@ func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 	}
 
 	return Summary{
-		GameName:    p.currentGame().Name,
+		GameName:    game.Name,
 		ProfileName: profile,
 		Installed:   len(mods),
 		Enabled:     enabled,
@@ -142,8 +152,9 @@ func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 }
 
 func (p *coreProvider) Sources() []string {
-	sources := make([]string, 0, len(p.currentGame().SourceIDs))
-	for id := range p.currentGame().SourceIDs {
+	game := p.currentGame()
+	sources := make([]string, 0, len(game.SourceIDs))
+	for id := range game.SourceIDs {
 		sources = append(sources, id)
 	}
 	sort.Strings(sources)
@@ -280,10 +291,11 @@ func (p *coreProvider) Search(ctx context.Context, sourceID, query string, page 
 // installedModKeys returns the set of domain.ModKey(sourceID, modID) values
 // installed in the active profile, used to mark search results as installed.
 func (p *coreProvider) installedModKeys() (map[string]bool, error) {
+	game := p.currentGame()
 	profile := p.currentProfile()
-	installed, err := p.svc.GetInstalledMods(p.currentGame().ID, profile)
+	installed, err := p.svc.GetInstalledMods(game.ID, profile)
 	if err != nil {
-		return nil, fmt.Errorf("loading installed mods for %s/%s: %w", p.currentGame().ID, profile, err)
+		return nil, fmt.Errorf("loading installed mods for %s/%s: %w", game.ID, profile, err)
 	}
 	keys := make(map[string]bool, len(installed))
 	for _, mod := range installed {
@@ -443,10 +455,11 @@ func (p *coreProvider) SetProfile(name string) {
 }
 
 func (p *coreProvider) Profiles(_ context.Context) ([]ProfileItem, error) {
+	game := p.currentGame()
 	activeProfile := p.currentProfile()
-	profiles, err := p.svc.NewProfileManager().List(p.currentGame().ID)
+	profiles, err := p.svc.NewProfileManager().List(game.ID)
 	if err != nil {
-		return nil, fmt.Errorf("listing profiles for %s: %w", p.currentGame().ID, err)
+		return nil, fmt.Errorf("listing profiles for %s: %w", game.ID, err)
 	}
 
 	items := make([]ProfileItem, 0, len(profiles))
@@ -551,18 +564,23 @@ func (p *coreProvider) hookRunner() *core.HookRunner {
 	return p.cachedRunner
 }
 
-// resolvedHooks resolves activeProfile's hooks, mirroring
+// resolvedHooks resolves activeProfile's hooks for game, mirroring
 // cmd/lmm/hooks.go's getResolvedHooks (minus its --no-hooks short-circuit -
-// see hookRunner's doc comment). Takes the already-resolved profile as a
-// parameter, rather than reading p.profile itself, so every caller reads
-// p.profile exactly once via currentProfile() (Task 6 item b) - see the
-// struct's doc comment.
+// see hookRunner's doc comment). Takes BOTH the already-resolved profile
+// AND the already-snapshotted game as parameters, rather than reading
+// p.profile/p.game itself, so every caller reads each exactly once via
+// currentProfile()/currentGame() (Task 6 item b / Task 8 review) - and,
+// just as importantly, so this method never takes gameMu.RLock nested
+// inside hooksMu's critical section: taking a second lock inside the first
+// is exactly the nesting the struct's lock-ordering doc comment forbids
+// (see gameMu's doc comment - the same reasoning already kept profileMu
+// out of here since Task 6).
 //
 // Task 6 item c: unlike hookRunner, this result genuinely varies per
 // profile (a profile's hooks.yaml overrides can differ from another's), so
-// it is cached only until SetProfile rebinds the session (see that
-// method's doc comment and cachedHooks' own).
-func (p *coreProvider) resolvedHooks(activeProfile string) *core.ResolvedHooks {
+// it is cached only until SetProfile/SetGame rebinds the session (see
+// those methods' doc comments and cachedHooks' own).
+func (p *coreProvider) resolvedHooks(game *domain.Game, activeProfile string) *core.ResolvedHooks {
 	p.hooksMu.Lock()
 	defer p.hooksMu.Unlock()
 	if p.cachedHooks != nil {
@@ -571,20 +589,24 @@ func (p *coreProvider) resolvedHooks(activeProfile string) *core.ResolvedHooks {
 
 	var profile *domain.Profile
 	if activeProfile != "" {
-		if pr, err := config.LoadProfile(p.svc.ConfigDir(), p.currentGame().ID, activeProfile); err == nil {
+		if pr, err := config.LoadProfile(p.svc.ConfigDir(), game.ID, activeProfile); err == nil {
 			profile = pr
 		}
 	}
-	p.cachedHooks = core.ResolveHooks(p.currentGame(), profile)
+	p.cachedHooks = core.ResolveHooks(game, profile)
 	return p.cachedHooks
 }
 
-// hookContext mirrors cmd/lmm/hooks.go's makeHookContext.
-func (p *coreProvider) hookContext() core.HookContext {
+// hookContext mirrors cmd/lmm/hooks.go's makeHookContext. Takes the
+// already-snapshotted game as a parameter (rather than reading
+// currentGame() itself, let alone three times - the Task 8 review's TOCTOU
+// finding) so all three fields are guaranteed to describe the SAME game
+// even if a concurrent SetGame lands mid-call.
+func (p *coreProvider) hookContext(game *domain.Game) core.HookContext {
 	return core.HookContext{
-		GameID:   p.currentGame().ID,
-		GamePath: p.currentGame().InstallPath,
-		ModPath:  p.currentGame().ModPath,
+		GameID:   game.ID,
+		GamePath: game.InstallPath,
+		ModPath:  game.ModPath,
 	}
 }
 
@@ -614,15 +636,16 @@ func (p *coreProvider) DisableMod(ctx context.Context, item ModItem) (ActionOutc
 // doUninstall passes to core.UninstallMod (KeepCache=false, Force=false -
 // see hookRunner's doc comment for why hooks are never disabled here).
 func (p *coreProvider) UninstallMod(ctx context.Context, item ModItem) (ActionOutcome, error) {
+	game := p.currentGame()
 	profile := p.currentProfile()
 	opts := core.UninstallOptions{
 		KeepCache:   false,
-		Hooks:       p.resolvedHooks(profile),
+		Hooks:       p.resolvedHooks(game, profile),
 		HookRunner:  p.hookRunner(),
-		HookContext: p.hookContext(),
+		HookContext: p.hookContext(game),
 		Force:       false,
 	}
-	result, err := p.svc.UninstallMod(ctx, p.currentGame(), profile, item.Source, item.ID, opts)
+	result, err := p.svc.UninstallMod(ctx, game, profile, item.Source, item.ID, opts)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("uninstalling %s: %w", item.Name, err)
 	}
@@ -638,14 +661,15 @@ func (p *coreProvider) UninstallMod(ctx context.Context, item ModItem) (ActionOu
 // static "working" state while this call is in flight; 5b streams
 // core.DeployProgress events.
 func (p *coreProvider) DeployProfile(ctx context.Context) (ActionOutcome, error) {
+	game := p.currentGame()
 	profile := p.currentProfile()
 	opts := core.DeployOptions{
-		Hooks:       p.resolvedHooks(profile),
+		Hooks:       p.resolvedHooks(game, profile),
 		HookRunner:  p.hookRunner(),
-		HookContext: p.hookContext(),
+		HookContext: p.hookContext(game),
 		Force:       false,
 	}
-	result, err := p.svc.DeployProfile(ctx, p.currentGame(), profile, opts, nil)
+	result, err := p.svc.DeployProfile(ctx, game, profile, opts, nil)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("deploying profile %s: %w", profile, err)
 	}
@@ -737,10 +761,11 @@ func purgeProgressLine(p core.DeployProgress) (ActionProgress, bool) {
 // uninstall.before_all hook failure, which core.PurgeProfile documents as
 // returning before anything in the result is populated anyway.
 func (p *coreProvider) PurgeProfile(ctx context.Context, progress func(ActionProgress)) (ActionOutcome, error) {
+	game := p.currentGame()
 	profile := p.currentProfile()
-	mods, err := p.svc.GetInstalledMods(p.currentGame().ID, profile)
+	mods, err := p.svc.GetInstalledMods(game.ID, profile)
 	if err != nil {
-		return ActionOutcome{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.currentGame().ID, profile, err)
+		return ActionOutcome{}, fmt.Errorf("loading installed mods for %s/%s: %w", game.ID, profile, err)
 	}
 	if len(mods) == 0 {
 		return ActionOutcome{Message: "no mods installed"}, nil
@@ -748,14 +773,14 @@ func (p *coreProvider) PurgeProfile(ctx context.Context, progress func(ActionPro
 
 	opts := core.PurgeOptions{
 		Uninstall:   false,
-		Hooks:       p.resolvedHooks(profile),
+		Hooks:       p.resolvedHooks(game, profile),
 		HookRunner:  p.hookRunner(),
-		HookContext: p.hookContext(),
+		HookContext: p.hookContext(game),
 		Force:       false,
 	}
 
 	adapter := deployProgressAdapter(progress, purgeProgressLine)
-	result, err := p.svc.PurgeProfile(ctx, p.currentGame(), profile, mods, opts, adapter)
+	result, err := p.svc.PurgeProfile(ctx, game, profile, mods, opts, adapter)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("purging profile %s: %w", profile, err)
 	}
@@ -819,7 +844,8 @@ func (p *coreProvider) PlanProfileSwitch(ctx context.Context, profileName string
 // caller applying a switch with progress=nil, e.g. a "fire and check the
 // outcome" caller, must still see the failure in Warnings).
 func (p *coreProvider) ApplyProfileSwitch(ctx context.Context, profileName string, progress func(ActionProgress)) (ActionOutcome, error) {
-	plan, err := p.svc.PlanProfileSwitch(ctx, p.currentGame(), profileName)
+	game := p.currentGame()
+	plan, err := p.svc.PlanProfileSwitch(ctx, game, profileName)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("planning switch to %s: %w", profileName, err)
 	}
@@ -856,7 +882,7 @@ func (p *coreProvider) ApplyProfileSwitch(ctx context.Context, profileName strin
 		}
 	}
 
-	result, err := p.svc.ApplyProfileSwitch(ctx, p.currentGame(), plan, onProgress)
+	result, err := p.svc.ApplyProfileSwitch(ctx, game, plan, onProgress)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("switching to %s: %w", profileName, err)
 	}
@@ -1077,8 +1103,9 @@ func (p *coreProvider) PlanInstall(ctx context.Context, item ModItem) (InstallPl
 // non-blocking "N file(s) conflict" warning philosophy (applyInstallBatchMod
 // in internal/core/flows.go) rather than the CLI's blocking one.
 func (p *coreProvider) ApplyInstall(ctx context.Context, item ModItem, progress func(ActionProgress)) (ActionOutcome, error) {
+	game := p.currentGame()
 	profile := p.currentProfile()
-	plan, err := p.svc.PlanInstall(ctx, p.currentGame(), profile, item.Source, item.ID, false)
+	plan, err := p.svc.PlanInstall(ctx, game, profile, item.Source, item.ID, false)
 	if err != nil {
 		return ActionOutcome{}, mapInstallNetworkError(fmt.Sprintf("planning install of %s", item.Name), item.Source, err)
 	}
@@ -1086,9 +1113,9 @@ func (p *coreProvider) ApplyInstall(ctx context.Context, item ModItem, progress 
 	var conflictWarnings []string
 	opts := core.InstallOptions{
 		SkipVerify:  false,
-		Hooks:       p.resolvedHooks(profile),
+		Hooks:       p.resolvedHooks(game, profile),
 		HookRunner:  p.hookRunner(),
-		HookContext: p.hookContext(),
+		HookContext: p.hookContext(game),
 		Force:       false,
 		ConfirmConflicts: func(conflicts []core.Conflict) bool {
 			for _, c := range conflicts {
@@ -1101,7 +1128,7 @@ func (p *coreProvider) ApplyInstall(ctx context.Context, item ModItem, progress 
 	adapter := deployProgressAdapter(progress, func(p core.DeployProgress) (ActionProgress, bool) {
 		return installProgressLine(item.Name, p)
 	})
-	result, err := p.svc.ApplyInstall(ctx, p.currentGame(), plan, opts, adapter)
+	result, err := p.svc.ApplyInstall(ctx, game, plan, opts, adapter)
 	if err != nil {
 		return ActionOutcome{}, mapInstallNetworkError(fmt.Sprintf("installing %s", item.Name), item.Source, err)
 	}
@@ -1148,13 +1175,14 @@ func (p *coreProvider) ApplyInstall(ctx context.Context, item ModItem, progress 
 // per-source failure is still legible inside the underlying joined
 // "source %s: %w" text this doesn't discard.
 func (p *coreProvider) CheckUpdates(ctx context.Context) (UpdatesView, error) {
+	game := p.currentGame()
 	profile := p.currentProfile()
-	installed, err := p.svc.GetInstalledMods(p.currentGame().ID, profile)
+	installed, err := p.svc.GetInstalledMods(game.ID, profile)
 	if err != nil {
-		return UpdatesView{}, fmt.Errorf("loading installed mods for %s/%s: %w", p.currentGame().ID, profile, err)
+		return UpdatesView{}, fmt.Errorf("loading installed mods for %s/%s: %w", game.ID, profile, err)
 	}
 
-	updates, checkErr := p.svc.NewUpdater().CheckUpdates(ctx, p.currentGame(), installed)
+	updates, checkErr := p.svc.NewUpdater().CheckUpdates(ctx, game, installed)
 	var view UpdatesView
 	for _, u := range updates {
 		view.Updates = append(view.Updates, UpdateItem{
@@ -1182,13 +1210,14 @@ func (p *coreProvider) CheckUpdates(ctx context.Context) (UpdatesView, error) {
 // and a real update may need that superseded-file-ID mapping to install
 // correctly; only a fresh CheckUpdates call can supply it.
 func (p *coreProvider) ApplyUpdate(ctx context.Context, u UpdateItem, progress func(ActionProgress)) (ActionOutcome, error) {
+	game := p.currentGame()
 	profile := p.currentProfile()
-	mod, err := p.svc.GetInstalledMod(u.Source, u.ID, p.currentGame().ID, profile)
+	mod, err := p.svc.GetInstalledMod(u.Source, u.ID, game.ID, profile)
 	if err != nil {
 		return ActionOutcome{}, fmt.Errorf("getting installed mod %s: %w", u.Name, err)
 	}
 
-	updates, err := p.svc.NewUpdater().CheckUpdates(ctx, p.currentGame(), []domain.InstalledMod{*mod})
+	updates, err := p.svc.NewUpdater().CheckUpdates(ctx, game, []domain.InstalledMod{*mod})
 	if err != nil {
 		return ActionOutcome{}, mapUpdateNetworkError(fmt.Sprintf("checking update for %s", u.Name), u.Source, err)
 	}
@@ -1198,16 +1227,16 @@ func (p *coreProvider) ApplyUpdate(ctx context.Context, u UpdateItem, progress f
 	upd := updates[0]
 
 	opts := core.UpdateOptions{
-		Hooks:       p.resolvedHooks(profile),
+		Hooks:       p.resolvedHooks(game, profile),
 		HookRunner:  p.hookRunner(),
-		HookContext: p.hookContext(),
+		HookContext: p.hookContext(game),
 		Force:       false,
 	}
 
 	adapter := deployProgressAdapter(progress, func(p core.DeployProgress) (ActionProgress, bool) {
 		return updateProgressLine(u.Name, p)
 	})
-	result, err := p.svc.ApplyUpdate(ctx, p.currentGame(), profile, upd, opts, adapter)
+	result, err := p.svc.ApplyUpdate(ctx, game, profile, upd, opts, adapter)
 	if err != nil {
 		return ActionOutcome{}, mapUpdateNetworkError(fmt.Sprintf("updating %s", u.Name), u.Source, err)
 	}

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -1589,3 +1589,79 @@ func TestCoreProviderActions_ApplyUpdate_MapsNotSupportedError(t *testing.T) {
 	assert.NotContains(t, err.Error(), "lmm install",
 		"an updates-capability gap must never suggest the install-path fallback")
 }
+
+// TestCoreProviderActions_SetUpdatePolicy_PersistsAndReadsBack is Task 5's
+// coreProvider guard: setting "auto" through the ActionProvider seam
+// persists via svc.SetModUpdatePolicy, visible in a direct
+// svc.GetInstalledMod read-back as domain.UpdateAuto - a real Service
+// fixture, no recording fake, so this proves the actual DB write/mapping
+// rather than just the wiring.
+func TestCoreProviderActions_SetUpdatePolicy_PersistsAndReadsBack(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	seedActionMod(t, svc, game, "src", "modP", "Mod P", "1.0", true, nil)
+	item := tui.ModItem{ID: "modP", Source: "src", Name: "Mod P"}
+
+	outcome, err := actions.SetUpdatePolicy(context.Background(), item, "auto")
+	require.NoError(t, err)
+	assert.Equal(t, "Mod P update policy: auto", outcome.Message)
+
+	mod, err := svc.GetInstalledMod("src", "modP", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, domain.UpdateAuto, mod.UpdatePolicy)
+}
+
+// TestCoreProviderActions_SetUpdatePolicy_UnknownPolicyErrors guards the
+// reject-not-default contract (service_core.go's parseUpdatePolicy): an
+// unrecognized policy string errors instead of silently mapping to
+// domain.UpdateNotify, and never reaches svc.SetModUpdatePolicy at all - the
+// mod's policy in the DB stays untouched.
+func TestCoreProviderActions_SetUpdatePolicy_UnknownPolicyErrors(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	seedActionMod(t, svc, game, "src", "modQ", "Mod Q", "1.0", true, nil)
+	item := tui.ModItem{ID: "modQ", Source: "src", Name: "Mod Q"}
+
+	_, err := actions.SetUpdatePolicy(context.Background(), item, "bogus")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown policy "bogus"`)
+
+	mod, err := svc.GetInstalledMod("src", "modQ", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, domain.UpdateNotify, mod.UpdatePolicy, "an unknown policy must never mutate the stored policy")
+}
+
+// TestCoreProviderOverview_MapsUpdatePolicyToWireString extends
+// TestCoreProviderOverview's own assertions (per task-5-brief.md: "extend
+// the existing Overview test's assertions minimally") to cover the
+// ModItem.UpdatePolicy field this task added: seeded UpdateAuto/UpdatePinned
+// mods must stringify to "auto"/"pin" (policyToString's documented wire
+// strings - NOT the CLI's own "pinned" spelling, see that function's doc
+// comment) in the Overview mapping.
+func TestCoreProviderOverview_MapsUpdatePolicyToWireString(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "201", SourceID: "nexusmods", GameID: game.ID, Name: "Auto Mod", Version: "1.0"},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateAuto,
+		Enabled:      true,
+	}))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "202", SourceID: "nexusmods", GameID: game.ID, Name: "Pinned Mod", Version: "1.0"},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdatePinned,
+		Enabled:      true,
+	}))
+
+	_, mods, err := provider.Overview(context.Background())
+	require.NoError(t, err)
+
+	byID := map[string]tui.ModItem{}
+	for _, m := range mods {
+		byID[m.ID] = m
+	}
+	require.Contains(t, byID, "101", "pre-existing fixture mod must still be present")
+	assert.Equal(t, "notify", byID["101"].UpdatePolicy, "the fixture's default UpdatePolicy (zero value) maps to notify")
+	require.Contains(t, byID, "201")
+	assert.Equal(t, "auto", byID["201"].UpdatePolicy)
+	require.Contains(t, byID, "202")
+	assert.Equal(t, "pin", byID["202"].UpdatePolicy)
+}

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -473,6 +473,58 @@ func TestCoreProviderSearchAllSourcesWarnings(t *testing.T) {
 	assert.NotEmpty(t, page.Results, "good source's results survive the failure")
 }
 
+// --- coreProvider: DeployedFiles ---
+
+// TestCoreProviderDeployedFiles guards the read-only files-overlay data path
+// (Task 4): DeployedFiles must return the exact relative paths a real
+// Installer.Install run recorded via SaveDeployedFile, sorted (the
+// underlying query already ORDER BYs relative_path - see
+// internal/storage/db/files.go's GetDeployedFilesForMod - so this also pins
+// that coreProvider does not need to re-sort defensively).
+func TestCoreProviderDeployedFiles(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+
+	gameCache := svc.GetGameCache(game)
+	files := map[string][]byte{
+		"textures/mod-a/main.dds": []byte("data"),
+		"mod-a.esp":               []byte("data"),
+	}
+	for path, content := range files {
+		require.NoError(t, gameCache.Store(game.ID, "nexusmods", "mod-a", "1.0", path, content))
+	}
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "mod-a",
+			SourceID: "nexusmods",
+			GameID:   game.ID,
+			Name:     "Mod A",
+			Version:  "1.0",
+		},
+		ProfileName: "default",
+		Enabled:     true,
+	}))
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "mod-a", SourceID: "nexusmods", Version: "1.0", GameID: game.ID}, "default"))
+
+	got, err := provider.DeployedFiles("nexusmods", "mod-a")
+	require.NoError(t, err)
+	require.Equal(t, []string{"mod-a.esp", "textures/mod-a/main.dds"}, got)
+}
+
+// TestCoreProviderDeployedFilesEmpty covers a mod with no deployed_files
+// rows at all - the fixture's mod "101" carries Deployed:true on its
+// InstalledMod DB row, but that flag is separate bookkeeping from the
+// deployed_files tracking table (only Installer.Install populates it via
+// SaveDeployedFile - see this file's other DeployedFiles test), so no
+// Install call means no tracked files.
+func TestCoreProviderDeployedFilesEmpty(t *testing.T) {
+	provider, _, _ := newCoreProviderFixture(t)
+
+	got, err := provider.DeployedFiles("nexusmods", "101")
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
 // --- coreProvider: ActionProvider ---
 
 // newCoreActionsFixture mirrors newCoreProviderFixture, but returns the

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -993,6 +993,128 @@ func TestCoreProviderActions_DeployProfile_ReportsFailedCount(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "the mod whose redownload failed must not be deployed")
 }
 
+// --- coreProvider: PurgeProfile (Task 7) ---
+
+// seedDeployedActionMod stores files in game's cache, saves an InstalledMod
+// DB row with Deployed already true, and actually deploys the files via
+// Installer.Install - the seed+install recipe TestCoreProviderDeployedFiles
+// (Task 3, above) established, extended with an explicit Deployed:true seed
+// (mirroring newCoreProviderFixture's own SkyUI row) so a purge test can
+// observe it flip to false.
+func seedDeployedActionMod(t *testing.T, svc *core.Service, game *domain.Game, sourceID, modID, name, version string, files map[string][]byte) {
+	t.Helper()
+
+	gameCache := svc.GetGameCache(game)
+	for path, content := range files {
+		require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, path, content))
+	}
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: sourceID, Name: name, Version: version, GameID: game.ID},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+		Deployed:     true,
+	}))
+	installer := svc.GetInstaller(game)
+	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: modID, SourceID: sourceID, Version: version, GameID: game.ID}, "default"))
+}
+
+// TestCoreProviderActions_PurgeProfile drives PurgeProfile against a real
+// Service: two mods are seeded pre-deployed and actually installed
+// (seedDeployedActionMod), then purged - proving the files are undeployed
+// for real, both DB rows flip Deployed=false (not deleted - Uninstall is
+// always false, see coreProvider.PurgeProfile's own doc comment), the
+// outcome message counts them, and the progress adapter streams the
+// DeployPurging header plus a "✓"-line per mod (purgeProgressLine's
+// composed lines, observed here directly - unlike the TUI-model-level pump
+// tests in purge_test.go, this calls the progress callback synchronously
+// per event with no single-slot-channel coalescing in between).
+func TestCoreProviderActions_PurgeProfile(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	seedDeployedActionMod(t, svc, game, "src", "1", "Mod One", "1.0", map[string][]byte{"one.esp": []byte("1")})
+	seedDeployedActionMod(t, svc, game, "src", "2", "Mod Two", "1.0", map[string][]byte{"two.esp": []byte("2")})
+
+	var ticks []tui.ActionProgress
+	outcome, err := actions.PurgeProfile(context.Background(), func(p tui.ActionProgress) { ticks = append(ticks, p) })
+	require.NoError(t, err)
+	assert.Equal(t, "Purged 2 mod(s)", outcome.Message)
+	assert.Empty(t, outcome.Warnings)
+
+	_, err = os.Lstat(filepath.Join(game.ModPath, "one.esp"))
+	assert.True(t, os.IsNotExist(err), "purge must undeploy mod 1's files")
+	_, err = os.Lstat(filepath.Join(game.ModPath, "two.esp"))
+	assert.True(t, os.IsNotExist(err), "purge must undeploy mod 2's files")
+
+	mod1, err := svc.GetInstalledMod("src", "1", game.ID, "default")
+	require.NoError(t, err)
+	assert.False(t, mod1.Deployed, "purge must flip Deployed to false, not delete the record")
+	mod2, err := svc.GetInstalledMod("src", "2", game.ID, "default")
+	require.NoError(t, err)
+	assert.False(t, mod2.Deployed)
+
+	var lines []string
+	for _, tick := range ticks {
+		lines = append(lines, tick.Line)
+	}
+	assert.Contains(t, lines, "purging 2 mod(s)…")
+	checkmarks := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, "✓ ") {
+			checkmarks++
+		}
+	}
+	assert.Equal(t, 2, checkmarks, "must observe a ✓-line per purged mod")
+}
+
+// TestCoreProviderActions_PurgeProfile_SkipAndWarningsSurface guards the
+// Skipped -> Warnings prefixing coreProvider.PurgeProfile documents
+// (service_core.go's prefixSkipped): a game-level uninstall.before_each
+// hook that always fails skips the mod entirely (core.PurgeResult.Skipped,
+// not Purged), and that skip must surface in ActionOutcome.Warnings with
+// its own "Skipped " lead-in. Uses the SAME direct
+// game.Hooks.Uninstall.BeforeEach technique
+// TestCoreProviderActions_UninstallMod_RunsUninstallHooksMatchingCLIConfig
+// (above) already established in this file - simpler than round-tripping a
+// hooks.yaml fixture, and already proven to resolve through
+// coreProvider.resolvedHooks, so this test reuses it rather than
+// introducing a second hook-wiring mechanism.
+func TestCoreProviderActions_PurgeProfile_SkipAndWarningsSurface(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	scriptsDir := t.TempDir()
+	failScript := createActionsTestScript(t, scriptsDir, "before_each.sh", `#!/bin/bash
+echo "boom" >&2
+exit 1`)
+	game.Hooks.Uninstall.BeforeEach = failScript
+
+	seedDeployedActionMod(t, svc, game, "src", "1", "Test Mod", "1.0", map[string][]byte{"plugin.esp": []byte("data")})
+
+	outcome, err := actions.PurgeProfile(context.Background(), nil)
+	require.NoError(t, err, "a before_each skip must not fail the whole purge")
+	assert.Equal(t, "Purged 0 mod(s)", outcome.Message)
+	require.Len(t, outcome.Warnings, 1)
+	assert.Contains(t, outcome.Warnings[0], "Skipped Test Mod: uninstall.before_each hook failed")
+
+	_, err = os.Lstat(filepath.Join(game.ModPath, "plugin.esp"))
+	assert.NoError(t, err, "a skipped mod's files must remain deployed - purge never touched it")
+
+	mod, err := svc.GetInstalledMod("src", "1", game.ID, "default")
+	require.NoError(t, err)
+	assert.True(t, mod.Deployed, "a skipped mod's Deployed flag must be untouched")
+}
+
+// TestCoreProviderActions_PurgeProfile_Empty guards the empty-mods
+// short-circuit (coreProvider.PurgeProfile's own doc comment): no installed
+// mods means no core.PurgeProfile call at all, just a plain "no mods
+// installed" outcome with no error and no warnings.
+func TestCoreProviderActions_PurgeProfile_Empty(t *testing.T) {
+	actions, _, _ := newCoreActionsFixture(t)
+
+	outcome, err := actions.PurgeProfile(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "no mods installed", outcome.Message)
+	assert.Empty(t, outcome.Warnings)
+}
+
 func TestCoreProviderActions_PlanProfileSwitch_MapsBucketsToDisplayStrings(t *testing.T) {
 	actions, svc, game := newCoreActionsFixture(t)
 	pm := svc.NewProfileManager()

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -1591,6 +1591,61 @@ func TestCoreProviderActions_ApplyUpdate_MapsNotSupportedError(t *testing.T) {
 }
 
 // TestCoreProviderActions_SetUpdatePolicy_PersistsAndReadsBack is Task 5's
+// TestCoreProviderActions_CreateProfile proves CreateProfile persists a real,
+// empty profile via svc.NewProfileManager().Create, readable back with
+// pm.Get, and that a duplicate create is rejected (ProfileManager.Create's
+// own "profile already exists" guard - internal/core/profile.go).
+func TestCoreProviderActions_CreateProfile(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+
+	outcome, err := actions.CreateProfile(context.Background(), "extra")
+	require.NoError(t, err)
+	assert.Equal(t, "Created profile: extra", outcome.Message)
+
+	pm := svc.NewProfileManager()
+	profile, err := pm.Get(game.ID, "extra")
+	require.NoError(t, err)
+	assert.Equal(t, "extra", profile.Name)
+
+	_, err = actions.CreateProfile(context.Background(), "extra")
+	assert.Error(t, err, "creating a colliding name a second time must error")
+}
+
+// TestCoreProviderActions_DeleteProfile proves DeleteProfile removes a real,
+// non-active profile's YAML via svc.NewProfileManager().Delete - a
+// subsequent pm.Get for the same name returns domain.ErrProfileNotFound.
+func TestCoreProviderActions_DeleteProfile(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "extra")
+	require.NoError(t, err)
+
+	outcome, err := actions.DeleteProfile(context.Background(), "extra")
+	require.NoError(t, err)
+	assert.Equal(t, "Deleted profile: extra", outcome.Message)
+
+	_, err = pm.Get(game.ID, "extra")
+	assert.ErrorIs(t, err, domain.ErrProfileNotFound)
+}
+
+// TestCoreProviderActions_DeleteActiveProfileRefused proves the
+// defense-in-depth guard in coreProvider.DeleteProfile: deleting the
+// session's own active profile ("default", per newCoreActionsFixture) errors
+// without ever calling ProfileManager.Delete - the profile is still present
+// afterward.
+func TestCoreProviderActions_DeleteActiveProfileRefused(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+
+	_, err := actions.DeleteProfile(context.Background(), "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot delete the active profile")
+
+	pm := svc.NewProfileManager()
+	profile, err := pm.Get(game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "default", profile.Name, "the refused delete must leave the active profile untouched")
+}
+
 // coreProvider guard: setting "auto" through the ActionProvider seam
 // persists via svc.SetModUpdatePolicy, visible in a direct
 // svc.GetInstalledMod read-back as domain.UpdateAuto - a real Service

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -143,6 +143,51 @@ func TestCoreProviderProfileFieldRaceGuard(t *testing.T) {
 	wg.Wait()
 }
 
+// TestCoreProviderGameFieldRaceGuard is Task 8's race test, mirroring
+// TestCoreProviderProfileFieldRaceGuard immediately above in full (gameMu's
+// own doc comment guards the identical race for p.game that profileMu
+// guards for p.profile): a Search call blocked genuinely in-flight (past
+// the network call, about to proceed into installedModKeys' own
+// p.currentGame().ID read - the same spot p.currentProfile() is read right
+// after unblocking) overlaps a concurrent SetGame call on the SAME
+// coreProvider instance. Passes functionally either way; the point is
+// `go test -race` must NOT report a data race on p.game.
+func TestCoreProviderGameFieldRaceGuard(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+	game.SourceIDs = map[string]string{"blocking": "testgame"}
+	src := &blockingSource{id: "blocking", entered: make(chan struct{}), release: make(chan struct{})}
+	svc.RegisterSource(src)
+
+	second := &domain.Game{
+		ID:          "second-game",
+		Name:        "Second Game",
+		InstallPath: t.TempDir(),
+		ModPath:     t.TempDir(),
+	}
+	require.NoError(t, svc.AddGame(second))
+
+	rebinder, ok := provider.(interface{ SetGame(string) error })
+	require.True(t, ok, "coreProvider must implement the gameRebinder shape")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = provider.Search(context.Background(), "blocking", "query", 0)
+	}()
+
+	<-src.entered // Search is now blocked inside the "network call", about
+	// to proceed straight into installedModKeys' p.currentGame().ID read the
+	// instant release is closed below.
+	go func() {
+		defer wg.Done()
+		_ = rebinder.SetGame(second.ID)
+	}()
+	close(src.release)
+
+	wg.Wait()
+}
+
 // netSource is a fuller source.ModSource test double than stubSource above:
 // it serves real download content over an httptest.Server, so coreProvider's
 // network-touching ActionProvider methods (PlanInstall/ApplyInstall/
@@ -1841,4 +1886,142 @@ func TestCoreProviderOverview_MapsUpdatePolicyToWireString(t *testing.T) {
 	assert.Equal(t, "auto", byID["201"].UpdatePolicy)
 	require.Contains(t, byID, "202")
 	assert.Equal(t, "pin", byID["202"].UpdatePolicy)
+}
+
+// --- Task 8: in-TUI game switcher ---
+
+// TestCoreProviderListGames guards ListGames' basic contract: every
+// configured game is listed, sorted by Name (mirroring SourceInfos' own
+// sorting - svc.ListGames ranges over an internal map, so iteration order
+// isn't otherwise deterministic), with exactly the fixture's own game -
+// the one bound at construction time - marked Active.
+func TestCoreProviderListGames(t *testing.T) {
+	provider, svc, game := newCoreProviderFixture(t)
+
+	second := &domain.Game{
+		ID:          "second-game",
+		Name:        "A Second Game", // sorts before "Test Game"
+		InstallPath: t.TempDir(),
+		ModPath:     t.TempDir(),
+	}
+	require.NoError(t, svc.AddGame(second))
+
+	games, err := provider.ListGames()
+	require.NoError(t, err)
+	require.Len(t, games, 2)
+
+	require.Equal(t, "A Second Game", games[0].Name, "must be sorted by Name")
+	require.Equal(t, "Test Game", games[1].Name)
+
+	byID := map[string]tui.GameInfo{}
+	for _, g := range games {
+		byID[g.ID] = g
+	}
+	require.True(t, byID[game.ID].Active, "the fixture's game (bound at construction) must be marked Active")
+	require.False(t, byID[second.ID].Active)
+}
+
+// TestCoreProviderSetGame guards SetGame's rebind contract: after switching,
+// Overview/Profiles reflect the NEW game's own data (not the game bound at
+// construction); an unknown id is refused, with the current binding left
+// completely untouched.
+func TestCoreProviderSetGame(t *testing.T) {
+	provider, svc, _ := newCoreProviderFixture(t)
+
+	second := &domain.Game{
+		ID:          "second-game",
+		Name:        "Second Game",
+		InstallPath: t.TempDir(),
+		ModPath:     t.TempDir(),
+	}
+	require.NoError(t, svc.AddGame(second))
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(second.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(second.ID, "default"))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "301", SourceID: "nexusmods", GameID: second.ID, Name: "Second Game Mod", Version: "1.0"},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+
+	rebinder, ok := provider.(interface{ SetGame(string) error })
+	require.True(t, ok, "coreProvider must implement the gameRebinder hook (SetGame(string) error)")
+	require.NoError(t, rebinder.SetGame(second.ID))
+
+	summary, mods, err := provider.Overview(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Second Game", summary.GameName)
+	require.Equal(t, "default", summary.ProfileName, "SetGame must resolve the new game's OWN default profile")
+	require.Len(t, mods, 1)
+	require.Equal(t, "Second Game Mod", mods[0].Name)
+
+	profiles, err := provider.Profiles(context.Background())
+	require.NoError(t, err)
+	require.Len(t, profiles, 1, "Profiles must be scoped to the NEW game, not the one bound at construction")
+	require.Equal(t, "default", profiles[0].Name)
+	require.True(t, profiles[0].Active)
+
+	err = rebinder.SetGame("no-such-game")
+	require.Error(t, err)
+	summary, _, err = provider.Overview(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Second Game", summary.GameName, "an unknown id must leave the current binding untouched")
+}
+
+// TestCoreProviderActions_SetGame_InvalidatesHooksCache guards SetGame's
+// hooks-cache invalidation, mirroring
+// TestCoreProviderActions_SetProfile_InvalidatesHooksCache's own seam
+// exactly (see that test's doc comment for the full reasoning) but keyed on
+// GAME instead of profile: a stale ResolvedHooks cached from the FIRST
+// game's hooks must never leak into an action run against the SECOND.
+func TestCoreProviderActions_SetGame_InvalidatesHooksCache(t *testing.T) {
+	actions, svc, game := newCoreActionsFixture(t)
+	scriptsDir := t.TempDir()
+	firstLog := filepath.Join(scriptsDir, "first.log")
+	secondLog := filepath.Join(scriptsDir, "second.log")
+	firstScript := createActionsTestScript(t, scriptsDir, "first_before_all.sh", `#!/bin/bash
+echo hit >> `+firstLog+`
+exit 0`)
+	secondScript := createActionsTestScript(t, scriptsDir, "second_before_all.sh", `#!/bin/bash
+echo hit >> `+secondLog+`
+exit 0`)
+
+	game.Hooks.Uninstall.BeforeAll = firstScript
+	seedActionMod(t, svc, game, "src", "1", "Mod One", "1.0", true, map[string][]byte{"one.esp": []byte("d")})
+	seedActionProfileMod(t, svc, game.ID, "default", "src", "1", "1.0")
+
+	_, err := actions.UninstallMod(context.Background(), tui.ModItem{ID: "1", Source: "src", Name: "Mod One"})
+	require.NoError(t, err)
+	firstLogContent, err := os.ReadFile(firstLog)
+	require.NoError(t, err)
+	assert.Equal(t, "hit\n", string(firstLogContent), "must resolve and run the FIRST game's own hook")
+
+	second := &domain.Game{
+		ID:          "second-game",
+		Name:        "Second Game",
+		InstallPath: t.TempDir(),
+		ModPath:     t.TempDir(),
+		LinkMethod:  domain.LinkSymlink,
+	}
+	second.Hooks.Uninstall.BeforeAll = secondScript
+	require.NoError(t, svc.AddGame(second))
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(second.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(second.ID, "default"))
+	seedActionMod(t, svc, second, "src", "2", "Mod Two", "1.0", true, map[string][]byte{"two.esp": []byte("d")})
+	seedActionProfileMod(t, svc, second.ID, "default", "src", "2", "1.0")
+
+	rebinder, ok := actions.(interface{ SetGame(string) error })
+	require.True(t, ok, "coreProvider must implement the gameRebinder hook (SetGame(string) error)")
+	require.NoError(t, rebinder.SetGame(second.ID))
+
+	_, err = actions.UninstallMod(context.Background(), tui.ModItem{ID: "2", Source: "src", Name: "Mod Two"})
+	require.NoError(t, err)
+	secondLogContent, err := os.ReadFile(secondLog)
+	require.NoError(t, err)
+	assert.Equal(t, "hit\n", string(secondLogContent),
+		"resolvedHooks must be recomputed after SetGame: the SECOND game's own hook must run, not one cached from the first")
 }

--- a/internal/tui/sources_view_test.go
+++ b/internal/tui/sources_view_test.go
@@ -186,6 +186,7 @@ func (longSourcesProvider) Search(context.Context, string, string, int) (SearchP
 	return SearchPage{}, nil
 }
 func (longSourcesProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
+func (longSourcesProvider) ListGames() ([]GameInfo, error)                 { return nil, nil }
 
 // TestSourcesViewFitsPanelWidthNarrowTerminal guards that sourcesView rows
 // truncate to the panel's content width (not the full terminal width) to

--- a/internal/tui/sources_view_test.go
+++ b/internal/tui/sources_view_test.go
@@ -185,6 +185,7 @@ func (longSourcesProvider) SourceInfos() []SourceInfo {
 func (longSourcesProvider) Search(context.Context, string, string, int) (SearchPage, error) {
 	return SearchPage{}, nil
 }
+func (longSourcesProvider) DeployedFiles(string, string) ([]string, error) { return nil, nil }
 
 // TestSourcesViewFitsPanelWidthNarrowTerminal guards that sourcesView rows
 // truncate to the panel's content width (not the full terminal width) to


### PR DESCRIPTION
Closes the Phase 6a slice of #37 (v1.13.0). Design doc: [docs/plans/2026-07-23-tui-phase6a-workflows-design.md](https://github.com/DonovanMods/linux-mod-manager/blob/feat/tui-phase6a-workflows/docs/plans/2026-07-23-tui-phase6a-workflows-design.md); implementation plan alongside it.

## What's new (all riding Phase 5's modal/action machinery; CLI untouched)

- **Purge behind a confirmation view** — `X` on Dashboard/Installed Mods: confirm modal lists the mods, then streams per-mod progress from `core.PurgeProfile` (#61's extraction, now consumed as designed). `purge --uninstall` stays CLI-only.
- **Per-mod deployed-files panel** — `f` on Installed Mods.
- **Update-policy editing** — `P`: notify/auto/pin picker with the current policy marked.
- **In-TUI game switcher** — `g` from any screen: rebinds the session (providers, active profile, sources) and reloads; demoed in `--prototype` via a second canned game.
- **Profile create/delete** — `c`/`d` on Profiles; delete refuses the active profile; create validates duplicates inline.
- **Help overlay** — `?` restructured into per-screen key groups (current screen first) with a height-capped "+N more" tail.

Under the hood: three reusable modal primitives (picker with scroll-window height cap, text-input modal, info overlay), a `gameRebinder` seam with a mutex-guarded game snapshot per operation, and a **Fixed**: in-flight data loads are now generation-checked, so a load racing a game or profile switch can no longer repopulate stale data.

## Process

Executed via subagent-driven development: per-task spec+quality reviews (fix rounds recorded in `.superpowers/sdd/progress.md`), a final whole-branch review, and `go test ./...` + `go test -race ./internal/tui/` green throughout. Deferred polish from the reviews is batched in #68.

## Merge gate

Interactive TUI smoke test (checklist in the review ledger; summary): purge confirm/cancel + one real purge, files overlay toggle, policy pick, game switch from every screen incl. mid-action refusal, profile create/delete guards, focused-input swallowing of `XfPgcd`, `?` groups at 80×24, quit-while-purging drain, ~40-col degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)