### PR TITLE
fix: stop misreporting local mods in `lmm update` (v1.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-07-25
+
+### Added
+
+- `lmm update --json` gains a `skipped` block reporting how many installed mods were never checked, by reason (`pinned`, `local`). An empty `updates` array previously meant both "nothing to update" and "nothing was looked at", with no way to tell them apart
+- The TUI's update check reports skipped mods as a `Not checked:` warning, matching what the CLI prints
+
+### Fixed
+
+- `lmm update` printed "All mods are up to date" when every installed mod was a local import. Local mods have no remote source and are filtered before any source is queried, so nothing was ever compared. Local and pinned mods are now reported separately, since the remedies differ — a pin can be lifted, a local mod can never be checked
+- `lmm update <mod-id>` failed with "mod X not found in profile Y" (exit 1) for a local mod that *was* in the profile. The lookup matched on source as well as ID, and the resolved source is the game's configured remote, so a local mod could never match. It now says the mod is local and exits 0; a mod genuinely absent from the profile is still an error. A mod belonging to a different configured source now names the source to retry with, instead of claiming the mod is missing
+- The TUI reported a local mod as "already up to date" for the same reason, and now says it is local
+
 ## [1.15.0] - 2026-07-25
 
 ### Added
@@ -892,7 +905,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.15.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.16.0...HEAD
+[1.16.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.15.0...v1.16.0
 [1.15.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.14.1...v1.15.0
 [1.14.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.14.0...v1.14.1
 [1.14.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.13.1...v1.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.16.0] - 2026-07-25
 
+### Changed
+
+- **`lmm update` now exits non-zero when the update check itself fails.** Previously it exited 0 even when every source errored, so a script could not tell a completed check from a failed one. Partial results are still printed and auto-updates are still applied before the non-zero exit — the change is the exit status, not the work done. **If you script `lmm update`, check your error handling**: a run that used to appear to succeed during an outage will now fail
+- `lmm update --json` gains an `error` field, set only when the check failed. The document is otherwise unchanged, and stdout still contains exactly one JSON document in the failure case
+
 ### Added
 
 - `lmm update --json` gains a `skipped` block reporting how many installed mods were never checked, by reason (`pinned`, `local`). An empty `updates` array previously meant both "nothing to update" and "nothing was looked at", with no way to tell them apart

--- a/cmd/lmm/local_update_test.go
+++ b/cmd/lmm/local_update_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
@@ -62,7 +65,10 @@ func TestDoUpdate_ReportsSkippedLocalCount(t *testing.T) {
 	seedLocalMod(t, svc, game, "localA", "Local A")
 
 	out := captureStdout(t, func() error {
-		return doUpdate(context.Background(), svc, game, nil)
+		// The seeded remote source is unregistered, so the check fails and
+		// doUpdate reports non-zero; this test is about the output.
+		_ = doUpdate(context.Background(), svc, game, nil)
+		return nil
 	})
 
 	assert.Contains(t, out, "1 local mod", "should report the skipped local mod")
@@ -135,7 +141,8 @@ func TestDoUpdate_CheckFailed_DoesNotClaimUpToDate(t *testing.T) {
 	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
 
 	out := captureStdout(t, func() error {
-		return doUpdate(context.Background(), svc, game, nil)
+		_ = doUpdate(context.Background(), svc, game, nil)
+		return nil
 	})
 
 	assert.NotContains(t, out, "up to date", "the check failed, so currency was never established")
@@ -180,4 +187,93 @@ func TestDoUpdate_AmbiguousRemoteOnly_OmitsLocalCaveat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "curseforge, nexusmods", "sources listed, sorted")
 	assert.NotContains(t, err.Error(), "local mods cannot", "no local candidate, so no local caveat")
+}
+
+// TestDoUpdate_CheckFailed_ReturnsError: a check that failed should exit
+// non-zero. It reported the failure itself (warning on stderr plus the
+// "did not complete" line), so ErrReported suppresses a duplicate message.
+func TestDoUpdate_CheckFailed_ReturnsError(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+
+	var err error
+	_ = captureStdout(t, func() error {
+		err = doUpdate(context.Background(), svc, game, nil)
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrReported, "already reported, so Execute must not print it again")
+}
+
+// TestDoUpdate_CheckFailed_JSONCarriesError: --json consumers cannot see the
+// stderr warning, so the failure has to be in the document itself.
+func TestDoUpdate_CheckFailed_JSONCarriesError(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	var err error
+	raw := captureStdout(t, func() error {
+		err = doUpdate(context.Background(), svc, game, nil)
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrReported)
+
+	// Exactly one document: if Execute also printed {"error":...}, a caller
+	// piping stdout to a parser would choke on trailing content.
+	dec := json.NewDecoder(strings.NewReader(raw))
+	var out struct {
+		Error   string `json:"error"`
+		Updates []any  `json:"updates"`
+	}
+	require.NoError(t, dec.Decode(&out))
+	assert.NotEmpty(t, out.Error, "the failure must be visible in the JSON")
+	assert.Empty(t, out.Updates)
+	assert.False(t, dec.More(), "stdout must hold exactly one JSON document")
+}
+
+// TestDoUpdate_CheckSucceeded_ReturnsNil guards the other direction: a check
+// that completed must not start failing just because nothing needed updating.
+func TestDoUpdate_CheckSucceeded_ReturnsNil(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	seedLocalMod(t, svc, game, "localA", "Local A") // filtered, so no source is queried
+
+	_ = captureStdout(t, func() error {
+		return doUpdate(context.Background(), svc, game, nil)
+	})
+
+	err := func() error {
+		var e error
+		_ = captureStdout(t, func() error {
+			e = doUpdate(context.Background(), svc, game, nil)
+			return nil
+		})
+		return e
+	}()
+	assert.NoError(t, err, "nothing failed; everything was simply skipped")
+}
+
+// TestReportError_SuppressesAlreadyReported pins the Execute-side contract.
+func TestReportError_SuppressesAlreadyReported(t *testing.T) {
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		reportError(fmt.Errorf("wrapped: %w", ErrReported))
+		return nil
+	})
+	assert.Empty(t, out, "an already-reported error must not be printed again")
+
+	out = captureStdout(t, func() error {
+		reportError(errors.New("some other failure"))
+		return nil
+	})
+	assert.Contains(t, out, "some other failure", "unreported errors still print")
 }

--- a/cmd/lmm/local_update_test.go
+++ b/cmd/lmm/local_update_test.go
@@ -235,7 +235,12 @@ func TestDoUpdate_CheckFailed_JSONCarriesError(t *testing.T) {
 	require.NoError(t, dec.Decode(&out))
 	assert.NotEmpty(t, out.Error, "the failure must be visible in the JSON")
 	assert.Empty(t, out.Updates)
-	assert.False(t, dec.More(), "stdout must hold exactly one JSON document")
+	// Checks the unread remainder rather than Decoder.More(). More() does in
+	// fact return true for a second top-level document, but that is incidental
+	// to what it documents ("another element in the current array or object"),
+	// and it says nothing about trailing bytes that are not valid JSON.
+	trailing := strings.TrimSpace(raw[dec.InputOffset():])
+	assert.Empty(t, trailing, "stdout must hold exactly one JSON document, found trailing content")
 }
 
 // TestDoUpdate_CheckSucceeded_ReturnsNil guards the other direction: a check

--- a/cmd/lmm/local_update_test.go
+++ b/cmd/lmm/local_update_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedLocalMod seeds an imported-from-disk mod: present in the profile, but
+// with no remote source, so CheckUpdates filters it out.
+func seedLocalMod(t *testing.T, svc *core.Service, game *domain.Game, modID, name string) {
+	t.Helper()
+	require.NoError(t, svc.GetGameCache(game).Store(game.ID, domain.SourceLocal, modID, "1.0", name+".esp", []byte("data")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: domain.SourceLocal, Name: name, Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+	pm := svc.NewProfileManager()
+	if _, err := pm.Get(game.ID, "default"); err != nil {
+		require.ErrorIs(t, err, domain.ErrProfileNotFound)
+		_, err := pm.Create(game.ID, "default")
+		require.NoError(t, err)
+	}
+	require.NoError(t, pm.AddMod(game.ID, "default", domain.ModReference{SourceID: domain.SourceLocal, ModID: modID, Version: "1.0"}))
+}
+
+func localUpdateGame(t *testing.T) (*core.Service, *domain.Game) {
+	t.Helper()
+	svc, game := setupDoDeployTest(t)
+	game.SourceIDs = map[string]string{"src": "src"}
+	return svc, game
+}
+
+// TestDoUpdate_AllLocal_DoesNotClaimUpToDate: local mods are filtered before
+// any source is queried, so "All mods are up to date" describes a check that
+// never happened.
+func TestDoUpdate_AllLocal_DoesNotClaimUpToDate(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	seedLocalMod(t, svc, game, "localA", "Local A")
+
+	out := captureStdout(t, func() error {
+		return doUpdate(context.Background(), svc, game, nil)
+	})
+
+	assert.NotContains(t, out, "up to date", "nothing was checked, so nothing can be up to date")
+	assert.Contains(t, out, "local", "should say the mods were skipped as local")
+}
+
+// TestDoUpdate_ReportsSkippedLocalCount: mixed profile — the checkable mod is
+// reported normally, and the local one is disclosed rather than vanishing.
+func TestDoUpdate_ReportsSkippedLocalCount(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+	seedLocalMod(t, svc, game, "localA", "Local A")
+
+	out := captureStdout(t, func() error {
+		return doUpdate(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "1 local mod", "should report the skipped local mod")
+}
+
+// TestDoUpdate_SingleLocalMod_SaysLocalNotNotFound: the lookup matched on
+// source as well as ID, so a local mod reported "not found in profile" — with
+// exit 1 — for a mod that is plainly in the profile.
+func TestDoUpdate_SingleLocalMod_SaysLocalNotNotFound(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	seedLocalMod(t, svc, game, "localA", "Local A")
+
+	var err error
+	out := captureStdout(t, func() error {
+		err = doUpdate(context.Background(), svc, game, []string{"localA"})
+		return nil
+	})
+
+	assert.NoError(t, err, "a present-but-uncheckable mod is not an error")
+	assert.NotContains(t, out, "not found", "the mod is in the profile")
+	assert.Contains(t, out, "local", "should say why it cannot be checked")
+}
+
+// TestDoUpdate_SingleUnknownMod_StillErrors guards the other direction: a mod
+// genuinely absent from the profile must still be an error.
+func TestDoUpdate_SingleUnknownMod_StillErrors(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	seedLocalMod(t, svc, game, "localA", "Local A")
+
+	err := doUpdate(context.Background(), svc, game, []string{"nosuchmod"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestDoUpdate_JSONReportsSkipped: --json consumers have the same blind spot.
+func TestDoUpdate_JSONReportsSkipped(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	seedLocalMod(t, svc, game, "localA", "Local A")
+	seedDeployableMod(t, svc, game, "b", "Mod B", "b.esp")
+	setPolicy(t, svc, game, "b", domain.UpdatePinned)
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	var out struct {
+		Skipped struct {
+			Pinned int `json:"pinned"`
+			Local  int `json:"local"`
+		} `json:"skipped"`
+	}
+	raw := captureStdout(t, func() error {
+		return doUpdate(context.Background(), svc, game, nil)
+	})
+	require.NoError(t, json.Unmarshal([]byte(raw), &out))
+	assert.Equal(t, 1, out.Skipped.Local)
+	assert.Equal(t, 1, out.Skipped.Pinned)
+}

--- a/cmd/lmm/local_update_test.go
+++ b/cmd/lmm/local_update_test.go
@@ -160,3 +160,24 @@ func TestDoUpdate_SingleMod_AmbiguousAcrossSources(t *testing.T) {
 	assert.Contains(t, err.Error(), "curseforge", "must name the candidate sources")
 	assert.Contains(t, err.Error(), domain.SourceLocal, "must name the candidate sources")
 }
+
+// TestDoUpdate_AmbiguousRemoteOnly_OmitsLocalCaveat: the local aside is only
+// relevant when a candidate actually is local; on a purely remote ambiguity it
+// is noise.
+func TestDoUpdate_AmbiguousRemoteOnly_OmitsLocalCaveat(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	for _, src := range []string{"nexusmods", "curseforge"} {
+		require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+			Mod:          domain.Mod{ID: "12345", SourceID: src, Name: "Twin " + src, Version: "1.0", GameID: game.ID},
+			ProfileName:  "default",
+			UpdatePolicy: domain.UpdateNotify,
+			Enabled:      true,
+		}))
+	}
+
+	err := doUpdate(context.Background(), svc, game, []string{"12345"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "curseforge, nexusmods", "sources listed, sorted")
+	assert.NotContains(t, err.Error(), "local mods cannot", "no local candidate, so no local caveat")
+}

--- a/cmd/lmm/local_update_test.go
+++ b/cmd/lmm/local_update_test.go
@@ -122,3 +122,41 @@ func TestDoUpdate_JSONReportsSkipped(t *testing.T) {
 	assert.Equal(t, 1, out.Skipped.Local)
 	assert.Equal(t, 1, out.Skipped.Pinned)
 }
+
+// TestDoUpdate_CheckFailed_DoesNotClaimUpToDate: when CheckUpdates fails, the
+// warning goes to stderr and stdout used to say "All mods are up to date" —
+// currency was never established, and a caller reading stdout sees a false
+// success. Same defect class as the local/pinned cases this file covers.
+//
+// The seeded mod's source is not registered with the service, so the check
+// errors and returns no updates.
+func TestDoUpdate_CheckFailed_DoesNotClaimUpToDate(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+
+	out := captureStdout(t, func() error {
+		return doUpdate(context.Background(), svc, game, nil)
+	})
+
+	assert.NotContains(t, out, "up to date", "the check failed, so currency was never established")
+}
+
+// TestDoUpdate_SingleMod_AmbiguousAcrossSources: mod IDs are only unique within
+// a source, so a profile can hold the same ID twice. Reporting one arbitrarily
+// as "belongs to source X" would name whichever happened to come last.
+func TestDoUpdate_SingleMod_AmbiguousAcrossSources(t *testing.T) {
+	svc, game := localUpdateGame(t)
+	seedLocalMod(t, svc, game, "12345", "Local Twin")
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "12345", SourceID: "curseforge", Name: "Remote Twin", Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+
+	err := doUpdate(context.Background(), svc, game, []string{"12345"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "curseforge", "must name the candidate sources")
+	assert.Contains(t, err.Error(), domain.SourceLocal, "must name the candidate sources")
+}

--- a/cmd/lmm/pin_visibility_test.go
+++ b/cmd/lmm/pin_visibility_test.go
@@ -143,7 +143,10 @@ func TestDoUpdate_SomePinned_SeparatesFromPrecedingOutput(t *testing.T) {
 	setPolicy(t, svc, game, "a", domain.UpdatePinned)
 
 	out := captureStdout(t, func() error {
-		return doUpdate(context.Background(), svc, game, nil)
+		// Mod B's source is unregistered, so the check fails and doUpdate
+		// reports non-zero; this test is about the separator.
+		_ = doUpdate(context.Background(), svc, game, nil)
+		return nil
 	})
 
 	// Asserts the separator, not the preceding sentence: which summary line

--- a/cmd/lmm/pin_visibility_test.go
+++ b/cmd/lmm/pin_visibility_test.go
@@ -146,5 +146,10 @@ func TestDoUpdate_SomePinned_SeparatesFromPrecedingOutput(t *testing.T) {
 		return doUpdate(context.Background(), svc, game, nil)
 	})
 
-	assert.Contains(t, out, "up to date.\n\n1 pinned mod skipped", "needs a blank line after preceding output")
+	// Asserts the separator, not the preceding sentence: which summary line
+	// precedes it depends on whether the check succeeded, and tying the two
+	// together made this test encode a bug (it used to accept "All mods are up
+	// to date" after a check that had actually failed).
+	assert.Contains(t, out, "\n\n1 pinned mod skipped", "needs a blank line after preceding output")
+	assert.NotEqual(t, "\n", out[:1], "but not a leading blank line")
 }

--- a/cmd/lmm/pin_visibility_test.go
+++ b/cmd/lmm/pin_visibility_test.go
@@ -151,5 +151,7 @@ func TestDoUpdate_SomePinned_SeparatesFromPrecedingOutput(t *testing.T) {
 	// together made this test encode a bug (it used to accept "All mods are up
 	// to date" after a check that had actually failed).
 	assert.Contains(t, out, "\n\n1 pinned mod skipped", "needs a blank line after preceding output")
-	assert.NotEqual(t, "\n", out[:1], "but not a leading blank line")
+	// HasPrefix, not out[:1]: a regression that suppressed output entirely
+	// should fail this assertion, not panic on an index out of range.
+	assert.False(t, strings.HasPrefix(out, "\n"), "but not a leading blank line")
 }

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -23,6 +23,15 @@ import (
 // When returned from a command, Execute exits with code 2.
 var ErrCancelled = errors.New("cancelled")
 
+// ErrReported marks a failure the command has already communicated in its own
+// output format. Execute still exits 1, but prints nothing further.
+//
+// Needed because the two would otherwise collide: under --json, Execute prints
+// {"error":"..."} on any returned error, so a command that has already written
+// a complete JSON document would emit a second one and break any caller piping
+// stdout to a parser.
+var ErrReported = errors.New("already reported")
+
 var (
 	version = "1.16.0"
 
@@ -116,12 +125,21 @@ func Execute() {
 		if errors.Is(err, ErrCancelled) || errors.Is(err, context.Canceled) {
 			os.Exit(2)
 		}
-		if jsonOutput {
-			fmt.Printf(`{"error":%q}`+"\n", err.Error())
-		} else {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		}
+		reportError(err)
 		os.Exit(1)
+	}
+}
+
+// reportError prints err in the active output format, unless the command
+// already reported it (ErrReported).
+func reportError(err error) {
+	if errors.Is(err, ErrReported) {
+		return
+	}
+	if jsonOutput {
+		fmt.Printf(`{"error":%q}`+"\n", err.Error())
+	} else {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 	}
 }
 

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -24,7 +24,7 @@ import (
 var ErrCancelled = errors.New("cancelled")
 
 var (
-	version = "1.15.0"
+	version = "1.16.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/update.go
+++ b/cmd/lmm/update.go
@@ -27,6 +27,15 @@ type updateJSONOutput struct {
 	GameID  string          `json:"game_id"`
 	Profile string          `json:"profile"`
 	Updates []updateModJSON `json:"updates"`
+	// Skipped reports installed mods that were never checked, so a consumer
+	// can tell "nothing to update" apart from "nothing was looked at". An
+	// empty updates array means both, and only this distinguishes them.
+	Skipped updateSkippedJSON `json:"skipped"`
+}
+
+type updateSkippedJSON struct {
+	Pinned int `json:"pinned"`
+	Local  int `json:"local"`
 }
 
 type updateModJSON struct {
@@ -116,15 +125,31 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 	// If specific mod ID provided, update just that mod
 	if len(args) > 0 {
 		modID := args[0]
-		var targetMod *domain.InstalledMod
+		var targetMod, otherSourceMod *domain.InstalledMod
 		for i := range installed {
-			if installed[i].ID == modID && installed[i].SourceID == updateSource {
+			if installed[i].ID != modID {
+				continue
+			}
+			if installed[i].SourceID == updateSource {
 				targetMod = &installed[i]
 				break
 			}
+			// Same ID, different source. Remember it so a mod that IS in the
+			// profile is never reported as missing: matching on source as well
+			// as ID used to make a local mod look absent.
+			otherSourceMod = &installed[i]
 		}
 		if targetMod == nil {
-			return fmt.Errorf("mod %s not found in profile %s", modID, profileName)
+			if otherSourceMod == nil {
+				return fmt.Errorf("mod %s not found in profile %s", modID, profileName)
+			}
+			if otherSourceMod.SourceID == domain.SourceLocal {
+				// Present, just not checkable — informational, not an error.
+				fmt.Printf("%s is a local mod — no remote source to check for updates.\n", otherSourceMod.Name)
+				return nil
+			}
+			return fmt.Errorf("mod %s in profile %s belongs to source %q, not %q; retry with --source %s",
+				modID, profileName, otherSourceMod.SourceID, updateSource, otherSourceMod.SourceID)
 		}
 
 		return applySingleUpdate(ctx, service, game, targetMod, profileName)
@@ -152,7 +177,11 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 		if jsonOutput {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
-			if err := enc.Encode(updateJSONOutput{GameID: game.ID, Profile: profileName, Updates: []updateModJSON{}}); err != nil {
+			skips := core.CountUpdateSkips(installed)
+			if err := enc.Encode(updateJSONOutput{
+				GameID: game.ID, Profile: profileName, Updates: []updateModJSON{},
+				Skipped: updateSkippedJSON{Pinned: skips.Pinned, Local: skips.Local},
+			}); err != nil {
 				return fmt.Errorf("encoding json: %w", err)
 			}
 			return nil
@@ -160,21 +189,25 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 		// "All mods are up to date" would be false if the only reason there is
 		// nothing to report is that every mod was skipped. An empty profile
 		// returned earlier, so len(installed) is non-zero here.
-		pinned := countPinned(installed)
-		if pinned == len(installed) {
-			printPinnedSkipped(pinned)
+		skips := core.CountUpdateSkips(installed)
+		if skips.Total() == len(installed) {
+			printSkipped(skips)
 			return nil
 		}
 		fmt.Println("All mods are up to date.")
-		if pinned > 0 {
+		if skips.Total() > 0 {
 			fmt.Println()
-			printPinnedSkipped(pinned)
+			printSkipped(skips)
 		}
 		return nil
 	}
 
 	if jsonOutput {
-		out := updateJSONOutput{GameID: game.ID, Profile: profileName, Updates: make([]updateModJSON, len(updates))}
+		skips := core.CountUpdateSkips(installed)
+		out := updateJSONOutput{
+			GameID: game.ID, Profile: profileName, Updates: make([]updateModJSON, len(updates)),
+			Skipped: updateSkippedJSON{Pinned: skips.Pinned, Local: skips.Local},
+		}
 		for i, u := range updates {
 			out.Updates[i] = updateModJSON{
 				ModID:        u.InstalledMod.ID,
@@ -222,9 +255,9 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 	}
 
 	fmt.Printf("\n%d update(s) available.\n", len(updates))
-	if pinned := countPinned(installed); pinned > 0 {
+	if skips := core.CountUpdateSkips(installed); skips.Total() > 0 {
 		fmt.Println()
-		printPinnedSkipped(pinned)
+		printSkipped(skips)
 	}
 
 	// Show changelogs where available
@@ -465,34 +498,29 @@ func doUpdateRollback(ctx context.Context, service *core.Service, game *domain.G
 	return nil
 }
 
-// countPinned reports how many installed mods CheckUpdates will skip because
-// they are pinned. Pinned mods never become update rows, so without this they
-// disappear from `lmm update` output entirely.
-func countPinned(installed []domain.InstalledMod) int {
-	n := 0
-	for _, mod := range installed {
-		if mod.UpdatePolicy == domain.UpdatePinned {
-			n++
-		}
-	}
-	return n
-}
-
-// printPinnedSkipped notes skipped pinned mods, if any. No-op at zero so the
-// common case stays quiet.
+// printSkipped notes the mods CheckUpdates filtered out, if any. No-op at zero
+// so the common case stays quiet.
 //
-// Emits no leading blank line: when every mod is pinned this is the whole
+// Pinned and local get separate lines because the remedies differ: a pin is a
+// reversible choice, a local mod has no remote and never will.
+//
+// Emits no leading blank line: when every mod is skipped this is the whole
 // output, and a leading newline would render as a stray blank first line.
 // Callers with preceding output add their own separator.
-func printPinnedSkipped(pinned int) {
-	if pinned == 0 {
-		return
+func printSkipped(skips core.UpdateSkips) {
+	if skips.Pinned > 0 {
+		fmt.Printf("%d pinned mod%s skipped — see `lmm list -v`.\n", skips.Pinned, plural(skips.Pinned))
 	}
-	plural := "s"
-	if pinned == 1 {
-		plural = ""
+	if skips.Local > 0 {
+		fmt.Printf("%d local mod%s skipped (no remote source to check).\n", skips.Local, plural(skips.Local))
 	}
-	fmt.Printf("%d pinned mod%s skipped — see `lmm list -v`.\n", pinned, plural)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func policyToString(policy domain.UpdatePolicy) string {

--- a/cmd/lmm/update.go
+++ b/cmd/lmm/update.go
@@ -32,6 +32,10 @@ type updateJSONOutput struct {
 	// can tell "nothing to update" apart from "nothing was looked at". An
 	// empty updates array means both, and only this distinguishes them.
 	Skipped updateSkippedJSON `json:"skipped"`
+	// Error is set when the check itself failed. An empty updates array
+	// otherwise means "nothing to update"; with this set it means the answer
+	// is unknown. Omitted on success so the common document stays unchanged.
+	Error string `json:"error,omitempty"`
 }
 
 type updateSkippedJSON struct {
@@ -198,18 +202,34 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 		fmt.Fprintf(os.Stderr, "Warning: %v\n", checkErr)
 	}
 
+	// finish is returned at every exit below rather than bailing out early: a
+	// partial check still has results worth printing and auto-updates worth
+	// applying, so the non-zero exit has to come after that work, not instead
+	// of it. ErrReported because the failure is already on stderr (or in the
+	// JSON document) and Execute must not print it twice.
+	finish := func() error {
+		if checkErr != nil {
+			return fmt.Errorf("update check incomplete: %w", ErrReported)
+		}
+		return nil
+	}
+
 	if len(updates) == 0 {
 		if jsonOutput {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
 			skips := core.CountUpdateSkips(installed)
-			if err := enc.Encode(updateJSONOutput{
+			out := updateJSONOutput{
 				GameID: game.ID, Profile: profileName, Updates: []updateModJSON{},
 				Skipped: updateSkippedJSON{Pinned: skips.Pinned, Local: skips.Local},
-			}); err != nil {
+			}
+			if checkErr != nil {
+				out.Error = checkErr.Error()
+			}
+			if err := enc.Encode(out); err != nil {
 				return fmt.Errorf("encoding json: %w", err)
 			}
-			return nil
+			return finish()
 		}
 		// "All mods are up to date" would be false if the only reason there is
 		// nothing to report is that every mod was skipped. An empty profile
@@ -217,7 +237,7 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 		skips := core.CountUpdateSkips(installed)
 		if skips.Total() == len(installed) {
 			printSkipped(skips)
-			return nil
+			return finish()
 		}
 		// A failed check produces no updates too. Claiming currency here would
 		// repeat the defect this whole command's reporting was fixed for: the
@@ -232,7 +252,7 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 			fmt.Println()
 			printSkipped(skips)
 		}
-		return nil
+		return finish()
 	}
 
 	if jsonOutput {
@@ -240,6 +260,9 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 		out := updateJSONOutput{
 			GameID: game.ID, Profile: profileName, Updates: make([]updateModJSON, len(updates)),
 			Skipped: updateSkippedJSON{Pinned: skips.Pinned, Local: skips.Local},
+		}
+		if checkErr != nil {
+			out.Error = checkErr.Error()
 		}
 		for i, u := range updates {
 			out.Updates[i] = updateModJSON{
@@ -255,7 +278,7 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 		if err := enc.Encode(out); err != nil {
 			return fmt.Errorf("encoding json: %w", err)
 		}
-		return nil
+		return finish()
 	}
 
 	// Display available updates with policy
@@ -324,7 +347,7 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 			}
 		}
 		fmt.Println("\nUse without --dry-run to apply updates.")
-		return nil
+		return finish()
 	}
 
 	// Apply auto-updates
@@ -360,7 +383,7 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 		}
 	}
 
-	return nil
+	return finish()
 }
 
 func applySingleUpdate(ctx context.Context, service *core.Service, game *domain.Game, mod *domain.InstalledMod, profileName string) error {

--- a/cmd/lmm/update.go
+++ b/cmd/lmm/update.go
@@ -157,12 +157,23 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 					modID, profileName, candidates[0].SourceID, updateSource, candidates[0].SourceID)
 			default:
 				sources := make([]string, 0, len(candidates))
+				hasLocal := false
 				for _, c := range candidates {
 					sources = append(sources, c.SourceID)
+					if c.SourceID == domain.SourceLocal {
+						hasLocal = true
+					}
 				}
 				sort.Strings(sources) // deterministic regardless of install order
-				return fmt.Errorf("mod %s is in profile %s under multiple sources (%s); retry with --source to choose (local mods cannot be update-checked)",
-					modID, profileName, strings.Join(sources, ", "))
+				// The local caveat only earns its place when one of the
+				// candidates actually is local; on a purely remote ambiguity
+				// (nexusmods vs curseforge) it is noise.
+				caveat := ""
+				if hasLocal {
+					caveat = " (local mods cannot be update-checked)"
+				}
+				return fmt.Errorf("mod %s is in profile %s under multiple sources (%s); retry with --source to choose%s",
+					modID, profileName, strings.Join(sources, ", "), caveat)
 			}
 		}
 

--- a/cmd/lmm/update.go
+++ b/cmd/lmm/update.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -125,7 +126,13 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 	// If specific mod ID provided, update just that mod
 	if len(args) > 0 {
 		modID := args[0]
-		var targetMod, otherSourceMod *domain.InstalledMod
+		var targetMod *domain.InstalledMod
+		// Mod IDs are only unique within a source, so the same ID can appear
+		// more than once in a profile. Collect every candidate rather than
+		// keeping one: naming an arbitrary source would be wrong roughly half
+		// the time. Matching on source as well as ID is also what used to make
+		// a local mod look absent from its own profile.
+		var candidates []*domain.InstalledMod
 		for i := range installed {
 			if installed[i].ID != modID {
 				continue
@@ -134,22 +141,29 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 				targetMod = &installed[i]
 				break
 			}
-			// Same ID, different source. Remember it so a mod that IS in the
-			// profile is never reported as missing: matching on source as well
-			// as ID used to make a local mod look absent.
-			otherSourceMod = &installed[i]
+			candidates = append(candidates, &installed[i])
 		}
 		if targetMod == nil {
-			if otherSourceMod == nil {
+			switch len(candidates) {
+			case 0:
 				return fmt.Errorf("mod %s not found in profile %s", modID, profileName)
+			case 1:
+				if candidates[0].SourceID == domain.SourceLocal {
+					// Present, just not checkable — informational, not an error.
+					fmt.Printf("%s is a local mod — no remote source to check for updates.\n", candidates[0].Name)
+					return nil
+				}
+				return fmt.Errorf("mod %s in profile %s belongs to source %q, not %q; retry with --source %s",
+					modID, profileName, candidates[0].SourceID, updateSource, candidates[0].SourceID)
+			default:
+				sources := make([]string, 0, len(candidates))
+				for _, c := range candidates {
+					sources = append(sources, c.SourceID)
+				}
+				sort.Strings(sources) // deterministic regardless of install order
+				return fmt.Errorf("mod %s is in profile %s under multiple sources (%s); retry with --source to choose (local mods cannot be update-checked)",
+					modID, profileName, strings.Join(sources, ", "))
 			}
-			if otherSourceMod.SourceID == domain.SourceLocal {
-				// Present, just not checkable — informational, not an error.
-				fmt.Printf("%s is a local mod — no remote source to check for updates.\n", otherSourceMod.Name)
-				return nil
-			}
-			return fmt.Errorf("mod %s in profile %s belongs to source %q, not %q; retry with --source %s",
-				modID, profileName, otherSourceMod.SourceID, updateSource, otherSourceMod.SourceID)
 		}
 
 		return applySingleUpdate(ctx, service, game, targetMod, profileName)
@@ -164,13 +178,13 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 
 	// Check for updates (partial results returned even when some mods fail to fetch)
 	updater := service.NewUpdater()
-	updates, err := updater.CheckUpdates(ctx, game, installed)
-	if err != nil {
-		if errors.Is(err, domain.ErrAuthRequired) {
+	updates, checkErr := updater.CheckUpdates(ctx, game, installed)
+	if checkErr != nil {
+		if errors.Is(checkErr, domain.ErrAuthRequired) {
 			return authPromptError(updateSource)
 		}
 		// Surface warning but continue to show partial updates
-		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", checkErr)
 	}
 
 	if len(updates) == 0 {
@@ -194,7 +208,15 @@ func doUpdate(ctx context.Context, service *core.Service, game *domain.Game, arg
 			printSkipped(skips)
 			return nil
 		}
-		fmt.Println("All mods are up to date.")
+		// A failed check produces no updates too. Claiming currency here would
+		// repeat the defect this whole command's reporting was fixed for: the
+		// warning goes to stderr, so a caller reading stdout would see only a
+		// false success.
+		if checkErr != nil {
+			fmt.Println("Update check did not complete — see the warning above. No results to report.")
+		} else {
+			fmt.Println("All mods are up to date.")
+		}
 		if skips.Total() > 0 {
 			fmt.Println()
 			printSkipped(skips)

--- a/internal/core/update_skips_test.go
+++ b/internal/core/update_skips_test.go
@@ -1,0 +1,49 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mod(id, source string, policy domain.UpdatePolicy) domain.InstalledMod {
+	return domain.InstalledMod{
+		Mod:          domain.Mod{ID: id, SourceID: source},
+		UpdatePolicy: policy,
+	}
+}
+
+// TestCountUpdateSkips_MatchesFilter pins the invariant the counts exist for:
+// Total must equal exactly how many mods CheckUpdates' own filter drops, or the
+// reported "N skipped" would contradict what actually happened.
+func TestCountUpdateSkips_MatchesFilter(t *testing.T) {
+	installed := []domain.InstalledMod{
+		mod("a", "nexusmods", domain.UpdateNotify),
+		mod("b", "nexusmods", domain.UpdatePinned),
+		mod("c", domain.SourceLocal, domain.UpdateNotify),
+		mod("d", domain.SourceLocal, domain.UpdatePinned), // both reasons
+		mod("e", "curseforge", domain.UpdateAuto),
+	}
+
+	skips := CountUpdateSkips(installed)
+	assert.Equal(t, 2, skips.Pinned, "b and d")
+	assert.Equal(t, 1, skips.Local, "c only — d is already counted as pinned")
+
+	filtered := 0
+	for _, m := range installed {
+		if !UpdateCheckable(m) {
+			filtered++
+		}
+	}
+	assert.Equal(t, filtered, skips.Total(), "counts must match the filter exactly")
+	assert.LessOrEqual(t, skips.Total(), len(installed), "a mod must never be counted twice")
+}
+
+func TestUpdateCheckable(t *testing.T) {
+	assert.True(t, UpdateCheckable(mod("a", "nexusmods", domain.UpdateNotify)))
+	assert.True(t, UpdateCheckable(mod("a", "nexusmods", domain.UpdateAuto)))
+	assert.False(t, UpdateCheckable(mod("a", "nexusmods", domain.UpdatePinned)))
+	assert.False(t, UpdateCheckable(mod("a", domain.SourceLocal, domain.UpdateNotify)))
+}

--- a/internal/core/updater.go
+++ b/internal/core/updater.go
@@ -26,46 +26,6 @@ func NewUpdater(registry *source.Registry) *Updater {
 // like NexusMods address games by their own domain, so each source's batch is
 // translated via game.SourceIDs before the call (empty mapping = keep the lmm
 // id, matching the search-side semantics in Service.SearchMods/GetMod).
-// UpdateCheckable reports whether CheckUpdates will query a source for mod.
-// Two reasons it will not: the mod is pinned (a user choice, reversible with
-// `lmm mod set-update`), or it is a local import with no remote to ask.
-//
-// Exported because both interfaces need to explain the gap between "mods
-// installed" and "mods checked" - without it, a filtered mod silently vanishes
-// from update output and the user is told everything is up to date. Callers
-// must use this rather than re-testing the fields, so the reported counts can
-// never drift from what CheckUpdates actually skipped.
-func UpdateCheckable(mod domain.InstalledMod) bool {
-	return mod.UpdatePolicy != domain.UpdatePinned && mod.SourceID != domain.SourceLocal
-}
-
-// UpdateSkips counts the mods CheckUpdates will filter out, by reason. The two
-// are reported separately because the remedies differ: a pin can be lifted, a
-// local mod can never be checked.
-type UpdateSkips struct {
-	Pinned int
-	Local  int
-}
-
-// Total is the number of mods that will not be checked at all.
-func (s UpdateSkips) Total() int { return s.Pinned + s.Local }
-
-// CountUpdateSkips tallies why CheckUpdates will skip mods in installed. A mod
-// that is both pinned and local counts once, as pinned, so Total never exceeds
-// len(installed).
-func CountUpdateSkips(installed []domain.InstalledMod) UpdateSkips {
-	var s UpdateSkips
-	for _, mod := range installed {
-		switch {
-		case mod.UpdatePolicy == domain.UpdatePinned:
-			s.Pinned++
-		case mod.SourceID == domain.SourceLocal:
-			s.Local++
-		}
-	}
-	return s
-}
-
 func (u *Updater) CheckUpdates(ctx context.Context, game *domain.Game, installed []domain.InstalledMod) ([]domain.Update, error) {
 	var checkable []domain.InstalledMod
 	for _, mod := range installed {
@@ -123,6 +83,46 @@ func (u *Updater) CheckUpdates(ctx context.Context, game *domain.Game, installed
 		return allUpdates, fmt.Errorf("update check had %d source error(s): %w", len(checkErrs), errors.Join(checkErrs...))
 	}
 	return allUpdates, nil
+}
+
+// UpdateCheckable reports whether CheckUpdates will query a source for mod.
+// Two reasons it will not: the mod is pinned (a user choice, reversible with
+// `lmm mod set-update`), or it is a local import with no remote to ask.
+//
+// Exported because both interfaces need to explain the gap between "mods
+// installed" and "mods checked" - without it, a filtered mod silently vanishes
+// from update output and the user is told everything is up to date. Callers
+// must use this rather than re-testing the fields, so the reported counts can
+// never drift from what CheckUpdates actually skipped.
+func UpdateCheckable(mod domain.InstalledMod) bool {
+	return mod.UpdatePolicy != domain.UpdatePinned && mod.SourceID != domain.SourceLocal
+}
+
+// UpdateSkips counts the mods CheckUpdates will filter out, by reason. The two
+// are reported separately because the remedies differ: a pin can be lifted, a
+// local mod can never be checked.
+type UpdateSkips struct {
+	Pinned int
+	Local  int
+}
+
+// Total is the number of mods that will not be checked at all.
+func (s UpdateSkips) Total() int { return s.Pinned + s.Local }
+
+// CountUpdateSkips tallies why CheckUpdates will skip mods in installed. A mod
+// that is both pinned and local counts once, as pinned, so Total never exceeds
+// len(installed).
+func CountUpdateSkips(installed []domain.InstalledMod) UpdateSkips {
+	var s UpdateSkips
+	for _, mod := range installed {
+		switch {
+		case mod.UpdatePolicy == domain.UpdatePinned:
+			s.Pinned++
+		case mod.SourceID == domain.SourceLocal:
+			s.Local++
+		}
+	}
+	return s
 }
 
 // GetAutoUpdateMods filters installed mods to those with auto-update enabled

--- a/internal/core/updater.go
+++ b/internal/core/updater.go
@@ -26,11 +26,50 @@ func NewUpdater(registry *source.Registry) *Updater {
 // like NexusMods address games by their own domain, so each source's batch is
 // translated via game.SourceIDs before the call (empty mapping = keep the lmm
 // id, matching the search-side semantics in Service.SearchMods/GetMod).
+// UpdateCheckable reports whether CheckUpdates will query a source for mod.
+// Two reasons it will not: the mod is pinned (a user choice, reversible with
+// `lmm mod set-update`), or it is a local import with no remote to ask.
+//
+// Exported because both interfaces need to explain the gap between "mods
+// installed" and "mods checked" - without it, a filtered mod silently vanishes
+// from update output and the user is told everything is up to date. Callers
+// must use this rather than re-testing the fields, so the reported counts can
+// never drift from what CheckUpdates actually skipped.
+func UpdateCheckable(mod domain.InstalledMod) bool {
+	return mod.UpdatePolicy != domain.UpdatePinned && mod.SourceID != domain.SourceLocal
+}
+
+// UpdateSkips counts the mods CheckUpdates will filter out, by reason. The two
+// are reported separately because the remedies differ: a pin can be lifted, a
+// local mod can never be checked.
+type UpdateSkips struct {
+	Pinned int
+	Local  int
+}
+
+// Total is the number of mods that will not be checked at all.
+func (s UpdateSkips) Total() int { return s.Pinned + s.Local }
+
+// CountUpdateSkips tallies why CheckUpdates will skip mods in installed. A mod
+// that is both pinned and local counts once, as pinned, so Total never exceeds
+// len(installed).
+func CountUpdateSkips(installed []domain.InstalledMod) UpdateSkips {
+	var s UpdateSkips
+	for _, mod := range installed {
+		switch {
+		case mod.UpdatePolicy == domain.UpdatePinned:
+			s.Pinned++
+		case mod.SourceID == domain.SourceLocal:
+			s.Local++
+		}
+	}
+	return s
+}
+
 func (u *Updater) CheckUpdates(ctx context.Context, game *domain.Game, installed []domain.InstalledMod) ([]domain.Update, error) {
-	// Filter out pinned mods and local mods (local mods have no remote source)
 	var checkable []domain.InstalledMod
 	for _, mod := range installed {
-		if mod.UpdatePolicy != domain.UpdatePinned && mod.SourceID != domain.SourceLocal {
+		if UpdateCheckable(mod) {
 			checkable = append(checkable, mod)
 		}
 	}

--- a/internal/tui/local_update_test.go
+++ b/internal/tui/local_update_test.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUpdateSkipWarning_ReportsBothReasons: the TUI's update check shares
+// core's filter, so skipped mods vanish there too. UpdatesView.Warnings is the
+// existing channel for "here is what you should know about this result".
+func TestUpdateSkipWarning_ReportsBothReasons(t *testing.T) {
+	skips := core.UpdateSkips{Pinned: 2, Local: 1}
+	msg := updateSkipWarning(skips)
+
+	assert.Contains(t, msg, "2 pinned")
+	assert.Contains(t, msg, "1 local")
+}
+
+// TestUpdateSkipWarning_SingularAndEmpty: no warning when nothing was skipped,
+// and correct singular wording for one.
+func TestUpdateSkipWarning_SingularAndEmpty(t *testing.T) {
+	assert.Empty(t, updateSkipWarning(core.UpdateSkips{}), "nothing skipped means no warning")
+
+	one := updateSkipWarning(core.UpdateSkips{Pinned: 1})
+	assert.Contains(t, one, "1 pinned mod ")
+	assert.NotContains(t, one, "mods")
+	assert.NotContains(t, one, "local", "should not mention a reason that did not apply")
+}
+
+// TestApplyUpdate_LocalMod_MessageSaysLocal mirrors the CLI: a local mod is
+// filtered before any source call, so "already up to date" describes a check
+// that never ran.
+func TestApplyUpdate_LocalMod_MessageSaysLocal(t *testing.T) {
+	msg := notCheckedMessage("Some Mod", domain.InstalledMod{
+		Mod:          domain.Mod{SourceID: domain.SourceLocal},
+		UpdatePolicy: domain.UpdateNotify,
+	})
+	assert.Contains(t, msg, "local")
+	assert.NotContains(t, msg, "up to date")
+
+	pinned := notCheckedMessage("Some Mod", domain.InstalledMod{
+		Mod:          domain.Mod{SourceID: "nexusmods"},
+		UpdatePolicy: domain.UpdatePinned,
+	})
+	assert.Contains(t, pinned, "pinned")
+	assert.NotContains(t, pinned, "up to date")
+
+	// A genuinely current mod still reports currency.
+	current := notCheckedMessage("Some Mod", domain.InstalledMod{
+		Mod:          domain.Mod{SourceID: "nexusmods"},
+		UpdatePolicy: domain.UpdateNotify,
+	})
+	assert.Contains(t, current, "up to date")
+}

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -1293,6 +1294,47 @@ func (p *coreProvider) ApplyInstall(ctx context.Context, item ModItem, progress 
 // Task 7) - the FULL cleaned text, with no truncation (see that field's own
 // doc comment: the TUI's changelog overlay handles overflow itself, unlike
 // the CLI's 800/500-char truncation, which stays CLI-side).
+// notCheckedMessage explains an empty update result for a single mod. Zero
+// results has two very different causes: the mod was compared against its
+// source and is current, or it was filtered out by core.UpdateCheckable and
+// never compared at all. Reporting the second as "up to date" claims currency
+// that was never established - a pinned mod may well have a newer version.
+func notCheckedMessage(name string, mod domain.InstalledMod) string {
+	switch {
+	case mod.UpdatePolicy == domain.UpdatePinned:
+		return fmt.Sprintf("%q is pinned — not checked (P to change)", name)
+	case mod.SourceID == domain.SourceLocal:
+		return fmt.Sprintf("%q is a local mod — no remote source to check", name)
+	default:
+		return fmt.Sprintf("%q is already up to date", name)
+	}
+}
+
+// updateSkipWarning describes mods core.CheckUpdates filtered out, for
+// UpdatesView.Warnings. Empty when nothing was skipped, so the common case adds
+// no noise. Mirrors cmd/lmm/update.go's printSkipped; the counts come from the
+// same core helper, so the two interfaces cannot disagree about what happened.
+func updateSkipWarning(skips core.UpdateSkips) string {
+	var parts []string
+	if skips.Pinned > 0 {
+		parts = append(parts, fmt.Sprintf("%d pinned mod%s (P to change)", skips.Pinned, tuiPlural(skips.Pinned)))
+	}
+	if skips.Local > 0 {
+		parts = append(parts, fmt.Sprintf("%d local mod%s (no remote source)", skips.Local, tuiPlural(skips.Local)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "Not checked: " + strings.Join(parts, ", ")
+}
+
+func tuiPlural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
 func (p *coreProvider) CheckUpdates(ctx context.Context) (UpdatesView, error) {
 	game := p.currentGame()
 	profile := p.currentProfile()
@@ -1309,6 +1351,9 @@ func (p *coreProvider) CheckUpdates(ctx context.Context) (UpdatesView, error) {
 			FromVersion: u.InstalledMod.Version, ToVersion: u.NewVersion,
 			Changelog: core.CleanChangelog(u.Changelog),
 		})
+	}
+	if skipped := updateSkipWarning(core.CountUpdateSkips(installed)); skipped != "" {
+		view.Warnings = append(view.Warnings, skipped)
 	}
 	if checkErr != nil {
 		if errors.Is(checkErr, domain.ErrAuthRequired) {
@@ -1342,13 +1387,7 @@ func (p *coreProvider) ApplyUpdate(ctx context.Context, u UpdateItem, progress f
 		return ActionOutcome{}, mapUpdateNetworkError(fmt.Sprintf("checking update for %s", u.Name), u.Source, err)
 	}
 	if len(updates) == 0 {
-		// Pinned mods are filtered out before the source is queried, so no
-		// version comparison happened - saying "up to date" would claim
-		// currency that was never checked.
-		if mod.UpdatePolicy == domain.UpdatePinned {
-			return ActionOutcome{Message: fmt.Sprintf("%q is pinned — not checked (P to change)", u.Name)}, nil
-		}
-		return ActionOutcome{Message: fmt.Sprintf("%q is already up to date", u.Name)}, nil
+		return ActionOutcome{Message: notCheckedMessage(u.Name, *mod)}, nil
 	}
 	upd := updates[0]
 


### PR DESCRIPTION
Closes #100.

`CheckUpdates` filters **local** mods alongside pinned ones — they have no remote to ask. #92 gave pinned mods honest reporting; local mods were left behind, producing two wrong outputs.

## Bug 1 — a check that never happened, reported as success

```
$ lmm -g localonly update      # profile contains only local mods
All mods are up to date.
```

Nothing was compared. `--json` was equally silent: an empty `updates` array meant both "nothing to update" and "nothing was looked at", with no way to distinguish them.

## Bug 2 — a present mod reported as missing, with exit 1

```
$ lmm -g localonly update localA
Error: mod localA not found in profile default     # exit 1
```

The mod **is** in the profile. The lookup matched on ID *and* source, and `updateSource` resolves to the game's configured remote, so a `local` mod could never match. This one is worse than bug 1: a hard failure whose stated reason is **false** rather than merely incomplete. A user could reasonably conclude their profile was corrupt.

It also affected any mod from a configured-but-not-selected source, not just local ones.

## Changes

- **`core.UpdateCheckable`** extracts the filter predicate; **`core.CountUpdateSkips`** tallies by reason. `CheckUpdates` and both interfaces now share one definition, so the reported counts can't drift from what was actually skipped. A test asserts `Total()` equals exactly what the filter drops.
- `lmm update` reports pinned and local **separately** — the remedies differ, a pin lifts and a local mod never becomes checkable — and no longer claims currency when everything was filtered.
- `lmm update --json` gains a `skipped` block.
- The single-mod lookup distinguishes **absent** (still an error) from **present-but-uncheckable** (informational, exit 0). A same-ID-different-source mod now names the source to retry with.
- **TUI parity:** `notCheckedMessage` covers pinned/local/current for a single mod; `CheckUpdates` adds a `Not checked:` warning through the existing `UpdatesView.Warnings` channel.

## Verification

Test-first; all RED first except the "genuinely missing mod still errors" guard, which correctly passed from the start — that one exists to stop the fix from swallowing real errors.

**Both issue reproductions re-run against the built binary:**

```
$ lmm -g localonly update
1 local mod skipped (no remote source to check).

$ lmm -g localonly update localA
Data is a local mod — no remote source to check for updates.      # exit 0

$ lmm -g testgame update          # 2 local + 1 pinned
1 pinned mod skipped — see `lmm list -v`.
2 local mods skipped (no remote source to check).

$ lmm -g localonly update nosuchmod
Error: mod nosuchmod not found in profile default                 # exit 1, unchanged

$ lmm -g testgame update --json
  "updates": [],
  "skipped": { "pinned": 1, "local": 2 }
```

v1.15.0's all-pinned behavior re-checked for regression. `go vet`, `go test ./...`, `gofmt` clean. No CI on this repo, so verification is local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)