### PR TITLE
test(cli): make cmd/lmm tests hermetic in any run order or subset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.3] - 2026-07-27
+
+### Fixed
+
+- **Test isolation (cmd/lmm)**: a package-level `TestMain` now points the `configDir`/`dataDir` globals at throwaway temp dirs before any test runs, so every command test is hermetic in any run order or `-run` subset (#115). Previously, tests that never assigned the globals (e.g. `TestInstallCmd_NoGame`, `TestListCmd_NoGame`) fell back to the user's real `~/.config/lmm` — a subset run resolved the real default game and stalled on the interactive source-picker prompt; the full suite passed only through accidental ordering. `TestPackageGlobals_HermeticDefaults` pins the guard.
+
 ## [1.18.2] - 2026-07-27
 
 ### Fixed
@@ -970,7 +976,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.18.2...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.18.3...HEAD
+[1.18.3]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.18.2...v1.18.3
 [1.18.2]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.18.1...v1.18.2
 [1.18.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.18.0...v1.18.1
 [1.18.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.17.1...v1.18.0

--- a/cmd/lmm/main_test.go
+++ b/cmd/lmm/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMain makes every test in this package hermetic regardless of run order
+// or -run subset (issue #115). The configDir/dataDir package globals default
+// to the user's real ~/.config/lmm and ~/.local/share/lmm when empty, so
+// tests that never assign them (the "no game specified" early-return tests)
+// would otherwise read — and could write — the developer's real lmm state.
+// Tests that need isolated state still assign their own t.TempDir() dirs;
+// these shared throwaway dirs are only the floor under everything else.
+func TestMain(m *testing.M) {
+	cfg, err := os.MkdirTemp("", "lmm-test-config-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "creating test config dir: %v\n", err)
+		os.Exit(1)
+	}
+	data, err := os.MkdirTemp("", "lmm-test-data-")
+	if err != nil {
+		_ = os.RemoveAll(cfg)
+		fmt.Fprintf(os.Stderr, "creating test data dir: %v\n", err)
+		os.Exit(1)
+	}
+	configDir = cfg
+	dataDir = data
+
+	code := m.Run()
+
+	_ = os.RemoveAll(cfg)
+	_ = os.RemoveAll(data)
+	os.Exit(code)
+}
+
+// TestPackageGlobals_HermeticDefaults pins the test-isolation guard for this
+// package (issue #115). getServiceConfig treats empty configDir/dataDir as
+// "use the real ~/.config/lmm and ~/.local/share/lmm", so any test that runs
+// while the globals are unset escapes the sandbox — a subset run like
+// `go test ./cmd/lmm/... -run TestInstallCmd` used to hit the user's real
+// config and stall on an interactive source-picker prompt. TestMain must
+// point both globals at throwaway temp dirs before any test runs; if this
+// test fails in a subset run, that guard has been removed or broken.
+func TestPackageGlobals_HermeticDefaults(t *testing.T) {
+	require.NotEmpty(t, configDir,
+		"configDir is empty: getServiceConfig would fall back to the real ~/.config/lmm")
+	require.NotEmpty(t, dataDir,
+		"dataDir is empty: getServiceConfig would fall back to the real ~/.local/share/lmm")
+}

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -34,7 +34,7 @@ var ErrCancelled = errors.New("cancelled")
 var ErrReported = errors.New("already reported")
 
 var (
-	version = "1.18.2"
+	version = "1.18.3"
 
 	// Global flags
 	configDir  string


### PR DESCRIPTION
Fixes #115

## Problem

`cmd/lmm` tests that leave the package globals `configDir`/`dataDir` unset (the "no game specified" early-return tests, e.g. `TestInstallCmd_NoGame`, `TestListCmd_NoGame`) fell through `getServiceConfig()`'s empty-string defaulting to the user's **real** `~/.config/lmm`. Reproduced during PR review:

```
go test ./cmd/lmm/... -run TestInstallCmd -v
```

resolved the real default game and stalled on the interactive source picker ("7 Days to Die has multiple mod sources configured…" → `"reading input: EOF" does not contain "no game specified"`). The full suite passed only because earlier tests happened to leave the globals pointing at their temp dirs — accidental ordering, not isolation. A prior partial fix (the 0.7.x-era "Test isolation fix" that gave `TestUninstallCmd_NoGame` et al. their own `t.TempDir()`) missed the `install`/`list` tests, so the class of bug survived.

## Fix

- `TestMain` in [cmd/lmm/main_test.go](cmd/lmm/main_test.go) points both globals at throwaway temp dirs before `m.Run()` — a hermetic floor under every test, in any order or `-run` subset. Tests that need their own isolated state keep assigning `t.TempDir()` as before.
- `TestPackageGlobals_HermeticDefaults` pins the guard (TDD red→green: it fails in a subset run without the `TestMain` assignment).

## Verification

- `go test ./cmd/lmm/... -run TestInstallCmd` and `-run TestListCmd` subsets now pass
- `go test ./cmd/lmm/... -shuffle=on` passes
- Full suite `go test ./...` passes; `gofmt`/`go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)