### PR TITLE
fix: tech-debt quick wins — DB permissions, profile link_method, dead table, download staging (v1.14.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.1] - 2026-07-25
+
+### Security
+
+- `~/.local/share/lmm/lmm.db` is now created owner-only (`0600`), along with its `-wal`/`-shm` sidecars, and the data directory is created `0700` instead of `0755`. The database stores auth tokens in plaintext, and SQLite created it world-readable under a typical umask, so any other local user could read your NexusMods/CurseForge API keys. Permissions are re-applied on every open, so existing installs are fixed the next time `lmm` runs. This is a mitigation, not a replacement for encrypting the tokens themselves (#79)
+
+### Fixed
+
+- Profiles no longer accumulate a `link_method: symlink` line the user never set. `LinkMethod.String()` never returns an empty string, so the `omitempty` tag never fired and every profile mutation (create, add/remove mod, reorder, set-default, import) rewrote the file with a phantom override; exported profiles carried it to other machines too. The key is now written only when explicitly set. Note the profile-level override still has no effect at deploy time — that remains #81
+- Downloads and local-archive imports are staged under `~/.local/share/lmm/downloads` (the location the PRD has always specified) instead of `$TMPDIR`. `/tmp` is tmpfs on most modern distributions, so large mod archives were being downloaded and extracted in RAM
+
+### Changed
+
+- Dropped the `mod_cache` table (schema v11). It was created by the v1 migration and never read or written — the cache is keyed entirely by directory layout, with no database mirror to fall out of sync
+
 ## [1.14.0] - 2026-07-24
 
 ### Added
@@ -865,7 +880,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.14.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.14.1...HEAD
+[1.14.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.14.0...v1.14.1
 [1.14.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.13.1...v1.14.0
 [1.13.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.12.3...v1.13.0

--- a/cmd/lmm/game.go
+++ b/cmd/lmm/game.go
@@ -215,12 +215,13 @@ func runGameDetect(cmd *cobra.Command, args []string) error {
 		if err := config.SaveGame(svcCfg.ConfigDir, game); err != nil {
 			return fmt.Errorf("saving game %s: %w", g.Slug, err)
 		}
+		// No LinkMethod: a detected game's default profile should inherit the
+		// game/global setting, not pin an override.
 		defaultProfile := &domain.Profile{
-			Name:       "default",
-			GameID:     g.Slug,
-			Mods:       nil,
-			LinkMethod: domain.LinkSymlink,
-			IsDefault:  true,
+			Name:      "default",
+			GameID:    g.Slug,
+			Mods:      nil,
+			IsDefault: true,
 		}
 		if err := config.SaveProfile(svcCfg.ConfigDir, defaultProfile); err != nil {
 			return fmt.Errorf("creating default profile for %s: %w", g.Slug, err)

--- a/cmd/lmm/import.go
+++ b/cmd/lmm/import.go
@@ -96,7 +96,7 @@ func doImport(ctx context.Context, cmd *cobra.Command, service *core.Service, ga
 	}
 
 	// Create importer
-	importer := core.NewImporter(service.GetGameCache(game))
+	importer := service.NewImporter(game)
 
 	// Set up import options
 	opts := core.ImportOptions{
@@ -358,7 +358,7 @@ func runImportScan(cmd *cobra.Command, game *domain.Game, service *core.Service,
 	}
 
 	// Create importer and scan
-	importer := core.NewImporter(service.GetGameCache(game))
+	importer := service.NewImporter(game)
 	opts := core.ScanOptions{
 		ProfileName: profileName,
 		DryRun:      importDryRun,
@@ -528,7 +528,7 @@ func runImportScan(cmd *cobra.Command, game *domain.Game, service *core.Service,
 		}
 
 		// Check for duplicates before importing
-		importer := core.NewImporter(service.GetGameCache(game))
+		importer := service.NewImporter(game)
 		if dup := importer.FindDuplicateMod(r.Mod.Name, currentMods); dup != nil {
 			fmt.Printf("  ⊘ %s: skipped (duplicate of \"%s\")\n", r.FileName, dup.Name)
 			skipped++

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -142,7 +142,10 @@ func initService() (*core.Service, error) {
 	if err := os.MkdirAll(cfg.ConfigDir, 0755); err != nil {
 		return nil, fmt.Errorf("creating config dir: %w", err)
 	}
-	if err := os.MkdirAll(cfg.DataDir, 0755); err != nil {
+	// Owner-only: this holds lmm.db, whose auth_tokens table stores API keys in
+	// plaintext. Also closes the window between SQLite creating the DB at 0644 and
+	// the db package tightening it.
+	if err := os.MkdirAll(cfg.DataDir, 0700); err != nil {
 		return nil, fmt.Errorf("creating data dir: %w", err)
 	}
 	if err := os.MkdirAll(cfg.CacheDir, 0755); err != nil {

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -24,7 +24,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.14.0"
+	version = "1.14.1"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -143,10 +143,15 @@ func initService() (*core.Service, error) {
 		return nil, fmt.Errorf("creating config dir: %w", err)
 	}
 	// Owner-only: this holds lmm.db, whose auth_tokens table stores API keys in
-	// plaintext. Also closes the window between SQLite creating the DB at 0644 and
-	// the db package tightening it.
+	// plaintext, plus the downloads staging root. Also closes the window between
+	// SQLite creating the DB at 0644 and the db package tightening it.
 	if err := os.MkdirAll(cfg.DataDir, 0700); err != nil {
 		return nil, fmt.Errorf("creating data dir: %w", err)
+	}
+	// MkdirAll leaves an existing directory's mode alone, so installs predating
+	// the line above keep a 0755 data dir without this.
+	if err := os.Chmod(cfg.DataDir, 0700); err != nil {
+		return nil, fmt.Errorf("restricting data dir: %w", err)
 	}
 	if err := os.MkdirAll(cfg.CacheDir, 0755); err != nil {
 		return nil, fmt.Errorf("creating cache dir: %w", err)

--- a/cmd/lmm/root_test.go
+++ b/cmd/lmm/root_test.go
@@ -57,6 +57,26 @@ func TestInitService_DataDirIsOwnerOnly(t *testing.T) {
 	assert.Equal(t, fs.FileMode(0700), info.Mode().Perm(), "data dir must not be group- or world-readable")
 }
 
+// TestInitService_TightensExistingDataDir covers installs predating the 0700
+// change: MkdirAll is a no-op on an existing directory, so a legacy 0755 data
+// dir stays permissive unless it is explicitly tightened. It now holds the
+// downloads staging root as well as the DB.
+func TestInitService_TightensExistingDataDir(t *testing.T) {
+	configDir = t.TempDir()
+	dataDir = filepath.Join(t.TempDir(), "lmm")
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+
+	svc, err := initService()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	info, err := os.Stat(dataDir)
+	require.NoError(t, err)
+	assert.Equal(t, fs.FileMode(0700), info.Mode().Perm(), "an existing permissive data dir should be tightened")
+}
+
 // TestRunRoot_PropagatesContextCancellation pins the contract that the root command
 // runs under the caller's context, so SIGINT and explicit cancellation reach RunE
 // handlers via cmd.Context(). Regression guard against reverting to rootCmd.Execute().

--- a/cmd/lmm/root_test.go
+++ b/cmd/lmm/root_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -31,6 +34,27 @@ func TestInitService_RegistersSources(t *testing.T) {
 	require.NoError(t, err, "curseforge source should be registered by default")
 	assert.Equal(t, "curseforge", src.ID())
 	assert.Equal(t, "CurseForge", src.Name())
+}
+
+// TestInitService_DataDirIsOwnerOnly pins that the data directory is created 0700.
+// It contains lmm.db, which holds auth tokens in plaintext (#79); an owner-only
+// directory also closes the window between SQLite creating the DB at 0644 and the
+// db package chmod'ing it.
+func TestInitService_DataDirIsOwnerOnly(t *testing.T) {
+	configDir = t.TempDir()
+	// Nest under the temp dir so initService does the creating — t.TempDir() itself
+	// is already 0700, which would make the assertion vacuous.
+	dataDir = filepath.Join(t.TempDir(), "lmm")
+
+	svc, err := initService()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	info, err := os.Stat(dataDir)
+	require.NoError(t, err)
+	assert.Equal(t, fs.FileMode(0700), info.Mode().Perm(), "data dir must not be group- or world-readable")
 }
 
 // TestRunRoot_PropagatesContextCancellation pins the contract that the root command

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -225,7 +225,6 @@ lmm status --game skyrim-se
 
 Internal state and metadata:
 
-- Mod cache metadata (source, ID, version, files)
 - Installation records
 - Download history
 - Authentication tokens (encrypted)
@@ -255,11 +254,15 @@ User-editable configuration:
 ├── lmm.db               # SQLite database
 ├── cache/
 │   └── <game-slug>/
-│       └── <mod-id>/
-│           ├── metadata.json
-│           └── files/
+│       └── <source-id>-<mod-id>/
+│           └── <version>/
 └── downloads/           # Temporary download location
 ```
+
+The cache carries no sidecar metadata: a cached mod is identified entirely by its
+path, and its contents are enumerated by walking the directory. This keeps the
+cache self-describing — deleting a directory by hand is a valid way to evict it,
+with nothing left to reconcile.
 
 ---
 

--- a/internal/core/importer.go
+++ b/internal/core/importer.go
@@ -33,14 +33,26 @@ type ImportResult struct {
 type Importer struct {
 	cache     *cache.Cache
 	extractor *Extractor
+	// stagingRoot is where archives are extracted before being committed to the
+	// cache. Empty means fall back to $TMPDIR — see newStagingDir.
+	stagingRoot string
 }
 
-// NewImporter creates a new Importer
+// NewImporter creates a new Importer that stages extraction in the OS temp dir.
+// Prefer Service.NewImporter, which stages under the data dir instead.
 func NewImporter(cache *cache.Cache) *Importer {
 	return &Importer{
 		cache:     cache,
 		extractor: NewExtractor(),
 	}
+}
+
+// NewImporter creates an Importer for game, staging archive extraction under the
+// service's data dir rather than $TMPDIR.
+func (s *Service) NewImporter(game *domain.Game) *Importer {
+	imp := NewImporter(s.GetGameCache(game))
+	imp.stagingRoot = s.stagingRoot()
+	return imp
 }
 
 // Import imports a mod from a local archive file
@@ -114,10 +126,10 @@ func (i *Importer) Import(ctx context.Context, archivePath string, game *domain.
 			return nil, fmt.Errorf("unsupported archive format: %s", filepath.Ext(archivePath))
 		}
 
-		// Extract to temp directory first
-		tempDir, err := os.MkdirTemp("", "lmm-import-*")
+		// Extract to a staging directory first
+		tempDir, err := newStagingDir(i.stagingRoot, "lmm-import-*")
 		if err != nil {
-			return nil, fmt.Errorf("creating temp directory: %w", err)
+			return nil, err
 		}
 		defer func() {
 			if cerr := os.RemoveAll(tempDir); err == nil && cerr != nil {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -332,10 +332,10 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 		return s.ingestLocalToCache(gameCache, game, mod, file, localPath)
 	}
 
-	// Create temp directory for download
-	tempDir, err := os.MkdirTemp("", "lmm-download-*")
+	// Stage the download under the data dir, not $TMPDIR — see newStagingDir.
+	tempDir, err := newStagingDir(s.stagingRoot(), "lmm-download-*")
 	if err != nil {
-		return nil, fmt.Errorf("creating temp directory: %w", err)
+		return nil, err
 	}
 	defer func() {
 		if cerr := os.RemoveAll(tempDir); err == nil && cerr != nil {

--- a/internal/core/service_staging_test.go
+++ b/internal/core/service_staging_test.go
@@ -1,0 +1,90 @@
+package core_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDownloadModStagesUnderDataDir drives a real HTTP download end to end and
+// pins where the archive is staged. The unit tests around newStagingDir cover the
+// helper; this covers the wiring, which is what actually regressed to $TMPDIR.
+func TestDownloadModStagesUnderDataDir(t *testing.T) {
+	archive := []byte("mod payload bytes")
+	sum := sha256.Sum256(archive)
+	archiveSHA := hex.EncodeToString(sum[:])
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	manifest := fmt.Sprintf(`
+version: 1
+mods:
+  - id: cool-mod
+    name: Cool Mod
+    version: 1.2.0
+    files:
+      - id: main
+        filename: cool-mod-1.2.0.zip
+        version: 1.2.0
+        url: %s/files/cool-mod-1.2.0.zip
+        sha256: %s
+        primary: true
+`, srv.URL, archiveSHA)
+	mux.HandleFunc("/mods.yaml", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(manifest)) })
+	mux.HandleFunc("/files/", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(archive) })
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "staging-repo",
+		Name:      "Staging Repo",
+		Type:      custom.TypeManifest,
+		AllowHTTP: true, // httptest serves plain http
+		Manifest:  &custom.ManifestConfig{URL: srv.URL + "/mods.yaml"},
+	})
+	require.NoError(t, err)
+
+	dataDir := t.TempDir()
+	svc, err := core.NewService(core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: dataDir, CacheDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(src)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), DeployMode: domain.DeployCopy}
+	require.NoError(t, svc.AddGame(game))
+
+	ctx := context.Background()
+	res, err := src.Search(ctx, source.SearchQuery{Query: "cool", GameID: "testgame", PageSize: 20})
+	require.NoError(t, err)
+	require.Len(t, res.Mods, 1)
+	mod := res.Mods[0]
+
+	files, err := src.GetModFiles(ctx, &mod)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	_, err = svc.DownloadMod(ctx, "staging-repo", game, &mod, &files[0], nil)
+	require.NoError(t, err)
+
+	downloads := filepath.Join(dataDir, "downloads")
+	assert.DirExists(t, downloads, "downloads should be staged under the data dir, not $TMPDIR")
+
+	// The per-download subdirectory is removed on success; only the root remains.
+	entries, err := os.ReadDir(downloads)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "staging directory should be cleaned up after a successful download")
+}

--- a/internal/core/staging.go
+++ b/internal/core/staging.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// stagingDirName is the data-dir subdirectory holding in-flight downloads and
+// archive extraction, per the layout in docs/PRD.md.
+const stagingDirName = "downloads"
+
+// stagingRoot returns where this service stages downloads and extraction, or ""
+// when no data dir is configured (newStagingDir then falls back to $TMPDIR).
+func (s *Service) stagingRoot() string {
+	if s.dataDir == "" {
+		return ""
+	}
+	return filepath.Join(s.dataDir, stagingDirName)
+}
+
+// newStagingDir creates a scratch directory under root, creating root itself if
+// needed. An empty root falls back to the OS temp dir.
+//
+// Staging under the data dir rather than $TMPDIR matters for large mods: /tmp is
+// tmpfs on most modern distros, so a multi-GB archive would be downloaded and
+// extracted in RAM. The data dir is also on the same filesystem as the cache the
+// content is ultimately committed into.
+//
+// Callers own the returned directory and must remove it.
+func newStagingDir(root, pattern string) (string, error) {
+	if root != "" {
+		if err := os.MkdirAll(root, 0755); err != nil {
+			return "", fmt.Errorf("creating staging directory: %w", err)
+		}
+	}
+
+	dir, err := os.MkdirTemp(root, pattern)
+	if err != nil {
+		return "", fmt.Errorf("creating staging directory: %w", err)
+	}
+	return dir, nil
+}

--- a/internal/core/staging.go
+++ b/internal/core/staging.go
@@ -30,8 +30,14 @@ func (s *Service) stagingRoot() string {
 // Callers own the returned directory and must remove it.
 func newStagingDir(root, pattern string) (string, error) {
 	if root != "" {
-		if err := os.MkdirAll(root, 0755); err != nil {
+		// 0700, not 0755: in-flight downloads and extracted mod trees live here.
+		// Inheriting privacy from the data dir is not enough — an install predating
+		// the data dir being tightened may still be 0755.
+		if err := os.MkdirAll(root, 0700); err != nil {
 			return "", fmt.Errorf("creating staging directory: %w", err)
+		}
+		if err := os.Chmod(root, 0700); err != nil {
+			return "", fmt.Errorf("restricting staging directory: %w", err)
 		}
 	}
 

--- a/internal/core/staging_test.go
+++ b/internal/core/staging_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,6 +24,21 @@ func TestNewStagingDir_CreatesUnderRoot(t *testing.T) {
 	assert.Equal(t, root, filepath.Dir(dir), "staging dir should be created directly under the root")
 	assert.DirExists(t, dir)
 	assert.True(t, strings.HasPrefix(filepath.Base(dir), "lmm-download-"), "pattern should be honored, got %q", filepath.Base(dir))
+}
+
+// TestNewStagingDir_RootIsOwnerOnly pins the staging root to 0700. In-flight
+// downloads and extracted mod trees live here, and relying on the data dir's
+// permissions is not enough: a legacy install's data dir may still be 0755.
+func TestNewStagingDir_RootIsOwnerOnly(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "downloads")
+
+	dir, err := newStagingDir(root, "lmm-download-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	info, err := os.Stat(root)
+	require.NoError(t, err)
+	assert.Equal(t, fs.FileMode(0700), info.Mode().Perm(), "staging root must not be group- or world-readable")
 }
 
 // TestNewStagingDir_CreatesMissingRoot: the downloads directory is created on

--- a/internal/core/staging_test.go
+++ b/internal/core/staging_test.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewStagingDir_CreatesUnderRoot pins that scratch space for downloads and
+// archive extraction lives under the data dir rather than $TMPDIR. /tmp is tmpfs
+// on most modern distros, so staging a multi-GB mod archive there spends RAM.
+func TestNewStagingDir_CreatesUnderRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "downloads")
+
+	dir, err := newStagingDir(root, "lmm-download-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	assert.Equal(t, root, filepath.Dir(dir), "staging dir should be created directly under the root")
+	assert.DirExists(t, dir)
+	assert.True(t, strings.HasPrefix(filepath.Base(dir), "lmm-download-"), "pattern should be honored, got %q", filepath.Base(dir))
+}
+
+// TestNewStagingDir_CreatesMissingRoot: the downloads directory is created on
+// demand, so core works as a library without the CLI having pre-made it.
+func TestNewStagingDir_CreatesMissingRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "nested", "downloads")
+
+	dir, err := newStagingDir(root, "lmm-import-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	assert.DirExists(t, root)
+	assert.Equal(t, root, filepath.Dir(dir))
+}
+
+// TestNewStagingDir_FallsBackToTempDir keeps callers without a configured data
+// dir working, rather than failing or writing to the process's working directory.
+func TestNewStagingDir_FallsBackToTempDir(t *testing.T) {
+	dir, err := newStagingDir("", "lmm-download-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	assert.Equal(t, os.TempDir(), filepath.Dir(dir))
+}
+
+// TestService_StagingRoot pins the location against the PRD's documented layout.
+func TestService_StagingRoot(t *testing.T) {
+	dataDir := t.TempDir()
+	svc := &Service{dataDir: dataDir}
+
+	assert.Equal(t, filepath.Join(dataDir, "downloads"), svc.stagingRoot())
+}
+
+// TestService_StagingRoot_EmptyDataDir yields "", which newStagingDir reads as
+// "fall back to $TMPDIR" — never the relative path "downloads".
+func TestService_StagingRoot_EmptyDataDir(t *testing.T) {
+	svc := &Service{}
+
+	assert.Empty(t, svc.stagingRoot())
+}

--- a/internal/domain/profile.go
+++ b/internal/domain/profile.go
@@ -17,14 +17,17 @@ type GameHooksExplicit struct {
 
 // Profile represents a collection of mods with a specific configuration
 type Profile struct {
-	Name          string            // Profile identifier
-	GameID        string            // Which game this profile is for
-	Mods          []ModReference    // Mods in load order (first = lowest priority)
-	Overrides     map[string][]byte // Config file overrides (path -> content)
-	LinkMethod    LinkMethod        // Override game's default link method (optional)
-	IsDefault     bool              // Is this the default profile for the game?
-	Hooks         GameHooks         // Profile-level hook overrides
-	HooksExplicit GameHooksExplicit // Tracks which hooks were explicitly set
+	Name       string            // Profile identifier
+	GameID     string            // Which game this profile is for
+	Mods       []ModReference    // Mods in load order (first = lowest priority)
+	Overrides  map[string][]byte // Config file overrides (path -> content)
+	LinkMethod LinkMethod        // Override game's default link method (optional)
+	// LinkMethodExplicit distinguishes "not set" (inherit from game/global) from an
+	// explicit "symlink", which is LinkMethod's zero value. Mirrors Game.LinkMethodExplicit.
+	LinkMethodExplicit bool
+	IsDefault          bool              // Is this the default profile for the game?
+	Hooks              GameHooks         // Profile-level hook overrides
+	HooksExplicit      GameHooksExplicit // Tracks which hooks were explicitly set
 }
 
 // ExportedProfile is the YAML-serializable format for sharing

--- a/internal/storage/config/profiles.go
+++ b/internal/storage/config/profiles.go
@@ -135,11 +135,12 @@ func LoadProfile(configDir, gameID, profileName string) (*domain.Profile, error)
 	}
 
 	profile := &domain.Profile{
-		Name:       cfg.Name,
-		GameID:     cfg.GameID,
-		LinkMethod: domain.ParseLinkMethod(cfg.LinkMethod),
-		IsDefault:  cfg.IsDefault,
-		Mods:       make([]domain.ModReference, len(cfg.Mods)),
+		Name:               cfg.Name,
+		GameID:             cfg.GameID,
+		LinkMethod:         domain.ParseLinkMethod(cfg.LinkMethod),
+		LinkMethodExplicit: cfg.LinkMethod != "",
+		IsDefault:          cfg.IsDefault,
+		Mods:               make([]domain.ModReference, len(cfg.Mods)),
 	}
 
 	for i, m := range cfg.Mods {
@@ -169,11 +170,16 @@ func SaveProfile(configDir string, profile *domain.Profile) error {
 		return err
 	}
 	cfg := ProfileConfig{
-		Name:       profile.Name,
-		GameID:     profile.GameID,
-		LinkMethod: profile.LinkMethod.String(),
-		IsDefault:  profile.IsDefault,
-		Mods:       make([]ModReferenceConfig, len(profile.Mods)),
+		Name:      profile.Name,
+		GameID:    profile.GameID,
+		IsDefault: profile.IsDefault,
+		Mods:      make([]ModReferenceConfig, len(profile.Mods)),
+	}
+	// Only write link_method if explicitly set: String() never returns "", so
+	// assigning it unconditionally defeats `omitempty` and bakes a phantom
+	// symlink override into every profile file.
+	if profile.LinkMethodExplicit {
+		cfg.LinkMethod = profile.LinkMethod.String()
 	}
 
 	for i, m := range profile.Mods {
@@ -256,10 +262,12 @@ func DeleteProfile(configDir, gameID, profileName string) error {
 // ExportProfile exports a profile to a portable format
 func ExportProfile(profile *domain.Profile) ([]byte, error) {
 	exported := domain.ExportedProfile{
-		Name:       profile.Name,
-		GameID:     profile.GameID,
-		Mods:       profile.Mods,
-		LinkMethod: profile.LinkMethod.String(),
+		Name:   profile.Name,
+		GameID: profile.GameID,
+		Mods:   profile.Mods,
+	}
+	if profile.LinkMethodExplicit {
+		exported.LinkMethod = profile.LinkMethod.String()
 	}
 	if len(profile.Overrides) > 0 {
 		exported.Overrides = make(map[string]string)
@@ -284,10 +292,11 @@ func ImportProfile(data []byte) (*domain.Profile, error) {
 	}
 
 	p := &domain.Profile{
-		Name:       exported.Name,
-		GameID:     exported.GameID,
-		Mods:       exported.Mods,
-		LinkMethod: domain.ParseLinkMethod(exported.LinkMethod),
+		Name:               exported.Name,
+		GameID:             exported.GameID,
+		Mods:               exported.Mods,
+		LinkMethod:         domain.ParseLinkMethod(exported.LinkMethod),
+		LinkMethodExplicit: exported.LinkMethod != "",
 	}
 	if len(exported.Overrides) > 0 {
 		p.Overrides = make(map[string][]byte)

--- a/internal/storage/config/profiles_test.go
+++ b/internal/storage/config/profiles_test.go
@@ -160,3 +160,131 @@ func TestDeleteProfile_RejectsInvalidName(t *testing.T) {
 		})
 	}
 }
+
+// profileYAML reads a saved profile back as raw text, so tests can assert on the
+// keys actually written rather than on what a round-trip happens to reconstruct.
+func profileYAML(t *testing.T, configDir, gameID, profileName string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(configDir, "games", gameID, "profiles", profileName+".yaml"))
+	require.NoError(t, err)
+	return string(data)
+}
+
+// TestSaveProfile_OmitsLinkMethodWhenNotExplicit guards the regression that made
+// the profile-level override unimplementable: LinkMethod.String() never returns
+// "", so `omitempty` never fired and every profile file gained a phantom
+// `link_method: symlink` — indistinguishable from a deliberate choice.
+func TestSaveProfile_OmitsLinkMethodWhenNotExplicit(t *testing.T) {
+	configDir := t.TempDir()
+	profile := &domain.Profile{Name: "default", GameID: "skyrim-se"}
+
+	require.NoError(t, SaveProfile(configDir, profile))
+
+	assert.NotContains(t, profileYAML(t, configDir, "skyrim-se", "default"), "link_method",
+		"a profile with no explicit link method must not write the key")
+}
+
+func TestSaveProfile_WritesExplicitLinkMethod(t *testing.T) {
+	configDir := t.TempDir()
+	profile := &domain.Profile{
+		Name:               "default",
+		GameID:             "skyrim-se",
+		LinkMethod:         domain.LinkCopy,
+		LinkMethodExplicit: true,
+	}
+
+	require.NoError(t, SaveProfile(configDir, profile))
+
+	assert.Contains(t, profileYAML(t, configDir, "skyrim-se", "default"), "link_method: copy")
+}
+
+// TestSaveProfile_PreservesExplicitSymlink pins the case the explicit flag exists
+// for: symlink is the zero value, so without the flag it is indistinguishable
+// from unset and would be dropped on save.
+func TestSaveProfile_PreservesExplicitSymlink(t *testing.T) {
+	configDir := t.TempDir()
+	profile := &domain.Profile{
+		Name:               "default",
+		GameID:             "skyrim-se",
+		LinkMethod:         domain.LinkSymlink,
+		LinkMethodExplicit: true,
+	}
+
+	require.NoError(t, SaveProfile(configDir, profile))
+
+	assert.Contains(t, profileYAML(t, configDir, "skyrim-se", "default"), "link_method: symlink")
+}
+
+func TestLoadProfile_TracksLinkMethodExplicit(t *testing.T) {
+	tests := map[string]struct {
+		yaml           string
+		wantExplicit   bool
+		wantLinkMethod domain.LinkMethod
+	}{
+		"absent":   {"name: default\ngame_id: skyrim-se\n", false, domain.LinkSymlink},
+		"hardlink": {"name: default\ngame_id: skyrim-se\nlink_method: hardlink\n", true, domain.LinkHardlink},
+		"symlink":  {"name: default\ngame_id: skyrim-se\nlink_method: symlink\n", true, domain.LinkSymlink},
+	}
+
+	for label, tc := range tests {
+		t.Run(label, func(t *testing.T) {
+			configDir := t.TempDir()
+			profileDir := filepath.Join(configDir, "games", "skyrim-se", "profiles")
+			require.NoError(t, os.MkdirAll(profileDir, 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(profileDir, "default.yaml"), []byte(tc.yaml), 0644))
+
+			profile, err := LoadProfile(configDir, "skyrim-se", "default")
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantExplicit, profile.LinkMethodExplicit)
+			assert.Equal(t, tc.wantLinkMethod, profile.LinkMethod)
+		})
+	}
+}
+
+// TestSaveProfile_RoundTripDoesNotInventLinkMethod is the end-to-end shape of the
+// bug: every profile mutation goes load -> modify -> save, so a phantom key added
+// on save would be read back as explicit on the next load and become permanent.
+func TestSaveProfile_RoundTripDoesNotInventLinkMethod(t *testing.T) {
+	configDir := t.TempDir()
+	require.NoError(t, SaveProfile(configDir, &domain.Profile{Name: "default", GameID: "skyrim-se"}))
+
+	loaded, err := LoadProfile(configDir, "skyrim-se", "default")
+	require.NoError(t, err)
+	require.False(t, loaded.LinkMethodExplicit)
+
+	require.NoError(t, SaveProfile(configDir, loaded))
+
+	assert.NotContains(t, profileYAML(t, configDir, "skyrim-se", "default"), "link_method")
+}
+
+func TestExportProfile_OmitsLinkMethodWhenNotExplicit(t *testing.T) {
+	data, err := ExportProfile(&domain.Profile{Name: "default", GameID: "skyrim-se"})
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(data), "link_method",
+		"an exported profile must not carry a link method the user never set")
+}
+
+func TestExportProfile_WritesExplicitLinkMethod(t *testing.T) {
+	data, err := ExportProfile(&domain.Profile{
+		Name:               "default",
+		GameID:             "skyrim-se",
+		LinkMethod:         domain.LinkHardlink,
+		LinkMethodExplicit: true,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), "link_method: hardlink")
+}
+
+func TestImportProfile_TracksLinkMethodExplicit(t *testing.T) {
+	imported, err := ImportProfile([]byte("name: default\ngame_id: skyrim-se\n"))
+	require.NoError(t, err)
+	assert.False(t, imported.LinkMethodExplicit, "absent link_method must not import as explicit")
+
+	imported, err = ImportProfile([]byte("name: default\ngame_id: skyrim-se\nlink_method: copy\n"))
+	require.NoError(t, err)
+	assert.True(t, imported.LinkMethodExplicit)
+	assert.Equal(t, domain.LinkCopy, imported.LinkMethod)
+}

--- a/internal/storage/db/db.go
+++ b/internal/storage/db/db.go
@@ -2,10 +2,18 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 
 	_ "modernc.org/sqlite"
 )
+
+// secureFileMode is the permission mask for the database and its WAL/SHM sidecars.
+// The auth_tokens table holds API keys in plaintext, so the file must not be
+// readable by other local users.
+const secureFileMode = 0600
 
 // DB wraps the SQLite database connection
 type DB struct {
@@ -27,6 +35,14 @@ func New(path string) (*DB, error) {
 		return nil, fmt.Errorf("setting pragmas: %w", err)
 	}
 
+	// After the pragmas, so the WAL/SHM sidecars exist and get tightened too.
+	if err := restrictPermissions(path); err != nil {
+		if closeErr := sqlDB.Close(); closeErr != nil {
+			return nil, fmt.Errorf("%w (closing database: %v)", err, closeErr)
+		}
+		return nil, err
+	}
+
 	database := &DB{DB: sqlDB}
 
 	if err := database.migrate(); err != nil {
@@ -37,4 +53,24 @@ func New(path string) (*DB, error) {
 	}
 
 	return database, nil
+}
+
+// restrictPermissions tightens the database file and its WAL/SHM sidecars to
+// owner-only. SQLite creates these itself — 0644 under a typical umask — so they
+// can only be fixed after the fact; the data directory is created 0700 by the
+// caller, which keeps the brief window between creation and chmod from being
+// useful. Applied on every open, so databases predating this get tightened too.
+//
+// Paths that do not exist are skipped: an in-memory database (":memory:") has no
+// file, and the sidecars are absent until WAL mode has something to write.
+func restrictPermissions(path string) error {
+	for _, p := range []string{path, path + "-wal", path + "-shm"} {
+		if err := os.Chmod(p, secureFileMode); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("restricting permissions on %s: %w", p, err)
+		}
+	}
+	return nil
 }

--- a/internal/storage/db/db.go
+++ b/internal/storage/db/db.go
@@ -35,7 +35,9 @@ func New(path string) (*DB, error) {
 		return nil, fmt.Errorf("setting pragmas: %w", err)
 	}
 
-	// After the pragmas, so the WAL/SHM sidecars exist and get tightened too.
+	// Before any write, so the main database file is already 0600 when SQLite
+	// creates the WAL/SHM sidecars — it derives their mode from this file. The
+	// sidecars do not exist yet at this point; they are handled after migrations.
 	if err := restrictPermissions(path); err != nil {
 		if closeErr := sqlDB.Close(); closeErr != nil {
 			return nil, fmt.Errorf("%w (closing database: %v)", err, closeErr)

--- a/internal/storage/db/db.go
+++ b/internal/storage/db/db.go
@@ -52,6 +52,18 @@ func New(path string) (*DB, error) {
 		return nil, fmt.Errorf("running migrations: %w", err)
 	}
 
+	// Again after migrations: the WAL/SHM sidecars do not exist yet at the call
+	// above (verified — the pragma alone does not create them), so they are only
+	// tightened here. They currently land at 0600 regardless, because SQLite
+	// derives their mode from the main database file we just restricted, but that
+	// is driver behavior rather than a contract — this makes it explicit.
+	if err := restrictPermissions(path); err != nil {
+		if closeErr := sqlDB.Close(); closeErr != nil {
+			return nil, fmt.Errorf("%w (closing database: %v)", err, closeErr)
+		}
+		return nil, err
+	}
+
 	return database, nil
 }
 

--- a/internal/storage/db/db_test.go
+++ b/internal/storage/db/db_test.go
@@ -31,11 +31,54 @@ func TestNew_RunsMigrations(t *testing.T) {
 	err = database.QueryRow("SELECT COUNT(*) FROM installed_mods").Scan(&count)
 	assert.NoError(t, err)
 
-	err = database.QueryRow("SELECT COUNT(*) FROM mod_cache").Scan(&count)
-	assert.NoError(t, err)
-
 	err = database.QueryRow("SELECT COUNT(*) FROM auth_tokens").Scan(&count)
 	assert.NoError(t, err)
+}
+
+// TestNew_DropsModCacheTable pins the removal of the mod_cache table. It was
+// created in v1 and never read or written — caching is keyed by directory layout
+// in internal/storage/cache, with no DB mirror.
+func TestNew_DropsModCacheTable(t *testing.T) {
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+
+	var count int
+	err = database.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'mod_cache'").Scan(&count)
+	require.NoError(t, err)
+	assert.Zero(t, count, "mod_cache should have been dropped")
+}
+
+// TestNew_DropsModCacheTableOnUpgrade covers the upgrade path rather than a fresh
+// install: a database left at v10 still has the table and must lose it on open.
+func TestNew_DropsModCacheTableOnUpgrade(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lmm.db")
+
+	database, err := db.New(path)
+	require.NoError(t, err)
+
+	// Rewind to v10 and recreate the table as v1 left it.
+	_, err = database.Exec("DELETE FROM schema_migrations WHERE version >= 11")
+	require.NoError(t, err)
+	_, err = database.Exec(`CREATE TABLE mod_cache (
+		source_id TEXT NOT NULL,
+		mod_id TEXT NOT NULL,
+		game_id TEXT NOT NULL,
+		metadata TEXT,
+		cached_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY(source_id, mod_id, game_id)
+	)`)
+	require.NoError(t, err)
+	require.NoError(t, database.Close())
+
+	reopened, err := db.New(path)
+	require.NoError(t, err)
+	defer func() { _ = reopened.Close() }()
+
+	var count int
+	err = reopened.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'mod_cache'").Scan(&count)
+	require.NoError(t, err)
+	assert.Zero(t, count, "upgrading from v10 should drop mod_cache")
 }
 
 // TestNew_AppliesAllMigrations verifies migrations v4–v7 are applied (installed_mod_files, deployed, checksum, deployed_files).

--- a/internal/storage/db/db_test.go
+++ b/internal/storage/db/db_test.go
@@ -1,6 +1,9 @@
 package db_test
 
 import (
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -63,6 +66,51 @@ func TestNew_AppliesAllMigrations(t *testing.T) {
 	err = database.QueryRow("SELECT COALESCE(MAX(version), 0) FROM schema_migrations").Scan(&version)
 	assert.NoError(t, err)
 	assert.GreaterOrEqual(t, version, 7, "schema_migrations should have at least version 7")
+}
+
+// TestNew_RestrictsFilePermissions pins that the database is owner-only. It holds
+// auth tokens in plaintext (#79), and SQLite creates it 0644 under a typical umask.
+func TestNew_RestrictsFilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lmm.db")
+
+	database, err := db.New(path)
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, fs.FileMode(0600), info.Mode().Perm(), "database must not be group- or world-readable")
+
+	// WAL mode is on, so the sidecars carry the same token bytes.
+	for _, suffix := range []string{"-wal", "-shm"} {
+		sidecar := path + suffix
+		info, err := os.Stat(sidecar)
+		if os.IsNotExist(err) {
+			continue
+		}
+		require.NoError(t, err)
+		assert.Equal(t, fs.FileMode(0600), info.Mode().Perm(), "%s must not be group- or world-readable", sidecar)
+	}
+}
+
+// TestNew_TightensExistingPermissions covers installs predating the fix: an already
+// world-readable database must be tightened on open, not just on creation.
+func TestNew_TightensExistingPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lmm.db")
+
+	database, err := db.New(path)
+	require.NoError(t, err)
+	require.NoError(t, database.Close())
+
+	require.NoError(t, os.Chmod(path, 0644))
+
+	reopened, err := db.New(path)
+	require.NoError(t, err)
+	defer func() { _ = reopened.Close() }()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, fs.FileMode(0600), info.Mode().Perm(), "existing permissive database should be tightened on open")
 }
 
 func TestInstalledMods_SaveAndGet(t *testing.T) {

--- a/internal/storage/db/db_test.go
+++ b/internal/storage/db/db_test.go
@@ -124,14 +124,13 @@ func TestNew_RestrictsFilePermissions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, fs.FileMode(0600), info.Mode().Perm(), "database must not be group- or world-readable")
 
-	// WAL mode is on, so the sidecars carry the same token bytes.
+	// WAL mode is on, so the sidecars carry the same token bytes. They are
+	// required to exist rather than skipped-if-absent: migrations write, which
+	// creates them, and a skip would make this assertion vacuous.
 	for _, suffix := range []string{"-wal", "-shm"} {
 		sidecar := path + suffix
 		info, err := os.Stat(sidecar)
-		if os.IsNotExist(err) {
-			continue
-		}
-		require.NoError(t, err)
+		require.NoError(t, err, "%s should exist once migrations have written", sidecar)
 		assert.Equal(t, fs.FileMode(0600), info.Mode().Perm(), "%s must not be group- or world-readable", sidecar)
 	}
 }

--- a/internal/storage/db/migrations.go
+++ b/internal/storage/db/migrations.go
@@ -32,6 +32,7 @@ func (d *DB) migrate() error {
 		migrateV8,
 		migrateV9,
 		migrateV10,
+		migrateV11,
 	}
 
 	for i := version; i < len(migrations); i++ {
@@ -176,5 +177,14 @@ func migrateV9(d *DB) error {
 
 func migrateV10(d *DB) error {
 	_, err := d.Exec(`ALTER TABLE installed_mods ADD COLUMN previous_file_ids TEXT DEFAULT '[]'`)
+	return err
+}
+
+// migrateV11 drops mod_cache, created in v1 and never read or written. The cache
+// is keyed entirely by directory layout (internal/storage/cache), so a DB mirror
+// would only add a way for the two to disagree; the metadata that turned out to
+// matter was added to installed_mods in v9 instead.
+func migrateV11(d *DB) error {
+	_, err := d.Exec(`DROP TABLE IF EXISTS mod_cache`)
 	return err
 }


### PR DESCRIPTION
Four tech-debt items from the `TODO.local.md` audit, each verified against the code before being written up. Every entry in that file was checked; the valid ones became #79–#87, the two deliberate deferrals became #88/#89 (closed as not planned with rationale), and one entry — user-defined mod sources — turned out to be stale, having shipped in v1.6.0–v1.10.0.

Two of the four fixes here were **not** in `TODO.local.md`; they were found while verifying the entries that were.

Released as **v1.14.1** (all four are fixes, no new functionality).

## Closes #80 — database and data dir were world-readable

`lmm.db` stores auth tokens in plaintext, and SQLite created it `0644` under a typical umask with nothing chmod'ing it afterward; the data dir was `0755`. On a multi-user machine any local user could read another user's NexusMods/CurseForge API keys. WAL mode is on, so `lmm.db-wal` carried the same bytes.

Permissions are applied on every open rather than only at creation, so **existing installs are fixed on the next run**. Paths that don't exist are skipped, which covers `:memory:` and sidecars WAL hasn't created yet.

This is a mitigation, not a fix for the plaintext storage itself — that's #79, which needs a key-source decision (OS keyring vs. local keyfile) before any code.

## Closes #82 — phantom `link_method` in every profile file

*(Found during verification, not in the TODO.)*

`LinkMethod.String()` never returns `""`, so assigning it unconditionally in `SaveProfile` defeated the `omitempty` tag. Every profile file gained a literal `link_method: symlink` the user never set, rewritten on every profile mutation — create, add/remove mod, reorder, set-default, import. `ExportProfile` carried it to other machines the same way.

Because `domain.Profile` had no explicit-tracking flag (unlike `domain.Game`), "unset" and "deliberately symlink" were indistinguishable once written. That makes #81 a footgun: a naive "profile wins" implementation would read `symlink` back out of every existing profile file and silently downgrade every per-game `hardlink`/`copy` setup. **So this had to land before #81, not as part of it.**

Adds `Profile.LinkMethodExplicit` mirroring `Game.LinkMethodExplicit`. No behavior change today — `Profile.LinkMethod` is still not consulted at deploy time.

⚠️ **Note for #81:** existing profile files already carrying the phantom `link_method: symlink` will be read as *explicit* by this change. Anyone with such a file will pin symlink once #81 lands. Flagged on the issue.

## Closes #84 — dropped the dead `mod_cache` table

Created by migration v1 and never read or written — not one INSERT, SELECT, UPDATE, or DELETE anywhere in `internal/` or `cmd/`. It has been an empty table in every install since v1.

Caching is keyed entirely by directory layout: presence is an `os.Stat` on `cache/<game>/<source>-<mod>/<version>`, and the file list comes from walking the tree. A DB mirror would only add a way for the two to disagree — today you can `rm -rf` a cache directory and `Exists()` stays correct. The metadata that turned out to matter was added to `installed_mods` in v9 instead.

v1 is left untouched since existing databases already applied it; v11 drops the table on both fresh installs and upgrades. The PRD is corrected too — it listed cache metadata as SQLite state and depicted a per-mod `metadata.json` that was never written either.

⚠️ **One-way migration.** There's no down-migration in this project's scheme. Nothing is lost (the table has always been empty), but a downgrade to 1.14.0 leaves `schema_migrations` at 11 while the code expects 10 — harmless, the loop just applies nothing.

## Closes #83 — downloads staged in `$TMPDIR`

`docs/PRD.md` has specified `~/.local/share/lmm/downloads` since the start, but no code ever created or referenced it: both scratch paths called `os.MkdirTemp("", ...)`, whose empty root falls back to `os.TempDir()`.

`/tmp` is tmpfs on most modern distributions, so downloading and extracting a multi-GB mod archive spent **RAM** rather than disk — precisely the workload this tool exists for. Staging under the data dir also puts scratch space on the same filesystem as the cache the content is committed into.

`Importer` had no data dir, so `Service.NewImporter` now constructs one wired to the staging root; the bare `NewImporter` is kept for callers without a service and documented as `$TMPDIR`-backed.

## Testing

Test-first throughout — every fix started from a failing test.

- `TestNew_RestrictsFilePermissions`, `TestNew_TightensExistingPermissions`, `TestInitService_DataDirIsOwnerOnly`
- 8 new `link_method` cases in `profiles_test.go`, which previously had **zero** coverage of the field — including a round-trip test capturing the actual bug shape (load → modify → save reads the phantom key back as explicit)
- `TestNew_DropsModCacheTable` plus an upgrade-path case that rewinds a real database to v10, recreates the table, and reopens
- `TestDownloadModStagesUnderDataDir` drives a **real HTTP download** end to end through the service against an `httptest` server, rather than only unit-testing the helper — the wiring is what regressed. Confirmed non-vacuous: reverting the fix makes it fail.

**Verified against the built binary**, not just the suite: data dir comes out `drwx------`, `lmm.db` `-rw-------`, and a real database reports schema v11 with `mod_cache` absent.

`go build`, `go vet`, `go test ./...`, and `gofmt` are all clean. `trunk` is not installed on this machine, so that check did not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
