### PR TITLE
feat: surface update-policy/pin state in both interfaces (v1.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-07-25
+
+### Added
+
+- `lmm list --verbose` gains a `POLICY` column showing each mod's update policy (`notify`, `auto`, or `pinned`), and `lmm list --json` gains a matching `update_policy` field. The field is emitted unconditionally rather than gated on `--verbose`, since a JSON consumer has no other way to see that a mod is held back from updates
+- The TUI's Installed Mods rows gain a flags column marking pinned mods with `pin`. Pin state was previously discoverable only by opening the `P` policy picker on each mod one at a time
+
+### Fixed
+
+- `lmm update <mod-id>` reported a pinned mod as "already up to date". Pinned mods are filtered out before their source is ever queried, so no version comparison happened and a newer version may well have existed. It now says the mod is pinned, at which version, and names the command that unpins it. The TUI's equivalent message had the same problem and the same fix
+- `lmm update` no longer prints "All mods are up to date" when every installed mod was skipped as pinned, and now reports how many pinned mods it skipped when there were any
+
 ## [1.14.1] - 2026-07-25
 
 ### Security
@@ -880,7 +892,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.14.1...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.14.1...v1.15.0
 [1.14.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.14.0...v1.14.1
 [1.14.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.13.1...v1.14.0
 [1.13.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.13.0...v1.13.1

--- a/cmd/lmm/list.go
+++ b/cmd/lmm/list.go
@@ -30,6 +30,10 @@ type listModJSON struct {
 	Enabled  bool   `json:"enabled"`
 	Deployed bool   `json:"deployed"`
 	Method   string `json:"link_method"`
+	// UpdatePolicy is "notify", "auto", or "pinned". Emitted unconditionally,
+	// not gated on --verbose: a JSON consumer has no other way to see that a
+	// mod is held back from updates.
+	UpdatePolicy string `json:"update_policy"`
 }
 
 var listCmd = &cobra.Command{
@@ -82,13 +86,14 @@ func doList(cmd *cobra.Command, service *core.Service, game *domain.Game) error 
 				sourceDisplay = "local"
 			}
 			out.Mods[i] = listModJSON{
-				ID:       mod.ID,
-				Name:     mod.Name,
-				Version:  mod.Version,
-				Source:   sourceDisplay,
-				Enabled:  mod.Enabled,
-				Deployed: mod.Deployed,
-				Method:   mod.LinkMethod.String(),
+				ID:           mod.ID,
+				Name:         mod.Name,
+				Version:      mod.Version,
+				Source:       sourceDisplay,
+				Enabled:      mod.Enabled,
+				Deployed:     mod.Deployed,
+				Method:       mod.LinkMethod.String(),
+				UpdatePolicy: policyToString(mod.UpdatePolicy),
 			}
 		}
 		enc := json.NewEncoder(os.Stdout)
@@ -115,8 +120,8 @@ func doList(cmd *cobra.Command, service *core.Service, game *domain.Game) error 
 	header := "ID\tNAME\tVERSION\tAUTHOR"
 	sep := "--\t----\t-------\t------"
 	if verbose {
-		header = "ID\tNAME\tVERSION\tAUTHOR\tSOURCE\tENABLED\tDEPLOYED\tMETHOD"
-		sep = "--\t----\t-------\t------\t------\t-------\t--------\t------"
+		header = "ID\tNAME\tVERSION\tAUTHOR\tSOURCE\tENABLED\tDEPLOYED\tMETHOD\tPOLICY"
+		sep = "--\t----\t-------\t------\t------\t-------\t--------\t------\t------"
 	}
 	if _, err := fmt.Fprintln(w, header); err != nil {
 		return fmt.Errorf("writing header: %w", err)
@@ -144,7 +149,7 @@ func doList(cmd *cobra.Command, service *core.Service, game *domain.Game) error 
 			if mod.SourceID == domain.SourceLocal {
 				sourceDisplay = "(local)"
 			}
-			row = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s", mod.ID, truncate(mod.Name, 40), mod.Version, truncate(author, 20), sourceDisplay, enabled, deployed, mod.LinkMethod.String())
+			row = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s", mod.ID, truncate(mod.Name, 40), mod.Version, truncate(author, 20), sourceDisplay, enabled, deployed, mod.LinkMethod.String(), policyToString(mod.UpdatePolicy))
 		} else {
 			row = fmt.Sprintf("%s\t%s\t%s\t%s", mod.ID, truncate(mod.Name, 40), mod.Version, truncate(author, 20))
 		}

--- a/cmd/lmm/pin_visibility_test.go
+++ b/cmd/lmm/pin_visibility_test.go
@@ -115,3 +115,36 @@ func TestDoUpdate_ReportsSkippedPinnedCount(t *testing.T) {
 
 	assert.Contains(t, out, "2 pinned", "should report how many mods were skipped")
 }
+
+// TestDoUpdate_AllPinned_NoLeadingBlankLine: when every mod is pinned the
+// skipped-count line is the entire output, so a leading newline shows up as a
+// stray blank first line with nothing to separate it from.
+func TestDoUpdate_AllPinned_NoLeadingBlankLine(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	game.SourceIDs = map[string]string{"src": "src"}
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+	setPolicy(t, svc, game, "a", domain.UpdatePinned)
+
+	out := captureStdout(t, func() error {
+		return doUpdate(context.Background(), svc, game, nil)
+	})
+
+	assert.False(t, strings.HasPrefix(out, "\n"), "output must not open with a blank line, got %q", out)
+	assert.Contains(t, out, "1 pinned mod skipped")
+}
+
+// TestDoUpdate_SomePinned_SeparatesFromPrecedingOutput: the counterpart — when
+// something is printed first, the line still needs a blank line above it.
+func TestDoUpdate_SomePinned_SeparatesFromPrecedingOutput(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	game.SourceIDs = map[string]string{"src": "src"}
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+	seedDeployableMod(t, svc, game, "b", "Mod B", "b.esp")
+	setPolicy(t, svc, game, "a", domain.UpdatePinned)
+
+	out := captureStdout(t, func() error {
+		return doUpdate(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "up to date.\n\n1 pinned mod skipped", "needs a blank line after preceding output")
+}

--- a/cmd/lmm/pin_visibility_test.go
+++ b/cmd/lmm/pin_visibility_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setPolicy overwrites a seeded mod's update policy.
+func setPolicy(t *testing.T, svc *core.Service, game *domain.Game, modID string, policy domain.UpdatePolicy) {
+	t.Helper()
+	require.NoError(t, svc.SetModUpdatePolicy("src", modID, game.ID, "default", policy))
+}
+
+// listVerbose runs doList with --verbose and returns stdout.
+func listVerbose(t *testing.T, svc *core.Service, game *domain.Game, asJSON bool) string {
+	t.Helper()
+	oldVerbose, oldJSON := verbose, jsonOutput
+	verbose, jsonOutput = !asJSON, asJSON
+	t.Cleanup(func() { verbose, jsonOutput = oldVerbose, oldJSON })
+
+	return captureStdout(t, func() error {
+		return doList(&cobra.Command{}, svc, game)
+	})
+}
+
+// TestList_VerboseShowsUpdatePolicy: pinning works but was invisible — no
+// listing surfaced it, so reviewing which mods are pinned meant probing each
+// one individually.
+func TestList_VerboseShowsUpdatePolicy(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+	seedDeployableMod(t, svc, game, "b", "Mod B", "b.esp")
+	setPolicy(t, svc, game, "b", domain.UpdatePinned)
+
+	out := listVerbose(t, svc, game, false)
+
+	assert.Contains(t, out, "POLICY", "verbose listing needs a policy column")
+	lines := strings.Split(out, "\n")
+	var rowA, rowB string
+	for _, l := range lines {
+		switch {
+		case strings.Contains(l, "Mod A"):
+			rowA = l
+		case strings.Contains(l, "Mod B"):
+			rowB = l
+		}
+	}
+	require.NotEmpty(t, rowA)
+	require.NotEmpty(t, rowB)
+	assert.Contains(t, rowB, "pinned", "the pinned mod's row should say so")
+	assert.Contains(t, rowA, "notify", "an unpinned mod should show its policy too")
+}
+
+// TestList_JSONIncludesUpdatePolicy: --json consumers could not see pin state
+// at all. Present unconditionally, not gated on --verbose.
+func TestList_JSONIncludesUpdatePolicy(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+	setPolicy(t, svc, game, "a", domain.UpdatePinned)
+
+	var out struct {
+		Mods []struct {
+			ID           string `json:"id"`
+			UpdatePolicy string `json:"update_policy"`
+		} `json:"mods"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(listVerbose(t, svc, game, true)), &out))
+	require.Len(t, out.Mods, 1)
+	assert.Equal(t, "pinned", out.Mods[0].UpdatePolicy)
+}
+
+// TestApplySingleUpdate_PinnedSaysPinned: the old message claimed "already up
+// to date", which is not what happened — the mod was filtered out as pinned
+// before any version comparison, so a newer version may well exist.
+func TestApplySingleUpdate_PinnedSaysPinned(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+	setPolicy(t, svc, game, "a", domain.UpdatePinned)
+
+	mod, err := svc.GetInstalledMod("src", "a", game.ID, "default")
+	require.NoError(t, err)
+
+	out := captureStdout(t, func() error {
+		return applySingleUpdate(context.Background(), svc, game, mod, "default")
+	})
+
+	assert.Contains(t, out, "pinned", "must say the mod is pinned")
+	assert.NotContains(t, out, "up to date", "must not claim currency it never checked")
+	assert.Contains(t, out, "set-update", "should name the command that unpins")
+}
+
+// TestDoUpdate_ReportsSkippedPinnedCount: pinned mods are filtered before the
+// source is queried, so they vanish from `lmm update` with no trace.
+func TestDoUpdate_ReportsSkippedPinnedCount(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	// doUpdate resolves a source before doing anything else.
+	game.SourceIDs = map[string]string{"src": "src"}
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+	seedDeployableMod(t, svc, game, "b", "Mod B", "b.esp")
+	setPolicy(t, svc, game, "a", domain.UpdatePinned)
+	setPolicy(t, svc, game, "b", domain.UpdatePinned)
+
+	out := captureStdout(t, func() error {
+		return doUpdate(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "2 pinned", "should report how many mods were skipped")
+}

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -24,7 +24,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.14.1"
+	version = "1.15.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/update.go
+++ b/cmd/lmm/update.go
@@ -164,7 +164,10 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 			return nil
 		}
 		fmt.Println("All mods are up to date.")
-		printPinnedSkipped(countPinned(installed))
+		if pinned := countPinned(installed); pinned > 0 {
+			fmt.Println()
+			printPinnedSkipped(pinned)
+		}
 		return nil
 	}
 
@@ -217,7 +220,10 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 	}
 
 	fmt.Printf("\n%d update(s) available.\n", len(updates))
-	printPinnedSkipped(countPinned(installed))
+	if pinned := countPinned(installed); pinned > 0 {
+		fmt.Println()
+		printPinnedSkipped(pinned)
+	}
 
 	// Show changelogs where available
 	var withChangelog []domain.Update
@@ -472,6 +478,10 @@ func countPinned(installed []domain.InstalledMod) int {
 
 // printPinnedSkipped notes skipped pinned mods, if any. No-op at zero so the
 // common case stays quiet.
+//
+// Emits no leading blank line: when every mod is pinned this is the whole
+// output, and a leading newline would render as a stray blank first line.
+// Callers with preceding output add their own separator.
 func printPinnedSkipped(pinned int) {
 	if pinned == 0 {
 		return
@@ -480,7 +490,7 @@ func printPinnedSkipped(pinned int) {
 	if pinned == 1 {
 		plural = ""
 	}
-	fmt.Printf("\n%d pinned mod%s skipped — see `lmm list -v`.\n", pinned, plural)
+	fmt.Printf("%d pinned mod%s skipped — see `lmm list -v`.\n", pinned, plural)
 }
 
 func policyToString(policy domain.UpdatePolicy) string {

--- a/cmd/lmm/update.go
+++ b/cmd/lmm/update.go
@@ -157,7 +157,14 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 			}
 			return nil
 		}
+		// "All mods are up to date" would be false if the only reason there is
+		// nothing to report is that every mod was skipped.
+		if pinned := countPinned(installed); pinned == len(installed) {
+			printPinnedSkipped(pinned)
+			return nil
+		}
 		fmt.Println("All mods are up to date.")
+		printPinnedSkipped(countPinned(installed))
 		return nil
 	}
 
@@ -210,6 +217,7 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 	}
 
 	fmt.Printf("\n%d update(s) available.\n", len(updates))
+	printPinnedSkipped(countPinned(installed))
 
 	// Show changelogs where available
 	var withChangelog []domain.Update
@@ -293,6 +301,14 @@ func applySingleUpdate(ctx context.Context, service *core.Service, game *domain.
 	}
 
 	if len(updates) == 0 {
+		// A pinned mod is filtered out before the source is queried, so no
+		// version comparison ever happened — reporting it as up to date would
+		// claim currency that was never checked.
+		if mod.UpdatePolicy == domain.UpdatePinned {
+			fmt.Printf("%s is pinned at v%s and was not checked.\n", mod.Name, mod.Version)
+			fmt.Printf("Unpin with: lmm mod set-update %s --notify\n", mod.ID)
+			return nil
+		}
 		fmt.Printf("%s is already up to date (v%s).\n", mod.Name, mod.Version)
 		return nil
 	}
@@ -439,6 +455,32 @@ func doUpdateRollback(ctx context.Context, service *core.Service, game *domain.G
 
 	fmt.Printf("\n✓ Rolled back: %s %s → %s\n", result.ModName, result.FromVersion, result.ToVersion)
 	return nil
+}
+
+// countPinned reports how many installed mods CheckUpdates will skip because
+// they are pinned. Pinned mods never become update rows, so without this they
+// disappear from `lmm update` output entirely.
+func countPinned(installed []domain.InstalledMod) int {
+	n := 0
+	for _, mod := range installed {
+		if mod.UpdatePolicy == domain.UpdatePinned {
+			n++
+		}
+	}
+	return n
+}
+
+// printPinnedSkipped notes skipped pinned mods, if any. No-op at zero so the
+// common case stays quiet.
+func printPinnedSkipped(pinned int) {
+	if pinned == 0 {
+		return
+	}
+	plural := "s"
+	if pinned == 1 {
+		plural = ""
+	}
+	fmt.Printf("\n%d pinned mod%s skipped — see `lmm list -v`.\n", pinned, plural)
 }
 
 func policyToString(policy domain.UpdatePolicy) string {

--- a/cmd/lmm/update.go
+++ b/cmd/lmm/update.go
@@ -158,13 +158,15 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 			return nil
 		}
 		// "All mods are up to date" would be false if the only reason there is
-		// nothing to report is that every mod was skipped.
-		if pinned := countPinned(installed); pinned == len(installed) {
+		// nothing to report is that every mod was skipped. An empty profile
+		// returned earlier, so len(installed) is non-zero here.
+		pinned := countPinned(installed)
+		if pinned == len(installed) {
 			printPinnedSkipped(pinned)
 			return nil
 		}
 		fmt.Println("All mods are up to date.")
-		if pinned := countPinned(installed); pinned > 0 {
+		if pinned > 0 {
 			fmt.Println()
 			printPinnedSkipped(pinned)
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1817,7 +1817,10 @@ func (m Model) row(index int, label string) string {
 	return prefix + label
 }
 
-// modRow renders one Installed Mods row: name / status / author / version.
+// modRow renders one Installed Mods row: name / status / flags / author /
+// version. The flags column is a fixed width so it is blank rather than absent
+// for an unpinned mod - a variable-width flag would shift author and version
+// between rows, the same alignment defect described below.
 // Finding 2 (smoke test): the name column used to be a fixed 28 runes with
 // no truncation, so a longer name overflowed it and shifted every
 // subsequent column to the right, breaking row alignment. Status/author/
@@ -1830,21 +1833,36 @@ func (m Model) row(index int, label string) string {
 // never reach lipgloss's automatic line-wrap.
 func (m Model) modRow(index, width int, mod ModItem) string {
 	const prefixWidth = 2 // m.row()'s "> "/"  " selection marker
-	const gaps = 3        // separating spaces between the 4 columns
+	const gaps = 4        // separating spaces between the 5 columns
 	const minName = 8
+	// Fixed, not proportional: the marker is the whole point of the column, so
+	// it must not be the first thing a narrow terminal truncates.
+	const flagsWidth = 3 // "pin"
 
 	avail := max(width-m.theme.Panel.GetHorizontalFrameSize()-prefixWidth-gaps, minName)
 	statusWidth := min(11, max(avail/6, 1)) // "disabled"/"deployed" are 8 runes
 	authorWidth := min(16, max(avail/5, 1))
 	versionWidth := min(7, max(avail/8, 1))
-	nameWidth := max(avail-statusWidth-authorWidth-versionWidth, minName)
+	nameWidth := max(avail-flagsWidth-statusWidth-authorWidth-versionWidth, minName)
 
-	line := fmt.Sprintf("%-*s %-*s %-*s %*s",
+	line := fmt.Sprintf("%-*s %-*s %-*s %-*s %*s",
 		nameWidth, truncate(mod.Name, nameWidth),
 		statusWidth, truncate(mod.Status, statusWidth),
+		flagsWidth, modFlags(mod),
 		authorWidth, truncate(mod.Author, authorWidth),
 		versionWidth, truncate(mod.Version, versionWidth))
 	return m.row(index, line)
+}
+
+// modFlags renders the per-mod flag column: "pin" for a mod held back from
+// update checks, empty otherwise. The wire string is "pin" (not the CLI's
+// "pinned") per ModItem.UpdatePolicy's documented values - see
+// service_core.go's policyToString for why the two interfaces differ.
+func modFlags(mod ModItem) string {
+	if mod.UpdatePolicy == "pin" {
+		return "pin"
+	}
+	return ""
 }
 
 func (m Model) panel(width int) lipgloss.Style {

--- a/internal/tui/pin_visibility_test.go
+++ b/internal/tui/pin_visibility_test.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModRow_ShowsPinFlag: ModItem.UpdatePolicy was populated but read only to
+// mark the current choice inside the 'P' picker, so reviewing pins meant
+// opening the picker on every mod one at a time.
+func TestModRow_ShowsPinFlag(t *testing.T) {
+	m, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	pinned := ModItem{Name: "Pinned Mod", Author: "Auth", Version: "1.0", Status: "deployed", UpdatePolicy: "pin"}
+	notify := ModItem{Name: "Normal Mod", Author: "Auth", Version: "1.0", Status: "deployed", UpdatePolicy: "notify"}
+
+	assert.Contains(t, m.modRow(0, 80, pinned), "pin", "a pinned mod's row must show it")
+	assert.NotContains(t, m.modRow(0, 80, notify), "pin", "an unpinned mod must not be marked")
+}
+
+// TestModRow_PinFlagSurvivesNarrowTerminal guards the 80-column budget: the
+// marker is useless if it is the first thing truncation eats.
+func TestModRow_PinFlagSurvivesNarrowTerminal(t *testing.T) {
+	m, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	pinned := ModItem{Name: "A Mod With A Fairly Long Name", Author: "Some Author", Version: "1.2.3", Status: "deployed", UpdatePolicy: "pin"}
+	for _, width := range []int{80, 60, 40} {
+		assert.Contains(t, m.modRow(0, width, pinned), "pin", "pin marker must survive at width %d", width)
+	}
+}
+
+// TestModRow_NoTrailingColumnDrift: the flags column is blank for unpinned
+// mods, so later columns must still line up across rows.
+func TestModRow_NoTrailingColumnDrift(t *testing.T) {
+	m, err := NewPrototypeModel(Options{Theme: "wizardry"})
+	require.NoError(t, err)
+
+	pinned := ModItem{Name: "Mod", Author: "Auth", Version: "1.0", Status: "deployed", UpdatePolicy: "pin"}
+	notify := ModItem{Name: "Mod", Author: "Auth", Version: "1.0", Status: "deployed", UpdatePolicy: "notify"}
+
+	a := ansi.Strip(m.modRow(0, 80, pinned))
+	b := ansi.Strip(m.modRow(0, 80, notify))
+	assert.Equal(t, len([]rune(a)), len([]rune(b)), "rows must be the same width whether or not the flag is set")
+	assert.Equal(t, strings.LastIndex(a, "1.0"), strings.LastIndex(b, "1.0"), "version column must not shift")
+}

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -1342,6 +1342,12 @@ func (p *coreProvider) ApplyUpdate(ctx context.Context, u UpdateItem, progress f
 		return ActionOutcome{}, mapUpdateNetworkError(fmt.Sprintf("checking update for %s", u.Name), u.Source, err)
 	}
 	if len(updates) == 0 {
+		// Pinned mods are filtered out before the source is queried, so no
+		// version comparison happened - saying "up to date" would claim
+		// currency that was never checked.
+		if mod.UpdatePolicy == domain.UpdatePinned {
+			return ActionOutcome{Message: fmt.Sprintf("%q is pinned — not checked (P to change)", u.Name)}, nil
+		}
 		return ActionOutcome{Message: fmt.Sprintf("%q is already up to date", u.Name)}, nil
 	}
 	upd := updates[0]


### PR DESCRIPTION
Closes #92.

Pinning already worked — `CheckUpdates` filters pinned mods before any source is queried ([updater.go:33](../blob/main/internal/core/updater.go#L33)), and every apply path is gated behind that check. What was missing is that **nothing showed which mods were pinned**, and one message actively lied about it.

## The visibility gap

`ModItem.UpdatePolicy` was populated but read in exactly one place — marking the current choice inside the `P` picker. Pin twenty mods and the only way to review them was opening that picker twenty times. Nothing in `lmm list` (text or JSON), `lmm mod show`, or the TUI rows surfaced it.

## The false message

`lmm update <pinned-id>` printed **"already up to date"**. The mod was filtered out as pinned, so no version comparison ever ran — a newer version may well have existed. The TUI had the same wording and the same problem.

A test also surfaced a case I hadn't anticipated: with *every* installed mod pinned, `lmm update` printed **"All mods are up to date."** — describing a check that never happened.

## Changes

- `lmm list -v` gains a `POLICY` column; `--json` gains `update_policy` **unconditionally**, not gated on `--verbose`, since a JSON consumer has no other way to see pin state
- TUI Installed Mods rows gain a fixed-width flags column showing `pin`. **Fixed** rather than proportional so a narrow terminal can't truncate away the very thing the column exists for, and **blank rather than absent** for unpinned mods so author/version don't shift between rows — the same alignment defect `modRow`'s doc comment already documents
- Pinned mods now say so; the CLI names the command that unpins them
- `lmm update` reports how many pinned mods it skipped, and short-circuits the false "All mods are up to date" when everything was skipped

## Testing

Test-first throughout; all seven started RED.

CLI (`cmd/lmm/pin_visibility_test.go`): POLICY column shows both `pinned` and `notify`, JSON field present, pinned message says "pinned" and *not* "up to date" and names `set-update`, skipped-count reported.

TUI (`internal/tui/pin_visibility_test.go`): marker present for pinned and absent for unpinned, **survives at widths 80/60/40**, and a column-drift guard asserting pinned and unpinned rows are the same rune width with the version column at the same offset.

**Verified against the built binary**, not only tests — a real game config, imported mods, one pinned:

```
ID        NAME  VERSION  AUTHOR  SOURCE   ENABLED  DEPLOYED  METHOD   POLICY
12345     Data  1.0      -       nexus…   yes      yes       symlink  pinned

$ lmm update 12345
Data is pinned at v1.0 and was not checked.
Unpin with: lmm mod set-update 12345 --notify

$ lmm update
1 pinned mod skipped — see `lmm list -v`.
```

Rendered TUI rows at 80 and 60 columns confirm the marker and alignment.

`go vet`, `go test ./...`, `gofmt` clean. No CI on this repo, so verification is local.

## Noted, not fixed

`lmm update` can still print "All mods are up to date" when the only installed mods are **local** (never checkable, filtered alongside pinned at `updater.go:33`). Same class of misstatement, different cause — out of scope here. Happy to file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)