### PR TITLE
fix(security): reject path-traversal profile names before filesystem access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.4] - 2026-07-23
+
+### Security
+
+- Profile names are now validated before any filesystem access: names that are empty (or whitespace-only), contain path separators, or contain ".." are rejected with a clear "invalid profile name" error. Previously a name like `../../../evil` passed to `lmm profile create`/`delete` (or a crafted `profile import` file) would be joined into the profile path unchecked, letting profile save/delete write or remove `.yaml` files outside `~/.config/lmm/games/<game>/profiles/`. The guard lives in the storage layer, so the CLI, TUI, and profile import all share it.
+
 ## [1.12.3] - 2026-07-23
 
 ### Fixed
@@ -815,7 +821,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.3...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.4...HEAD
+[1.12.4]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.3...v1.12.4
 [1.12.3]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.2...v1.12.3
 [1.12.2]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.1...v1.12.2
 [1.12.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.0...v1.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Profile names are now validated before any filesystem access: names that are empty (or whitespace-only), contain path separators, or contain ".." are rejected with a clear "invalid profile name" error. Previously a name like `../../../evil` passed to `lmm profile create`/`delete` (or a crafted `profile import` file) would be joined into the profile path unchecked, letting profile save/delete write or remove `.yaml` files outside `~/.config/lmm/games/<game>/profiles/`. The guard lives in the storage layer, so the CLI, TUI, and profile import all share it.
+- Profile names and game IDs are now validated before any filesystem access: values that are empty (or whitespace-only), contain path separators, or contain ".." are rejected with a clear "invalid profile name" / "invalid game ID" error. Previously a name like `../../../evil` passed to `lmm profile create`/`delete` — or a crafted `name`/`game_id` in a `profile import` file — would be joined into the profile path unchecked, letting profile save/delete write or remove `.yaml` files outside `~/.config/lmm/games/<game>/profiles/`. The guard lives in the storage layer, so the CLI, TUI, and profile import all share it.
 
 ### Fixed
 

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -24,7 +24,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.12.3"
+	version = "1.12.4"
 
 	// Global flags
 	configDir  string

--- a/internal/core/profile.go
+++ b/internal/core/profile.go
@@ -33,7 +33,7 @@ func (pm *ProfileManager) Create(gameID, name string) (*domain.Profile, error) {
 	}
 	// The validation error is the user-facing message; don't bury it under
 	// the existence-check wrapping.
-	if errors.Is(err, domain.ErrInvalidProfileName) {
+	if errors.Is(err, domain.ErrInvalidProfileName) || errors.Is(err, domain.ErrInvalidGameID) {
 		return nil, err
 	}
 	if err != domain.ErrProfileNotFound {

--- a/internal/core/profile.go
+++ b/internal/core/profile.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -29,6 +30,11 @@ func (pm *ProfileManager) Create(gameID, name string) (*domain.Profile, error) {
 	_, err := config.LoadProfile(pm.configDir, gameID, name)
 	if err == nil {
 		return nil, fmt.Errorf("profile already exists: %s", name)
+	}
+	// The validation error is the user-facing message; don't bury it under
+	// the existence-check wrapping.
+	if errors.Is(err, domain.ErrInvalidProfileName) {
+		return nil, err
 	}
 	if err != domain.ErrProfileNotFound {
 		return nil, fmt.Errorf("checking profile: %w", err)

--- a/internal/core/profile_test.go
+++ b/internal/core/profile_test.go
@@ -1,6 +1,9 @@
 package core_test
 
 import (
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
@@ -42,6 +45,71 @@ func TestProfileManager_Create_DuplicateName(t *testing.T) {
 
 	_, err = pm.Create("skyrim-se", "survival")
 	assert.Error(t, err) // Should fail - duplicate name
+}
+
+func TestProfileManager_Create_RejectsPathTraversalName(t *testing.T) {
+	tests := map[string]string{
+		"parent traversal": "../evil",
+		"deep traversal":   "../../../etc/cron.d/evil",
+		"subdirectory":     "a/b",
+		"absolute path":    "/etc/evil",
+		"empty":            "",
+		"whitespace only":  "   ",
+	}
+
+	for label, name := range tests {
+		t.Run(label, func(t *testing.T) {
+			// Nest configDir so traversal payloads land inside the walkable
+			// temp root instead of escaping it.
+			tempDir := t.TempDir()
+			configDir := filepath.Join(tempDir, "deep", "nested", "config")
+			require.NoError(t, os.MkdirAll(configDir, 0755))
+			database, err := db.New(":memory:")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, database.Close())
+			})
+
+			pm := core.NewProfileManager(configDir, database)
+
+			_, err = pm.Create("skyrim-se", name)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrInvalidProfileName)
+			// The validation error is the user-facing message; it must not be
+			// buried under the existence-check wrapping.
+			assert.NotContains(t, err.Error(), "checking profile")
+
+			// No file may be written anywhere - inside or outside the
+			// profiles directory.
+			var files []string
+			err = filepath.Walk(tempDir, func(path string, info fs.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.Mode().IsRegular() {
+					files = append(files, path)
+				}
+				return nil
+			})
+			require.NoError(t, err)
+			assert.Empty(t, files, "no file may be written for an invalid profile name")
+		})
+	}
+}
+
+func TestProfileManager_Delete_RejectsPathTraversalName(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, database.Close())
+	})
+
+	pm := core.NewProfileManager(dir, database)
+
+	err = pm.Delete("skyrim-se", "../evil")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrInvalidProfileName)
 }
 
 func TestProfileManager_List(t *testing.T) {

--- a/internal/core/profile_test.go
+++ b/internal/core/profile_test.go
@@ -104,6 +104,38 @@ func TestProfileManager_Create_RejectsPathTraversalName(t *testing.T) {
 	}
 }
 
+func TestProfileManager_Import_RejectsPathTraversalGameID(t *testing.T) {
+	// The attack vector Copilot flagged on PR #72: profile import parses
+	// game_id from untrusted YAML and joins it into the save path.
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, "deep", "nested", "config")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, database.Close())
+	})
+
+	pm := core.NewProfileManager(configDir, database)
+
+	_, err = pm.Import([]byte("name: innocent\ngame_id: ../../../evil\nmods: []\n"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrInvalidGameID)
+
+	var files []string
+	err = filepath.Walk(tempDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, files, "no file may be written for an invalid game ID")
+}
+
 func TestProfileManager_Delete_RejectsPathTraversalName(t *testing.T) {
 	dir := t.TempDir()
 	database, err := db.New(":memory:")

--- a/internal/core/profile_test.go
+++ b/internal/core/profile_test.go
@@ -48,16 +48,23 @@ func TestProfileManager_Create_DuplicateName(t *testing.T) {
 }
 
 func TestProfileManager_Create_RejectsPathTraversalName(t *testing.T) {
-	tests := map[string]string{
-		"parent traversal": "../evil",
-		"deep traversal":   "../../../etc/cron.d/evil",
-		"subdirectory":     "a/b",
-		"absolute path":    "/etc/evil",
-		"empty":            "",
-		"whitespace only":  "   ",
+	// Each payload is a func of the test's temp root so path-shaped payloads
+	// stay inside it — even a guard regression can only touch the sandbox.
+	fixed := func(name string) func(string) string {
+		return func(string) string { return name }
+	}
+	tests := map[string]func(root string) string{
+		"parent traversal": fixed("../evil"),
+		"deep traversal":   fixed("../../../etc/cron.d/evil"),
+		"subdirectory":     fixed("a/b"),
+		"absolute path": func(root string) string {
+			return filepath.Join(root, "outside", "evil")
+		},
+		"empty":           fixed(""),
+		"whitespace only": fixed("   "),
 	}
 
-	for label, name := range tests {
+	for label, makeName := range tests {
 		t.Run(label, func(t *testing.T) {
 			// Nest configDir so traversal payloads land inside the walkable
 			// temp root instead of escaping it.
@@ -72,7 +79,7 @@ func TestProfileManager_Create_RejectsPathTraversalName(t *testing.T) {
 
 			pm := core.NewProfileManager(configDir, database)
 
-			_, err = pm.Create("skyrim-se", name)
+			_, err = pm.Create("skyrim-se", makeName(tempDir))
 			require.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrInvalidProfileName)
 			// The validation error is the user-facing message; it must not be

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -9,8 +9,11 @@ var (
 	ErrModNotFound     = errors.New("mod not found")
 	ErrGameNotFound    = errors.New("game not found")
 	ErrProfileNotFound = errors.New("profile not found")
-	// ErrInvalidProfileName rejects profile names that are empty or would
-	// escape the profiles directory (path separators, ".." segments).
+	// ErrInvalidProfileName rejects profile names that are empty or
+	// whitespace-only, or contain a path separator ("/" or "\") or the
+	// substring ".." anywhere. The rule is deliberately conservative —
+	// harmless names like "foo..bar" are also rejected — so a valid name
+	// is always a single path segment inside the profiles directory.
 	ErrInvalidProfileName = errors.New("invalid profile name")
 	ErrDependencyLoop     = errors.New("circular dependency detected")
 	ErrAuthRequired       = errors.New("authentication required")

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -15,12 +15,16 @@ var (
 	// harmless names like "foo..bar" are also rejected — so a valid name
 	// is always a single path segment inside the profiles directory.
 	ErrInvalidProfileName = errors.New("invalid profile name")
-	ErrDependencyLoop     = errors.New("circular dependency detected")
-	ErrAuthRequired       = errors.New("authentication required")
-	ErrInvalidConfig      = errors.New("invalid configuration")
-	ErrFileConflict       = errors.New("file conflict detected")
-	ErrDownloadFailed     = errors.New("download failed")
-	ErrLinkFailed         = errors.New("link operation failed")
+	// ErrInvalidGameID applies the same rule to game IDs, which are joined
+	// into the same on-disk paths (and reachable from untrusted YAML via
+	// profile import).
+	ErrInvalidGameID  = errors.New("invalid game ID")
+	ErrDependencyLoop = errors.New("circular dependency detected")
+	ErrAuthRequired   = errors.New("authentication required")
+	ErrInvalidConfig  = errors.New("invalid configuration")
+	ErrFileConflict   = errors.New("file conflict detected")
+	ErrDownloadFailed = errors.New("download failed")
+	ErrLinkFailed     = errors.New("link operation failed")
 )
 
 // DeployError aggregates a primary failure with optional rollback / cleanup

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -9,12 +9,15 @@ var (
 	ErrModNotFound     = errors.New("mod not found")
 	ErrGameNotFound    = errors.New("game not found")
 	ErrProfileNotFound = errors.New("profile not found")
-	ErrDependencyLoop  = errors.New("circular dependency detected")
-	ErrAuthRequired    = errors.New("authentication required")
-	ErrInvalidConfig   = errors.New("invalid configuration")
-	ErrFileConflict    = errors.New("file conflict detected")
-	ErrDownloadFailed  = errors.New("download failed")
-	ErrLinkFailed      = errors.New("link operation failed")
+	// ErrInvalidProfileName rejects profile names that are empty or would
+	// escape the profiles directory (path separators, ".." segments).
+	ErrInvalidProfileName = errors.New("invalid profile name")
+	ErrDependencyLoop     = errors.New("circular dependency detected")
+	ErrAuthRequired       = errors.New("authentication required")
+	ErrInvalidConfig      = errors.New("invalid configuration")
+	ErrFileConflict       = errors.New("file conflict detected")
+	ErrDownloadFailed     = errors.New("download failed")
+	ErrLinkFailed         = errors.New("link operation failed")
 )
 
 // DeployError aggregates a primary failure with optional rollback / cleanup

--- a/internal/storage/config/profiles.go
+++ b/internal/storage/config/profiles.go
@@ -89,22 +89,32 @@ func parseProfileHooks(yaml ProfileHooksYAML) (domain.GameHooks, domain.GameHook
 	return hooks, explicit
 }
 
-// validateProfileName rejects names that are empty or would resolve outside
-// the profiles directory once joined (filepath.Join collapses ".." segments,
-// so "../../evil" would otherwise escape configDir entirely).
-func validateProfileName(name string) error {
-	if strings.TrimSpace(name) == "" {
-		return fmt.Errorf("%w: name is empty", domain.ErrInvalidProfileName)
+// validateSegment rejects values that are empty or would resolve outside
+// their directory once joined (filepath.Join collapses ".." segments, so
+// "../../evil" would otherwise escape configDir entirely). Failures wrap
+// sentinel so callers can branch on which field was invalid.
+func validateSegment(value string, sentinel error) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%w: value is empty", sentinel)
 	}
-	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
-		return fmt.Errorf("%w: %q must not contain path separators or \"..\"", domain.ErrInvalidProfileName, name)
+	if strings.ContainsAny(value, `/\`) || strings.Contains(value, "..") {
+		return fmt.Errorf("%w: %q must not contain path separators or \"..\"", sentinel, value)
 	}
 	return nil
 }
 
+// validateProfilePath guards both path segments a profile file path is built
+// from: the game ID and the profile name.
+func validateProfilePath(gameID, profileName string) error {
+	if err := validateSegment(gameID, domain.ErrInvalidGameID); err != nil {
+		return err
+	}
+	return validateSegment(profileName, domain.ErrInvalidProfileName)
+}
+
 // LoadProfile reads a profile from disk
 func LoadProfile(configDir, gameID, profileName string) (*domain.Profile, error) {
-	if err := validateProfileName(profileName); err != nil {
+	if err := validateProfilePath(gameID, profileName); err != nil {
 		return nil, err
 	}
 	profilePath := filepath.Join(configDir, "games", gameID, "profiles", profileName+".yaml")
@@ -152,7 +162,7 @@ func LoadProfile(configDir, gameID, profileName string) (*domain.Profile, error)
 
 // SaveProfile writes a profile to disk
 func SaveProfile(configDir string, profile *domain.Profile) error {
-	if err := validateProfileName(profile.Name); err != nil {
+	if err := validateProfilePath(profile.GameID, profile.Name); err != nil {
 		return err
 	}
 	cfg := ProfileConfig{
@@ -224,7 +234,7 @@ func ListProfiles(configDir, gameID string) ([]string, error) {
 
 // DeleteProfile removes a profile from disk
 func DeleteProfile(configDir, gameID, profileName string) error {
-	if err := validateProfileName(profileName); err != nil {
+	if err := validateProfilePath(gameID, profileName); err != nil {
 		return err
 	}
 	profilePath := filepath.Join(configDir, "games", gameID, "profiles", profileName+".yaml")

--- a/internal/storage/config/profiles.go
+++ b/internal/storage/config/profiles.go
@@ -212,6 +212,9 @@ func SaveProfile(configDir string, profile *domain.Profile) error {
 
 // ListProfiles returns all profile names for a game
 func ListProfiles(configDir, gameID string) ([]string, error) {
+	if err := validateSegment(gameID, domain.ErrInvalidGameID); err != nil {
+		return nil, err
+	}
 	profileDir := filepath.Join(configDir, "games", gameID, "profiles")
 	entries, err := os.ReadDir(profileDir)
 	if err != nil {

--- a/internal/storage/config/profiles.go
+++ b/internal/storage/config/profiles.go
@@ -89,8 +89,24 @@ func parseProfileHooks(yaml ProfileHooksYAML) (domain.GameHooks, domain.GameHook
 	return hooks, explicit
 }
 
+// validateProfileName rejects names that are empty or would resolve outside
+// the profiles directory once joined (filepath.Join collapses ".." segments,
+// so "../../evil" would otherwise escape configDir entirely).
+func validateProfileName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("%w: name is empty", domain.ErrInvalidProfileName)
+	}
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		return fmt.Errorf("%w: %q must not contain path separators or \"..\"", domain.ErrInvalidProfileName, name)
+	}
+	return nil
+}
+
 // LoadProfile reads a profile from disk
 func LoadProfile(configDir, gameID, profileName string) (*domain.Profile, error) {
+	if err := validateProfileName(profileName); err != nil {
+		return nil, err
+	}
 	profilePath := filepath.Join(configDir, "games", gameID, "profiles", profileName+".yaml")
 	data, err := os.ReadFile(profilePath)
 	if err != nil {
@@ -136,6 +152,9 @@ func LoadProfile(configDir, gameID, profileName string) (*domain.Profile, error)
 
 // SaveProfile writes a profile to disk
 func SaveProfile(configDir string, profile *domain.Profile) error {
+	if err := validateProfileName(profile.Name); err != nil {
+		return err
+	}
 	cfg := ProfileConfig{
 		Name:       profile.Name,
 		GameID:     profile.GameID,
@@ -205,6 +224,9 @@ func ListProfiles(configDir, gameID string) ([]string, error) {
 
 // DeleteProfile removes a profile from disk
 func DeleteProfile(configDir, gameID, profileName string) error {
+	if err := validateProfileName(profileName); err != nil {
+		return err
+	}
 	profilePath := filepath.Join(configDir, "games", gameID, "profiles", profileName+".yaml")
 	if err := os.Remove(profilePath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/storage/config/profiles.go
+++ b/internal/storage/config/profiles.go
@@ -89,10 +89,13 @@ func parseProfileHooks(yaml ProfileHooksYAML) (domain.GameHooks, domain.GameHook
 	return hooks, explicit
 }
 
-// validateSegment rejects values that are empty or would resolve outside
-// their directory once joined (filepath.Join collapses ".." segments, so
-// "../../evil" would otherwise escape configDir entirely). Failures wrap
-// sentinel so callers can branch on which field was invalid.
+// validateSegment enforces that value is usable as a single path segment:
+// non-empty (after trimming whitespace), no path separators ("/" or "\"),
+// and no ".." substring. The rule is deliberately conservative — harmless
+// values like "foo..bar" or non-escaping subpaths like "a/b" are rejected
+// too — because filepath.Join collapses ".." segments, so anything less
+// strict risks resolving outside configDir (e.g. "../../evil"). Failures
+// wrap sentinel so callers can branch on which field was invalid.
 func validateSegment(value string, sentinel error) error {
 	if strings.TrimSpace(value) == "" {
 		return fmt.Errorf("%w: value is empty", sentinel)

--- a/internal/storage/config/profiles_test.go
+++ b/internal/storage/config/profiles_test.go
@@ -116,6 +116,18 @@ func TestLoadProfile_RejectsInvalidGameID(t *testing.T) {
 	}
 }
 
+func TestListProfiles_RejectsInvalidGameID(t *testing.T) {
+	for label, makeID := range invalidProfileNames {
+		t.Run(label, func(t *testing.T) {
+			tempDir := t.TempDir()
+			_, err := ListProfiles(tempDir, makeID(tempDir))
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrInvalidGameID)
+		})
+	}
+}
+
 func TestDeleteProfile_RejectsInvalidGameID(t *testing.T) {
 	for label, makeID := range invalidProfileNames {
 		t.Run(label, func(t *testing.T) {

--- a/internal/storage/config/profiles_test.go
+++ b/internal/storage/config/profiles_test.go
@@ -12,18 +12,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// invalidProfileNames are names that must be rejected before any filesystem
-// access: they are empty, or would resolve to a path outside the profiles
-// directory once joined (filepath.Join collapses ".." segments).
-var invalidProfileNames = map[string]string{
-	"empty":            "",
-	"whitespace only":  "   ",
-	"parent traversal": "../evil",
-	"deep traversal":   "../../../etc/cron.d/evil",
-	"subdirectory":     "a/b",
-	"absolute path":    "/etc/evil",
-	"bare dotdot":      "..",
-	"backslash":        `a\b`,
+// fixedName adapts a constant payload to invalidProfileNames' shape.
+func fixedName(name string) func(string) string {
+	return func(string) string { return name }
+}
+
+// invalidProfileNames builds names that must be rejected before any
+// filesystem access: they are empty, or would resolve to a path outside the
+// profiles directory once joined (filepath.Join collapses ".." segments).
+// Each payload is a func of the test's temp root so path-shaped payloads
+// stay inside it — even a guard regression can only touch the sandbox.
+var invalidProfileNames = map[string]func(root string) string{
+	"empty":            fixedName(""),
+	"whitespace only":  fixedName("   "),
+	"parent traversal": fixedName("../evil"),
+	"deep traversal":   fixedName("../../../etc/cron.d/evil"),
+	"subdirectory":     fixedName("a/b"),
+	"absolute path": func(root string) string {
+		return filepath.Join(root, "outside", "evil")
+	},
+	"bare dotdot": fixedName(".."),
+	"backslash":   fixedName(`a\b`),
 }
 
 // listRegularFiles returns every regular file under root, relative to root.
@@ -48,7 +57,7 @@ func listRegularFiles(t *testing.T, root string) []string {
 }
 
 func TestSaveProfile_RejectsInvalidName(t *testing.T) {
-	for label, name := range invalidProfileNames {
+	for label, makeName := range invalidProfileNames {
 		t.Run(label, func(t *testing.T) {
 			// configDir is nested so traversal payloads land inside the
 			// walkable temp root instead of escaping it.
@@ -56,7 +65,7 @@ func TestSaveProfile_RejectsInvalidName(t *testing.T) {
 			configDir := filepath.Join(tempDir, "deep", "nested", "config")
 			require.NoError(t, os.MkdirAll(configDir, 0755))
 
-			profile := &domain.Profile{Name: name, GameID: "skyrim-se"}
+			profile := &domain.Profile{Name: makeName(tempDir), GameID: "skyrim-se"}
 			err := SaveProfile(configDir, profile)
 
 			require.Error(t, err)
@@ -67,9 +76,10 @@ func TestSaveProfile_RejectsInvalidName(t *testing.T) {
 }
 
 func TestLoadProfile_RejectsInvalidName(t *testing.T) {
-	for label, name := range invalidProfileNames {
+	for label, makeName := range invalidProfileNames {
 		t.Run(label, func(t *testing.T) {
-			_, err := LoadProfile(t.TempDir(), "skyrim-se", name)
+			tempDir := t.TempDir()
+			_, err := LoadProfile(tempDir, "skyrim-se", makeName(tempDir))
 
 			require.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrInvalidProfileName)
@@ -78,7 +88,7 @@ func TestLoadProfile_RejectsInvalidName(t *testing.T) {
 }
 
 func TestDeleteProfile_RejectsInvalidName(t *testing.T) {
-	for label, name := range invalidProfileNames {
+	for label, makeName := range invalidProfileNames {
 		t.Run(label, func(t *testing.T) {
 			// Plant a file where "../evil" would resolve to prove Delete
 			// never touches paths outside the profiles directory.
@@ -89,7 +99,7 @@ func TestDeleteProfile_RejectsInvalidName(t *testing.T) {
 			victim := filepath.Join(gameDir, "evil.yaml")
 			require.NoError(t, os.WriteFile(victim, []byte("do not delete"), 0644))
 
-			err := DeleteProfile(configDir, "skyrim-se", name)
+			err := DeleteProfile(configDir, "skyrim-se", makeName(tempDir))
 
 			require.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrInvalidProfileName)

--- a/internal/storage/config/profiles_test.go
+++ b/internal/storage/config/profiles_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// invalidProfileNames are names that must be rejected before any filesystem
+// access: they are empty, or would resolve to a path outside the profiles
+// directory once joined (filepath.Join collapses ".." segments).
+var invalidProfileNames = map[string]string{
+	"empty":            "",
+	"whitespace only":  "   ",
+	"parent traversal": "../evil",
+	"deep traversal":   "../../../etc/cron.d/evil",
+	"subdirectory":     "a/b",
+	"absolute path":    "/etc/evil",
+	"bare dotdot":      "..",
+	"backslash":        `a\b`,
+}
+
+// listRegularFiles returns every regular file under root, relative to root.
+func listRegularFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	err := filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			files = append(files, rel)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return files
+}
+
+func TestSaveProfile_RejectsInvalidName(t *testing.T) {
+	for label, name := range invalidProfileNames {
+		t.Run(label, func(t *testing.T) {
+			// configDir is nested so traversal payloads land inside the
+			// walkable temp root instead of escaping it.
+			tempDir := t.TempDir()
+			configDir := filepath.Join(tempDir, "deep", "nested", "config")
+			require.NoError(t, os.MkdirAll(configDir, 0755))
+
+			profile := &domain.Profile{Name: name, GameID: "skyrim-se"}
+			err := SaveProfile(configDir, profile)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrInvalidProfileName)
+			assert.Empty(t, listRegularFiles(t, tempDir), "no file may be written for an invalid profile name")
+		})
+	}
+}
+
+func TestLoadProfile_RejectsInvalidName(t *testing.T) {
+	for label, name := range invalidProfileNames {
+		t.Run(label, func(t *testing.T) {
+			_, err := LoadProfile(t.TempDir(), "skyrim-se", name)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrInvalidProfileName)
+		})
+	}
+}
+
+func TestDeleteProfile_RejectsInvalidName(t *testing.T) {
+	for label, name := range invalidProfileNames {
+		t.Run(label, func(t *testing.T) {
+			// Plant a file where "../evil" would resolve to prove Delete
+			// never touches paths outside the profiles directory.
+			tempDir := t.TempDir()
+			configDir := filepath.Join(tempDir, "config")
+			gameDir := filepath.Join(configDir, "games", "skyrim-se")
+			require.NoError(t, os.MkdirAll(filepath.Join(gameDir, "profiles"), 0755))
+			victim := filepath.Join(gameDir, "evil.yaml")
+			require.NoError(t, os.WriteFile(victim, []byte("do not delete"), 0644))
+
+			err := DeleteProfile(configDir, "skyrim-se", name)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrInvalidProfileName)
+			assert.FileExists(t, victim, "delete must not remove files outside the profiles directory")
+		})
+	}
+}

--- a/internal/storage/config/profiles_test.go
+++ b/internal/storage/config/profiles_test.go
@@ -87,6 +87,47 @@ func TestLoadProfile_RejectsInvalidName(t *testing.T) {
 	}
 }
 
+func TestSaveProfile_RejectsInvalidGameID(t *testing.T) {
+	for label, makeID := range invalidProfileNames {
+		t.Run(label, func(t *testing.T) {
+			tempDir := t.TempDir()
+			configDir := filepath.Join(tempDir, "deep", "nested", "config")
+			require.NoError(t, os.MkdirAll(configDir, 0755))
+
+			profile := &domain.Profile{Name: "good", GameID: makeID(tempDir)}
+			err := SaveProfile(configDir, profile)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrInvalidGameID)
+			assert.Empty(t, listRegularFiles(t, tempDir), "no file may be written for an invalid game ID")
+		})
+	}
+}
+
+func TestLoadProfile_RejectsInvalidGameID(t *testing.T) {
+	for label, makeID := range invalidProfileNames {
+		t.Run(label, func(t *testing.T) {
+			tempDir := t.TempDir()
+			_, err := LoadProfile(tempDir, makeID(tempDir), "good")
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrInvalidGameID)
+		})
+	}
+}
+
+func TestDeleteProfile_RejectsInvalidGameID(t *testing.T) {
+	for label, makeID := range invalidProfileNames {
+		t.Run(label, func(t *testing.T) {
+			tempDir := t.TempDir()
+			err := DeleteProfile(tempDir, makeID(tempDir), "good")
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrInvalidGameID)
+		})
+	}
+}
+
 func TestDeleteProfile_RejectsInvalidName(t *testing.T) {
 	for label, makeName := range invalidProfileNames {
 		t.Run(label, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Profile names and game IDs were joined into profile file paths unchecked (`filepath.Join(configDir, "games", gameID, "profiles", name+".yaml")`), and `filepath.Join` collapses `..` segments — so a name like `../../../evil` passed to `lmm profile create`/`delete`, or a crafted `name`/`game_id` in a `profile import` file, let `SaveProfile`/`DeleteProfile` write or remove `.yaml` files **outside** `<configDir>/games/<gameID>/profiles/`. During RED-phase testing, `DeleteProfile("../evil")` really did delete a planted file above the profiles directory, and `profile import` with `game_id: ../../../evil` succeeded silently.

## Fix

- New `validateSegment`/`validateProfilePath` guard in `internal/storage/config/profiles.go`, called at the top of `LoadProfile`, `SaveProfile`, and `DeleteProfile` — the layer that touches the filesystem, so CLI, TUI, and profile import all share it. Rejects values that are empty/whitespace-only, contain `/` or `\`, or contain `..`.
- New `domain.ErrInvalidProfileName` and `domain.ErrInvalidGameID` sentinels; `ProfileManager.Create` surfaces them directly instead of wrapping in "checking profile:" so the user-facing message stays clean.
- Version bumped to **1.13.1** (rebumped from 1.12.4 after v1.13.0 shipped mid-review) with a `Security` CHANGELOG entry; the section also absorbs #71's TUI inline-validation entry since both release together.

## Testing

- TDD: all new tests written first and watched fail for the right reasons (create/import succeeded silently; delete removed the out-of-tree victim file).
- Core: `TestProfileManager_Create_RejectsPathTraversalName`, `_Delete_RejectsPathTraversalName`, `_Import_RejectsPathTraversalGameID`. Config: table-driven `Save/Load/DeleteProfile_RejectsInvalidName` and `_RejectsInvalidGameID` — including walks asserting no file is ever written and a planted outside file survives delete. Path-shaped payloads are derived from each test's temp root so the tests are hermetic by construction.
- Full suite, `go vet`, `gofmt` clean.
- End-to-end with the built binary: `profile create "../../../evil"`, `profile delete`, and `profile import` with a crafted `game_id` all fail with clear errors; normal names unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)