### PR TITLE
fix(tui): reject path separators and ".." inline in the new-profile modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- TUI: the new-profile modal now rejects names containing path separators or `..` inline (matching the config layer's validation), instead of only surfacing the failure after submit
+
 ## [1.13.0] - 2026-07-23
 
 ### Added

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -900,12 +900,13 @@ type profileCreateSubmittedMsg struct {
 // configured - mirrors editSelectedModPolicy/uninstallSelectedMod's own
 // guard shape, minus a selection requirement, since creating a profile needs
 // no row selected. Opens the input modal with validate rejecting names
-// containing path separators or ".." (a client-side mirror of the config
-// layer's validateProfileName guard, so the user sees the refusal inline
-// instead of only after submit) and an EXACT (case-sensitive) match against
-// a name already in m.profiles - the input modal's own "name required"
-// handling already covers the empty case (see pendingInput's doc comment),
-// so validate here never needs to.
+// containing path separators or ".." (such names would be interpreted as
+// file paths under the profiles directory; the config layer refuses them
+// too, but checking here surfaces the refusal inline instead of only after
+// submit) and an EXACT (case-sensitive) match against a name already in
+// m.profiles - the input modal's own "name required" handling already
+// covers the empty case (see pendingInput's doc comment), so validate here
+// never needs to.
 // submit dispatches profileCreateSubmittedMsg on the next tick rather than
 // calling buildAction directly - see that message's own doc comment for why.
 func (m Model) createProfilePrompt() (Model, tea.Cmd) {

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -899,10 +899,13 @@ type profileCreateSubmittedMsg struct {
 // create flow): a no-op on the wrong screen or with no ActionProvider
 // configured - mirrors editSelectedModPolicy/uninstallSelectedMod's own
 // guard shape, minus a selection requirement, since creating a profile needs
-// no row selected. Opens the input modal with validate rejecting only an
-// EXACT (case-sensitive) match against a name already in m.profiles - the
-// input modal's own "name required" handling already covers the empty case
-// (see pendingInput's doc comment), so validate here never needs to.
+// no row selected. Opens the input modal with validate rejecting names
+// containing path separators or ".." (a client-side mirror of the config
+// layer's validateProfileName guard, so the user sees the refusal inline
+// instead of only after submit) and an EXACT (case-sensitive) match against
+// a name already in m.profiles - the input modal's own "name required"
+// handling already covers the empty case (see pendingInput's doc comment),
+// so validate here never needs to.
 // submit dispatches profileCreateSubmittedMsg on the next tick rather than
 // calling buildAction directly - see that message's own doc comment for why.
 func (m Model) createProfilePrompt() (Model, tea.Cmd) {
@@ -920,6 +923,9 @@ func (m Model) createProfilePrompt() (Model, tea.Cmd) {
 		title: "new profile",
 		input: input,
 		validate: func(value string) string {
+			if strings.ContainsAny(value, `/\`) || strings.Contains(value, "..") {
+				return `name must not contain path separators or ".."`
+			}
 			if existing[value] {
 				return "profile already exists"
 			}

--- a/internal/tui/profile_mgmt_test.go
+++ b/internal/tui/profile_mgmt_test.go
@@ -54,16 +54,23 @@ func TestCreateProfileDuplicateNameValidatesInModal(t *testing.T) {
 }
 
 // TestCreateProfilePathTraversalNameValidatesInModal covers the validate
-// closure's client-side mirror of the config layer's validateProfileName
-// guard: names containing path separators or ".." would become file paths
-// under the profiles directory, so typing one and pressing enter keeps the
-// modal open with an inline error, and never dispatches - rather than only
-// failing after submit via ActionOutcome.
+// closure's path-traversal check: names containing path separators or ".."
+// would become file paths under the profiles directory (the config layer
+// refuses them too), so typing one and pressing enter keeps the modal open
+// with an inline error, and never dispatches - rather than only failing
+// after submit via ActionOutcome.
 func TestCreateProfilePathTraversalNameValidatesInModal(t *testing.T) {
 	t.Parallel()
 
-	for _, name := range []string{"../evil", "foo/bar", `foo\bar`} {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{name: "dot dot", input: "../evil"},
+		{name: "forward slash", input: "foo/bar"},
+		{name: "backslash", input: `foo\bar`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			rec := &recordingActions{}
@@ -72,7 +79,7 @@ func TestCreateProfilePathTraversalNameValidatesInModal(t *testing.T) {
 
 			updated, _ := model.Update(keyRunes("c"))
 			model = updated.(Model)
-			model = typeString(t, model, name)
+			model = typeString(t, model, tc.input)
 			updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 			model = updated.(Model)
 

--- a/internal/tui/profile_mgmt_test.go
+++ b/internal/tui/profile_mgmt_test.go
@@ -53,6 +53,37 @@ func TestCreateProfileDuplicateNameValidatesInModal(t *testing.T) {
 	require.Empty(t, rec.CreateProfileCalls)
 }
 
+// TestCreateProfilePathTraversalNameValidatesInModal covers the validate
+// closure's client-side mirror of the config layer's validateProfileName
+// guard: names containing path separators or ".." would become file paths
+// under the profiles directory, so typing one and pressing enter keeps the
+// modal open with an inline error, and never dispatches - rather than only
+// failing after submit via ActionOutcome.
+func TestCreateProfilePathTraversalNameValidatesInModal(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"../evil", "foo/bar", `foo\bar`} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := &recordingActions{}
+			model := modelWithActions(t, rec)
+			model.screen = ScreenProfiles
+
+			updated, _ := model.Update(keyRunes("c"))
+			model = updated.(Model)
+			model = typeString(t, model, name)
+			updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			model = updated.(Model)
+
+			require.Nil(t, cmd, "a validation error must not dispatch anything")
+			require.NotNil(t, model.inputModal, "modal must stay open on a validation error")
+			require.Equal(t, `name must not contain path separators or ".."`, model.inputModal.errMsg)
+			require.Empty(t, rec.CreateProfileCalls)
+		})
+	}
+}
+
 // TestCreateProfileSubmitRunsActionAndRefreshes drives the full round trip:
 // 'c' opens the modal, typing a new name and pressing enter dispatches a
 // deferred profileCreateSubmittedMsg (the closure-over-stale-Model problem


### PR DESCRIPTION
## Summary

The config layer's `validateProfileName` (on `claude/epic-meitner-d34a10`) rejects profile names containing path separators or `..`, but the TUI's new-profile modal only surfaced that failure after submit, via `ActionOutcome`. This mirrors the check client-side in `createProfilePrompt`'s validate closure, so typing e.g. `../evil` and pressing enter keeps the modal open with an inline `name must not contain path separators or ".."` error and never dispatches the action.

- Check runs before the existing duplicate-name validation; empty names remain handled by the input modal itself
- Updated `createProfilePrompt`'s doc comment (it previously claimed validate rejects *only* exact duplicates)
- CHANGELOG entry under `[Unreleased]`

The client-side check is independent of the epic-meitner branch — it's safe whether or not that lands first; together they form defense-in-depth.

## Test plan

- TDD: new table-driven `TestCreateProfilePathTraversalNameValidatesInModal` (`../evil`, `foo/bar`, `foo\bar`) failed on all three cases before the fix — asserts the modal stays open with the inline error and no `CreateProfile` call is made
- `go test ./...` green; `gofmt`/`go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)