### PR TITLE
fix(core): record the installed file's version, not the mod's latest (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `lmm verify` now also checks each installed mod's recorded version against what its stored file ID(s) actually report upstream, surfacing `version_mismatch` (issue, fixable) and `version_unverifiable` (warning, not fixable — reinstall instead) statuses alongside the existing file checks
-- `lmm verify --fix` repairs a `version_mismatch` by re-keying the cache entry to the source-reported version, correcting the DB row and active profile record, and re-linking symlink deployments (a blocked rename, when a cache entry already exists under the target version, is left alone and reported via a new additive `note` field rather than clobbered)
+- `lmm verify --fix` repairs a `version_mismatch` by re-keying the cache entry to the source-reported version, correcting the DB row and active profile record, and re-linking symlink deployments (a blocked rename, when a cache entry already exists under the target version, is left alone and reported via a new additive `note` field rather than clobbered); since the mod cache is shared across profiles, a successful rename also corrects any other profile's stale record for the same mod (DB, profile record, and re-linking if deployed), surfaced as its own output line per profile in text mode or folded into the `note` field in `--json`
 - `--json` verify output gains the optional `note` field, set only on a `--fix` repair whose cache rename was skipped
 
 ## [1.22.0] - 2026-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `lmm verify` now also checks each installed mod's recorded version against what its stored file ID(s) actually report upstream, surfacing `version_mismatch` (issue, fixable) and `version_unverifiable` (warning, not fixable — reinstall instead) statuses alongside the existing file checks
 - `lmm verify --fix` repairs a `version_mismatch` by re-keying the cache entry to the source-reported version, correcting the DB row and active profile record, and re-linking symlink deployments (a blocked rename, when a cache entry already exists under the target version, is left alone and reported via a new additive `note` field rather than clobbered); since the mod cache is shared across profiles, a successful rename also corrects any other profile's stale record for the same mod (DB, profile record, and re-linking if deployed), surfaced as its own output line per profile in text mode or folded into the `note` field in `--json`
-- `--json` verify output gains the optional `note` field, set only on a `--fix` repair whose cache rename was skipped
+- `--json` verify output gains the optional `note` field carrying repair/skip detail — blocked cache renames, sibling-profile repair outcomes, and repair/re-download failure reasons
 
 ## [1.22.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1060,7 +1060,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.22.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.23.0...HEAD
 [1.23.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.22.0...v1.23.0
 [1.22.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.20.1...v1.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-07-28
+
+### Fixed
+
+- Installed mods now record the version of the file that was actually selected and downloaded, not the mod's overall "latest" version, across every install path (primary install, batch/dependency installs, profile switch, import, and the CLI's batch-install and profile-apply flows) — the mod cache is keyed to match, so a file pinned to an older release no longer gets stamped or cached under a newer version it isn't (#94)
+
+### Added
+
+- `lmm verify` now also checks each installed mod's recorded version against what its stored file ID(s) actually report upstream, surfacing `version_mismatch` (issue, fixable) and `version_unverifiable` (warning, not fixable — reinstall instead) statuses alongside the existing file checks
+- `lmm verify --fix` repairs a `version_mismatch` by re-keying the cache entry to the source-reported version, correcting the DB row and active profile record, and re-linking symlink deployments (a blocked rename, when a cache entry already exists under the target version, is left alone and reported via a new additive `note` field rather than clobbered)
+- `--json` verify output gains the optional `note` field, set only on a `--fix` repair whose cache rename was skipped
+
 ## [1.22.0] - 2026-07-28
 
 ### Changed
@@ -1049,6 +1061,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MIT License
 
 [Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.22.0...HEAD
+[1.23.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.22.0...v1.23.0
 [1.22.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.20.1...v1.21.0
 [1.20.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.20.0...v1.20.1

--- a/README.md
+++ b/README.md
@@ -777,7 +777,7 @@ A `directory` source now shows up with real capabilities in `lmm source list` (`
 | `lmm update --dry-run`                 | Preview what would update                            |
 | `lmm update rollback <mod-id>`         | Rollback to previous version                         |
 | `lmm verify`                           | Verify cached mod files (see below)                  |
-| `lmm verify --fix`                     | Re-download missing files, populate missing checksums |
+| `lmm verify --fix`                     | Re-download missing files, populate missing checksums, repair version-record mismatches |
 | `lmm mod enable <mod-id>`              | Enable a disabled mod                                |
 | `lmm mod disable <mod-id>`             | Disable mod (keep in cache)                          |
 | `lmm mod set-update <mod-id> --auto`   | Enable auto-updates for mod                          |
@@ -897,6 +897,13 @@ When you run `lmm update`, the tool checks each installed mod against the source
 - **? ModName (fileID) - NO CHECKSUM** - File was installed without a stored checksum (e.g. before checksum support or with `--skip-verify`).
 - **! ModName - FILE COUNT MISMATCH** - The cache directory exists but is empty, when downloads were expected (per-mod, not per-file); not repaired by `--fix`.
 - **? Unknown mod ID - SKIPPED** - A stored checksum row references a mod that's no longer installed; not repaired by `--fix`.
+
+`lmm verify` also contacts each installed mod's source to check its recorded version against what the stored file ID(s) actually are upstream (issue #94: older installs could record the mod's "latest" version instead of the version of the file that was actually downloaded and deployed), reporting per mod:
+
+- **X ModName - VERSION MISMATCH (recorded X, source reports Y)** - The recorded version doesn't match what the installed file ID(s) report upstream; use `--fix` to repair.
+- **? ModName - VERSION UNVERIFIABLE** - None of the recorded file ID(s) are listed by the source anymore; not repaired by `--fix` (reinstall the mod instead).
+
+Mods installed from a local source, mods requiring manual download, and mods with no recorded file IDs are skipped silently. `--fix` repairs a VERSION MISMATCH by re-keying the cache entry to the effective (source-reported) version, correcting the DB row and active profile record, and re-linking symlink deployments; if a cache entry already exists under the effective version the rename is skipped and a note is printed (also included as `note` in `--json` output) while the DB/profile are still corrected.
 
 ## Architecture
 

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -1039,6 +1039,7 @@ func batchInstallMods(ctx context.Context, service *core.Service, game *domain.G
 
 		selectedFile := selectPrimaryFile(files)
 		fmt.Printf("  File: %s\n", displayFileLabel(*selectedFile))
+		mod.Version = domain.EffectiveInstalledVersion(mod.Version, []*domain.DownloadableFile{selectedFile}) // #94
 
 		// Download
 		progressFn := func(p core.DownloadProgress) {

--- a/cmd/lmm/install.go
+++ b/cmd/lmm/install.go
@@ -1003,6 +1003,12 @@ func batchInstallMods(ctx context.Context, service *core.Service, game *domain.G
 		// Run install.before_each hook
 		hookCtx.ModID = mod.ID
 		hookCtx.ModName = mod.Name
+		// Deliberately the mod-level version, not the #94 effective-file
+		// stamp: this hook fires before file selection below, unlike
+		// applyInstallPrimary (internal/core/flows.go) where the stamp is
+		// computed before its own hook fires. Not a bug to "fix" in either
+		// direction - each hook sees whatever version is actually known at
+		// its point in the flow.
 		hookCtx.ModVersion = mod.Version
 		if err := runInstallHook(ctx, hookRunner, resolvedHooks, &hookCtx, "install.before_each", resolvedHooks.GetInstallBeforeEach()); err != nil {
 			fmt.Printf("  Skipped: install.before_each hook failed: %v\n", err)

--- a/cmd/lmm/install_test.go
+++ b/cmd/lmm/install_test.go
@@ -1051,3 +1051,25 @@ func TestDoInstall_FailurePath_PrintsAccumulatedDiagnosticsBeforeError(t *testin
 	_, dbErr := svc.GetInstalledMod("test-src", "mod1", "g1", "default")
 	assert.Error(t, dbErr)
 }
+
+// TestBatchInstallMods_StampsSelectedFileVersion guards issue #94 for
+// batchInstallMods (the multi-select/dependency-resolved install save
+// site): when the selected primary file carries its own version distinct
+// from the mod's latest version, the persisted InstalledMod row must record
+// the file's version - the version of the bytes actually deployed - not the
+// mod-level "latest" version, so subsequent update checks compare against
+// what's really on disk.
+func TestBatchInstallMods_StampsSelectedFileVersion(t *testing.T) {
+	svc, game, src := setupDoInstallTest(t)
+	mod := &domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: "1.0", Author: "Someone", GameID: "g1"}
+	src.AddMod(mod, []domain.DownloadableFile{
+		{ID: "main", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.1"},
+	})
+	src.AddDownload("main", []byte("plugin content"))
+
+	require.NoError(t, batchInstallMods(context.Background(), svc, game, []*domain.Mod{mod}, "default"))
+
+	installed, err := svc.GetInstalledMod("test-src", "mod1", "g1", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.1", installed.Version, "installed mod version must be the selected file's version, not the mod's latest version")
+}

--- a/cmd/lmm/install_test.go
+++ b/cmd/lmm/install_test.go
@@ -387,6 +387,11 @@ type fakeInstallSource struct {
 	// gameIDCapturingSource pattern, for tests asserting a caller applied
 	// (or didn't apply) the game's per-source ID mapping before calling in.
 	receivedGameFileIDs []string
+
+	// getModFilesErr, when set, makes GetModFiles return this error
+	// instead of a normal lookup - for tests exercising a "source
+	// unreachable" path (nil by default, so every other test is unaffected).
+	getModFilesErr error
 }
 
 func newFakeInstallSource(id string) *fakeInstallSource {
@@ -433,6 +438,9 @@ func (s *fakeInstallSource) GetDependencies(ctx context.Context, mod *domain.Mod
 }
 func (s *fakeInstallSource) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
 	s.receivedGameFileIDs = append(s.receivedGameFileIDs, mod.GameID)
+	if s.getModFilesErr != nil {
+		return nil, s.getModFilesErr
+	}
 	return s.files[mod.ID], nil
 }
 func (s *fakeInstallSource) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {

--- a/cmd/lmm/install_test.go
+++ b/cmd/lmm/install_test.go
@@ -381,6 +381,12 @@ type fakeInstallSource struct {
 	files     map[string][]domain.DownloadableFile
 	downloads map[string][]byte // fileID -> raw content
 	srv       *httptest.Server
+
+	// receivedGameFileIDs records the mod.GameID GetModFiles was actually
+	// called with, in call order - mirrors internal/core/updater_test.go's
+	// gameIDCapturingSource pattern, for tests asserting a caller applied
+	// (or didn't apply) the game's per-source ID mapping before calling in.
+	receivedGameFileIDs []string
 }
 
 func newFakeInstallSource(id string) *fakeInstallSource {
@@ -426,6 +432,7 @@ func (s *fakeInstallSource) GetDependencies(ctx context.Context, mod *domain.Mod
 	return s.mods[mod.ID].Dependencies, nil
 }
 func (s *fakeInstallSource) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	s.receivedGameFileIDs = append(s.receivedGameFileIDs, mod.GameID)
 	return s.files[mod.ID], nil
 }
 func (s *fakeInstallSource) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {

--- a/cmd/lmm/profile.go
+++ b/cmd/lmm/profile.go
@@ -1060,6 +1060,7 @@ func doProfileApply(ctx context.Context, service *core.Service, game *domain.Gam
 			if usedFallback && len(fileIDsToUse) > 0 {
 				fmt.Printf("    Warning: stored file IDs not found, using primary\n")
 			}
+			mod.Version = domain.EffectiveInstalledVersion(mod.Version, filesToDownload) // #94
 
 			// Download each file
 			progressFn := func(p core.DownloadProgress) {

--- a/cmd/lmm/profile_test.go
+++ b/cmd/lmm/profile_test.go
@@ -478,3 +478,40 @@ func TestDoProfileApply_PrintsDeterministicOrder_MatchesProfileMods(t *testing.T
 	assert.Less(t, insB, insC, "install-eligible mods must print in profile.Mods order")
 	assert.Less(t, insC, insA, "install-eligible mods must print in profile.Mods order")
 }
+
+// TestDoProfileApply_StampsSelectedFileVersion guards issue #94 for
+// doProfileApply's "install missing mods" save site: when a mod referenced
+// by the profile (but not yet installed) has a primary file whose version
+// differs from the mod's latest version, the persisted InstalledMod row
+// must record the file's version - the version of the bytes actually
+// downloaded and deployed - not the mod-level "latest" version. Reuses
+// fakeInstallSource (defined in install_test.go, same package) rather than
+// setupDoProfileSwitchTest's sourceless default, since this path needs a
+// real GetMod/GetModFiles/download round-trip.
+func TestDoProfileApply_StampsSelectedFileVersion(t *testing.T) {
+	svc, game := setupDoProfileSwitchTest(t)
+
+	src := newFakeInstallSource("test-src")
+	t.Cleanup(src.Close)
+	svc.RegisterSource(src)
+	game.SourceIDs = map[string]string{"test-src": game.ID}
+
+	src.AddMod(&domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: "1.0", GameID: game.ID},
+		[]domain.DownloadableFile{
+			{ID: "main", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.1"},
+		})
+	src.AddDownload("main", []byte("plugin content"))
+
+	pm := getProfileManager(svc)
+	require.NoError(t, pm.AddMod(game.ID, "default", domain.ModReference{SourceID: "test-src", ModID: "mod1", Version: "1.0"}))
+
+	origYes := profileApplyYes
+	profileApplyYes = true
+	t.Cleanup(func() { profileApplyYes = origYes })
+
+	require.NoError(t, doProfileApply(context.Background(), svc, game, nil))
+
+	installed, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.1", installed.Version, "installed mod version must be the selected file's version, not the profile ref's version")
+}

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -35,7 +35,7 @@ var ErrCancelled = errors.New("cancelled")
 var ErrReported = errors.New("already reported")
 
 var (
-	version = "1.22.0"
+	version = "1.23.0"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -114,7 +114,7 @@ Examples:
 }
 
 func init() {
-	verifyCmd.Flags().BoolVar(&verifyFix, "fix", false, "re-download files that are missing or lack a stored checksum")
+	verifyCmd.Flags().BoolVar(&verifyFix, "fix", false, "re-download missing files, fill missing checksums, repair version records")
 	verifyCmd.Flags().StringVarP(&verifyProfile, "profile", "p", "", "profile to verify (default: active profile)")
 
 	rootCmd.AddCommand(verifyCmd)

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -30,7 +30,8 @@ type verifyFileJSON struct {
 	ModID   string `json:"mod_id"`
 	ModName string `json:"mod_name"`
 	FileID  string `json:"file_id"`
-	Status  string `json:"status"` // ok, missing, no_checksum, file_count_mismatch, skipped, version_mismatch, version_unverifiable
+	Status  string `json:"status"`         // ok, missing, no_checksum, file_count_mismatch, skipped, version_mismatch, version_unverifiable
+	Note    string `json:"note,omitempty"` // optional detail; currently only set by a --fix VERSION MISMATCH repair whose cache rename was skipped because the effective-version cache dir already existed
 }
 
 var verifyCmd = &cobra.Command{
@@ -76,22 +77,26 @@ from the recorded version to the effective (source-reported) one, the DB
 row and the active profile's record are corrected to match, and any
 symlink deployment is re-linked (its target lived inside the just-renamed
 cache dir and would otherwise dangle). If a cache entry already exists
-under the effective version, the rename is skipped and a note is printed,
-but the DB and profile are still corrected. VERSION UNVERIFIABLE is never
+under the effective version, the rename is skipped - the existing
+deployment is left pointing at the still-intact recorded-version cache
+dir rather than being re-linked into the unverified pre-existing one -
+and a note is printed (also included as "note" in --json output), but
+the DB and profile are still corrected. VERSION UNVERIFIABLE is never
 fixable automatically since there is no matching upstream file to compare
 against - reinstall the mod instead.
 
 --json emits {game_id, profile, files: [{mod_id, mod_name, file_id,
-status}], issues, warnings}; status is one of "ok", "missing",
+status, note}], issues, warnings}; status is one of "ok", "missing",
 "no_checksum", "file_count_mismatch", "skipped", "version_mismatch", or
-"version_unverifiable". issues counts MISSING files and VERSION MISMATCH
-rows (a successful --fix repair of either decrements it back out);
-warnings counts everything else that isn't OK.
+"version_unverifiable"; note is omitted except on a --fix VERSION
+MISMATCH repair whose cache rename was skipped. issues counts MISSING
+files and VERSION MISMATCH rows (a successful --fix repair of either
+decrements it back out); warnings counts everything else that isn't OK.
 
 Examples:
   lmm verify --game skyrim-se           # Verify all mods
   lmm verify 12345 --game skyrim-se     # Verify specific mod
-  lmm verify --fix --game skyrim-se     # Re-download missing files, populate missing checksums`,
+  lmm verify --fix --game skyrim-se     # Re-download missing files, populate checksums, repair version records`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runVerify,
 }
@@ -270,6 +275,7 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 				} else {
 					if jsonOutput {
 						jsonFiles[len(jsonFiles)-1].Status = "ok"
+						jsonFiles[len(jsonFiles)-1].Note = note
 					} else {
 						fmt.Printf("  %s\n", colorGreen(fmt.Sprintf("Repaired: %s → %s", recorded, effective)))
 						if note != "" {
@@ -388,7 +394,7 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 	if issues > 0 || warnings > 0 {
 		fmt.Printf("%d issue(s), %d warning(s) found.\n", issues, warnings)
 		if (issues > 0 || warnings > 0) && !verifyFix {
-			fmt.Println("Run with --fix to re-download missing files and populate missing checksums.")
+			fmt.Println("Run with --fix to re-download missing files, populate missing checksums, and repair version-record mismatches.")
 		}
 	} else {
 		fmt.Println(colorGreen("All files verified OK."))
@@ -405,22 +411,37 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 //  1. Cache re-key: if the cache dir for the recorded version exists and
 //     the one for effective does not, rename it. If the effective-version
 //     dir already exists, leave the cache alone and return a note instead
-//     of clobbering it via os.Rename. If the rename itself fails, return
-//     immediately with no DB write - the row stays version_mismatch and
-//     the DB/cache never disagree in a new way.
+//     of clobbering it via os.Rename - the existing deployment (if any)
+//     still points at the intact recorded-version dir, so step 4 below is
+//     skipped in this case rather than re-linking into the unvetted
+//     pre-existing one. If the rename itself fails, return immediately
+//     with no DB write - the row stays version_mismatch and the DB/cache
+//     never disagree in a new way.
 //  2. DB: mutate mod.Version and save the full row (deliberately not
 //     UpdateModVersion, which would shift the wrong value into
 //     PreviousVersion and poison rollback).
 //  3. Profile: upsert the corrected version into the active profile's YAML
 //     record.
-//  4. Re-link: if the mod is Deployed via a symlink, the game-dir symlinks
-//     point INTO the cache dir renamed in step 1 and are now dangling -
-//     re-run the installer to refresh them. Hardlink/copy deployments are
-//     untouched by the cache rename, so they're left alone.
+//  4. Re-link: skipped when step 1 left the cache alone (note != "" - the
+//     current symlinks already point at valid content, so there's nothing
+//     to fix). Otherwise, if the mod is Deployed via a symlink, the
+//     game-dir symlinks point INTO the cache dir renamed in step 1 and are
+//     now dangling - re-run the installer to refresh them. Hardlink/copy
+//     deployments are untouched by the cache rename, so they're left
+//     alone regardless.
 //
 // mod is mutated in place (Version set to effective) only once the DB save
 // that carries it has actually succeeded, so a failure partway through
-// never leaves the in-memory row claiming a fix that didn't happen.
+// never leaves the in-memory row claiming a fix that didn't happen. If
+// step 4 itself fails (e.g. a read-only game dir), the DB/profile version
+// correction from steps 2-3 is NOT rolled back - retrying it would just
+// repeat the same rename-already-done state - but Deployed is cleared and
+// saved before returning the error: effective == mod.Version by then, so
+// a later `verify --fix` no longer sees a version_mismatch to retry, and
+// leaving Deployed true would falsely claim a working deployment that
+// isn't there. Clearing it at least keeps that one field honest so other
+// surfaces (status displays, a future `lmm deploy`, which redeploys every
+// enabled mod regardless of its recorded Deployed value) aren't misled.
 func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, profile string, mod *domain.InstalledMod, effective string) (note string, err error) {
 	gameCache := svc.GetGameCache(game)
 	oldPath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
@@ -451,8 +472,16 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 		return note, fmt.Errorf("updating profile record: %w", err)
 	}
 
-	if mod.Deployed && mod.LinkMethod == domain.LinkSymlink {
+	// A blocked rename (note != "") leaves the existing deployment pointed
+	// at the still-intact recorded-version cache dir - nothing dangles, so
+	// re-linking would only repoint a working deployment into the
+	// unvetted pre-existing effective-version dir for no reason.
+	if note == "" && mod.Deployed && mod.LinkMethod == domain.LinkSymlink {
 		if err := svc.GetInstaller(game).Install(cmd.Context(), game, &mod.Mod, profile); err != nil {
+			mod.Deployed = false
+			if saveErr := svc.SaveInstalledMod(mod); saveErr != nil {
+				return note, fmt.Errorf("relinking deployed files: %w (also failed to clear deployed flag: %v)", err, saveErr)
+			}
 			return note, fmt.Errorf("relinking deployed files: %w", err)
 		}
 	}

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -30,7 +30,7 @@ type verifyFileJSON struct {
 	ModID   string `json:"mod_id"`
 	ModName string `json:"mod_name"`
 	FileID  string `json:"file_id"`
-	Status  string `json:"status"` // ok, missing, no_checksum, file_count_mismatch, skipped
+	Status  string `json:"status"` // ok, missing, no_checksum, file_count_mismatch, skipped, version_mismatch, version_unverifiable
 }
 
 var verifyCmd = &cobra.Command{
@@ -53,10 +53,33 @@ Use --fix to re-download files that are MISSING or have NO CHECKSUM,
 storing a fresh checksum afterwards. FILE COUNT MISMATCH and SKIPPED
 are not repaired by --fix.
 
+verify also contacts each installed mod's source to check its recorded
+version against what the stored file ID(s) actually are upstream (issue
+#94: older installs could record the mod's "latest" version instead of
+the version of the file that was actually downloaded and deployed):
+
+    X NAME - VERSION MISMATCH (recorded X, source reports Y)
+                                         recorded version doesn't match
+                                         what the installed file ID(s)
+                                         report upstream
+    ? NAME - VERSION UNVERIFIABLE       none of the recorded file ID(s)
+                                         are listed by the source anymore
+                                         (reinstall to refresh)
+
+Mods installed from a local source, mods requiring manual download, and
+mods with no recorded file IDs are skipped silently - there is nothing
+to check against. If the source can't be reached, the mod is reported
+as skipped with a warning instead of failing the whole run.
+
+VERSION MISMATCH is not yet repaired by --fix (a future release adds
+that); VERSION UNVERIFIABLE is never fixable automatically since there is
+no matching upstream file to compare against - reinstall the mod instead.
+
 --json emits {game_id, profile, files: [{mod_id, mod_name, file_id,
 status}], issues, warnings}; status is one of "ok", "missing",
-"no_checksum", "file_count_mismatch", or "skipped". issues counts
-MISSING files (a successful --fix repair decrements it back out);
+"no_checksum", "file_count_mismatch", "skipped", "version_mismatch", or
+"version_unverifiable". issues counts MISSING files and VERSION MISMATCH
+rows (a successful --fix repair of MISSING decrements it back out);
 warnings counts everything else that isn't OK.
 
 Examples:
@@ -165,6 +188,78 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 				warnings++
 			}
 		}
+	}
+
+	// Per-mod version-record check: the recorded Version vs what the stored
+	// file ID(s) actually report upstream (issue #94's detection half -
+	// installs before this fix could stamp the mod's "latest" version
+	// instead of the version of the file that was really downloaded and
+	// deployed; Task A7 adds the --fix repair for VERSION MISMATCH rows).
+	// One entry per installed mod, FileID left empty (there's no single
+	// file at fault - the row's version metadata as a whole is what's
+	// wrong).
+	ctx := cmd.Context()
+	installedMods, err := svc.GetInstalledMods(game.ID, profile)
+	if err != nil {
+		return fmt.Errorf("getting installed mods: %w", err)
+	}
+	for i := range installedMods {
+		mod := &installedMods[i]
+		if modFilter != "" && mod.ID != modFilter {
+			continue
+		}
+		// Nothing to check against: local imports and manual downloads have
+		// no source to query, and a mod with no recorded file IDs predates
+		// even the buggy stamping this check exists to catch.
+		if mod.SourceID == domain.SourceLocal || mod.ManualDownload || len(mod.FileIDs) == 0 {
+			continue
+		}
+
+		sourceFiles, err := svc.GetModFiles(ctx, mod.SourceID, &mod.Mod)
+		if err != nil {
+			if jsonOutput {
+				jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: "", Status: "skipped"})
+			} else {
+				fmt.Printf("%s %s - could not check version (source unreachable)\n", colorYellow("?"), mod.Name)
+			}
+			warnings++
+			continue
+		}
+
+		var matched []*domain.DownloadableFile
+		for _, id := range mod.FileIDs {
+			for j := range sourceFiles {
+				if sourceFiles[j].ID == id {
+					matched = append(matched, &sourceFiles[j])
+					break
+				}
+			}
+		}
+
+		if len(matched) == 0 {
+			if jsonOutput {
+				jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: "", Status: "version_unverifiable"})
+			} else {
+				fmt.Printf("%s %s - VERSION UNVERIFIABLE (recorded file ID(s) no longer found upstream; reinstall to refresh the recorded version)\n", colorYellow("?"), mod.Name)
+			}
+			warnings++
+			continue
+		}
+
+		effective := domain.EffectiveInstalledVersion(mod.Version, matched)
+		if effective != mod.Version {
+			if jsonOutput {
+				jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: "", Status: "version_mismatch"})
+			} else {
+				fmt.Printf("%s %s - VERSION MISMATCH (recorded %s, source reports %s)\n", colorRed("X"), mod.Name, mod.Version, effective)
+			}
+			issues++
+			continue
+		}
+
+		// Recorded version matches what the source reports - OK, but not
+		// printed per-line (same quiet-ok convention as the file loop below).
+		checked++
 	}
 
 	for _, f := range files {

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -274,9 +274,10 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 		if err != nil {
 			if jsonOutput {
 				// Copilot round 6 (PR #128): the source-unreachable reason
-				// must reach --json too, not just the text-mode line below
-				// - status stays "skipped" and warnings is unaffected,
-				// only the note is new.
+				// must reach --json too, not just the text-mode line below.
+				// Status stays "skipped", and the note carries the reason;
+				// the shared warnings++ below fires for both output modes,
+				// exactly as it did before the note existed.
 				jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: "", Status: "skipped", Note: fmt.Sprintf("could not check version: %v", err)})
 			} else {
 				fmt.Printf("%s %s - could not check version (source unreachable)\n", colorYellow("?"), mod.Name)

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -558,17 +558,22 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 // sibling Deployed via symlink has its links re-created through the
 // installer exactly like the primary row's would be; on a per-sibling
 // re-link failure, that row's Deployed flag alone is cleared (matching the
-// primary row's own re-link-failure handling) and processing continues
+// primary row's own re-link-failure handling), but - unlike the DB/profile
+// steps, which did succeed - this is reported as a FAILURE, not folded
+// into "repaired": the version record is correct, but the deployment
+// itself is still broken, so printing the same green "Repaired" line
+// would misreport a partial fix as a clean success. Processing continues
 // with the remaining siblings rather than aborting the whole pass.
 //
 // Per DEV.md's "never swallow errors without logging/context": a failure
 // to correct one sibling (pm.List itself, or a given sibling's
-// SaveInstalledMod/UpsertMod) is NOT silently skipped - it's printed as a
-// warning in text mode and folded into the returned summary, since a
-// write failure here leaves that profile in exactly the orphaned state
-// this whole repair exists to fix, indistinguishable from "was never a
-// candidate" if left unreported. The loop still continues past a single
-// sibling's failure - best-effort, not all-or-nothing.
+// SaveInstalledMod/UpsertMod/re-link) is NOT silently skipped - it's
+// printed as a warning in text mode and folded into the returned summary,
+// since a write or re-link failure here leaves that profile in exactly
+// the orphaned/dangling state this whole repair exists to fix,
+// indistinguishable from "was never a candidate" if left unreported. The
+// loop still continues past a single sibling's failure - best-effort, not
+// all-or-nothing.
 //
 // Returns a human-readable summary of which profiles were repaired and/or
 // failed (empty if neither), for the caller to fold into repairModVersion's
@@ -623,7 +628,18 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 		if sibling.Deployed && sibling.LinkMethod == domain.LinkSymlink {
 			if err := svc.GetInstaller(game).Install(cmd.Context(), game, &sibling.Mod, p.Name); err != nil {
 				sibling.Deployed = false
-				_ = svc.SaveInstalledMod(sibling) //nolint:errcheck // best-effort: the version correction above already stands regardless
+				if saveErr := svc.SaveInstalledMod(sibling); saveErr != nil {
+					failed = append(failed, fmt.Sprintf("%s (relinking deployed files: %v; also failed to clear deployed flag: %v)", p.Name, err, saveErr))
+				} else {
+					failed = append(failed, fmt.Sprintf("%s (relinking deployed files: %v)", p.Name, err))
+				}
+				if !jsonOutput {
+					fmt.Printf("  Warning: could not repair profile %s: %v\n", p.Name, err)
+				}
+				// The version correction (DB + profile, above) stands, but
+				// the deployment itself is still broken - report this as a
+				// failure, not a clean "Repaired" success.
+				continue
 			}
 		}
 

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -551,6 +552,14 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 // rename actually happened; a blocked/skipped rename never orphans
 // anything, so siblings are left alone in that case.
 //
+// A profile that never had the mod installed at all (GetInstalledMod
+// returning domain.ErrModNotFound) is a normal, silent skip - it was never
+// a repair candidate. Any OTHER lookup error (a genuine DB failure) is
+// deliberately NOT treated the same way: it means we couldn't even tell
+// whether that profile needed repair, which is surfaced as a per-sibling
+// failure below rather than silently looking identical to "not a
+// candidate".
+//
 // Sibling rows whose Version differs from recorded are a different state
 // entirely (not something this repair caused) and are left untouched, per
 // the same DB-load-mutate-save pattern the primary path uses (never
@@ -597,7 +606,23 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 		}
 
 		sibling, err := svc.GetInstalledMod(mod.SourceID, mod.ID, game.ID, p.Name)
-		if err != nil || sibling.Version != recorded {
+		if err != nil {
+			if !errors.Is(err, domain.ErrModNotFound) {
+				// A genuine lookup failure (DB error, corruption, etc.) is
+				// NOT the same as "this profile never had the mod" - the
+				// latter is a normal, silent skip; the former means we
+				// couldn't even tell whether this profile needed repair,
+				// which must be surfaced the same as any other per-sibling
+				// failure rather than looking indistinguishable from "not a
+				// candidate".
+				failed = append(failed, fmt.Sprintf("%s (checking sibling: %v)", p.Name, err))
+				if !jsonOutput {
+					fmt.Printf("  Warning: could not repair profile %s: %v\n", p.Name, err)
+				}
+			}
+			continue
+		}
+		if sibling.Version != recorded {
 			continue
 		}
 

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -71,15 +71,21 @@ mods with no recorded file IDs are skipped silently - there is nothing
 to check against. If the source can't be reached, the mod is reported
 as skipped with a warning instead of failing the whole run.
 
-VERSION MISMATCH is not yet repaired by --fix (a future release adds
-that); VERSION UNVERIFIABLE is never fixable automatically since there is
-no matching upstream file to compare against - reinstall the mod instead.
+Use --fix to repair VERSION MISMATCH too: the cache entry is re-keyed
+from the recorded version to the effective (source-reported) one, the DB
+row and the active profile's record are corrected to match, and any
+symlink deployment is re-linked (its target lived inside the just-renamed
+cache dir and would otherwise dangle). If a cache entry already exists
+under the effective version, the rename is skipped and a note is printed,
+but the DB and profile are still corrected. VERSION UNVERIFIABLE is never
+fixable automatically since there is no matching upstream file to compare
+against - reinstall the mod instead.
 
 --json emits {game_id, profile, files: [{mod_id, mod_name, file_id,
 status}], issues, warnings}; status is one of "ok", "missing",
 "no_checksum", "file_count_mismatch", "skipped", "version_mismatch", or
 "version_unverifiable". issues counts MISSING files and VERSION MISMATCH
-rows (a successful --fix repair of MISSING decrements it back out);
+rows (a successful --fix repair of either decrements it back out);
 warnings counts everything else that isn't OK.
 
 Examples:
@@ -248,12 +254,31 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 
 		effective := domain.EffectiveInstalledVersion(mod.Version, matched)
 		if effective != mod.Version {
+			recorded := mod.Version
 			if jsonOutput {
 				jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: "", Status: "version_mismatch"})
 			} else {
-				fmt.Printf("%s %s - VERSION MISMATCH (recorded %s, source reports %s)\n", colorRed("X"), mod.Name, mod.Version, effective)
+				fmt.Printf("%s %s - VERSION MISMATCH (recorded %s, source reports %s)\n", colorRed("X"), mod.Name, recorded, effective)
 			}
 			issues++
+			if verifyFix && mod.SourceID != domain.SourceLocal {
+				note, repairErr := repairModVersion(cmd, svc, game, profile, mod, effective)
+				if repairErr != nil {
+					if !jsonOutput {
+						fmt.Printf("  Repair failed: %v\n", repairErr)
+					}
+				} else {
+					if jsonOutput {
+						jsonFiles[len(jsonFiles)-1].Status = "ok"
+					} else {
+						fmt.Printf("  %s\n", colorGreen(fmt.Sprintf("Repaired: %s → %s", recorded, effective)))
+						if note != "" {
+							fmt.Printf("  Note: %s\n", note)
+						}
+					}
+					issues--
+				}
+			}
 			continue
 		}
 
@@ -370,6 +395,69 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 	}
 
 	return nil
+}
+
+// repairModVersion repairs a VERSION MISMATCH row for --fix (issue #94):
+// the recorded Version doesn't match what the stored file ID(s) actually
+// are upstream (effective), so the cache entry, DB row, and profile record
+// are all keyed by the wrong version. Fix sequence:
+//
+//  1. Cache re-key: if the cache dir for the recorded version exists and
+//     the one for effective does not, rename it. If the effective-version
+//     dir already exists, leave the cache alone and return a note instead
+//     of clobbering it via os.Rename. If the rename itself fails, return
+//     immediately with no DB write - the row stays version_mismatch and
+//     the DB/cache never disagree in a new way.
+//  2. DB: mutate mod.Version and save the full row (deliberately not
+//     UpdateModVersion, which would shift the wrong value into
+//     PreviousVersion and poison rollback).
+//  3. Profile: upsert the corrected version into the active profile's YAML
+//     record.
+//  4. Re-link: if the mod is Deployed via a symlink, the game-dir symlinks
+//     point INTO the cache dir renamed in step 1 and are now dangling -
+//     re-run the installer to refresh them. Hardlink/copy deployments are
+//     untouched by the cache rename, so they're left alone.
+//
+// mod is mutated in place (Version set to effective) only once the DB save
+// that carries it has actually succeeded, so a failure partway through
+// never leaves the in-memory row claiming a fix that didn't happen.
+func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, profile string, mod *domain.InstalledMod, effective string) (note string, err error) {
+	gameCache := svc.GetGameCache(game)
+	oldPath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
+	newPath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, effective)
+
+	if _, statErr := os.Stat(oldPath); statErr == nil {
+		if _, statErr := os.Stat(newPath); statErr == nil {
+			note = fmt.Sprintf("cache entry for %s already exists; left %s in place", effective, mod.Version)
+		} else if renameErr := os.Rename(oldPath, newPath); renameErr != nil {
+			return "", fmt.Errorf("renaming cache entry: %w", renameErr)
+		}
+	}
+
+	updated := *mod
+	updated.Version = effective
+	if err := svc.SaveInstalledMod(&updated); err != nil {
+		return note, fmt.Errorf("saving installed mod: %w", err)
+	}
+	*mod = updated
+
+	pm := getProfileManager(svc)
+	if err := pm.UpsertMod(game.ID, profile, domain.ModReference{
+		SourceID: mod.SourceID,
+		ModID:    mod.ID,
+		Version:  effective,
+		FileIDs:  mod.FileIDs,
+	}); err != nil {
+		return note, fmt.Errorf("updating profile record: %w", err)
+	}
+
+	if mod.Deployed && mod.LinkMethod == domain.LinkSymlink {
+		if err := svc.GetInstaller(game).Install(cmd.Context(), game, &mod.Mod, profile); err != nil {
+			return note, fmt.Errorf("relinking deployed files: %w", err)
+		}
+	}
+
+	return note, nil
 }
 
 // redownloadModFile re-downloads a single mod file and extracts to cache, then updates checksum in DB.

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -237,7 +237,7 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 			continue
 		}
 
-		sourceFiles, err := svc.GetModFiles(ctx, mod.SourceID, &mod.Mod)
+		sourceFiles, err := svc.GetModFiles(ctx, mod.SourceID, sourceMappedMod(game, &mod.Mod))
 		if err != nil {
 			if jsonOutput {
 				jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: "", Status: "skipped"})
@@ -474,6 +474,28 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 // isn't there. Clearing it at least keeps that one field honest so other
 // surfaces (status displays, a future `lmm deploy`, which redeploys every
 // enabled mod regardless of its recorded Deployed value) aren't misled.
+// sourceMappedMod returns a copy of mod with GameID translated through the
+// game's per-source ID mapping (game.SourceIDs) - the same rule
+// Service.GetMod already applies (internal/core/service.go) before calling
+// into a source. Installed rows persist the LMM game ID (see
+// setupDoVerifyVersionTest and every InstalledMod fixture: GameID:
+// game.ID), but Service.GetModFiles does NOT translate it itself - unlike
+// GetMod, it forwards straight to the source. Sources like NexusMods
+// address games by their own domain (e.g. "skyrimspecialedition"), so any
+// direct svc.GetModFiles call driven off an installed row's mod.Mod (as
+// opposed to one already sourced from the source itself, e.g. a fresh
+// search result) needs this translation first or it silently queries the
+// wrong game. An empty mapping value means "this source applies to any
+// game" (e.g. directory sources: `donovan-mods: ""`) and must not blank
+// out the LMM ID - matches Service.GetMod's `ok && id != ""` guard exactly.
+func sourceMappedMod(game *domain.Game, mod *domain.Mod) *domain.Mod {
+	mapped := *mod
+	if id, ok := game.SourceIDs[mod.SourceID]; ok && id != "" {
+		mapped.GameID = id
+	}
+	return &mapped
+}
+
 func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, profile string, mod *domain.InstalledMod, effective string) (note string, err error) {
 	recorded := mod.Version
 	gameCache := svc.GetGameCache(game)

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -273,7 +273,11 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 		sourceFiles, err := svc.GetModFiles(ctx, mod.SourceID, sourceMappedMod(game, &mod.Mod))
 		if err != nil {
 			if jsonOutput {
-				jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: "", Status: "skipped"})
+				// Copilot round 6 (PR #128): the source-unreachable reason
+				// must reach --json too, not just the text-mode line below
+				// - status stays "skipped" and warnings is unaffected,
+				// only the note is new.
+				jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: "", Status: "skipped", Note: fmt.Sprintf("could not check version: %v", err)})
 			} else {
 				fmt.Printf("%s %s - could not check version (source unreachable)\n", colorYellow("?"), mod.Name)
 			}

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -32,7 +33,7 @@ type verifyFileJSON struct {
 	ModName string `json:"mod_name"`
 	FileID  string `json:"file_id"`
 	Status  string `json:"status"`         // ok, missing, no_checksum, file_count_mismatch, skipped, version_mismatch, version_unverifiable
-	Note    string `json:"note,omitempty"` // optional detail; set by a --fix VERSION MISMATCH repair whose cache rename was skipped because the effective-version cache dir already existed, and/or which also repaired the same mod's stale record in other profiles sharing the cache
+	Note    string `json:"note,omitempty"` // optional detail: a blocked cache rename, sibling-repair results, a --fix repair/redownload failure reason, or a file-count-check lookup failure - omitted when there's nothing extra to add
 }
 
 var verifyCmd = &cobra.Command{
@@ -83,22 +84,26 @@ deployment is left pointing at the still-intact recorded-version cache
 dir rather than being re-linked into the unverified pre-existing one -
 and a note is printed (also included as "note" in --json output), but
 the DB and profile are still corrected. Since the mod cache is shared
-across profiles, a successful rename also corrects any OTHER profile
-whose record still holds the same stale version (DB, profile record, and
-re-linking a symlink deployment the same way) - printed as its own
-"Repaired (profile ...)" line per profile in text mode, or folded into
-the "note" field as "also repaired in profile(s): ..." in --json.
-VERSION UNVERIFIABLE is never fixable automatically since there is no
-matching upstream file to compare against - reinstall the mod instead.
+across profiles, a rename also corrects any OTHER profile whose record
+still holds the same stale version AND the same file selection (DB,
+profile record, and re-linking a symlink deployment the same way) -
+printed as its own "Repaired (profile ...)" line per profile in text
+mode, or folded into the "note" field as "also repaired in profile(s):
+..." in --json. A same-version sibling recording DIFFERENT files is left
+alone instead, with a note naming it and suggesting a manual
+"verify --fix -p" run scoped to that profile. VERSION UNVERIFIABLE is
+never fixable automatically since there is no matching upstream file to
+compare against - reinstall the mod instead.
 
 --json emits {game_id, profile, files: [{mod_id, mod_name, file_id,
 status, note}], issues, warnings}; status is one of "ok", "missing",
 "no_checksum", "file_count_mismatch", "skipped", "version_mismatch", or
-"version_unverifiable"; note is omitted except on a --fix VERSION
-MISMATCH repair whose cache rename was skipped, or which also repaired
-the same mod in other profiles. issues counts MISSING files and VERSION
-MISMATCH rows (a successful --fix repair of either decrements it back
-out); warnings counts everything else that isn't OK.
+"version_unverifiable"; note adds detail where there's something extra to
+say - a blocked cache rename, sibling-repair results, a --fix repair or
+redownload failure's reason, or a file-count-check lookup failure - and is
+omitted otherwise. issues counts MISSING files and VERSION MISMATCH rows
+(a successful --fix repair of either decrements it back out); warnings
+counts everything else that isn't OK.
 
 Examples:
   lmm verify --game skyrim-se           # Verify all mods
@@ -185,6 +190,21 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 		sourceID, modID, _ := strings.Cut(key, ":")
 		mod, err := svc.GetInstalledMod(sourceID, modID, game.ID, profile)
 		if err != nil {
+			// A not-installed mod (an orphaned checksum row - the main
+			// per-file loop below reports this exact case itself, as
+			// "Unknown mod ... - SKIPPED") is a normal, silent skip here;
+			// reporting it again in this pre-pass would just duplicate
+			// that warning. Any OTHER lookup error (a genuine DB failure)
+			// is NOT a normal skip and must not be swallowed (epic98 audit
+			// Finding 5).
+			if !errors.Is(err, domain.ErrModNotFound) {
+				if jsonOutput {
+					jsonFiles = append(jsonFiles, verifyFileJSON{ModID: modID, ModName: "", FileID: "", Status: "skipped", Note: err.Error()})
+				} else {
+					fmt.Printf("%s Mod %s - could not check file count: %v\n", colorYellow("?"), modID, err)
+				}
+				warnings++
+			}
 			continue
 		}
 		if modFilter != "" && mod.ID != modFilter {
@@ -196,6 +216,19 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 		}
 		cachedFiles, err := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
 		if err != nil {
+			// A real filesystem error walking the cache dir (permission
+			// denied, I/O error) is not the same as "cache is empty" - the
+			// FILE COUNT MISMATCH case just below - and must be surfaced,
+			// not silently treated as "nothing to report" (audit Finding 5).
+			if !reportedMismatch[key] {
+				if jsonOutput {
+					jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: "", Status: "skipped", Note: err.Error()})
+				} else {
+					fmt.Printf("%s %s - could not check cached file count: %v\n", colorYellow("?"), mod.Name, err)
+				}
+				reportedMismatch[key] = true
+				warnings++
+			}
 			continue
 		}
 		actualCount := len(cachedFiles)
@@ -289,14 +322,18 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 				if repairErr != nil {
 					if jsonOutput {
 						// The PRIMARY row itself wasn't fixed (status/issues
-						// stay as already recorded above), but note can
+						// stay as already recorded above). The failure
+						// reason itself (audit Finding 7) and note can
 						// still carry a successful SIBLING repair - see
-						// repairModVersion's doc comment - and dropping it
-						// here would make that repair invisible to a --json
-						// caller even though it genuinely happened.
+						// repairModVersion's doc comment - and dropping
+						// either here would make them invisible to a
+						// --json caller even though they genuinely
+						// happened/occurred.
+						repairNote := "repair failed: " + repairErr.Error()
 						if note != "" {
-							jsonFiles[len(jsonFiles)-1].Note = note
+							repairNote += "; " + note
 						}
+						jsonFiles[len(jsonFiles)-1].Note = repairNote
 					} else {
 						fmt.Printf("  Repair failed: %v\n", repairErr)
 					}
@@ -351,7 +388,12 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 			issues++
 			if verifyFix && mod.SourceID != domain.SourceLocal {
 				if err := redownloadModFile(cmd, svc, game, profile, mod, f.FileID); err != nil {
-					if !jsonOutput {
+					if jsonOutput {
+						// audit Finding 7: the row was already appended
+						// above (Status "missing") - the failure reason
+						// must reach --json too, not just this text line.
+						jsonFiles[len(jsonFiles)-1].Note = err.Error()
+					} else {
 						fmt.Printf("  Re-download failed: %v\n", err)
 					}
 				} else {
@@ -371,7 +413,9 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 			if verifyFix && mod.SourceID != domain.SourceLocal {
 				if err := redownloadModFile(cmd, svc, game, profile, mod, f.FileID); err != nil {
 					if jsonOutput {
-						jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: f.FileID, Status: "no_checksum"})
+						// audit Finding 7: the failure reason must reach
+						// --json, not just the text-mode line below.
+						jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: f.FileID, Status: "no_checksum", Note: err.Error()})
 					} else {
 						fmt.Printf("%s %s (%s) - NO CHECKSUM\n", colorYellow("?"), mod.Name, f.FileID)
 						fmt.Printf("  Re-download to populate checksum failed: %v\n", err)
@@ -453,6 +497,26 @@ func sourceMappedMod(game *domain.Game, mod *domain.Mod) *domain.Mod {
 	return &mapped
 }
 
+// cacheDirExists reports whether a cache mod-version directory exists,
+// distinguishing "genuinely absent" (fs.ErrNotExist - a normal state: the
+// version was cleared, or never cached) from any OTHER stat failure
+// (permission denied, I/O error, a corrupted mount, etc.), which must NOT
+// be silently treated as "absent" (epic98 audit Finding 4): proceeding to
+// a DB write on the strength of a check that itself failed would violate
+// the invariant that no DB write happens unless the cache state was
+// actually verified first - the same invariant os.Rename's own failure
+// path already protects.
+func cacheDirExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
 // repairModVersion repairs a VERSION MISMATCH row for --fix (issue #94):
 // the recorded Version doesn't match what the stored file ID(s) actually
 // are upstream (effective), so the cache entry, DB row, and profile record
@@ -464,50 +528,70 @@ func sourceMappedMod(game *domain.Game, mod *domain.Mod) *domain.Mod {
 //     of clobbering it via os.Rename - the existing deployment (if any)
 //     still points at the intact recorded-version dir, so step 4 below is
 //     skipped in this case rather than re-linking into the unvetted
-//     pre-existing one. If the rename itself fails, return immediately
-//     with no DB write - the row stays version_mismatch and the DB/cache
-//     never disagree in a new way.
-//  2. DB: mutate mod.Version and save the full row (deliberately not
-//     UpdateModVersion, which would shift the wrong value into
-//     PreviousVersion and poison rollback).
-//  3. Profile: upsert the corrected version into the active profile's YAML
-//     record.
+//     pre-existing one. If the rename itself fails, OR either stat check
+//     itself fails for a reason other than "doesn't exist" (audit Finding
+//     4), return immediately with no DB write - the row stays
+//     version_mismatch and the DB/cache never disagree in a new way.
+//  2. Profile: upsert the corrected version into the active profile's YAML
+//     record. Runs BEFORE step 3's DB write (audit Finding 3, swapped from
+//     the original order): the DB row is the signal doVerify's own
+//     mismatch detection reads (GetInstalledMods, not the profile YAML),
+//     so it must be the LAST of these two writes to succeed - if the
+//     upsert fails here, the DB is untouched, so a retry still detects
+//     version_mismatch and can converge. The original order (DB first)
+//     let a profile-upsert failure leave the DB already at effective, so
+//     retries never re-detected the mismatch and the stale YAML ref could
+//     never self-heal.
+//  3. DB: SetModVersion - a plain version-column update (audit Finding 1),
+//     deliberately NOT SaveInstalledMod's full-row upsert, which always
+//     re-keys installed_mod_files (DELETE + a checksum-less re-INSERT)
+//     even though FileIDs is completely unchanged here, silently wiping
+//     every stored checksum for the mod on every repair. Also deliberately
+//     not UpdateModVersion, which would shift the wrong value into
+//     PreviousVersion and poison rollback - this is a correction, not an
+//     update.
 //  4. Re-link: skipped when step 1 left the cache alone (note != "" - the
 //     current symlinks already point at valid content, so there's nothing
 //     to fix). Otherwise, if the mod is Deployed via a symlink, the
 //     game-dir symlinks point INTO the cache dir renamed in step 1 and are
 //     now dangling - re-run the installer to refresh them. Hardlink/copy
 //     deployments are untouched by the cache rename, so they're left
-//     alone regardless.
-//  5. Sibling profiles: only when step 1 actually renamed the cache dir
-//     (the shared-cache-dir orphaning this step exists to fix can only
-//     happen then - a blocked or skipped rename leaves every profile's
-//     view of the cache untouched). Every OTHER profile's installed_mods
-//     row for the same (SourceID, ModID, GameID) whose Version still
-//     equals the OLD recorded version is corrected the same way (DB +
-//     profile YAML), and re-linked if Deployed via symlink - see
-//     repairSiblingProfiles. Runs unconditionally once step 1 has renamed
-//     the cache, even if step 4 above (the PRIMARY row's own re-link)
-//     failed - the primary's re-link outcome has no bearing on whether
-//     siblings were orphaned by the same rename.
+//     alone regardless. On failure, SetModDeployed (not SaveInstalledMod -
+//     audit Finding 1 again) clears the flag without touching file IDs.
+//  5. Sibling profiles: runs when step 1 renamed the cache THIS run, OR
+//     (audit Finding 2) when the cache already lives under the effective
+//     version from an EARLIER, partially-failed run - old path absent,
+//     new path present, and no blocked-rename note (which would mean the
+//     new dir was pre-existing/unvetted content, not this repair's own
+//     prior success). Without this, a retry after a run that renamed the
+//     cache but then failed before completing would see oldPath already
+//     gone, renamed=false, and skip siblings entirely - even though the
+//     shared cache dir has, in fact, already moved out from under them.
+//     Every OTHER profile's installed_mods row for the same (SourceID,
+//     ModID, GameID) whose Version still equals the OLD recorded version
+//     is corrected the same way (DB + profile YAML), and re-linked if
+//     Deployed via symlink - see repairSiblingProfiles. Runs
+//     unconditionally once triggered, even if step 4 above (the PRIMARY
+//     row's own re-link) failed - the primary's re-link outcome has no
+//     bearing on whether siblings were orphaned by the same rename.
 //
-// siblingFailures is the count of per-sibling failures from step 5 (a
-// pm.List failure counts as one), structurally propagated - not
+// siblingFailures is the count of per-sibling failures/declines from step
+// 5 (a pm.List failure counts as one), structurally propagated - not
 // string-matched out of note - so the caller can add it straight into its
 // own warnings counter. It's independent of err: siblingFailures can be
 // non-zero whether or not the PRIMARY row's own repair (this function's
 // err) succeeded, since a sibling's fate has no bearing on the primary's.
 //
-// mod is mutated in place (Version set to effective) only once the DB save
-// that carries it has actually succeeded, so a failure partway through
-// never leaves the in-memory row claiming a fix that didn't happen. If
-// step 4 itself fails (e.g. a read-only game dir), the DB/profile version
-// correction from steps 2-3 is NOT rolled back - retrying it would just
-// repeat the same rename-already-done state - but Deployed is cleared and
-// saved before returning the error: effective == mod.Version by then, so
-// a later `verify --fix` no longer sees a version_mismatch to retry, and
-// leaving Deployed true would falsely claim a working deployment that
-// isn't there. Clearing it at least keeps that one field honest so other
+// mod.Version is mutated in place only once step 3's DB write has actually
+// succeeded, so a failure partway through never leaves the in-memory row
+// claiming a fix that didn't happen. If step 4 itself fails (e.g. a
+// read-only game dir), the DB/profile version correction from steps 2-3 is
+// NOT rolled back - retrying it would just repeat the same
+// rename-already-done state - but Deployed is cleared and saved before
+// returning the error: effective == mod.Version by then, so a later
+// `verify --fix` no longer sees a version_mismatch to retry, and leaving
+// Deployed true would falsely claim a working deployment that isn't
+// there. Clearing it at least keeps that one field honest so other
 // surfaces (status displays, a future `lmm deploy`, which redeploys every
 // enabled mod regardless of its recorded Deployed value) aren't misled.
 func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, profile string, mod *domain.InstalledMod, effective string) (note string, siblingFailures int, err error) {
@@ -516,9 +600,18 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 	oldPath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, recorded)
 	newPath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, effective)
 
+	oldExists, statErr := cacheDirExists(oldPath)
+	if statErr != nil {
+		return "", 0, fmt.Errorf("checking cache entry for %s: %w", recorded, statErr)
+	}
+	newExists, statErr := cacheDirExists(newPath)
+	if statErr != nil {
+		return "", 0, fmt.Errorf("checking cache entry for %s: %w", effective, statErr)
+	}
+
 	var renamed bool
-	if _, statErr := os.Stat(oldPath); statErr == nil {
-		if _, statErr := os.Stat(newPath); statErr == nil {
+	if oldExists {
+		if newExists {
 			note = fmt.Sprintf("cache entry for %s already exists; left %s in place", effective, recorded)
 		} else if renameErr := os.Rename(oldPath, newPath); renameErr != nil {
 			return "", 0, fmt.Errorf("renaming cache entry: %w", renameErr)
@@ -526,13 +619,6 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 			renamed = true
 		}
 	}
-
-	updated := *mod
-	updated.Version = effective
-	if err := svc.SaveInstalledMod(&updated); err != nil {
-		return note, 0, fmt.Errorf("saving installed mod: %w", err)
-	}
-	*mod = updated
 
 	pm := getProfileManager(svc)
 	if err := pm.UpsertMod(game.ID, profile, domain.ModReference{
@@ -544,6 +630,11 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 		return note, 0, fmt.Errorf("updating profile record: %w", err)
 	}
 
+	if err := svc.SetModVersion(mod.SourceID, mod.ID, mod.GameID, profile, effective); err != nil {
+		return note, 0, fmt.Errorf("saving installed mod: %w", err)
+	}
+	mod.Version = effective
+
 	// A blocked rename (note != "") leaves the existing deployment pointed
 	// at the still-intact recorded-version cache dir - nothing dangles, so
 	// re-linking would only repoint a working deployment into the
@@ -552,7 +643,7 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 	if note == "" && mod.Deployed && mod.LinkMethod == domain.LinkSymlink {
 		if err := svc.GetInstaller(game).Install(cmd.Context(), game, &mod.Mod, profile); err != nil {
 			mod.Deployed = false
-			if saveErr := svc.SaveInstalledMod(mod); saveErr != nil {
+			if saveErr := svc.SetModDeployed(mod.SourceID, mod.ID, mod.GameID, profile, false); saveErr != nil {
 				relinkErr = fmt.Errorf("relinking deployed files: %w (also failed to clear deployed flag: %v)", err, saveErr)
 			} else {
 				relinkErr = fmt.Errorf("relinking deployed files: %w", err)
@@ -562,12 +653,8 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 
 	// Sibling repair runs regardless of the primary re-link's own outcome
 	// (above) - a sibling row's orphaning is caused by the cache rename,
-	// not by anything that happens to the primary row's deployment. note is
-	// always "" here: it's only ever set in the "blocked because a cache
-	// entry already exists" branch above, which is mutually exclusive with
-	// renamed == true (the rename either happened or was blocked, never
-	// both) - a plain assignment is enough, no concatenation needed.
-	if renamed {
+	// not by anything that happens to the primary row's deployment.
+	if renamed || (!oldExists && newExists && note == "") {
 		note, siblingFailures = repairSiblingProfiles(cmd, svc, game, profile, mod, recorded, effective)
 	}
 
@@ -578,15 +665,44 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 	return note, siblingFailures, nil
 }
 
+// fileIDsEqual reports whether two FileID sets are equal, ignoring order.
+// Used by repairSiblingProfiles (epic98 audit Finding 6) to gate
+// auto-repair on a sibling actually recording the SAME file selection as
+// the primary, not just the same (wrong) version string - two profiles can
+// legitimately record the same wrong version for DIFFERENT files (e.g. a
+// different optional file chosen at install time), and blindly stamping
+// the sibling with the primary's effective version would be wrong for
+// that sibling's own files.
+func fileIDsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, id := range a {
+		counts[id]++
+	}
+	for _, id := range b {
+		counts[id]--
+	}
+	for _, c := range counts {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // repairSiblingProfiles corrects every OTHER profile's installed_mods row
 // for the same (SourceID, ModID, GameID) that still records the OLD
 // (pre-repair) version, after repairModVersion has renamed the shared
 // cache dir out from under them - cache.ModPath has no profile segment
 // (internal/storage/cache/cache.go:29), so a rename done for one profile's
 // row silently orphans any sibling profile still pointing at the old
-// version, until that sibling is itself verified. Only called when a
-// rename actually happened; a blocked/skipped rename never orphans
-// anything, so siblings are left alone in that case.
+// version, until that sibling is itself verified. Only called when the
+// cache has actually moved to the effective version (this run's rename,
+// or an earlier run's - see repairModVersion's step 5 doc); a blocked or
+// never-attempted rename never orphans anything, so siblings are left
+// alone in that case.
 //
 // A profile that never had the mod installed at all (GetInstalledMod
 // returning domain.ErrModNotFound) is a normal, silent skip - it was never
@@ -597,10 +713,23 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 // candidate".
 //
 // Sibling rows whose Version differs from recorded are a different state
-// entirely (not something this repair caused) and are left untouched, per
-// the same DB-load-mutate-save pattern the primary path uses (never
-// UpdateModVersion, which would poison PreviousVersion/rollback). A
-// sibling Deployed via symlink has its links re-created through the
+// entirely (not something this repair caused) and are left untouched. A
+// sibling whose Version MATCHES but whose FileIDs do NOT (audit Finding 6,
+// via fileIDsEqual) is also left untouched - the recorded version is wrong
+// for that sibling too, but auto-stamping it with the PRIMARY's effective
+// version would be wrong when the underlying files differ - instead it's
+// surfaced as its own warning pointing at the right manual fix
+// (`verify --fix -p <profile>`).
+//
+// Like the primary path (repairModVersion), the profile YAML is upserted
+// BEFORE the DB version is set (audit Finding 3): the DB row is what a
+// LATER verify run's mismatch detection reads for that sibling too, so if
+// the upsert fails, the DB must stay at the old, still-detectable version
+// rather than silently converging to "no mismatch, nothing to retry".
+// SetModVersion/SetModDeployed (never SaveInstalledMod's full-row upsert,
+// which would wipe stored checksums - audit Finding 1) do the writes.
+//
+// A sibling Deployed via symlink has its links re-created through the
 // installer exactly like the primary row's would be; on a per-sibling
 // re-link failure, that row's Deployed flag alone is cleared (matching the
 // primary row's own re-link-failure handling), but - unlike the DB/profile
@@ -612,23 +741,24 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 //
 // Per DEV.md's "never swallow errors without logging/context": a failure
 // to correct one sibling (pm.List itself, or a given sibling's
-// SaveInstalledMod/UpsertMod/re-link) is NOT silently skipped - it's
-// printed as a warning in text mode and folded into the returned summary,
-// since a write or re-link failure here leaves that profile in exactly
-// the orphaned/dangling state this whole repair exists to fix,
+// UpsertMod/SetModVersion/re-link) is NOT silently skipped - it's printed
+// as a warning in text mode and folded into the returned summary, since a
+// write or re-link failure here leaves that profile in exactly the
+// orphaned/dangling state this whole repair exists to fix,
 // indistinguishable from "was never a candidate" if left unreported. The
 // loop still continues past a single sibling's failure - best-effort, not
 // all-or-nothing.
 //
-// Returns a human-readable summary of which profiles were repaired and/or
-// failed (empty if neither), for the caller to fold into repairModVersion's
-// own note - the --json contract's vehicle for surfacing this, per the
-// primary row's existing "note" field - and, structurally (not by
-// string-matching the note text), the count of per-sibling failures, so
-// the caller can add it straight into its own warnings counter: a failed
-// sibling repair is real, surfaced work left undone and must count as a
-// warning regardless of how the PRIMARY row's own repair turned out. A
-// pm.List failure counts as one.
+// Returns a human-readable summary of which profiles were repaired,
+// failed, and/or declined for differing file selection (empty if none),
+// for the caller to fold into repairModVersion's own note - the --json
+// contract's vehicle for surfacing this, per the primary row's existing
+// "note" field - and, structurally (not by string-matching the note
+// text), the combined count of per-sibling failures and declines, so the
+// caller can add it straight into its own warnings counter: both are
+// real, surfaced work left undone and must count as a warning regardless
+// of how the PRIMARY row's own repair turned out. A pm.List failure
+// counts as one.
 func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.Game, currentProfile string, mod *domain.InstalledMod, recorded, effective string) (note string, failedCount int) {
 	pm := getProfileManager(svc)
 	profiles, err := pm.List(game.ID)
@@ -640,7 +770,7 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 		return "sibling repair check FAILED: " + msg, 1
 	}
 
-	var repaired, failed []string
+	var repaired, failed, differs []string
 	for _, p := range profiles {
 		if p.Name == currentProfile {
 			continue
@@ -666,17 +796,13 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 		if sibling.Version != recorded {
 			continue
 		}
-
-		updated := *sibling
-		updated.Version = effective
-		if err := svc.SaveInstalledMod(&updated); err != nil {
-			failed = append(failed, fmt.Sprintf("%s (%v)", p.Name, err))
+		if !fileIDsEqual(sibling.FileIDs, mod.FileIDs) {
+			differs = append(differs, p.Name)
 			if !jsonOutput {
-				fmt.Printf("  Warning: could not repair profile %s: %v\n", p.Name, err)
+				fmt.Printf("  Warning: profile %s records the same version but differs in file selection; run verify --fix -p %s\n", p.Name, p.Name)
 			}
 			continue
 		}
-		*sibling = updated
 
 		if err := pm.UpsertMod(game.ID, p.Name, domain.ModReference{
 			SourceID: sibling.SourceID,
@@ -691,10 +817,18 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 			continue
 		}
 
+		if err := svc.SetModVersion(sibling.SourceID, sibling.ID, sibling.GameID, p.Name, effective); err != nil {
+			failed = append(failed, fmt.Sprintf("%s (%v)", p.Name, err))
+			if !jsonOutput {
+				fmt.Printf("  Warning: could not repair profile %s: %v\n", p.Name, err)
+			}
+			continue
+		}
+		sibling.Version = effective
+
 		if sibling.Deployed && sibling.LinkMethod == domain.LinkSymlink {
 			if err := svc.GetInstaller(game).Install(cmd.Context(), game, &sibling.Mod, p.Name); err != nil {
-				sibling.Deployed = false
-				if saveErr := svc.SaveInstalledMod(sibling); saveErr != nil {
+				if saveErr := svc.SetModDeployed(sibling.SourceID, sibling.ID, sibling.GameID, p.Name, false); saveErr != nil {
 					failed = append(failed, fmt.Sprintf("%s (relinking deployed files: %v; also failed to clear deployed flag: %v)", p.Name, err, saveErr))
 				} else {
 					failed = append(failed, fmt.Sprintf("%s (relinking deployed files: %v)", p.Name, err))
@@ -722,7 +856,10 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 	if len(failed) > 0 {
 		parts = append(parts, fmt.Sprintf("repair FAILED in profile(s): %s", strings.Join(failed, ", ")))
 	}
-	return strings.Join(parts, "; "), len(failed)
+	if len(differs) > 0 {
+		parts = append(parts, fmt.Sprintf("differs in file selection in profile(s): %s (run verify --fix -p <profile>)", strings.Join(differs, ", ")))
+	}
+	return strings.Join(parts, "; "), len(failed) + len(differs)
 }
 
 // redownloadModFile re-downloads a single mod file and extracts to cache, then updates checksum in DB.

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -325,14 +325,19 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 				warnings += siblingFailures
 				if repairErr != nil {
 					if jsonOutput {
-						// The PRIMARY row itself wasn't fixed (status/issues
-						// stay as already recorded above). The failure
-						// reason itself (audit Finding 7) and note can
-						// still carry a successful SIBLING repair - see
-						// repairModVersion's doc comment - and dropping
-						// either here would make them invisible to a
-						// --json caller even though they genuinely
-						// happened/occurred.
+						// The PRIMARY row keeps reporting version_mismatch
+						// (status/issues stay as already recorded above),
+						// but the repair may have PARTIALLY succeeded: a
+						// step-4 re-link failure surfaces here after the
+						// cache rename and the DB/profile version
+						// correction have already landed and are not
+						// rolled back (see repairModVersion's doc). The
+						// failure reason itself (audit Finding 7) and note
+						// can still carry a successful SIBLING repair -
+						// see repairModVersion's doc comment - and
+						// dropping either here would make them invisible
+						// to a --json caller even though they genuinely
+						// happened.
 						repairNote := "repair failed: " + repairErr.Error()
 						if note != "" {
 							repairNote += "; " + note

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -278,7 +278,14 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 			}
 			issues++
 			if verifyFix && mod.SourceID != domain.SourceLocal {
-				note, repairErr := repairModVersion(cmd, svc, game, profile, mod, effective)
+				note, siblingFailures, repairErr := repairModVersion(cmd, svc, game, profile, mod, effective)
+				// Sibling failures are warnings regardless of how the
+				// PRIMARY row's own repair turned out - a failed sibling
+				// repair is real, surfaced work left undone, and the
+				// warnings counter (fed into both the --json output and the
+				// text summary line below) must reflect it either way, not
+				// just when the primary repair also happened to succeed.
+				warnings += siblingFailures
 				if repairErr != nil {
 					if jsonOutput {
 						// The PRIMARY row itself wasn't fixed (status/issues
@@ -424,6 +431,28 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 	return nil
 }
 
+// sourceMappedMod returns a copy of mod with GameID translated through the
+// game's per-source ID mapping (game.SourceIDs) - the same rule
+// Service.GetMod already applies (internal/core/service.go) before calling
+// into a source. Installed rows persist the LMM game ID (see
+// setupDoVerifyVersionTest and every InstalledMod fixture: GameID:
+// game.ID), but Service.GetModFiles does NOT translate it itself - unlike
+// GetMod, it forwards straight to the source. Sources like NexusMods
+// address games by their own domain (e.g. "skyrimspecialedition"), so any
+// direct svc.GetModFiles call driven off an installed row's mod.Mod (as
+// opposed to one already sourced from the source itself, e.g. a fresh
+// search result) needs this translation first or it silently queries the
+// wrong game. An empty mapping value means "this source applies to any
+// game" (e.g. directory sources: `donovan-mods: ""`) and must not blank
+// out the LMM ID - matches Service.GetMod's `ok && id != ""` guard exactly.
+func sourceMappedMod(game *domain.Game, mod *domain.Mod) *domain.Mod {
+	mapped := *mod
+	if id, ok := game.SourceIDs[mod.SourceID]; ok && id != "" {
+		mapped.GameID = id
+	}
+	return &mapped
+}
+
 // repairModVersion repairs a VERSION MISMATCH row for --fix (issue #94):
 // the recorded Version doesn't match what the stored file ID(s) actually
 // are upstream (effective), so the cache entry, DB row, and profile record
@@ -462,6 +491,13 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 //     failed - the primary's re-link outcome has no bearing on whether
 //     siblings were orphaned by the same rename.
 //
+// siblingFailures is the count of per-sibling failures from step 5 (a
+// pm.List failure counts as one), structurally propagated - not
+// string-matched out of note - so the caller can add it straight into its
+// own warnings counter. It's independent of err: siblingFailures can be
+// non-zero whether or not the PRIMARY row's own repair (this function's
+// err) succeeded, since a sibling's fate has no bearing on the primary's.
+//
 // mod is mutated in place (Version set to effective) only once the DB save
 // that carries it has actually succeeded, so a failure partway through
 // never leaves the in-memory row claiming a fix that didn't happen. If
@@ -474,29 +510,7 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 // isn't there. Clearing it at least keeps that one field honest so other
 // surfaces (status displays, a future `lmm deploy`, which redeploys every
 // enabled mod regardless of its recorded Deployed value) aren't misled.
-// sourceMappedMod returns a copy of mod with GameID translated through the
-// game's per-source ID mapping (game.SourceIDs) - the same rule
-// Service.GetMod already applies (internal/core/service.go) before calling
-// into a source. Installed rows persist the LMM game ID (see
-// setupDoVerifyVersionTest and every InstalledMod fixture: GameID:
-// game.ID), but Service.GetModFiles does NOT translate it itself - unlike
-// GetMod, it forwards straight to the source. Sources like NexusMods
-// address games by their own domain (e.g. "skyrimspecialedition"), so any
-// direct svc.GetModFiles call driven off an installed row's mod.Mod (as
-// opposed to one already sourced from the source itself, e.g. a fresh
-// search result) needs this translation first or it silently queries the
-// wrong game. An empty mapping value means "this source applies to any
-// game" (e.g. directory sources: `donovan-mods: ""`) and must not blank
-// out the LMM ID - matches Service.GetMod's `ok && id != ""` guard exactly.
-func sourceMappedMod(game *domain.Game, mod *domain.Mod) *domain.Mod {
-	mapped := *mod
-	if id, ok := game.SourceIDs[mod.SourceID]; ok && id != "" {
-		mapped.GameID = id
-	}
-	return &mapped
-}
-
-func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, profile string, mod *domain.InstalledMod, effective string) (note string, err error) {
+func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, profile string, mod *domain.InstalledMod, effective string) (note string, siblingFailures int, err error) {
 	recorded := mod.Version
 	gameCache := svc.GetGameCache(game)
 	oldPath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, recorded)
@@ -507,7 +521,7 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 		if _, statErr := os.Stat(newPath); statErr == nil {
 			note = fmt.Sprintf("cache entry for %s already exists; left %s in place", effective, recorded)
 		} else if renameErr := os.Rename(oldPath, newPath); renameErr != nil {
-			return "", fmt.Errorf("renaming cache entry: %w", renameErr)
+			return "", 0, fmt.Errorf("renaming cache entry: %w", renameErr)
 		} else {
 			renamed = true
 		}
@@ -516,7 +530,7 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 	updated := *mod
 	updated.Version = effective
 	if err := svc.SaveInstalledMod(&updated); err != nil {
-		return note, fmt.Errorf("saving installed mod: %w", err)
+		return note, 0, fmt.Errorf("saving installed mod: %w", err)
 	}
 	*mod = updated
 
@@ -527,7 +541,7 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 		Version:  effective,
 		FileIDs:  mod.FileIDs,
 	}); err != nil {
-		return note, fmt.Errorf("updating profile record: %w", err)
+		return note, 0, fmt.Errorf("updating profile record: %w", err)
 	}
 
 	// A blocked rename (note != "") leaves the existing deployment pointed
@@ -554,14 +568,14 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 	// renamed == true (the rename either happened or was blocked, never
 	// both) - a plain assignment is enough, no concatenation needed.
 	if renamed {
-		note = repairSiblingProfiles(cmd, svc, game, profile, mod, recorded, effective)
+		note, siblingFailures = repairSiblingProfiles(cmd, svc, game, profile, mod, recorded, effective)
 	}
 
 	if relinkErr != nil {
-		return note, relinkErr
+		return note, siblingFailures, relinkErr
 	}
 
-	return note, nil
+	return note, siblingFailures, nil
 }
 
 // repairSiblingProfiles corrects every OTHER profile's installed_mods row
@@ -609,8 +623,13 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 // Returns a human-readable summary of which profiles were repaired and/or
 // failed (empty if neither), for the caller to fold into repairModVersion's
 // own note - the --json contract's vehicle for surfacing this, per the
-// primary row's existing "note" field.
-func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.Game, currentProfile string, mod *domain.InstalledMod, recorded, effective string) string {
+// primary row's existing "note" field - and, structurally (not by
+// string-matching the note text), the count of per-sibling failures, so
+// the caller can add it straight into its own warnings counter: a failed
+// sibling repair is real, surfaced work left undone and must count as a
+// warning regardless of how the PRIMARY row's own repair turned out. A
+// pm.List failure counts as one.
+func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.Game, currentProfile string, mod *domain.InstalledMod, recorded, effective string) (note string, failedCount int) {
 	pm := getProfileManager(svc)
 	profiles, err := pm.List(game.ID)
 	if err != nil {
@@ -618,7 +637,7 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 		if !jsonOutput {
 			fmt.Printf("  Warning: %s\n", msg)
 		}
-		return "sibling repair check FAILED: " + msg
+		return "sibling repair check FAILED: " + msg, 1
 	}
 
 	var repaired, failed []string
@@ -703,7 +722,7 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 	if len(failed) > 0 {
 		parts = append(parts, fmt.Sprintf("repair FAILED in profile(s): %s", strings.Join(failed, ", ")))
 	}
-	return strings.Join(parts, "; ")
+	return strings.Join(parts, "; "), len(failed)
 }
 
 // redownloadModFile re-downloads a single mod file and extracts to cache, then updates checksum in DB.

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -869,7 +869,7 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 // redownloadModFile re-downloads a single mod file and extracts to cache, then updates checksum in DB.
 func redownloadModFile(cmd *cobra.Command, svc *core.Service, game *domain.Game, profile string, mod *domain.InstalledMod, fileID string) error {
 	ctx := cmd.Context()
-	files, err := svc.GetModFiles(ctx, mod.SourceID, &mod.Mod)
+	files, err := svc.GetModFiles(ctx, mod.SourceID, sourceMappedMod(game, &mod.Mod))
 	if err != nil {
 		return fmt.Errorf("getting mod files: %w", err)
 	}

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -279,7 +279,17 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 			if verifyFix && mod.SourceID != domain.SourceLocal {
 				note, repairErr := repairModVersion(cmd, svc, game, profile, mod, effective)
 				if repairErr != nil {
-					if !jsonOutput {
+					if jsonOutput {
+						// The PRIMARY row itself wasn't fixed (status/issues
+						// stay as already recorded above), but note can
+						// still carry a successful SIBLING repair - see
+						// repairModVersion's doc comment - and dropping it
+						// here would make that repair invisible to a --json
+						// caller even though it genuinely happened.
+						if note != "" {
+							jsonFiles[len(jsonFiles)-1].Note = note
+						}
+					} else {
 						fmt.Printf("  Repair failed: %v\n", repairErr)
 					}
 				} else {
@@ -515,15 +525,13 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 
 	// Sibling repair runs regardless of the primary re-link's own outcome
 	// (above) - a sibling row's orphaning is caused by the cache rename,
-	// not by anything that happens to the primary row's deployment.
+	// not by anything that happens to the primary row's deployment. note is
+	// always "" here: it's only ever set in the "blocked because a cache
+	// entry already exists" branch above, which is mutually exclusive with
+	// renamed == true (the rename either happened or was blocked, never
+	// both) - a plain assignment is enough, no concatenation needed.
 	if renamed {
-		if siblingNote := repairSiblingProfiles(cmd, svc, game, profile, mod, recorded, effective); siblingNote != "" {
-			if note == "" {
-				note = siblingNote
-			} else {
-				note = note + "; " + siblingNote
-			}
-		}
+		note = repairSiblingProfiles(cmd, svc, game, profile, mod, recorded, effective)
 	}
 
 	if relinkErr != nil {
@@ -553,18 +561,31 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 // primary row's own re-link-failure handling) and processing continues
 // with the remaining siblings rather than aborting the whole pass.
 //
-// Returns a human-readable summary of which profiles were repaired (empty
-// if none), for the caller to fold into repairModVersion's own note - the
-// --json contract's vehicle for surfacing this, per the primary row's
-// existing "note" field.
+// Per DEV.md's "never swallow errors without logging/context": a failure
+// to correct one sibling (pm.List itself, or a given sibling's
+// SaveInstalledMod/UpsertMod) is NOT silently skipped - it's printed as a
+// warning in text mode and folded into the returned summary, since a
+// write failure here leaves that profile in exactly the orphaned state
+// this whole repair exists to fix, indistinguishable from "was never a
+// candidate" if left unreported. The loop still continues past a single
+// sibling's failure - best-effort, not all-or-nothing.
+//
+// Returns a human-readable summary of which profiles were repaired and/or
+// failed (empty if neither), for the caller to fold into repairModVersion's
+// own note - the --json contract's vehicle for surfacing this, per the
+// primary row's existing "note" field.
 func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.Game, currentProfile string, mod *domain.InstalledMod, recorded, effective string) string {
 	pm := getProfileManager(svc)
 	profiles, err := pm.List(game.ID)
 	if err != nil {
-		return ""
+		msg := fmt.Sprintf("could not enumerate profiles to check for shared-cache siblings: %v", err)
+		if !jsonOutput {
+			fmt.Printf("  Warning: %s\n", msg)
+		}
+		return "sibling repair check FAILED: " + msg
 	}
 
-	var repaired []string
+	var repaired, failed []string
 	for _, p := range profiles {
 		if p.Name == currentProfile {
 			continue
@@ -578,6 +599,10 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 		updated := *sibling
 		updated.Version = effective
 		if err := svc.SaveInstalledMod(&updated); err != nil {
+			failed = append(failed, fmt.Sprintf("%s (%v)", p.Name, err))
+			if !jsonOutput {
+				fmt.Printf("  Warning: could not repair profile %s: %v\n", p.Name, err)
+			}
 			continue
 		}
 		*sibling = updated
@@ -588,6 +613,10 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 			Version:  effective,
 			FileIDs:  sibling.FileIDs,
 		}); err != nil {
+			failed = append(failed, fmt.Sprintf("%s (%v)", p.Name, err))
+			if !jsonOutput {
+				fmt.Printf("  Warning: could not repair profile %s: %v\n", p.Name, err)
+			}
 			continue
 		}
 
@@ -604,10 +633,14 @@ func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.G
 		}
 	}
 
-	if len(repaired) == 0 {
-		return ""
+	var parts []string
+	if len(repaired) > 0 {
+		parts = append(parts, fmt.Sprintf("also repaired in profile(s): %s", strings.Join(repaired, ", ")))
 	}
-	return fmt.Sprintf("also repaired in profile(s): %s", strings.Join(repaired, ", "))
+	if len(failed) > 0 {
+		parts = append(parts, fmt.Sprintf("repair FAILED in profile(s): %s", strings.Join(failed, ", ")))
+	}
+	return strings.Join(parts, "; ")
 }
 
 // redownloadModFile re-downloads a single mod file and extracts to cache, then updates checksum in DB.

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -170,9 +170,10 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 	gameCache := svc.GetGameCache(game)
 	var issues, warnings int
 	// checked mixes two counters: per-FILE increments from the main loop
-	// below and per-MOD skip/ok increments from the version-record pre-pass
-	// above it - both feed the same "no files found" zero-check, so neither
-	// needed its own variable.
+	// below and per-MOD increments from the version-record pre-pass - and
+	// the pre-pass only counts its quiet-OK path (recorded version matches);
+	// its skip/mismatch paths continue without counting. Both feed the same
+	// "no files found" zero-check, so neither needed its own variable.
 	var checked int
 	var jsonFiles []verifyFileJSON
 

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -31,7 +31,7 @@ type verifyFileJSON struct {
 	ModName string `json:"mod_name"`
 	FileID  string `json:"file_id"`
 	Status  string `json:"status"`         // ok, missing, no_checksum, file_count_mismatch, skipped, version_mismatch, version_unverifiable
-	Note    string `json:"note,omitempty"` // optional detail; currently only set by a --fix VERSION MISMATCH repair whose cache rename was skipped because the effective-version cache dir already existed
+	Note    string `json:"note,omitempty"` // optional detail; set by a --fix VERSION MISMATCH repair whose cache rename was skipped because the effective-version cache dir already existed, and/or which also repaired the same mod's stale record in other profiles sharing the cache
 }
 
 var verifyCmd = &cobra.Command{
@@ -81,17 +81,23 @@ under the effective version, the rename is skipped - the existing
 deployment is left pointing at the still-intact recorded-version cache
 dir rather than being re-linked into the unverified pre-existing one -
 and a note is printed (also included as "note" in --json output), but
-the DB and profile are still corrected. VERSION UNVERIFIABLE is never
-fixable automatically since there is no matching upstream file to compare
-against - reinstall the mod instead.
+the DB and profile are still corrected. Since the mod cache is shared
+across profiles, a successful rename also corrects any OTHER profile
+whose record still holds the same stale version (DB, profile record, and
+re-linking a symlink deployment the same way) - printed as its own
+"Repaired (profile ...)" line per profile in text mode, or folded into
+the "note" field as "also repaired in profile(s): ..." in --json.
+VERSION UNVERIFIABLE is never fixable automatically since there is no
+matching upstream file to compare against - reinstall the mod instead.
 
 --json emits {game_id, profile, files: [{mod_id, mod_name, file_id,
 status, note}], issues, warnings}; status is one of "ok", "missing",
 "no_checksum", "file_count_mismatch", "skipped", "version_mismatch", or
 "version_unverifiable"; note is omitted except on a --fix VERSION
-MISMATCH repair whose cache rename was skipped. issues counts MISSING
-files and VERSION MISMATCH rows (a successful --fix repair of either
-decrements it back out); warnings counts everything else that isn't OK.
+MISMATCH repair whose cache rename was skipped, or which also repaired
+the same mod in other profiles. issues counts MISSING files and VERSION
+MISMATCH rows (a successful --fix repair of either decrements it back
+out); warnings counts everything else that isn't OK.
 
 Examples:
   lmm verify --game skyrim-se           # Verify all mods
@@ -157,6 +163,10 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 
 	gameCache := svc.GetGameCache(game)
 	var issues, warnings int
+	// checked mixes two counters: per-FILE increments from the main loop
+	// below and per-MOD skip/ok increments from the version-record pre-pass
+	// above it - both feed the same "no files found" zero-check, so neither
+	// needed its own variable.
 	var checked int
 	var jsonFiles []verifyFileJSON
 
@@ -429,6 +439,17 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 //     now dangling - re-run the installer to refresh them. Hardlink/copy
 //     deployments are untouched by the cache rename, so they're left
 //     alone regardless.
+//  5. Sibling profiles: only when step 1 actually renamed the cache dir
+//     (the shared-cache-dir orphaning this step exists to fix can only
+//     happen then - a blocked or skipped rename leaves every profile's
+//     view of the cache untouched). Every OTHER profile's installed_mods
+//     row for the same (SourceID, ModID, GameID) whose Version still
+//     equals the OLD recorded version is corrected the same way (DB +
+//     profile YAML), and re-linked if Deployed via symlink - see
+//     repairSiblingProfiles. Runs unconditionally once step 1 has renamed
+//     the cache, even if step 4 above (the PRIMARY row's own re-link)
+//     failed - the primary's re-link outcome has no bearing on whether
+//     siblings were orphaned by the same rename.
 //
 // mod is mutated in place (Version set to effective) only once the DB save
 // that carries it has actually succeeded, so a failure partway through
@@ -443,15 +464,19 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 // surfaces (status displays, a future `lmm deploy`, which redeploys every
 // enabled mod regardless of its recorded Deployed value) aren't misled.
 func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, profile string, mod *domain.InstalledMod, effective string) (note string, err error) {
+	recorded := mod.Version
 	gameCache := svc.GetGameCache(game)
-	oldPath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
+	oldPath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, recorded)
 	newPath := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, effective)
 
+	var renamed bool
 	if _, statErr := os.Stat(oldPath); statErr == nil {
 		if _, statErr := os.Stat(newPath); statErr == nil {
-			note = fmt.Sprintf("cache entry for %s already exists; left %s in place", effective, mod.Version)
+			note = fmt.Sprintf("cache entry for %s already exists; left %s in place", effective, recorded)
 		} else if renameErr := os.Rename(oldPath, newPath); renameErr != nil {
 			return "", fmt.Errorf("renaming cache entry: %w", renameErr)
+		} else {
+			renamed = true
 		}
 	}
 
@@ -476,17 +501,113 @@ func repairModVersion(cmd *cobra.Command, svc *core.Service, game *domain.Game, 
 	// at the still-intact recorded-version cache dir - nothing dangles, so
 	// re-linking would only repoint a working deployment into the
 	// unvetted pre-existing effective-version dir for no reason.
+	var relinkErr error
 	if note == "" && mod.Deployed && mod.LinkMethod == domain.LinkSymlink {
 		if err := svc.GetInstaller(game).Install(cmd.Context(), game, &mod.Mod, profile); err != nil {
 			mod.Deployed = false
 			if saveErr := svc.SaveInstalledMod(mod); saveErr != nil {
-				return note, fmt.Errorf("relinking deployed files: %w (also failed to clear deployed flag: %v)", err, saveErr)
+				relinkErr = fmt.Errorf("relinking deployed files: %w (also failed to clear deployed flag: %v)", err, saveErr)
+			} else {
+				relinkErr = fmt.Errorf("relinking deployed files: %w", err)
 			}
-			return note, fmt.Errorf("relinking deployed files: %w", err)
 		}
 	}
 
+	// Sibling repair runs regardless of the primary re-link's own outcome
+	// (above) - a sibling row's orphaning is caused by the cache rename,
+	// not by anything that happens to the primary row's deployment.
+	if renamed {
+		if siblingNote := repairSiblingProfiles(cmd, svc, game, profile, mod, recorded, effective); siblingNote != "" {
+			if note == "" {
+				note = siblingNote
+			} else {
+				note = note + "; " + siblingNote
+			}
+		}
+	}
+
+	if relinkErr != nil {
+		return note, relinkErr
+	}
+
 	return note, nil
+}
+
+// repairSiblingProfiles corrects every OTHER profile's installed_mods row
+// for the same (SourceID, ModID, GameID) that still records the OLD
+// (pre-repair) version, after repairModVersion has renamed the shared
+// cache dir out from under them - cache.ModPath has no profile segment
+// (internal/storage/cache/cache.go:29), so a rename done for one profile's
+// row silently orphans any sibling profile still pointing at the old
+// version, until that sibling is itself verified. Only called when a
+// rename actually happened; a blocked/skipped rename never orphans
+// anything, so siblings are left alone in that case.
+//
+// Sibling rows whose Version differs from recorded are a different state
+// entirely (not something this repair caused) and are left untouched, per
+// the same DB-load-mutate-save pattern the primary path uses (never
+// UpdateModVersion, which would poison PreviousVersion/rollback). A
+// sibling Deployed via symlink has its links re-created through the
+// installer exactly like the primary row's would be; on a per-sibling
+// re-link failure, that row's Deployed flag alone is cleared (matching the
+// primary row's own re-link-failure handling) and processing continues
+// with the remaining siblings rather than aborting the whole pass.
+//
+// Returns a human-readable summary of which profiles were repaired (empty
+// if none), for the caller to fold into repairModVersion's own note - the
+// --json contract's vehicle for surfacing this, per the primary row's
+// existing "note" field.
+func repairSiblingProfiles(cmd *cobra.Command, svc *core.Service, game *domain.Game, currentProfile string, mod *domain.InstalledMod, recorded, effective string) string {
+	pm := getProfileManager(svc)
+	profiles, err := pm.List(game.ID)
+	if err != nil {
+		return ""
+	}
+
+	var repaired []string
+	for _, p := range profiles {
+		if p.Name == currentProfile {
+			continue
+		}
+
+		sibling, err := svc.GetInstalledMod(mod.SourceID, mod.ID, game.ID, p.Name)
+		if err != nil || sibling.Version != recorded {
+			continue
+		}
+
+		updated := *sibling
+		updated.Version = effective
+		if err := svc.SaveInstalledMod(&updated); err != nil {
+			continue
+		}
+		*sibling = updated
+
+		if err := pm.UpsertMod(game.ID, p.Name, domain.ModReference{
+			SourceID: sibling.SourceID,
+			ModID:    sibling.ID,
+			Version:  effective,
+			FileIDs:  sibling.FileIDs,
+		}); err != nil {
+			continue
+		}
+
+		if sibling.Deployed && sibling.LinkMethod == domain.LinkSymlink {
+			if err := svc.GetInstaller(game).Install(cmd.Context(), game, &sibling.Mod, p.Name); err != nil {
+				sibling.Deployed = false
+				_ = svc.SaveInstalledMod(sibling) //nolint:errcheck // best-effort: the version correction above already stands regardless
+			}
+		}
+
+		repaired = append(repaired, p.Name)
+		if !jsonOutput {
+			fmt.Printf("  %s\n", colorGreen(fmt.Sprintf("Repaired (profile %s): %s → %s", p.Name, recorded, effective)))
+		}
+	}
+
+	if len(repaired) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("also repaired in profile(s): %s", strings.Join(repaired, ", "))
 }
 
 // redownloadModFile re-downloads a single mod file and extracts to cache, then updates checksum in DB.

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -163,6 +164,43 @@ func TestDoVerify_VersionUnverifiable_ReportedAsWarning(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected a version_unverifiable entry in JSON files: %+v", result.Files)
+}
+
+// TestDoVerify_VersionCheck_SourceUnreachable_JSONNotesReason guards PR
+// #128 Copilot round-6's suppressed finding: when svc.GetModFiles fails in
+// the version-record pre-pass (the "source unreachable" case), --json
+// emitted a "skipped" row with the error dropped entirely, while text mode
+// at least printed "could not check version (source unreachable)" - a
+// --json caller had no way to see WHY. Forces the failure via
+// fakeInstallSource.getModFilesErr (a real error the fake source itself
+// returns, not a permission trick, since this is a source-layer failure).
+func TestDoVerify_VersionCheck_SourceUnreachable_JSONNotesReason(t *testing.T) {
+	cmd, svc, game, src := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+		{ID: "2", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.0"},
+	})
+	src.getModFilesErr = errors.New("connection refused")
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	assert.Equal(t, 0, result.Issues, "source-unreachable is a warning, not an issue")
+	assert.Equal(t, 1, result.Warnings, "the warnings count must be unaffected by adding the note")
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.FileID == "" {
+			found = true
+			assert.Equal(t, "skipped", f.Status, "status must stay skipped")
+			assert.Contains(t, f.Note, "connection refused", "the source-unreachable reason must reach the JSON note, not just the text-mode line")
+		}
+	}
+	assert.True(t, found, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
 }
 
 // TestDoVerify_VersionCheck_MapsGameIDPerSourceMapping guards PR #128

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -1,9 +1,16 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVerifyCommand_Exists(t *testing.T) {
@@ -30,4 +37,124 @@ func TestVerifyCommand_AcceptsOptionalModID(t *testing.T) {
 
 	// Command should accept 0 or 1 arguments
 	assert.Contains(t, verifyCmd.Use, "[mod-id]")
+}
+
+// --- doVerify version-record check (issue #94, Task A6) ---
+//
+// setupDoVerifyVersionTest seeds a fakeInstallSource-backed service with a
+// single installed mod row (SourceID "test-src", ModID "mod1") whose
+// recorded Version/FileIDs the caller controls, plus a matching cache entry
+// and stored checksum so the pre-existing file-count/checksum checks in
+// doVerify report clean ("ok") and don't add noise to issues/warnings -
+// isolating the new version-record pre-pass as the only thing under test.
+// sourceFiles is what the fake source's GetModFiles returns for mod1 (the
+// upstream truth the check compares FileIDs against).
+func setupDoVerifyVersionTest(t *testing.T, recordedVersion string, fileIDs []string, sourceFiles []domain.DownloadableFile) (*cobra.Command, *core.Service, *domain.Game) {
+	t.Helper()
+
+	svc, game, src := setupDoInstallTest(t)
+
+	src.AddMod(&domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: recordedVersion, GameID: game.ID}, sourceFiles)
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:         domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: recordedVersion, GameID: game.ID},
+		ProfileName: "default",
+		Enabled:     true,
+		FileIDs:     fileIDs,
+	}))
+
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, "test-src", "mod1", recordedVersion, "mod1.esp", []byte("plugin content")))
+	for _, id := range fileIDs {
+		require.NoError(t, svc.SaveFileChecksum("test-src", "mod1", game.ID, "default", id, "deadbeef"))
+	}
+
+	verifyProfile = "default"
+	t.Cleanup(func() { verifyProfile = "" })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	return cmd, svc, game
+}
+
+// TestDoVerify_VersionMismatch_ReportedAsIssue guards issue #94's detection
+// half: an installed row recorded as version "1.5" whose stored file ID
+// "2" is, per the source, actually version "1.0" - the version of the bytes
+// really on disk. doVerify must flag this as "version_mismatch" (an issue,
+// not a warning) and show both the recorded and source-reported values, in
+// both text and --json output. Task A7 adds the --fix repair; this task is
+// detection only.
+func TestDoVerify_VersionMismatch_ReportedAsIssue(t *testing.T) {
+	cmd, svc, game := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+		{ID: "2", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.0"},
+	})
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "1.5", "text must show the recorded version")
+	assert.Contains(t, out, "1.0", "text must show the source-reported (effective) version")
+	assert.Contains(t, out, "1 issue(s)")
+	assert.NotContains(t, out, "0 issue(s)")
+
+	jsonOutput = true
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	assert.Equal(t, 1, result.Issues, "version mismatch must be bucketed as an issue")
+	assert.Equal(t, 0, result.Warnings)
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.Status == "version_mismatch" {
+			found = true
+			assert.Empty(t, f.FileID, "FileID left empty per brief - fix branch fills it in later")
+		}
+	}
+	assert.True(t, found, "expected a version_mismatch entry in JSON files: %+v", result.Files)
+}
+
+// TestDoVerify_VersionUnverifiable_ReportedAsWarning guards the other half:
+// when the source no longer lists the stored file ID at all (superseded/
+// removed upstream), doVerify can't compute an effective version to compare
+// against, so it must report "version_unverifiable" as a warning (not an
+// issue - there is nothing to definitively repair) rather than silently
+// treating it as OK or crashing.
+func TestDoVerify_VersionUnverifiable_ReportedAsWarning(t *testing.T) {
+	cmd, svc, game := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+		{ID: "3", Name: "Some Other File", FileName: "mod1-other.esp", IsPrimary: true, Category: "MAIN", Version: "2.0"},
+	})
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "1 warning(s)")
+
+	jsonOutput = true
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	assert.Equal(t, 0, result.Issues)
+	assert.Equal(t, 1, result.Warnings, "unverifiable version must be bucketed as a warning, not an issue")
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.Status == "version_unverifiable" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected a version_unverifiable entry in JSON files: %+v", result.Files)
 }

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -493,3 +493,284 @@ func TestDoVerify_Fix_VersionMismatch_Deployed_RelinkFails_ClearsDeployedFlag(t 
 	require.NoError(t, err)
 	assert.False(t, mod2.Deployed, "Deployed must still read false on the second run - nothing re-marks it deployed on its own")
 }
+
+// TestDoVerify_Fix_VersionMismatch_RenameFails_LeavesRecordUnchanged guards
+// the "os.Rename itself fails" branch of repairModVersion (as opposed to
+// scenario (c) above, where the rename is deliberately skipped because the
+// destination already exists) - a genuine filesystem error mid-rename. This
+// is the ordering invariant the whole repair sequence depends on: no DB
+// write may happen unless the cache rename actually succeeded, or the DB
+// and cache would disagree in a NEW way. Forces the failure by chmod-ing
+// the cache mod-key's parent directory (which holds the "1.5" dir and
+// would receive the renamed "1.0" one) read-only - os.Rename needs write
+// permission on the containing directory to unlink/relink an entry, even
+// though the directory is still readable/listable (execute bit intact).
+func TestDoVerify_Fix_VersionMismatch_RenameFails_LeavesRecordUnchanged(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game := setupDoVerifyFixTest(t, false)
+
+	gameCache := svc.GetGameCache(game)
+	oldPath := gameCache.ModPath(game.ID, "test-src", "mod1", "1.5")
+	parentDir := filepath.Dir(oldPath)
+
+	require.NoError(t, os.Chmod(parentDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(parentDir, 0o755) }) // restore before TempDir's own cleanup removes it
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	assert.Equal(t, 1, result.Issues, "a failed rename must not repair the row - the issue must still be counted")
+
+	mod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.5", mod.Version, "DB row must still hold the OLD version - no write happens when the rename itself fails")
+
+	assert.True(t, gameCache.Exists(game.ID, "test-src", "mod1", "1.5"), "old cache dir must be untouched under the old key")
+	assert.False(t, gameCache.Exists(game.ID, "test-src", "mod1", "1.0"), "no new cache dir must have been created under the effective key")
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.FileID == "" {
+			found = true
+			assert.Equal(t, "version_mismatch", f.Status, "JSON row must stay version_mismatch when the rename fails")
+		}
+	}
+	assert.True(t, found, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
+}
+
+// --- doVerify --fix repairs sibling-profile rows sharing the same cache dir
+// (final-fix-wave Finding 1) ---
+//
+// The mod cache is shared across profiles (cache.ModPath has no profile
+// segment - internal/storage/cache/cache.go:29) but installed_mods rows are
+// per-profile. When repairModVersion renames the shared cache dir for one
+// profile's row, a sibling profile holding the same mod at the same wrong
+// recorded version is left pointing at the now-missing dir until it, too,
+// is verified. setupDoVerifyFixSiblingTest builds on setupDoVerifyFixTest's
+// "default"-profile mismatch (recorded "1.5", effective "1.0") and adds:
+//   - "second": the SAME wrong recorded version ("1.5") - the sibling this
+//     fix must also correct.
+//   - "third": a DIFFERENT recorded version ("2.0") - a different state
+//     that must be left untouched (its own verify run's problem).
+func setupDoVerifyFixSiblingTest(t *testing.T) (*cobra.Command, *core.Service, *domain.Game) {
+	t.Helper()
+
+	cmd, svc, game := setupDoVerifyFixTest(t, false)
+
+	pm := getProfileManager(svc)
+
+	_, err := pm.Create(game.ID, "second")
+	require.NoError(t, err)
+	require.NoError(t, pm.AddMod(game.ID, "second", domain.ModReference{
+		SourceID: "test-src", ModID: "mod1", Version: "1.5", FileIDs: []string{"2"},
+	}))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:         domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: "1.5", GameID: game.ID},
+		ProfileName: "second",
+		Enabled:     true,
+		FileIDs:     []string{"2"},
+	}))
+
+	_, err = pm.Create(game.ID, "third")
+	require.NoError(t, err)
+	require.NoError(t, pm.AddMod(game.ID, "third", domain.ModReference{
+		SourceID: "test-src", ModID: "mod1", Version: "2.0", FileIDs: []string{"2"},
+	}))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:         domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: "2.0", GameID: game.ID},
+		ProfileName: "third",
+		Enabled:     true,
+		FileIDs:     []string{"2"},
+	}))
+
+	return cmd, svc, game
+}
+
+// TestDoVerify_Fix_VersionMismatch_SiblingProfile_NotDeployed_RepairsRecord
+// is the required end-to-end case: fixing the mismatch via the "default"
+// profile must also correct "second" (same stale recorded version) in both
+// the DB and its profile YAML ref, while leaving "third" (a different
+// recorded version) completely alone.
+func TestDoVerify_Fix_VersionMismatch_SiblingProfile_NotDeployed_RepairsRecord(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	assert.Equal(t, 0, result.Issues)
+
+	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", secondMod.Version, "sibling DB row must be corrected to the effective version")
+
+	pm := getProfileManager(svc)
+	secondProfile, err := pm.Get(game.ID, "second")
+	require.NoError(t, err)
+	found := false
+	for _, ref := range secondProfile.Mods {
+		if ref.SourceID == "test-src" && ref.ModID == "mod1" {
+			found = true
+			assert.Equal(t, "1.0", ref.Version, "sibling profile YAML ref must be corrected")
+		}
+	}
+	assert.True(t, found, "expected a mod1 ref in the second profile: %+v", secondProfile.Mods)
+
+	thirdMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "third")
+	require.NoError(t, err)
+	assert.Equal(t, "2.0", thirdMod.Version, "sibling with a different recorded version must not be touched")
+
+	thirdProfile, err := pm.Get(game.ID, "third")
+	require.NoError(t, err)
+	for _, ref := range thirdProfile.Mods {
+		if ref.SourceID == "test-src" && ref.ModID == "mod1" {
+			assert.Equal(t, "2.0", ref.Version, "sibling profile with a different recorded version must not be touched")
+		}
+	}
+
+	noteFound := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.FileID == "" {
+			noteFound = true
+			assert.Contains(t, f.Note, "second", "note must mention the repaired sibling profile")
+			assert.NotContains(t, f.Note, "third", "note must not mention the untouched, differently-versioned sibling")
+		}
+	}
+	assert.True(t, noteFound, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
+}
+
+// TestDoVerify_Fix_VersionMismatch_SiblingProfile_PrintsRepairedLine covers
+// the text-mode side: a dedicated "Repaired (profile ...)" line per
+// repaired sibling, distinct from the primary row's own "Repaired: ..."
+// line.
+func TestDoVerify_Fix_VersionMismatch_SiblingProfile_PrintsRepairedLine(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	assert.Contains(t, out, "Repaired")
+	assert.Contains(t, out, "second", "text output must mention the repaired sibling profile by name")
+}
+
+// TestDoVerify_Fix_VersionMismatch_RenameBlocked_SiblingsUntouched guards
+// the "keep blocked-rename semantics unchanged" requirement: when the cache
+// rename itself is blocked (destination already exists), no physical
+// rename happened, so sibling rows must be left exactly as they were - they
+// aren't orphaned by anything, so there's nothing to fix.
+func TestDoVerify_Fix_VersionMismatch_RenameBlocked_SiblingsUntouched(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, "test-src", "mod1", "1.0", "mod1.esp", []byte("pre-existing 1.0 content")))
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "Note")
+
+	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
+	require.NoError(t, err)
+	assert.Equal(t, "1.5", secondMod.Version, "sibling must be untouched when the cache rename itself was blocked")
+}
+
+// TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_Relinks guards
+// the deployed-sibling variant: a sibling row marked Deployed via symlink
+// has its links re-created through the installer exactly like the primary
+// row's would be, once the shared cache dir has actually moved.
+func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_Relinks(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
+	require.NoError(t, err)
+	secondMod.Deployed = true
+	secondMod.LinkMethod = domain.LinkSymlink
+	require.NoError(t, svc.SaveInstalledMod(secondMod))
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	assert.Equal(t, 0, result.Issues)
+
+	deployedPath := filepath.Join(game.ModPath, "mod1.esp")
+	info, err := os.Lstat(deployedPath)
+	require.NoError(t, err, "sibling's deployed symlink must have been (re-)created")
+	assert.True(t, info.Mode()&os.ModeSymlink != 0, "sibling deployment must be a symlink")
+
+	content, err := os.ReadFile(deployedPath)
+	require.NoError(t, err, "sibling symlink must resolve, not dangle")
+	assert.Equal(t, "plugin content", string(content))
+
+	afterMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
+	require.NoError(t, err)
+	assert.True(t, afterMod.Deployed, "Deployed remains true after a successful sibling re-link")
+}
+
+// TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_ClearsDeployedFlag
+// mirrors TestDoVerify_Fix_VersionMismatch_Deployed_RelinkFails_ClearsDeployedFlag
+// for a sibling row: when the sibling's own re-link fails, its Deployed
+// flag must be cleared - same honesty guarantee as the primary path - while
+// the version correction (DB + profile) from the earlier steps still
+// stands, for both the sibling AND the primary.
+func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_ClearsDeployedFlag(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
+	require.NoError(t, err)
+	secondMod.Deployed = true
+	secondMod.LinkMethod = domain.LinkSymlink
+	require.NoError(t, svc.SaveInstalledMod(secondMod))
+
+	require.NoError(t, os.Chmod(game.ModPath, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(game.ModPath, 0o755) }) // restore before TempDir's own cleanup removes it
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	_ = captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	afterMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", afterMod.Version, "the sibling's version correction must stand even though its re-link failed")
+	assert.False(t, afterMod.Deployed, "sibling Deployed must be cleared when its re-link fails")
+
+	primaryMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", primaryMod.Version, "the primary row must still be repaired despite the sibling's re-link failure")
+}

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -351,3 +351,145 @@ func TestDoVerify_Fix_VersionMismatch_RenameBlocked_StillFixesDB(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "1.0", mod.Version, "DB row must still be corrected even when the cache rename is blocked")
 }
+
+// TestDoVerify_Fix_VersionMismatch_RenameBlocked_JSONExposesNote guards the
+// --json half of the rename-blocked case: the text-mode "Note: ..." line
+// has no JSON equivalent unless the row itself carries it, so a --json
+// caller flipping a row from version_mismatch to ok has no way to tell a
+// clean repair from one where the cache rename was skipped. The repaired
+// row's "note" field must carry that detail.
+func TestDoVerify_Fix_VersionMismatch_RenameBlocked_JSONExposesNote(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixTest(t, false)
+
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, "test-src", "mod1", "1.0", "mod1.esp", []byte("pre-existing 1.0 content")))
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+
+	// FileID is empty specifically on the version-record pre-pass's own
+	// entry (the one this repair flips from version_mismatch to ok) - the
+	// later per-file loop emits its own separate "ok" entry for mod1 with
+	// FileID "2" that never carried a note, so filtering on FileID avoids
+	// asserting Note against the wrong entry.
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.FileID == "" {
+			found = true
+			assert.Equal(t, "ok", f.Status)
+			assert.NotEmpty(t, f.Note, "the blocked-rename note must be visible in JSON, not just text output")
+		}
+	}
+	assert.True(t, found, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
+}
+
+// TestDoVerify_Fix_VersionMismatch_RenameBlocked_Deployed_LeavesWorkingSymlinkAlone
+// guards the other half of the rename-blocked case: when the mod is
+// Deployed via symlink and the rename is blocked, the CURRENT symlink
+// still points at the intact recorded-version cache dir - it was never
+// touched by a rename. Re-linking in this case would repoint a working
+// deployment into the pre-existing effective-version dir, which is
+// unvetted (it's realistically a stray or partial copy, the very reason
+// the rename was blocked in the first place). --fix must leave it alone.
+func TestDoVerify_Fix_VersionMismatch_RenameBlocked_Deployed_LeavesWorkingSymlinkAlone(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixTest(t, true)
+
+	deployedPath := filepath.Join(game.ModPath, "mod1.esp")
+	preTarget, err := os.Readlink(deployedPath)
+	require.NoError(t, err)
+	require.Contains(t, preTarget, filepath.Join("test-src-mod1", "1.5"), "pre-state: deployed symlink points at the recorded-version cache dir")
+
+	gameCache := svc.GetGameCache(game)
+	// Pre-create the new-version cache dir with different content than the
+	// old dir, so a wrongful re-link would be observable via content, not
+	// just path.
+	require.NoError(t, gameCache.Store(game.ID, "test-src", "mod1", "1.0", "mod1.esp", []byte("unvetted 1.0 content")))
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "Note")
+
+	postTarget, err := os.Readlink(deployedPath)
+	require.NoError(t, err)
+	assert.Equal(t, preTarget, postTarget, "the deployment must still point at the original (intact) recorded-version cache dir, not be re-linked into the unvetted pre-existing one")
+
+	content, err := os.ReadFile(deployedPath)
+	require.NoError(t, err)
+	assert.Equal(t, "plugin content", string(content), "the working deployment's content must be untouched")
+
+	mod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", mod.Version, "DB is still corrected even though the deployment was left alone")
+	assert.True(t, mod.Deployed, "Deployed must remain true - the existing deployment is still valid")
+}
+
+// TestDoVerify_Fix_VersionMismatch_Deployed_RelinkFails_ClearsDeployedFlag
+// guards Important-1 from code review: once the cache re-key (step 1) and
+// DB save (step 2) succeed, mod.Version == effective - a LATER
+// `verify --fix` run can no longer detect a version_mismatch to retry,
+// even if the re-link (step 4) then fails and leaves the game-dir symlink
+// dangling. Leaving Deployed stuck at true in that case would have the DB
+// silently claim a working deployment that doesn't exist, with no way for
+// verify to ever flag it again. --fix must clear Deployed instead, so the
+// DB stays honest even though the specific version_mismatch signal that
+// triggered the repair is gone for good.
+func TestDoVerify_Fix_VersionMismatch_Deployed_RelinkFails_ClearsDeployedFlag(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game := setupDoVerifyFixTest(t, true)
+
+	// Force the re-link's installer.Install to fail: strip write
+	// permission from the game dir (which already holds the pre-fix
+	// symlink), so linker.Deploy's os.Remove(dst)/os.Symlink can't
+	// replace the stale entry.
+	require.NoError(t, os.Chmod(game.ModPath, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(game.ModPath, 0o755) }) // restore before TempDir's own cleanup removes it
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "Repair failed", "the re-link failure must be surfaced, not silently swallowed")
+
+	// Steps 1-3 (cache rename, DB save, profile upsert) already completed
+	// before the re-link failed, so the version correction stands.
+	mod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", mod.Version, "the version correction from steps 1-3 must stand even though step 4 failed")
+
+	// The state must not self-erase from detection: Deployed is cleared
+	// rather than left claiming a deployment that's actually dangling.
+	assert.False(t, mod.Deployed, "Deployed must be cleared when the re-link fails")
+
+	// A second run confirms the row is inert (not re-reported, not
+	// re-counted) rather than stuck retrying forever or erroring - the
+	// version_mismatch signal is genuinely gone; Deployed=false is the
+	// only remaining honest trace that the deployment still needs
+	// attention (e.g. via a subsequent `lmm deploy`, which redeploys every
+	// enabled mod regardless of its recorded Deployed value).
+	out2 := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.NotContains(t, out2, "VERSION MISMATCH", "the version is already corrected - a second run must not re-report it")
+
+	mod2, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.False(t, mod2.Deployed, "Deployed must still read false on the second run - nothing re-marks it deployed on its own")
+}

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -596,6 +596,42 @@ func setupDoVerifyFixSiblingTest(t *testing.T) (*cobra.Command, *core.Service, *
 	return cmd, svc, game
 }
 
+// TestDoVerify_Fix_VersionMismatch_SiblingProfile_NotInstalled_SkippedSilently
+// pins Copilot round-2's (suppressed, no inline thread) low-confidence
+// finding: repairSiblingProfiles must distinguish "this profile never had
+// the mod at all" (svc.GetInstalledMod returning domain.ErrModNotFound)
+// from a genuine lookup failure - the former is not a candidate and must
+// stay a silent skip (no warning, not in the failed list), unlike any
+// OTHER GetInstalledMod error, which the production code now surfaces the
+// same way as a SaveInstalledMod/UpsertMod/re-link failure. Adds a
+// "fourth" profile that exists (so pm.List finds it) but was never given
+// an InstalledMod row for mod1 at all - distinct from "third" (which DOES
+// have a row, just at a different recorded version, exercising the
+// `sibling.Version != recorded` branch instead).
+func TestDoVerify_Fix_VersionMismatch_SiblingProfile_NotInstalled_SkippedSilently(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	pm := getProfileManager(svc)
+	_, err := pm.Create(game.ID, "fourth")
+	require.NoError(t, err)
+	// Deliberately no pm.AddMod / svc.SaveInstalledMod for mod1 in "fourth" -
+	// it's a profile that exists but never had this mod installed.
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	assert.NotContains(t, out, "fourth", "a profile that never had the mod must be a silent skip - no warning, no mention at all")
+	assert.NotContains(t, out, "Warning", "the not-installed case must not be reported as a failure")
+
+	_, err = svc.GetInstalledMod("test-src", "mod1", game.ID, "fourth")
+	assert.ErrorIs(t, err, domain.ErrModNotFound, "sanity: 'fourth' genuinely has no row for mod1 - this is the ErrModNotFound path, not a different bug")
+}
+
 // TestDoVerify_Fix_VersionMismatch_SiblingProfile_NotDeployed_RepairsRecord
 // is the required end-to-end case: fixing the mismatch via the "default"
 // profile must also correct "second" (same stale recorded version) in both

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -228,6 +228,43 @@ func TestDoVerify_VersionCheck_EmptySourceMapping_KeepsLMMGameID(t *testing.T) {
 	assert.Equal(t, game.ID, src.receivedGameFileIDs[0], "an empty per-source mapping must keep the LMM game ID, not blank it out")
 }
 
+// TestDoVerify_FileCountPrePass_ListFilesFails_SurfacedAsWarning guards
+// audit Finding 5 (Minor): the file-count-mismatch pre-pass silently
+// `continue`d past a gameCache.ListFiles error, indistinguishable from
+// "cache exists and has content" - suppressing what should have been its
+// own report instead of just skipping the FILE COUNT MISMATCH check.
+// Forces a real filesystem error (not "file count is zero") by stripping
+// all permissions from the cached mod-version directory, so
+// filepath.WalkDir (which ListFiles uses) can't read it - while
+// gameCache.Exists (a plain os.Stat, needing only traversal permission on
+// ancestors) still reports the dir as present, reaching the ListFiles call
+// at all. Uses a matching recorded/source version so there's no VERSION
+// MISMATCH noise - isolating the file-count pre-pass as the only thing
+// under test.
+func TestDoVerify_FileCountPrePass_ListFilesFails_SurfacedAsWarning(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game, _ := setupDoVerifyVersionTest(t, "1.0", []string{"2"}, []domain.DownloadableFile{
+		{ID: "2", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.0"},
+	})
+
+	gameCache := svc.GetGameCache(game)
+	modDir := gameCache.ModPath(game.ID, "test-src", "mod1", "1.0")
+	require.NoError(t, os.Chmod(modDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(modDir, 0o755) }) // restore before TempDir's own cleanup removes it
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "could not check cached file count", "a real ListFiles error must be surfaced, not silently swallowed")
+	assert.Contains(t, out, "1 warning(s)", "the surfaced error must actually count as a warning, not just print")
+}
+
 // --- doVerify --fix repairs version_mismatch rows (issue #94, Task A7) ---
 //
 // setupDoVerifyFixTest builds on setupDoVerifyVersionTest with a "1.5"
@@ -248,12 +285,16 @@ func setupDoVerifyFixTest(t *testing.T, deployed bool) (*cobra.Command, *core.Se
 	})
 
 	if deployed {
+		// Targeted setters, not a full svc.SaveInstalledMod(mod) - the
+		// latter's full-row upsert would wipe the checksum
+		// setupDoVerifyVersionTest just seeded (the exact audit Finding 1
+		// bug pattern, here as a test-setup artifact rather than
+		// production code - fixed the same way).
+		require.NoError(t, svc.SetModDeployed("test-src", "mod1", game.ID, "default", true))
+		require.NoError(t, svc.SetModLinkMethod("test-src", "mod1", game.ID, "default", domain.LinkSymlink))
+
 		mod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
 		require.NoError(t, err)
-		mod.Deployed = true
-		mod.LinkMethod = domain.LinkSymlink
-		require.NoError(t, svc.SaveInstalledMod(mod))
-
 		require.NoError(t, svc.GetInstaller(game).Install(context.Background(), game, &mod.Mod, "default"))
 	}
 
@@ -556,6 +597,16 @@ func TestDoVerify_Fix_VersionMismatch_Deployed_RelinkFails_ClearsDeployedFlag(t 
 	})
 	assert.NotContains(t, out2, "VERSION MISMATCH", "the version is already corrected - a second run must not re-report it")
 
+	// Audit Finding 8: a second run must be genuinely CLEAN, not merely
+	// free of a re-reported VERSION MISMATCH. Before Finding 1's fix, the
+	// version-record repair's SaveInstalledMod calls silently wiped the
+	// mod's stored checksum, so THIS EXACT second run used to hit NO
+	// CHECKSUM and then a failing redownload attempt (this fixture never
+	// registers download content) - a real regression the original,
+	// narrower "NotContains VERSION MISMATCH" assertion didn't catch. This
+	// is the net that would have caught Finding 1.
+	assert.Contains(t, out2, "All files verified OK.", "the second run must be clean - not hit NO CHECKSUM or any other new issue")
+
 	mod2, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
 	require.NoError(t, err)
 	assert.False(t, mod2.Deployed, "Deployed must still read false on the second run - nothing re-marks it deployed on its own")
@@ -609,9 +660,173 @@ func TestDoVerify_Fix_VersionMismatch_RenameFails_LeavesRecordUnchanged(t *testi
 		if f.ModID == "mod1" && f.FileID == "" {
 			found = true
 			assert.Equal(t, "version_mismatch", f.Status, "JSON row must stay version_mismatch when the rename fails")
+			// Audit Finding 7: the reason the repair itself failed must
+			// reach --json, not just the text-mode "Repair failed: %v"
+			// line - a --json caller had zero visibility into why
+			// before this.
+			assert.NotEmpty(t, f.Note, "the repair failure reason must be visible in the JSON note, not text-only")
 		}
 	}
 	assert.True(t, found, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
+}
+
+// --- full-file audit (epic98), findings F1-F8 ---
+
+// TestDoVerify_Fix_VersionMismatch_PreservesFileChecksum guards audit
+// Finding 1 (Critical): every repair-path save used to be a full
+// svc.SaveInstalledMod, whose DB-layer upsert always replaces
+// installed_mod_files (DELETE + a checksum-less re-INSERT) even when
+// FileIDs is completely unchanged - silently wiping every stored checksum
+// for the mod's files on every successful version-record repair. The next
+// `verify` would then report NO CHECKSUM for the just-repaired mod, and
+// the next --fix would mass-redownload via redownloadModFile instead of
+// leaving the already-correct cached bytes alone.
+func TestDoVerify_Fix_VersionMismatch_PreservesFileChecksum(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixTest(t, false)
+
+	// Sanity: the fixture seeds a real checksum before the repair runs.
+	before, err := svc.GetFilesWithChecksums(game.ID, "default")
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+	require.Equal(t, "deadbeef", before[0].Checksum)
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	require.Contains(t, out, "Repaired", "sanity: the repair must have actually run")
+
+	after, err := svc.GetFilesWithChecksums(game.ID, "default")
+	require.NoError(t, err)
+	found := false
+	for _, f := range after {
+		if f.ModID == "mod1" && f.FileID == "2" {
+			found = true
+			assert.Equal(t, "deadbeef", f.Checksum, "a successful version-record repair must NOT wipe the stored checksum")
+		}
+	}
+	assert.True(t, found, "expected mod1's file '2' to still be tracked after the repair: %+v", after)
+
+	// Audit Finding 8: a second run must be genuinely CLEAN - this is the
+	// repair-success half of the "net that would have caught Finding 1"
+	// (the RelinkFails test above covers the failure half). Before
+	// Finding 1's fix, the checksum wipe this test guards against would
+	// have made this exact second run hit NO CHECKSUM and a failing
+	// redownload attempt, not a clean pass.
+	out2 := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out2, "All files verified OK.", "the second run must be clean, with no new issues or warnings introduced by the repair")
+}
+
+// TestDoVerify_Fix_VersionMismatch_RetryAfterPartialFailure_StillRepairsSiblings
+// guards audit Finding 2 (Important): the sibling pass was gated purely on
+// `renamed` (a rename performed THIS run), so a retry after an earlier
+// run's partial failure - one where the cache rename already succeeded but
+// a later step (DB save, profile upsert) then failed - would see oldPath
+// already gone and skip siblings entirely, even though the shared cache
+// dir has, in fact, already moved out from under them. Simulates exactly
+// that retry state: the cache already lives under the effective version
+// (as if a prior run's rename succeeded), while BOTH the primary and
+// sibling DB rows still record the old version (as if that prior run then
+// failed before completing).
+func TestDoVerify_Fix_VersionMismatch_RetryAfterPartialFailure_StillRepairsSiblings(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	gameCache := svc.GetGameCache(game)
+	oldPath := gameCache.ModPath(game.ID, "test-src", "mod1", "1.5")
+	newPath := gameCache.ModPath(game.ID, "test-src", "mod1", "1.0")
+	require.NoError(t, os.Rename(oldPath, newPath), "simulating a prior run's already-completed cache rename")
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	_ = captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", secondMod.Version, "the sibling must still be repaired on retry, even though no rename happened THIS run - the cache already lives at the effective version")
+}
+
+// TestDoVerify_Fix_VersionMismatch_UpsertModFailsBeforeDBWrite_ConvergesOnRetry
+// guards audit Finding 3 (Important): the ORIGINAL step order was cache
+// rename -> DB save -> profile upsert. If the DB save succeeded but the
+// profile upsert then failed, the DB already showed the effective version -
+// so the NEXT verify run would see no mismatch at all (recorded == source)
+// and would never re-detect or retry the now-permanently-stale profile
+// YAML. Swapping the order (profile upsert BEFORE the DB write) makes the
+// DB write the last, defining "done" signal: if upsert fails, the DB is
+// untouched, so a retry still sees version_mismatch and can converge.
+// Forces the upsert to fail by chmod-ing "default.yaml" read-only, then
+// runs --fix TWICE under the same failure condition and asserts the
+// SECOND run still reports version_mismatch (not silently "fixed").
+func TestDoVerify_Fix_VersionMismatch_UpsertModFailsBeforeDBWrite_ConvergesOnRetry(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game := setupDoVerifyFixTest(t, false)
+
+	defaultProfilePath := filepath.Join(configDir, "games", game.ID, "profiles", "default.yaml")
+	require.NoError(t, os.Chmod(defaultProfilePath, 0o444))
+	t.Cleanup(func() { _ = os.Chmod(defaultProfilePath, 0o644) }) // restore before TempDir's own cleanup removes it
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out1 := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out1, "Repair failed", "run 1 must fail visibly, not silently")
+
+	mod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.5", mod.Version, "the DB must NOT have been written when the profile upsert (which now runs first) fails")
+
+	out2 := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out2, "VERSION MISMATCH", "run 2 must still detect the mismatch - the DB was never corrupted into a false 'already fixed' state")
+}
+
+// TestDoVerify_Fix_VersionMismatch_OldPathStatErrorBlocksRepair guards
+// audit Finding 4 (Minor): the original code treated ANY os.Stat(oldPath)
+// error identically to "the old cache dir doesn't exist" (a normal,
+// nothing-to-rename state), including a genuine stat failure (permission
+// denied, I/O error) that isn't really telling us the dir is absent at
+// all. Forces a real stat error - not fs.ErrNotExist - by stripping ALL
+// permissions (0o000, no execute either) from the cache mod-key's parent
+// directory, so os.Stat can't even traverse into it to check.
+func TestDoVerify_Fix_VersionMismatch_OldPathStatErrorBlocksRepair(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game := setupDoVerifyFixTest(t, false)
+
+	gameCache := svc.GetGameCache(game)
+	oldPath := gameCache.ModPath(game.ID, "test-src", "mod1", "1.5")
+	parentDir := filepath.Dir(oldPath)
+
+	require.NoError(t, os.Chmod(parentDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(parentDir, 0o755) }) // restore before TempDir's own cleanup removes it
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	_ = captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	mod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.5", mod.Version, "a genuine stat failure on the old cache path must block the repair entirely - no DB write, same as an os.Rename failure")
 }
 
 // --- doVerify --fix repairs sibling-profile rows sharing the same cache dir
@@ -799,6 +1014,54 @@ func TestDoVerify_Fix_VersionMismatch_RenameBlocked_SiblingsUntouched(t *testing
 	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
 	require.NoError(t, err)
 	assert.Equal(t, "1.5", secondMod.Version, "sibling must be untouched when the cache rename itself was blocked")
+}
+
+// TestDoVerify_Fix_VersionMismatch_SiblingProfile_DifferentFileIDs_NotAutoRepaired
+// guards audit Finding 6 (Minor): repairSiblingProfiles matched a sibling
+// purely on Version equality, ignoring FileIDs entirely. Two profiles can
+// legitimately record the SAME wrong version for DIFFERENT files (e.g. one
+// profile picked a different optional file at install time) - blindly
+// stamping the sibling with the PRIMARY's effective version would be
+// wrong for that sibling's own files, causing churn (an unnecessary
+// rename plus a full redownload the next time that profile is verified).
+// A sibling whose FileIDs differ from the primary's must be left alone
+// (not auto-repaired) with a warning pointing at the right fix instead.
+func TestDoVerify_Fix_VersionMismatch_SiblingProfile_DifferentFileIDs_NotAutoRepaired(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	pm := getProfileManager(svc)
+	_, err := pm.Create(game.ID, "differs")
+	require.NoError(t, err)
+	require.NoError(t, pm.AddMod(game.ID, "differs", domain.ModReference{
+		SourceID: "test-src", ModID: "mod1", Version: "1.5", FileIDs: []string{"3"},
+	}))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:         domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: "1.5", GameID: game.ID},
+		ProfileName: "differs",
+		Enabled:     true,
+		FileIDs:     []string{"3"}, // same recorded version as "second", but a DIFFERENT file selection
+	}))
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "differs", "a warning must identify the profile whose file selection differs")
+	assert.Contains(t, out, "file selection", "the warning must explain why this sibling wasn't auto-repaired")
+
+	differsMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "differs")
+	require.NoError(t, err)
+	assert.Equal(t, "1.5", differsMod.Version, "a sibling with different FileIDs must NOT be auto-repaired, even though its recorded version matches")
+
+	// "second" (same version, SAME FileIDs as primary) must still be
+	// auto-repaired normally - this finding only withholds repair from
+	// siblings whose file selection actually differs.
+	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", secondMod.Version, "a sibling with matching FileIDs must still be auto-repaired")
 }
 
 // TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_Relinks guards
@@ -1161,4 +1424,98 @@ func TestDoVerify_VersionUnverifiable_WithModFilter_ChecksumRowsAlwaysExist(t *t
 
 	assert.Contains(t, out, "VERSION UNVERIFIABLE", "sanity: the scenario Claim 1 hypothesizes must actually be reached")
 	assert.NotContains(t, out, "No files found for mod", "checksum rows for mod1 exist (same installed_mod_files table backs both FileIDs and the checksum listing) - the main loop's checked++ must have fired")
+}
+
+// setupDoVerifyRedownloadTest builds a minimal fixture for the MISSING/NO
+// CHECKSUM --fix repair paths: a real fakeInstallSource-backed service and
+// an installed mod1/file "2", WITHOUT registering any download content for
+// "2" via src.AddDownload - so any redownloadModFile attempt genuinely
+// fails (the fake source's HTTP handler 404s), letting these tests force a
+// real repair failure without permission tricks.
+func setupDoVerifyRedownloadTest(t *testing.T) (*cobra.Command, *core.Service, *domain.Game, *fakeInstallSource) {
+	t.Helper()
+
+	svc, game, src := setupDoInstallTest(t)
+	src.AddMod(&domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: "1.0", GameID: game.ID},
+		[]domain.DownloadableFile{{ID: "2", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.0"}})
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:         domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: "1.0", GameID: game.ID},
+		ProfileName: "default",
+		Enabled:     true,
+		FileIDs:     []string{"2"},
+	}))
+
+	verifyProfile = "default"
+	t.Cleanup(func() { verifyProfile = "" })
+	verifyFix = true
+	t.Cleanup(func() { verifyFix = false })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	return cmd, svc, game, src
+}
+
+// TestDoVerify_Fix_Missing_JSONNotesRedownloadFailure guards audit Finding
+// 7 (Minor): a MISSING file's --fix redownload failure was reported ONLY
+// in text mode ("Re-download failed: %v") - a --json caller saw the row
+// stay Status "missing" with no indication of why the repair attempt
+// itself failed. No cache entry is ever Store()d for "1.0", so the file
+// is reported MISSING, and the fixture's missing download content makes
+// the redownload attempt fail for real.
+func TestDoVerify_Fix_Missing_JSONNotesRedownloadFailure(t *testing.T) {
+	cmd, svc, game, _ := setupDoVerifyRedownloadTest(t)
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.FileID == "2" {
+			found = true
+			assert.Equal(t, "missing", f.Status)
+			assert.NotEmpty(t, f.Note, "the redownload failure reason must reach the JSON note, not just the text-mode line")
+		}
+	}
+	assert.True(t, found, "expected a mod1 file entry in JSON files: %+v", result.Files)
+}
+
+// TestDoVerify_Fix_NoChecksum_JSONNotesRedownloadFailure is the NO
+// CHECKSUM half of audit Finding 7: same missing-download fixture, but
+// with the cache entry actually present (so the file reads as NO
+// CHECKSUM, not MISSING) and no checksum ever saved - the
+// redownload-to-populate-checksum attempt fails the same way.
+func TestDoVerify_Fix_NoChecksum_JSONNotesRedownloadFailure(t *testing.T) {
+	cmd, svc, game, _ := setupDoVerifyRedownloadTest(t)
+
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, "test-src", "mod1", "1.0", "mod1.esp", []byte("plugin content")))
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.FileID == "2" {
+			found = true
+			assert.Equal(t, "no_checksum", f.Status)
+			assert.NotEmpty(t, f.Note, "the redownload failure reason must reach the JSON note, not just the text-mode line")
+		}
+	}
+	assert.True(t, found, "expected a mod1 file entry in JSON files: %+v", result.Files)
 }

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -51,8 +51,11 @@ func TestVerifyCommand_AcceptsOptionalModID(t *testing.T) {
 // doVerify report clean ("ok") and don't add noise to issues/warnings -
 // isolating the new version-record pre-pass as the only thing under test.
 // sourceFiles is what the fake source's GetModFiles returns for mod1 (the
-// upstream truth the check compares FileIDs against).
-func setupDoVerifyVersionTest(t *testing.T, recordedVersion string, fileIDs []string, sourceFiles []domain.DownloadableFile) (*cobra.Command, *core.Service, *domain.Game) {
+// upstream truth the check compares FileIDs against). Also returns the
+// fakeInstallSource itself so callers that need to inspect what it actually
+// received (e.g. receivedGameFileIDs, for the per-source GameID-mapping
+// check) can do so - most callers ignore it.
+func setupDoVerifyVersionTest(t *testing.T, recordedVersion string, fileIDs []string, sourceFiles []domain.DownloadableFile) (*cobra.Command, *core.Service, *domain.Game, *fakeInstallSource) {
 	t.Helper()
 
 	svc, game, src := setupDoInstallTest(t)
@@ -78,7 +81,7 @@ func setupDoVerifyVersionTest(t *testing.T, recordedVersion string, fileIDs []st
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
 
-	return cmd, svc, game
+	return cmd, svc, game, src
 }
 
 // TestDoVerify_VersionMismatch_ReportedAsIssue guards issue #94's detection
@@ -89,7 +92,7 @@ func setupDoVerifyVersionTest(t *testing.T, recordedVersion string, fileIDs []st
 // both text and --json output. Task A7 adds the --fix repair; this task is
 // detection only.
 func TestDoVerify_VersionMismatch_ReportedAsIssue(t *testing.T) {
-	cmd, svc, game := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+	cmd, svc, game, _ := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
 		{ID: "2", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.0"},
 	})
 
@@ -131,7 +134,7 @@ func TestDoVerify_VersionMismatch_ReportedAsIssue(t *testing.T) {
 // issue - there is nothing to definitively repair) rather than silently
 // treating it as OK or crashing.
 func TestDoVerify_VersionUnverifiable_ReportedAsWarning(t *testing.T) {
-	cmd, svc, game := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+	cmd, svc, game, _ := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
 		{ID: "3", Name: "Some Other File", FileName: "mod1-other.esp", IsPrimary: true, Category: "MAIN", Version: "2.0"},
 	})
 
@@ -162,6 +165,69 @@ func TestDoVerify_VersionUnverifiable_ReportedAsWarning(t *testing.T) {
 	assert.True(t, found, "expected a version_unverifiable entry in JSON files: %+v", result.Files)
 }
 
+// TestDoVerify_VersionCheck_MapsGameIDPerSourceMapping guards PR #128
+// Copilot round-3's suppressed finding: the version-record pre-pass calls
+// svc.GetModFiles(ctx, mod.SourceID, &mod.Mod) where mod.GameID is the LMM
+// game ID (installed rows persist normalized IDs - see
+// setupDoVerifyVersionTest, which stamps GameID: game.ID). But
+// Service.GetModFiles (internal/core/service.go) forwards straight to the
+// source with NO game-ID translation, unlike Service.GetMod, which maps
+// through game.SourceIDs[sourceID] first. Sources like NexusMods address
+// games by their own domain (e.g. "skyrimspecialedition"), so whenever a
+// game's mapping differs from its LMM ID, the version check would silently
+// call the source with the wrong ID.
+//
+// setupDoInstallTest's fixture happens to map game.SourceIDs["test-src"]
+// to "g1" - the SAME as game.ID - which is exactly why none of the
+// existing detection tests caught this: the bug is invisible when the
+// mapped and unmapped IDs happen to coincide. This test deliberately
+// overrides the mapping to a different value so the wrong ID becomes
+// observable, using the same gameIDCapturingSource-style pattern as
+// internal/core/updater_test.go's TestCheckUpdatesTranslatesGameIDPerSourceMapping
+// (fakeInstallSource.receivedGameFileIDs here, since the two test doubles
+// live in different packages).
+func TestDoVerify_VersionCheck_MapsGameIDPerSourceMapping(t *testing.T) {
+	cmd, svc, game, src := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+		{ID: "2", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.0"},
+	})
+	game.SourceIDs["test-src"] = "mapped-domain"
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	_ = captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	require.Len(t, src.receivedGameFileIDs, 1, "GetModFiles must have been called exactly once for mod1's version check")
+	assert.Equal(t, "mapped-domain", src.receivedGameFileIDs[0], "the version-record check must translate GameID through game.SourceIDs, same rule as Service.GetMod")
+}
+
+// TestDoVerify_VersionCheck_EmptySourceMapping_KeepsLMMGameID covers the
+// other half of the mapping rule: an empty (but present) mapping value
+// means "this source applies to any game" (e.g. directory sources:
+// `donovan-mods: ""`) and must NOT blank out the LMM game ID - it must be
+// passed through unchanged, exactly like Service.GetMod's `ok && id != ""`
+// guard.
+func TestDoVerify_VersionCheck_EmptySourceMapping_KeepsLMMGameID(t *testing.T) {
+	cmd, svc, game, src := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+		{ID: "2", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.0"},
+	})
+	game.SourceIDs["test-src"] = ""
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	_ = captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	require.Len(t, src.receivedGameFileIDs, 1)
+	assert.Equal(t, game.ID, src.receivedGameFileIDs[0], "an empty per-source mapping must keep the LMM game ID, not blank it out")
+}
+
 // --- doVerify --fix repairs version_mismatch rows (issue #94, Task A7) ---
 //
 // setupDoVerifyFixTest builds on setupDoVerifyVersionTest with a "1.5"
@@ -177,7 +243,7 @@ func TestDoVerify_VersionUnverifiable_ReportedAsWarning(t *testing.T) {
 func setupDoVerifyFixTest(t *testing.T, deployed bool) (*cobra.Command, *core.Service, *domain.Game) {
 	t.Helper()
 
-	cmd, svc, game := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+	cmd, svc, game, _ := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
 		{ID: "2", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.0"},
 	})
 
@@ -1063,7 +1129,7 @@ func TestDoVerify_Fix_VersionMismatch_PrimaryRelinkFails_SiblingRepaired_JSONNot
 // and nothing else installed) and asserts the misleading message does
 // NOT appear.
 func TestDoVerify_VersionUnverifiable_WithModFilter_ChecksumRowsAlwaysExist(t *testing.T) {
-	cmd, svc, game := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+	cmd, svc, game, _ := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
 		{ID: "3", Name: "Some Other File", FileName: "mod1-other.esp", IsPrimary: true, Category: "MAIN", Version: "2.0"},
 	})
 

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -762,7 +762,7 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_Clears
 	jsonOutput = false
 	t.Cleanup(func() { jsonOutput = oldJSON })
 
-	_ = captureStdout(t, func() error {
+	out := captureStdout(t, func() error {
 		return doVerify(cmd, svc, game, nil)
 	})
 
@@ -774,6 +774,57 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_Clears
 	primaryMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
 	require.NoError(t, err)
 	assert.Equal(t, "1.0", primaryMod.Version, "the primary row must still be repaired despite the sibling's re-link failure")
+
+	// PR #128 Copilot review, Claim 2: a sibling re-link failure must be
+	// surfaced like any other per-sibling failure (SaveInstalledMod/
+	// UpsertMod already are, per the previous round) - not silently
+	// absorbed into a false "Repaired" success line while the deployment
+	// is actually left broken.
+	assert.Contains(t, out, "Warning", "a sibling re-link failure must print a warning, not be silently absorbed")
+	assert.Contains(t, out, "second", "the warning must identify which sibling profile's re-link failed")
+	assert.NotContains(t, out, "Repaired (profile second)", "a sibling whose re-link failed must not be reported as a clean success")
+}
+
+// TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_JSONNotesFailure
+// covers the --json half of PR #128 Copilot review Claim 2: the primary
+// row's "note" field must flag the sibling's re-link failure the same way
+// it already flags a SaveInstalledMod/UpsertMod failure - fresh state
+// from the text-mode test above since fixing the primary row is a real
+// mutation that can't be observed twice from one doVerify call.
+func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_JSONNotesFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
+	require.NoError(t, err)
+	secondMod.Deployed = true
+	secondMod.LinkMethod = domain.LinkSymlink
+	require.NoError(t, svc.SaveInstalledMod(secondMod))
+
+	require.NoError(t, os.Chmod(game.ModPath, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(game.ModPath, 0o755) }) // restore before TempDir's own cleanup removes it
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.FileID == "" {
+			found = true
+			assert.Contains(t, f.Note, "second", "JSON note must mention the sibling whose re-link failed")
+			assert.Contains(t, f.Note, "FAILED", "JSON note must clearly flag it as a failure, not a success")
+		}
+	}
+	assert.True(t, found, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
 }
 
 // --- re-review gaps: silent per-sibling failures + JSON note loss on
@@ -944,4 +995,50 @@ func TestDoVerify_Fix_VersionMismatch_PrimaryRelinkFails_SiblingRepaired_JSONNot
 	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
 	require.NoError(t, err)
 	assert.Equal(t, "1.0", secondMod.Version, "the sibling repair must have gone through independently of the primary's relink failure")
+}
+
+// --- PR #128 Copilot review round 1: verifying (not blindly fixing) two
+// claims against the actual code ---
+
+// TestDoVerify_VersionUnverifiable_WithModFilter_ChecksumRowsAlwaysExist is
+// evidence for refuting Copilot's Claim 1 (comment 3670171464): that
+// `checked` is only incremented on the pre-pass's OK path, so a filtered
+// run producing only VERSION MISMATCH/UNVERIFIABLE/source-unreachable
+// output with "no checksum rows" could still wrongly print "No files
+// found for mod ...".
+//
+// That premise doesn't hold: mod.FileIDs (what gates entry into the
+// pre-pass's version-check branches at all - see the `len(mod.FileIDs) ==
+// 0` skip in doVerify) and the `files` slice the main per-file loop
+// iterates (from svc.GetFilesWithChecksums) are BOTH sourced from the
+// exact same `installed_mod_files` table (see
+// internal/storage/db/mods.go: replaceModFileIDsTx populates it,
+// getModFileIDsBatch/GetModFileIDs and GetFilesWithChecksums both read it
+// with no additional filtering beyond game/profile). So whenever
+// mod.FileIDs is non-empty for a modFilter'd mod - the only way the
+// pre-pass can reach VERSION MISMATCH/UNVERIFIABLE/unreachable at all -
+// `files` filtered to that same mod ID is provably non-empty too, and the
+// main loop's unconditional `checked++` (before any per-file status
+// logic) fires for it. The "no checksum rows" state Claim 1 hypothesizes
+// cannot coexist with a non-empty FileIDs set under the current schema.
+//
+// This test constructs exactly the scenario Claim 1 describes (a
+// modFilter'd mod, VERSION UNVERIFIABLE - no matching file ID upstream -
+// and nothing else installed) and asserts the misleading message does
+// NOT appear.
+func TestDoVerify_VersionUnverifiable_WithModFilter_ChecksumRowsAlwaysExist(t *testing.T) {
+	cmd, svc, game := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+		{ID: "3", Name: "Some Other File", FileName: "mod1-other.esp", IsPrimary: true, Category: "MAIN", Version: "2.0"},
+	})
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, []string{"mod1"})
+	})
+
+	assert.Contains(t, out, "VERSION UNVERIFIABLE", "sanity: the scenario Claim 1 hypothesizes must actually be reached")
+	assert.NotContains(t, out, "No files found for mod", "checksum rows for mod1 exist (same installed_mod_files table backs both FileIDs and the checksum listing) - the main loop's checked++ must have fired")
 }

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -899,6 +899,12 @@ func setupDoVerifyFixSiblingTest(t *testing.T) (*cobra.Command, *core.Service, *
 		Enabled:     true,
 		FileIDs:     []string{"2"},
 	}))
+	// Seed a checksum for "second" too, mirroring "default"'s fixture
+	// (setupDoVerifyVersionTest) - realistic (a real sibling profile has
+	// its own recorded checksum, not a NULL one), and load-bearing for
+	// tests asserting the sibling repair path doesn't wipe it (audit
+	// Finding 1's class, Copilot round 8).
+	require.NoError(t, svc.SaveFileChecksum("test-src", "mod1", game.ID, "second", "2", "deadbeef"))
 
 	_, err = pm.Create(game.ID, "third")
 	require.NoError(t, err)
@@ -911,6 +917,7 @@ func setupDoVerifyFixSiblingTest(t *testing.T) (*cobra.Command, *core.Service, *
 		Enabled:     true,
 		FileIDs:     []string{"2"},
 	}))
+	require.NoError(t, svc.SaveFileChecksum("test-src", "mod1", game.ID, "third", "2", "deadbeef"))
 
 	return cmd, svc, game
 }
@@ -1109,11 +1116,12 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_DifferentFileIDs_NotAutoRep
 func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_Relinks(t *testing.T) {
 	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
 
-	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
-	require.NoError(t, err)
-	secondMod.Deployed = true
-	secondMod.LinkMethod = domain.LinkSymlink
-	require.NoError(t, svc.SaveInstalledMod(secondMod))
+	// Targeted setters, not a mutate-then-svc.SaveInstalledMod - the
+	// latter's full-row upsert would wipe the checksum
+	// setupDoVerifyVersionTest seeded (audit Finding 1's exact pattern,
+	// here as a test-setup artifact - Copilot round 8, PR #128).
+	require.NoError(t, svc.SetModDeployed("test-src", "mod1", game.ID, "second", true))
+	require.NoError(t, svc.SetModLinkMethod("test-src", "mod1", game.ID, "second", domain.LinkSymlink))
 
 	oldJSON := jsonOutput
 	jsonOutput = true
@@ -1135,6 +1143,18 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_Relinks(t *testing
 	require.NoError(t, err, "sibling symlink must resolve, not dangle")
 	assert.Equal(t, "plugin content", string(content))
 
+	// This doVerify run only checks the "default" profile - checking
+	// result.Files' status wouldn't observe whether "second"'s own
+	// checksum survived the targeted setters above, since verify never
+	// looks at a non-active profile's checksums. Check directly instead.
+	secondFiles, err := svc.GetFilesWithChecksums(game.ID, "second")
+	require.NoError(t, err)
+	for _, f := range secondFiles {
+		if f.ModID == "mod1" && f.FileID == "2" {
+			assert.Equal(t, "deadbeef", f.Checksum, "the targeted setters (and the sibling repair itself) must not wipe the seeded checksum")
+		}
+	}
+
 	afterMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
 	require.NoError(t, err)
 	assert.True(t, afterMod.Deployed, "Deployed remains true after a successful sibling re-link")
@@ -1152,11 +1172,10 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_Clears
 	}
 	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
 
-	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
-	require.NoError(t, err)
-	secondMod.Deployed = true
-	secondMod.LinkMethod = domain.LinkSymlink
-	require.NoError(t, svc.SaveInstalledMod(secondMod))
+	// Targeted setters, not a mutate-then-svc.SaveInstalledMod - see
+	// TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_Relinks.
+	require.NoError(t, svc.SetModDeployed("test-src", "mod1", game.ID, "second", true))
+	require.NoError(t, svc.SetModLinkMethod("test-src", "mod1", game.ID, "second", domain.LinkSymlink))
 
 	require.NoError(t, os.Chmod(game.ModPath, 0o555))
 	t.Cleanup(func() { _ = os.Chmod(game.ModPath, 0o755) }) // restore before TempDir's own cleanup removes it
@@ -1168,6 +1187,17 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_Clears
 	out := captureStdout(t, func() error {
 		return doVerify(cmd, svc, game, nil)
 	})
+
+	// This run only checks the "default" profile, so "NO CHECKSUM" in its
+	// own output wouldn't reflect whether "second"'s checksum survived the
+	// targeted setters above - check directly instead.
+	secondFiles, err := svc.GetFilesWithChecksums(game.ID, "second")
+	require.NoError(t, err)
+	for _, f := range secondFiles {
+		if f.ModID == "mod1" && f.FileID == "2" {
+			assert.Equal(t, "deadbeef", f.Checksum, "the targeted setters must not wipe the seeded checksum")
+		}
+	}
 
 	afterMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
 	require.NoError(t, err)
@@ -1200,11 +1230,10 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_JSONNo
 	}
 	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
 
-	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
-	require.NoError(t, err)
-	secondMod.Deployed = true
-	secondMod.LinkMethod = domain.LinkSymlink
-	require.NoError(t, svc.SaveInstalledMod(secondMod))
+	// Targeted setters, not a mutate-then-svc.SaveInstalledMod - see
+	// TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_Relinks.
+	require.NoError(t, svc.SetModDeployed("test-src", "mod1", game.ID, "second", true))
+	require.NoError(t, svc.SetModLinkMethod("test-src", "mod1", game.ID, "second", domain.LinkSymlink))
 
 	require.NoError(t, os.Chmod(game.ModPath, 0o555))
 	t.Cleanup(func() { _ = os.Chmod(game.ModPath, 0o755) }) // restore before TempDir's own cleanup removes it
@@ -1228,6 +1257,17 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_JSONNo
 		}
 	}
 	assert.True(t, found, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
+
+	// This run only checks the "default" profile, so result.Files wouldn't
+	// reflect whether "second"'s checksum survived the targeted setters
+	// above - check directly instead.
+	secondFiles, err := svc.GetFilesWithChecksums(game.ID, "second")
+	require.NoError(t, err)
+	for _, f := range secondFiles {
+		if f.ModID == "mod1" && f.FileID == "2" {
+			assert.Equal(t, "deadbeef", f.Checksum, "the targeted setters must not wipe the seeded checksum")
+		}
+	}
 }
 
 // --- re-review gaps: silent per-sibling failures + JSON note loss on
@@ -1379,11 +1419,16 @@ func TestDoVerify_Fix_VersionMismatch_PrimaryRelinkFails_SiblingRepaired_JSONNot
 	}
 	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
 
+	// Targeted setters, not a mutate-then-svc.SaveInstalledMod - see
+	// TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_Relinks (this
+	// straggler wasn't in Copilot round 8's three cited sites, but matches
+	// the same pattern - caught by grepping the whole file per the
+	// coordinator's instruction).
+	require.NoError(t, svc.SetModDeployed("test-src", "mod1", game.ID, "default", true))
+	require.NoError(t, svc.SetModLinkMethod("test-src", "mod1", game.ID, "default", domain.LinkSymlink))
+
 	primaryMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
 	require.NoError(t, err)
-	primaryMod.Deployed = true
-	primaryMod.LinkMethod = domain.LinkSymlink
-	require.NoError(t, svc.SaveInstalledMod(primaryMod))
 	require.NoError(t, svc.GetInstaller(game).Install(context.Background(), game, &primaryMod.Mod, "default"))
 
 	// Force the PRIMARY's own re-link to fail (same read-only-game-dir
@@ -1409,6 +1454,7 @@ func TestDoVerify_Fix_VersionMismatch_PrimaryRelinkFails_SiblingRepaired_JSONNot
 			assert.Equal(t, "version_mismatch", f.Status, "status must stay version_mismatch - the PRIMARY row itself was not fixed")
 			assert.Contains(t, f.Note, "second", "the successful sibling repair must still be visible in the note despite the primary relink failure")
 		}
+		assert.NotEqual(t, "no_checksum", f.Status, "the targeted setters must not have wiped the seeded checksum: %+v", f)
 	}
 	assert.True(t, found, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
 

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
@@ -773,4 +774,174 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_Deployed_RelinkFails_Clears
 	primaryMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
 	require.NoError(t, err)
 	assert.Equal(t, "1.0", primaryMod.Version, "the primary row must still be repaired despite the sibling's re-link failure")
+}
+
+// --- re-review gaps: silent per-sibling failures + JSON note loss on
+// primary relink failure (final-fix-wave, second round) ---
+
+// setupDoVerifyFixSiblingUpsertFailureTest builds on
+// setupDoVerifyFixSiblingTest and chmods the "second" profile's own YAML
+// file (not the shared profiles directory, which would also block the
+// PRIMARY profile's own already-completed upsert) read-only, so
+// config.SaveProfile's os.WriteFile - which needs write permission on the
+// file itself to truncate and rewrite it - fails specifically for
+// "second"'s sibling repair.
+func setupDoVerifyFixSiblingUpsertFailureTest(t *testing.T) (*cobra.Command, *core.Service, *domain.Game) {
+	t.Helper()
+
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	secondProfilePath := filepath.Join(configDir, "games", game.ID, "profiles", "second.yaml")
+	require.NoError(t, os.Chmod(secondProfilePath, 0o444))
+	t.Cleanup(func() { _ = os.Chmod(secondProfilePath, 0o644) }) // restore before TempDir's own cleanup removes it
+
+	return cmd, svc, game
+}
+
+// TestDoVerify_Fix_VersionMismatch_SiblingProfile_UpsertModFails_WarnsInTextMode
+// guards against DEV.md's "never swallow errors without logging/context":
+// repairSiblingProfiles must not silently `continue` past a failed
+// pm.UpsertMod for one sibling - it must print a warning identifying which
+// profile failed, while still processing any remaining siblings
+// (best-effort loop, not aborted - "third", a different recorded version
+// and never a repair candidate in the first place, is untouched either way).
+func TestDoVerify_Fix_VersionMismatch_SiblingProfile_UpsertModFails_WarnsInTextMode(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game := setupDoVerifyFixSiblingUpsertFailureTest(t)
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "Warning", "an UpsertMod failure for a sibling must be surfaced, not swallowed")
+	assert.Contains(t, out, "second", "the warning must identify which sibling profile failed")
+
+	thirdMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "third")
+	require.NoError(t, err)
+	assert.Equal(t, "2.0", thirdMod.Version, "a sibling that was never a candidate must not be touched by another sibling's failure")
+}
+
+// TestDoVerify_Fix_VersionMismatch_SiblingProfile_UpsertModFails_JSONNotesFailure
+// covers the --json half of the same failure: the primary row's "note"
+// field must fold in the failed sibling, not just the successful ones -
+// separate fresh state from the text-mode test above since fixing the
+// primary row (which succeeds regardless of the sibling's own failure) is
+// a real mutation that can't be observed twice from one doVerify call.
+func TestDoVerify_Fix_VersionMismatch_SiblingProfile_UpsertModFails_JSONNotesFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game := setupDoVerifyFixSiblingUpsertFailureTest(t)
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.FileID == "" {
+			found = true
+			assert.Contains(t, f.Note, "second", "JSON note must mention the failed sibling profile")
+			assert.Contains(t, f.Note, "FAILED", "JSON note must clearly flag the failure, not read as a success")
+		}
+	}
+	assert.True(t, found, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
+}
+
+// TestDoVerify_Fix_VersionMismatch_SiblingProfile_ListFails_WarnsOnce guards
+// the pm.List failure path: it must surface once (a warning line plus a
+// note), not be silently swallowed. Forces the failure by stripping read
+// permission from the shared profiles directory (0o311: search/write, no
+// read) so os.ReadDir (which pm.List/config.ListProfiles depends on) fails,
+// while by-path opens of already-known files (LoadProfile/SaveProfile of
+// the PRIMARY "default" profile, which only need search permission on
+// ancestor directories) keep working - the primary repair itself must
+// still succeed.
+func TestDoVerify_Fix_VersionMismatch_SiblingProfile_ListFails_WarnsOnce(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game := setupDoVerifyFixTest(t, false)
+
+	profilesDir := filepath.Join(configDir, "games", game.ID, "profiles")
+	require.NoError(t, os.Chmod(profilesDir, 0o311))
+	t.Cleanup(func() { _ = os.Chmod(profilesDir, 0o755) }) // restore before TempDir's own cleanup removes it
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Equal(t, 1, strings.Count(out, "Warning"), "the pm.List failure must be surfaced exactly once, not once per (nonexistent) sibling")
+
+	// The primary repair (by-path, unaffected by the missing read bit on
+	// the shared directory) must still have gone through.
+	mod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", mod.Version, "the primary row must still be repaired even though sibling discovery failed")
+}
+
+// TestDoVerify_Fix_VersionMismatch_PrimaryRelinkFails_SiblingRepaired_JSONNoteVisible
+// guards the second re-review gap: repairModVersion can return a non-empty
+// note (successful sibling repair) alongside a non-nil err (the PRIMARY
+// row's own re-link failed) - doVerify's caller must still attach that
+// note to the JSON row even though repairErr != nil, or a --json consumer
+// has zero visibility into the sibling repair that actually happened. The
+// row's status must stay "version_mismatch" (nothing about the primary
+// row itself was fixed) and issues must NOT be decremented.
+func TestDoVerify_Fix_VersionMismatch_PrimaryRelinkFails_SiblingRepaired_JSONNoteVisible(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-based test is meaningless as root")
+	}
+	cmd, svc, game := setupDoVerifyFixSiblingTest(t)
+
+	primaryMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	primaryMod.Deployed = true
+	primaryMod.LinkMethod = domain.LinkSymlink
+	require.NoError(t, svc.SaveInstalledMod(primaryMod))
+	require.NoError(t, svc.GetInstaller(game).Install(context.Background(), game, &primaryMod.Mod, "default"))
+
+	// Force the PRIMARY's own re-link to fail (same read-only-game-dir
+	// trick as TestDoVerify_Fix_VersionMismatch_Deployed_RelinkFails_ClearsDeployedFlag).
+	require.NoError(t, os.Chmod(game.ModPath, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(game.ModPath, 0o755) }) // restore before TempDir's own cleanup removes it
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	assert.Equal(t, 1, result.Issues, "the primary row's own repair failed, so the issue must still be counted")
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" && f.FileID == "" {
+			found = true
+			assert.Equal(t, "version_mismatch", f.Status, "status must stay version_mismatch - the PRIMARY row itself was not fixed")
+			assert.Contains(t, f.Note, "second", "the successful sibling repair must still be visible in the note despite the primary relink failure")
+		}
+	}
+	assert.True(t, found, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
+
+	// The sibling itself was, in fact, repaired.
+	secondMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "second")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", secondMod.Version, "the sibling repair must have gone through independently of the primary's relink failure")
 }

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -974,6 +974,14 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_UpsertModFails_WarnsInTextM
 	assert.Contains(t, out, "Warning", "an UpsertMod failure for a sibling must be surfaced, not swallowed")
 	assert.Contains(t, out, "second", "the warning must identify which sibling profile failed")
 
+	// PR #128 Copilot review round 4: a surfaced sibling failure must also
+	// move the needle on the actual warnings COUNT, not just print a line -
+	// the primary row's own repair succeeded (issues drops to 0), but the
+	// summary must not claim a clean "All files verified OK." while a
+	// sibling repair genuinely failed.
+	assert.Contains(t, out, "1 warning(s)", "a failed sibling repair must be counted as a warning in the summary")
+	assert.NotContains(t, out, "All files verified OK.", "the summary must not claim a clean run while a sibling repair failed")
+
 	thirdMod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "third")
 	require.NoError(t, err)
 	assert.Equal(t, "2.0", thirdMod.Version, "a sibling that was never a candidate must not be touched by another sibling's failure")
@@ -1009,6 +1017,12 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_UpsertModFails_JSONNotesFai
 		}
 	}
 	assert.True(t, found, "expected a mod1 version-check entry in JSON files: %+v", result.Files)
+
+	// PR #128 Copilot review round 4: the JSON "warnings" field must
+	// reflect the failed sibling repair - not just the note text - so a
+	// --json caller can detect the problem without string-matching "FAILED"
+	// inside a human-readable note.
+	assert.Equal(t, 1, result.Warnings, "the failed sibling repair must be counted in the JSON warnings field")
 }
 
 // TestDoVerify_Fix_VersionMismatch_SiblingProfile_ListFails_WarnsOnce guards
@@ -1038,6 +1052,10 @@ func TestDoVerify_Fix_VersionMismatch_SiblingProfile_ListFails_WarnsOnce(t *test
 		return doVerify(cmd, svc, game, nil)
 	})
 	assert.Equal(t, 1, strings.Count(out, "Warning"), "the pm.List failure must be surfaced exactly once, not once per (nonexistent) sibling")
+
+	// PR #128 Copilot review round 4: a pm.List failure counts as exactly
+	// one warning in the actual counter, not just in the printed text.
+	assert.Contains(t, out, "1 warning(s)", "the pm.List failure must count as exactly one warning")
 
 	// The primary repair (by-path, unaffected by the missing read bit on
 	// the shared directory) must still have gone through.

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
@@ -157,4 +159,195 @@ func TestDoVerify_VersionUnverifiable_ReportedAsWarning(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected a version_unverifiable entry in JSON files: %+v", result.Files)
+}
+
+// --- doVerify --fix repairs version_mismatch rows (issue #94, Task A7) ---
+//
+// setupDoVerifyFixTest builds on setupDoVerifyVersionTest with a "1.5"
+// recorded / "1.0" effective mismatch (same fixture the detection tests
+// above use) and additionally: creates the "default" profile file and seeds
+// a matching (stale) profile ref, so pm.UpsertMod's rename path is
+// exercised for real instead of hitting ErrProfileNotFound; and turns on
+// --fix. When deployed is true, the mod row is marked Deployed with a
+// symlink LinkMethod and the file is actually deployed into game.ModPath
+// via the real installer (not hand-rolled) so the pre-state - a symlink
+// pointing INTO the old-version cache dir - matches what a real install
+// would have produced before the rename.
+func setupDoVerifyFixTest(t *testing.T, deployed bool) (*cobra.Command, *core.Service, *domain.Game) {
+	t.Helper()
+
+	cmd, svc, game := setupDoVerifyVersionTest(t, "1.5", []string{"2"}, []domain.DownloadableFile{
+		{ID: "2", Name: "Main File", FileName: "mod1.esp", IsPrimary: true, Category: "MAIN", Version: "1.0"},
+	})
+
+	if deployed {
+		mod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+		require.NoError(t, err)
+		mod.Deployed = true
+		mod.LinkMethod = domain.LinkSymlink
+		require.NoError(t, svc.SaveInstalledMod(mod))
+
+		require.NoError(t, svc.GetInstaller(game).Install(context.Background(), game, &mod.Mod, "default"))
+	}
+
+	pm := getProfileManager(svc)
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.AddMod(game.ID, "default", domain.ModReference{
+		SourceID: "test-src", ModID: "mod1", Version: "1.5", FileIDs: []string{"2"},
+	}))
+
+	verifyFix = true
+	t.Cleanup(func() { verifyFix = false })
+
+	return cmd, svc, game
+}
+
+// TestDoVerify_Fix_VersionMismatch_NotDeployed_RepairsRecord guards
+// scenario (a): a mismatch row that isn't deployed gets fully repaired in
+// one pass - cache re-keyed to the effective version, DB row corrected,
+// profile ref corrected, JSON status flips to "ok", and issues drops back
+// to 0.
+func TestDoVerify_Fix_VersionMismatch_NotDeployed_RepairsRecord(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixTest(t, false)
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	assert.Equal(t, 0, result.Issues, "a successful repair must decrement issues back out")
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "mod1" {
+			found = true
+			assert.Equal(t, "ok", f.Status, "repaired row's JSON status must flip to ok")
+		}
+	}
+	assert.True(t, found, "expected a mod1 entry in JSON files: %+v", result.Files)
+
+	gameCache := svc.GetGameCache(game)
+	assert.True(t, gameCache.Exists(game.ID, "test-src", "mod1", "1.0"), "cache must exist under the effective (new) version key")
+	assert.False(t, gameCache.Exists(game.ID, "test-src", "mod1", "1.5"), "cache must no longer exist under the recorded (old) version key")
+
+	mod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", mod.Version, "DB row must be corrected to the effective version")
+
+	pm := getProfileManager(svc)
+	profile, err := pm.Get(game.ID, "default")
+	require.NoError(t, err)
+	profileFound := false
+	for _, ref := range profile.Mods {
+		if ref.SourceID == "test-src" && ref.ModID == "mod1" {
+			profileFound = true
+			assert.Equal(t, "1.0", ref.Version, "profile YAML ref must be corrected to the effective version")
+		}
+	}
+	assert.True(t, profileFound, "expected a profile ref for mod1: %+v", profile.Mods)
+}
+
+// TestDoVerify_Fix_VersionMismatch_NotDeployed_PrintsRepairedLine covers the
+// text-mode output side of scenario (a) separately from the JSON-mode
+// state assertions above, since a single doVerify call can only be
+// observed in one output mode at a time (the fix is a real mutation, not a
+// read-only check the test can safely run twice).
+func TestDoVerify_Fix_VersionMismatch_NotDeployed_PrintsRepairedLine(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixTest(t, false)
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	assert.Contains(t, out, "Repaired")
+	assert.Contains(t, out, "1.5")
+	assert.Contains(t, out, "1.0")
+	assert.Contains(t, out, "All files verified OK.", "the repaired mismatch must no longer be counted as an outstanding issue")
+}
+
+// TestDoVerify_Fix_VersionMismatch_Deployed_RelinksSymlink guards scenario
+// (b): when the mismatched mod is Deployed with a symlink LinkMethod, the
+// game-dir symlink points INTO the cache dir keyed by the recorded (wrong)
+// version. After --fix renames that cache dir to the effective version, the
+// old symlink target is gone - --fix must re-run the installer so the
+// symlink is refreshed and resolves again instead of dangling.
+func TestDoVerify_Fix_VersionMismatch_Deployed_RelinksSymlink(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixTest(t, true)
+
+	deployedPath := filepath.Join(game.ModPath, "mod1.esp")
+
+	// Sanity-check the pre-state: before --fix runs, the symlink exists and
+	// resolves (it was deployed from the "1.5"-keyed cache dir).
+	content, err := os.ReadFile(deployedPath)
+	require.NoError(t, err, "pre-state: symlink must resolve before the cache rename")
+	require.Equal(t, "plugin content", string(content))
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	assert.Equal(t, 0, result.Issues)
+
+	// The symlink must resolve post-fix - it was refreshed to point at the
+	// renamed ("1.0"-keyed) cache dir rather than left dangling.
+	info, err := os.Lstat(deployedPath)
+	require.NoError(t, err, "deployed symlink must still exist")
+	assert.True(t, info.Mode()&os.ModeSymlink != 0, "deployment must still be a symlink")
+
+	postContent, err := os.ReadFile(deployedPath)
+	require.NoError(t, err, "post-fix: symlink must resolve, not dangle")
+	assert.Equal(t, "plugin content", string(postContent))
+
+	target, err := os.Readlink(deployedPath)
+	require.NoError(t, err)
+	assert.Contains(t, target, filepath.Join("test-src-mod1", "1.0"), "symlink must point into the renamed (effective-version) cache dir")
+}
+
+// TestDoVerify_Fix_VersionMismatch_RenameBlocked_StillFixesDB guards
+// scenario (c): if a cache directory already exists under the effective
+// version (e.g. a partial/previous repair, or a stray manual copy), --fix
+// must not clobber it via os.Rename - it leaves the cache alone, emits a
+// note, but still corrects the DB row (the DB/cache disagreement this
+// check exists to catch must not become a NEW, different disagreement).
+func TestDoVerify_Fix_VersionMismatch_RenameBlocked_StillFixesDB(t *testing.T) {
+	cmd, svc, game := setupDoVerifyFixTest(t, false)
+
+	gameCache := svc.GetGameCache(game)
+	// Pre-create the new-version cache dir so the rename is blocked.
+	require.NoError(t, gameCache.Store(game.ID, "test-src", "mod1", "1.0", "mod1.esp", []byte("pre-existing 1.0 content")))
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	assert.Contains(t, out, "Note", "a note must be emitted when the rename is blocked")
+
+	// Cache left as-is: both the old and the pre-existing new entries remain.
+	assert.True(t, gameCache.Exists(game.ID, "test-src", "mod1", "1.5"), "old cache entry must be left in place, not renamed away")
+	assert.True(t, gameCache.Exists(game.ID, "test-src", "mod1", "1.0"), "pre-existing new cache entry must be left untouched")
+
+	// DB is still fixed despite the blocked rename.
+	mod, err := svc.GetInstalledMod("test-src", "mod1", game.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", mod.Version, "DB row must still be corrected even when the cache rename is blocked")
 }

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -1572,6 +1572,39 @@ func TestDoVerify_Fix_Missing_JSONNotesRedownloadFailure(t *testing.T) {
 	assert.True(t, found, "expected a mod1 file entry in JSON files: %+v", result.Files)
 }
 
+// TestDoVerify_Fix_Redownload_MapsGameIDPerSourceMapping guards the
+// follow-up d1c0e0f explicitly flagged as out of scope: redownloadModFile
+// (the MISSING/NO CHECKSUM --fix repair) had the identical unmapped
+// svc.GetModFiles(ctx, mod.SourceID, &mod.Mod) call the version-record
+// pre-pass was fixed for - mod.GameID is the LMM game ID (installed rows
+// persist normalized IDs), but Service.GetModFiles forwards straight to
+// the source with no game-ID translation, so on any game whose per-source
+// mapping differs from its LMM ID (e.g. "skyrim-se" vs NexusMods'
+// "skyrimspecialedition"), the redownload lookup queried the wrong game.
+// Same capture pattern as TestDoVerify_VersionCheck_MapsGameIDPerSourceMapping:
+// override the fixture's mapping (which otherwise coincides with game.ID,
+// hiding the bug) and assert via fakeInstallSource.receivedGameFileIDs.
+// The fixture's missing cache entry drives the MISSING branch; the NO
+// CHECKSUM branch routes through the same redownloadModFile call, so one
+// scenario pins both.
+func TestDoVerify_Fix_Redownload_MapsGameIDPerSourceMapping(t *testing.T) {
+	cmd, svc, game, src := setupDoVerifyRedownloadTest(t)
+	game.SourceIDs["test-src"] = "mapped-domain"
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	_ = captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	// Call 1 is the version-record pre-pass (already mapped, d1c0e0f);
+	// call 2 is redownloadModFile's own lookup for the MISSING repair.
+	require.Len(t, src.receivedGameFileIDs, 2, "expected GetModFiles twice: version pre-pass + redownload lookup")
+	assert.Equal(t, "mapped-domain", src.receivedGameFileIDs[1], "redownloadModFile must translate GameID through game.SourceIDs, same rule as Service.GetMod and the version-record pre-pass")
+}
+
 // TestDoVerify_Fix_NoChecksum_JSONNotesRedownloadFailure is the NO
 // CHECKSUM half of audit Finding 7: same missing-download fixture, but
 // with the cache entry actually present (so the file reads as NO

--- a/docs/man/man1/lmm-auth-login.1
+++ b/docs/man/man1/lmm-auth-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-auth-login - Authenticate with a mod source

--- a/docs/man/man1/lmm-auth-logout.1
+++ b/docs/man/man1/lmm-auth-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-auth-logout - Remove stored credentials for a mod source

--- a/docs/man/man1/lmm-auth-status.1
+++ b/docs/man/man1/lmm-auth-status.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-auth-status - Show authentication status for all sources

--- a/docs/man/man1/lmm-auth.1
+++ b/docs/man/man1/lmm-auth.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-auth - Manage authentication for mod sources

--- a/docs/man/man1/lmm-completion-bash.1
+++ b/docs/man/man1/lmm-completion-bash.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-completion-bash - Generate the autocompletion script for bash

--- a/docs/man/man1/lmm-completion-fish.1
+++ b/docs/man/man1/lmm-completion-fish.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-completion-fish - Generate the autocompletion script for fish

--- a/docs/man/man1/lmm-completion-powershell.1
+++ b/docs/man/man1/lmm-completion-powershell.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-completion-powershell - Generate the autocompletion script for powershell

--- a/docs/man/man1/lmm-completion-zsh.1
+++ b/docs/man/man1/lmm-completion-zsh.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-completion-zsh - Generate the autocompletion script for zsh

--- a/docs/man/man1/lmm-completion.1
+++ b/docs/man/man1/lmm-completion.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-completion - Generate the autocompletion script for the specified shell

--- a/docs/man/man1/lmm-conflicts.1
+++ b/docs/man/man1/lmm-conflicts.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-conflicts - Show all file conflicts in the current profile

--- a/docs/man/man1/lmm-deploy.1
+++ b/docs/man/man1/lmm-deploy.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-deploy - Deploy mods to game directory

--- a/docs/man/man1/lmm-game-add.1
+++ b/docs/man/man1/lmm-game-add.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-game-add - Add a game interactively

--- a/docs/man/man1/lmm-game-clear-default.1
+++ b/docs/man/man1/lmm-game-clear-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-game-clear-default - Clear the default game setting

--- a/docs/man/man1/lmm-game-detect.1
+++ b/docs/man/man1/lmm-game-detect.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-game-detect - Detect Steam games and add them to config

--- a/docs/man/man1/lmm-game-set-default.1
+++ b/docs/man/man1/lmm-game-set-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-game-set-default - Set the default game

--- a/docs/man/man1/lmm-game-show-default.1
+++ b/docs/man/man1/lmm-game-show-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-game-show-default - Show the current default game

--- a/docs/man/man1/lmm-game.1
+++ b/docs/man/man1/lmm-game.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-game - Game management commands

--- a/docs/man/man1/lmm-import.1
+++ b/docs/man/man1/lmm-import.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-import - Import mods from local files or scan mod_path

--- a/docs/man/man1/lmm-install.1
+++ b/docs/man/man1/lmm-install.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-install - Install a mod

--- a/docs/man/man1/lmm-list.1
+++ b/docs/man/man1/lmm-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-list - List installed mods

--- a/docs/man/man1/lmm-mod-disable.1
+++ b/docs/man/man1/lmm-mod-disable.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-mod-disable - Disable a mod without uninstalling

--- a/docs/man/man1/lmm-mod-edit.1
+++ b/docs/man/man1/lmm-mod-edit.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-mod-edit - Edit mod details (name, version, author, source, ID)

--- a/docs/man/man1/lmm-mod-enable.1
+++ b/docs/man/man1/lmm-mod-enable.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-mod-enable - Enable a disabled mod

--- a/docs/man/man1/lmm-mod-files.1
+++ b/docs/man/man1/lmm-mod-files.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-mod-files - List files deployed by a mod

--- a/docs/man/man1/lmm-mod-set-update.1
+++ b/docs/man/man1/lmm-mod-set-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-mod-set-update - Set update policy for a mod

--- a/docs/man/man1/lmm-mod-show.1
+++ b/docs/man/man1/lmm-mod-show.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-mod-show - Show mod details

--- a/docs/man/man1/lmm-mod.1
+++ b/docs/man/man1/lmm-mod.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-mod - Manage mod settings

--- a/docs/man/man1/lmm-profile-apply.1
+++ b/docs/man/man1/lmm-profile-apply.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-profile-apply - Apply profile to system

--- a/docs/man/man1/lmm-profile-create.1
+++ b/docs/man/man1/lmm-profile-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-profile-create - Create a new profile

--- a/docs/man/man1/lmm-profile-delete.1
+++ b/docs/man/man1/lmm-profile-delete.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-profile-delete - Delete a profile

--- a/docs/man/man1/lmm-profile-export.1
+++ b/docs/man/man1/lmm-profile-export.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-profile-export - Export a profile

--- a/docs/man/man1/lmm-profile-import.1
+++ b/docs/man/man1/lmm-profile-import.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-profile-import - Import a profile

--- a/docs/man/man1/lmm-profile-list.1
+++ b/docs/man/man1/lmm-profile-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-profile-list - List all profiles

--- a/docs/man/man1/lmm-profile-reorder.1
+++ b/docs/man/man1/lmm-profile-reorder.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-profile-reorder - View or change load order

--- a/docs/man/man1/lmm-profile-switch.1
+++ b/docs/man/man1/lmm-profile-switch.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-profile-switch - Switch to a different profile

--- a/docs/man/man1/lmm-profile-sync.1
+++ b/docs/man/man1/lmm-profile-sync.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-profile-sync - Sync profile to match installed mods

--- a/docs/man/man1/lmm-profile.1
+++ b/docs/man/man1/lmm-profile.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-profile - Manage mod profiles

--- a/docs/man/man1/lmm-purge.1
+++ b/docs/man/man1/lmm-purge.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-purge - Remove all deployed mods from game directory

--- a/docs/man/man1/lmm-search.1
+++ b/docs/man/man1/lmm-search.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-search - Search for mods

--- a/docs/man/man1/lmm-source-list.1
+++ b/docs/man/man1/lmm-source-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-source-list - List all mod sources

--- a/docs/man/man1/lmm-source-validate.1
+++ b/docs/man/man1/lmm-source-validate.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-source-validate - Validate a source definition file

--- a/docs/man/man1/lmm-source.1
+++ b/docs/man/man1/lmm-source.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-source - Manage mod sources

--- a/docs/man/man1/lmm-status.1
+++ b/docs/man/man1/lmm-status.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-status - Show current status

--- a/docs/man/man1/lmm-tui.1
+++ b/docs/man/man1/lmm-tui.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-tui - Launch the interactive terminal UI

--- a/docs/man/man1/lmm-uninstall.1
+++ b/docs/man/man1/lmm-uninstall.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-uninstall - Uninstall a mod

--- a/docs/man/man1/lmm-update-rollback.1
+++ b/docs/man/man1/lmm-update-rollback.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-update-rollback - Rollback a mod to its previous version

--- a/docs/man/man1/lmm-update.1
+++ b/docs/man/man1/lmm-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-update - Check for or apply mod updates

--- a/docs/man/man1/lmm-verify.1
+++ b/docs/man/man1/lmm-verify.1
@@ -64,18 +64,24 @@ under the effective version, the rename is skipped - the existing
 deployment is left pointing at the still-intact recorded-version cache
 dir rather than being re-linked into the unverified pre-existing one -
 and a note is printed (also included as "note" in --json output), but
-the DB and profile are still corrected. VERSION UNVERIFIABLE is never
-fixable automatically since there is no matching upstream file to compare
-against - reinstall the mod instead.
+the DB and profile are still corrected. Since the mod cache is shared
+across profiles, a successful rename also corrects any OTHER profile
+whose record still holds the same stale version (DB, profile record, and
+re-linking a symlink deployment the same way) - printed as its own
+"Repaired (profile ...)" line per profile in text mode, or folded into
+the "note" field as "also repaired in profile(s): ..." in --json.
+VERSION UNVERIFIABLE is never fixable automatically since there is no
+matching upstream file to compare against - reinstall the mod instead.
 
 .PP
 --json emits {game_id, profile, files: [{mod_id, mod_name, file_id,
 status, note}], issues, warnings}; status is one of "ok", "missing",
 "no_checksum", "file_count_mismatch", "skipped", "version_mismatch", or
 "version_unverifiable"; note is omitted except on a --fix VERSION
-MISMATCH repair whose cache rename was skipped. issues counts MISSING
-files and VERSION MISMATCH rows (a successful --fix repair of either
-decrements it back out); warnings counts everything else that isn't OK.
+MISMATCH repair whose cache rename was skipped, or which also repaired
+the same mod in other profiles. issues counts MISSING files and VERSION
+MISMATCH rows (a successful --fix repair of either decrements it back
+out); warnings counts everything else that isn't OK.
 
 .PP
 Examples:

--- a/docs/man/man1/lmm-verify.1
+++ b/docs/man/man1/lmm-verify.1
@@ -33,17 +33,55 @@ storing a fresh checksum afterwards. FILE COUNT MISMATCH and SKIPPED
 are not repaired by --fix.
 
 .PP
+verify also contacts each installed mod's source to check its recorded
+version against what the stored file ID(s) actually are upstream (issue
+#94: older installs could record the mod's "latest" version instead of
+the version of the file that was actually downloaded and deployed):
+
+.EX
+X NAME - VERSION MISMATCH (recorded X, source reports Y)
+                                     recorded version doesn't match
+                                     what the installed file ID(s)
+                                     report upstream
+? NAME - VERSION UNVERIFIABLE       none of the recorded file ID(s)
+                                     are listed by the source anymore
+                                     (reinstall to refresh)
+.EE
+
+.PP
+Mods installed from a local source, mods requiring manual download, and
+mods with no recorded file IDs are skipped silently - there is nothing
+to check against. If the source can't be reached, the mod is reported
+as skipped with a warning instead of failing the whole run.
+
+.PP
+Use --fix to repair VERSION MISMATCH too: the cache entry is re-keyed
+from the recorded version to the effective (source-reported) one, the DB
+row and the active profile's record are corrected to match, and any
+symlink deployment is re-linked (its target lived inside the just-renamed
+cache dir and would otherwise dangle). If a cache entry already exists
+under the effective version, the rename is skipped - the existing
+deployment is left pointing at the still-intact recorded-version cache
+dir rather than being re-linked into the unverified pre-existing one -
+and a note is printed (also included as "note" in --json output), but
+the DB and profile are still corrected. VERSION UNVERIFIABLE is never
+fixable automatically since there is no matching upstream file to compare
+against - reinstall the mod instead.
+
+.PP
 --json emits {game_id, profile, files: [{mod_id, mod_name, file_id,
-status}], issues, warnings}; status is one of "ok", "missing",
-"no_checksum", "file_count_mismatch", or "skipped". issues counts
-MISSING files (a successful --fix repair decrements it back out);
-warnings counts everything else that isn't OK.
+status, note}], issues, warnings}; status is one of "ok", "missing",
+"no_checksum", "file_count_mismatch", "skipped", "version_mismatch", or
+"version_unverifiable"; note is omitted except on a --fix VERSION
+MISMATCH repair whose cache rename was skipped. issues counts MISSING
+files and VERSION MISMATCH rows (a successful --fix repair of either
+decrements it back out); warnings counts everything else that isn't OK.
 
 .PP
 Examples:
   lmm verify --game skyrim-se           # Verify all mods
   lmm verify 12345 --game skyrim-se     # Verify specific mod
-  lmm verify --fix --game skyrim-se     # Re-download missing files, populate missing checksums
+  lmm verify --fix --game skyrim-se     # Re-download missing files, populate checksums, repair version records
 
 
 .SH OPTIONS

--- a/docs/man/man1/lmm-verify.1
+++ b/docs/man/man1/lmm-verify.1
@@ -96,7 +96,7 @@ Examples:
 
 .SH OPTIONS
 \fB--fix\fP[=false]
-	re-download files that are missing or lack a stored checksum
+	re-download missing files, fill missing checksums, repair version records
 
 .PP
 \fB-h\fP, \fB--help\fP[=false]

--- a/docs/man/man1/lmm-verify.1
+++ b/docs/man/man1/lmm-verify.1
@@ -65,23 +65,27 @@ deployment is left pointing at the still-intact recorded-version cache
 dir rather than being re-linked into the unverified pre-existing one -
 and a note is printed (also included as "note" in --json output), but
 the DB and profile are still corrected. Since the mod cache is shared
-across profiles, a successful rename also corrects any OTHER profile
-whose record still holds the same stale version (DB, profile record, and
-re-linking a symlink deployment the same way) - printed as its own
-"Repaired (profile ...)" line per profile in text mode, or folded into
-the "note" field as "also repaired in profile(s): ..." in --json.
-VERSION UNVERIFIABLE is never fixable automatically since there is no
-matching upstream file to compare against - reinstall the mod instead.
+across profiles, a rename also corrects any OTHER profile whose record
+still holds the same stale version AND the same file selection (DB,
+profile record, and re-linking a symlink deployment the same way) -
+printed as its own "Repaired (profile ...)" line per profile in text
+mode, or folded into the "note" field as "also repaired in profile(s):
+\&..." in --json. A same-version sibling recording DIFFERENT files is left
+alone instead, with a note naming it and suggesting a manual
+"verify --fix -p" run scoped to that profile. VERSION UNVERIFIABLE is
+never fixable automatically since there is no matching upstream file to
+compare against - reinstall the mod instead.
 
 .PP
 --json emits {game_id, profile, files: [{mod_id, mod_name, file_id,
 status, note}], issues, warnings}; status is one of "ok", "missing",
 "no_checksum", "file_count_mismatch", "skipped", "version_mismatch", or
-"version_unverifiable"; note is omitted except on a --fix VERSION
-MISMATCH repair whose cache rename was skipped, or which also repaired
-the same mod in other profiles. issues counts MISSING files and VERSION
-MISMATCH rows (a successful --fix repair of either decrements it back
-out); warnings counts everything else that isn't OK.
+"version_unverifiable"; note adds detail where there's something extra to
+say - a blocked cache rename, sibling-repair results, a --fix repair or
+redownload failure's reason, or a file-count-check lookup failure - and is
+omitted otherwise. issues counts MISSING files and VERSION MISMATCH rows
+(a successful --fix repair of either decrements it back out); warnings
+counts everything else that isn't OK.
 
 .PP
 Examples:

--- a/docs/man/man1/lmm-verify.1
+++ b/docs/man/man1/lmm-verify.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm-verify - Verify cached mod files

--- a/docs/man/man1/lmm.1
+++ b/docs/man/man1/lmm.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.22.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.23.0" "User Commands"
 
 .SH NAME
 lmm - Linux Mod Manager \- Terminal-based mod manager for Linux

--- a/docs/plans/2026-07-28-epic98-foundational-fixes.md
+++ b/docs/plans/2026-07-28-epic98-foundational-fixes.md
@@ -1,0 +1,360 @@
+# EPIC #98 Foundational Fixes (#94, #95) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the two live correctness bugs blocking EPIC #98 Phase 2: installed mods record the mod-level latest version instead of the installed file's version (#94, including a `lmm verify --fix` repair for pre-existing bad rows), and deploy/switch/import silently substitute the primary file when stored file IDs are gone upstream (#95).
+
+**Architecture:** Two sequential PRs. **PR A (#94)** adds a pure domain helper `EffectiveInstalledVersion` and stamps the resolved file version onto the in-flight `mod` copy after file selection and before the first download in each install-recording flow — one stamp per flow fixes the DB record, the profile `ModReference.Version`, and the cache directory key together, because all three read `mod.Version` downstream. It then adds a `version-record` check to `lmm verify` (network-backed, `--fix`able) that repairs pre-existing bad rows. **PR B (#95)** makes `selectDeployFiles`' primary-file fallback a policy parameter: deploy, profile switch, and import hard-fail that mod with a clear error (other mods continue); the update-apply path keeps the fallback because "use the new version's primary file" is correct update semantics when old file IDs are pruned upstream.
+
+**Tech Stack:** Go, cobra, modernc.org/sqlite (`:memory:` in tests), testify, `t.TempDir()` for cache dirs.
+
+**User decisions (2026-07-28):** #95 = hard-fail the affected mod (no opt-in fallback flag). #94 = forward-only recording fix is NOT sufficient alone (re-deploy doesn't heal old rows; update only heals when upstream moves) — a repair path is required, hence the verify check.
+
+## Global Constraints
+
+- TDD strictly: every behavioral task starts with a failing test, run to observe the failure, then implement, then re-run to green. (`~/.claude/CLAUDE.md`)
+- NEVER pipe `go test` output inside a `&&` chain (`go test ... | tail` masks failures). Run bare or capture `$?`. (project memory)
+- `git add` files BY NAME — never `git add -A` (untracked `IDEAS.md` must stay untracked). (project memory)
+- gofmt formatting (tabs); `go vet ./...` clean before each commit.
+- Error wrapping with `%w`; sentinel errors follow the existing pattern (`internal/core/flows.go:938` `errNoDeployFiles` — unexported, `doc comment`, declared above its function).
+- Byte-fidelity caution: `internal/core/flows.go` pins many user-facing strings via tests; when changing a message, update the pinning test in the same task, never "approximately".
+- CLI/TUI parity: behavior changes land in core so both interfaces inherit them; renderer changes touch both `cmd/lmm/` and `internal/tui/` in the same task.
+- Both PRs bump version (MINOR each) + CHANGELOG as their final task; tag on the MERGE COMMIT after merge. (repo conventions)
+- Work references GitHub issues #94 and #95 (EPIC #98). PR bodies end with the standard Claude Code attribution.
+
+## File Structure (both PRs)
+
+| File | Role in this plan |
+|---|---|
+| `internal/domain/mod.go` | New pure helper `EffectiveInstalledVersion` (PR A) |
+| `internal/domain/mod_test.go` | Table-driven tests for the helper (PR A) |
+| `internal/core/flows.go` | Version stamps in 4 flows (PR A); `selectDeployFiles` policy + call sites (PR B) |
+| `internal/core/flows_install_test.go`, `flows_test.go`, `flows_import_test.go`, `flows_update_test.go` | Flow-level tests (both PRs) |
+| `cmd/lmm/install.go` | Stamp in `batchInstallMods` (PR A) |
+| `cmd/lmm/profile.go` | Stamp in `doProfileApply` (PR A); `selectFilesToDownload` hard-fail (PR B) |
+| `cmd/lmm/verify.go` | `version-record` check + `--fix` repair (PR A) |
+| `cmd/lmm/verify_test.go` | First behavioral verify tests (PR A) |
+| `cmd/lmm/deploy.go` | Remove `DeployFallbackUsed` rendering (PR B) |
+| `internal/tui/service_core.go` | Remove fallback progress lines (PR B) |
+| `internal/tui/service_core_internal_test.go` | Update pinned renderings (PR B) |
+| `CHANGELOG.md`, `cmd/lmm/root.go`, `README.md` | Docs/version (both PRs) |
+
+---
+
+# PR A — #94: record the installed file's version (branch `fix/94-installed-file-version`)
+
+### Task A1: `domain.EffectiveInstalledVersion` helper
+
+**Files:**
+- Modify: `internal/domain/mod.go` (near `DownloadableFile`, `mod.go:39-50`)
+- Test: `internal/domain/mod_test.go`
+
+**Interfaces:**
+- Produces: `func EffectiveInstalledVersion(modVersion string, selected []*DownloadableFile) string` — used by Tasks A2–A7. Rule: first selected file with `IsPrimary && Version != ""`; else first selected file with `Version != ""`; else `modVersion`. Nil entries skipped.
+
+- [ ] **Step 1: Write the failing table-driven test** in `internal/domain/mod_test.go`:
+
+```go
+func TestEffectiveInstalledVersion(t *testing.T) {
+	f := func(id, version string, primary bool) *domain.DownloadableFile {
+		return &domain.DownloadableFile{ID: id, Version: version, IsPrimary: primary}
+	}
+	tests := []struct {
+		name     string
+		modVer   string
+		selected []*domain.DownloadableFile
+		want     string
+	}{
+		{"no files falls back to mod version", "1.5", nil, "1.5"},
+		{"single file with version wins", "1.5", []*domain.DownloadableFile{f("10", "1.0", false)}, "1.0"},
+		{"file without version falls back", "1.5", []*domain.DownloadableFile{f("10", "", true)}, "1.5"},
+		{"primary file version preferred over earlier non-primary", "1.5",
+			[]*domain.DownloadableFile{f("10", "0.9-patch", false), f("11", "1.0", true)}, "1.0"},
+		{"first non-empty when no primary has a version", "1.5",
+			[]*domain.DownloadableFile{f("10", "", true), f("11", "1.0", false)}, "1.0"},
+		{"nil entries skipped", "1.5", []*domain.DownloadableFile{nil, f("10", "1.0", false)}, "1.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, domain.EffectiveInstalledVersion(tt.modVer, tt.selected))
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run** `go test ./internal/domain/... -run TestEffectiveInstalledVersion -v` — expect FAIL (undefined function).
+- [ ] **Step 3: Implement** in `internal/domain/mod.go`, directly below the `DownloadableFile` struct:
+
+```go
+// EffectiveInstalledVersion resolves the version string that describes what
+// the selected files actually are: the primary selected file's Version when
+// it carries one, else the first selected file with a non-empty Version,
+// else modVersion (the mod-level version). Install-recording flows stamp
+// this onto the mod before downloading so the DB row, the profile
+// ModReference, and the cache directory key all describe the bytes on disk
+// (issue #94) instead of the mod-level latest.
+func EffectiveInstalledVersion(modVersion string, selected []*DownloadableFile) string {
+	for _, f := range selected {
+		if f != nil && f.IsPrimary && f.Version != "" {
+			return f.Version
+		}
+	}
+	for _, f := range selected {
+		if f != nil && f.Version != "" {
+			return f.Version
+		}
+	}
+	return modVersion
+}
+```
+
+- [ ] **Step 4: Run the test again** — expect PASS. Also run `go test ./internal/domain/...` (whole package) and `go vet ./internal/domain/...`.
+- [ ] **Step 5: Commit** `git add internal/domain/mod.go internal/domain/mod_test.go && git commit -m "feat(domain): EffectiveInstalledVersion resolves file-level install version (#94)"`
+
+### Task A2: stamp in `applyInstallPrimary` (single/primary install)
+
+**Files:**
+- Modify: `internal/core/flows.go:2889-2910` (`applyInstallPrimary`)
+- Test: `internal/core/flows_install_test.go`
+
+**Interfaces:**
+- Consumes: `domain.EffectiveInstalledVersion` (Task A1).
+- Context: `mod := plan.Mod` local copy at `flows.go:2890`; downloads via `s.DownloadModToCache(..., &mod, file, ...)` key the cache by `mod.Version` (`service.go:572`); the DB save (`flows.go:3028` area, `InstalledMod{Mod: mod}`) and reinstall-transaction check (`flows.go:2910`, `plan.Replaces.Version == mod.Version`) also read it. The stamp goes AFTER `mod := plan.Mod` and BEFORE the reinstall-transaction check, so a same-file reinstall (whose recorded version now equals the file version) still takes the transaction path.
+
+- [ ] **Step 1: Write the failing test** in `internal/core/flows_install_test.go`. Use the existing helpers (`newFlowsTestService`, `mockSourceWithDownloads`, `createTestZip`) and the embed-and-override mock pattern (e.g. `sizedFileSource` at `flows_install_test.go:65`):
+
+```go
+// oldFileSource serves two files: the primary/latest (v1.5) and an archived
+// older file (v1.0). mockSource's default GetModFiles is overridden.
+type oldFileSource struct {
+	*mockSourceWithDownloads
+}
+
+func (s *oldFileSource) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	return []domain.DownloadableFile{
+		{ID: "1", Name: "Main File", FileName: mod.ID + ".zip", Version: "1.5", IsPrimary: true},
+		{ID: "2", Name: "Old File", FileName: mod.ID + "-old.zip", Version: "1.0"},
+	}, nil
+}
+
+func TestApplyInstall_ExplicitOldFile_RecordsFileVersionAndCacheKey(t *testing.T) {
+	// Mirror the CLI --file path: PlanInstall, then overwrite plan.Files with
+	// the non-primary old file (cmd/lmm/install.go:497-513 does exactly this).
+	// Assert the DB row records "1.0" (not the mod-level "1.5"), the cache
+	// path is keyed "1.0", and CheckUpdates subsequently OFFERS an update -
+	// the user-visible symptom of #94 (an older install must not suppress
+	// its own update notifications).
+}
+```
+
+Test body outline (write it fully in the task):
+1. Build service with an `oldFileSource` whose mod has `Version: "1.5"`; register download content for file ID `"2"` via `AddDownload`.
+2. `plan, err := svc.PlanInstall(...)`; `require.NoError`; set `plan.Files = []domain.DownloadableFile{{ID: "2", ..., Version: "1.0"}}` (copy the old file entry from `GetModFiles`).
+3. `_, err = svc.ApplyInstall(ctx, game, plan, opts)`; `require.NoError`.
+4. Assert DB: `svc.GetInstalledMod(...)` row `.Version == "1.0"`.
+5. Assert cache: `svc.GetGameCache(game).Exists(game.ID, sourceID, modID, "1.0")` is true and `.Exists(..., "1.5")` is false.
+6. Assert update visibility: run `core.NewUpdater(registry).CheckUpdates(...)` against the same source and require exactly one update with `NewVersion == "1.5"` (mockSource-based sources use `domain.IsNewerVersion(inst.Version, remoteMod.Version)`; confirm the mock's `CheckUpdates` supports this — if `mockSource` has no `CheckUpdates`, assert instead via `domain.IsNewerVersion("1.0", "1.5")` == true AND add the CheckUpdates assertion at the source-mock level that does support it, e.g. `updateMockSource` in `updater_test.go:17`).
+
+- [ ] **Step 2: Run** `go test ./internal/core/... -run TestApplyInstall_ExplicitOldFile -v` — expect FAIL (row records "1.5", cache keyed "1.5").
+- [ ] **Step 3: Implement.** In `applyInstallPrimary` (`flows.go:2890`), immediately after `mod := plan.Mod` and before the reinstall-transaction check at `:2910`:
+
+```go
+	// #94: record what is actually being installed. plan.Files is the final
+	// selection (the CLI --file/picker path overwrites it after PlanInstall),
+	// and mod.Version keys the cache, the DB row, and the profile ref below.
+	selectedFiles := make([]*domain.DownloadableFile, len(plan.Files))
+	for i := range plan.Files {
+		selectedFiles[i] = &plan.Files[i]
+	}
+	mod.Version = domain.EffectiveInstalledVersion(mod.Version, selectedFiles)
+```
+
+- [ ] **Step 4: Run the test — PASS.** Then run the whole core package bare: `go test ./internal/core/...` (some existing tests may pin "1.5"-style recorded versions via the default `mockSource` single-file fixture whose file has no `Version` field set — those keep passing because empty file versions fall back to `mod.Version`; investigate any failure individually, do not blindly update goldens).
+- [ ] **Step 5: Commit** `git add internal/core/flows.go internal/core/flows_install_test.go && git commit -m "fix(core): install records the selected file's version, cache keyed to match (#94)"`
+
+### Task A3: stamp in `applyInstallBatchMod` (dependency/batch installs)
+
+**Files:**
+- Modify: `internal/core/flows.go:2757-2762` (`applyInstallBatchMod`)
+- Test: `internal/core/flows_install_test.go`
+
+**Interfaces:** Consumes `domain.EffectiveInstalledVersion`. Context: this path ignores `plan.Files` and re-resolves per mod — `selected, _, err := selectDeployFiles(files, nil)` at `flows.go:2757`, then `file := selected[0]` at `:2762`; downloads at `:2775` and the DB save at `:2809` read `mod.Version` through the `mod *domain.Mod` pointer (safe to stamp: `plan.Dependencies` entries are not re-read after apply).
+
+- [ ] **Step 1: Failing test:** a dependency mod whose source reports mod-level `Version: "2.0"` but whose primary file carries `Version: "2.0.1"`; install the parent; assert the dependency's DB row and cache dir carry `"2.0.1"`.
+- [ ] **Step 2: Run it** — FAIL.
+- [ ] **Step 3: Implement.** After `file := selected[0]` (`flows.go:2762`), before the `fileEvt` emit:
+
+```go
+	mod.Version = domain.EffectiveInstalledVersion(mod.Version, selected) // #94
+```
+
+- [ ] **Step 4: Re-run — PASS**; run `go test ./internal/core/...` bare.
+- [ ] **Step 5: Commit** `git add internal/core/flows.go internal/core/flows_install_test.go && git commit -m "fix(core): batch/dependency installs record file-level version (#94)"`
+
+### Task A4: stamp in `ApplyProfileSwitch` and `ApplyImport`
+
+**Files:**
+- Modify: `internal/core/flows.go:1929-1933` (switch) and `:3822-3826` (import)
+- Test: `internal/core/flows_test.go`, `internal/core/flows_import_test.go`
+
+**Interfaces:** Consumes `domain.EffectiveInstalledVersion`. Context: switch — `mod` fetched at `:1903`, `filesToDownload` from `selectDeployFiles(files, ref.FileIDs)` at `:1920`, downloads at `:1941`, save at `:1967`, profile ref at `:1980`. Import — `mod` at `:3785`, selection at `:3813`, downloads at `:3834`, save at `:3856`, ref at `:3869`. Stamp between the `usedFallback` emit block and the download loop in each.
+
+- [ ] **Step 1: Failing tests** (one per flow, mirroring `TestService_ApplyProfileSwitch_InstallLoop_FallbackUsedWhenStoredFileIDsNotFound` at `flows_test.go:2673` for setup style, and `TestApplyImportRedownloadUsesStoredFileIDs` at `flows_import_test.go:328`): source lists file `"1"` `Version: "1.0"` (matching the stored `FileIDs`) while the mod-level version is `"1.5"`; run the flow; assert the saved row's `.Version == "1.0"` and cache `Exists(..., "1.0")`.
+- [ ] **Step 2: Run both** — FAIL.
+- [ ] **Step 3: Implement**, identically in both flows:
+
+```go
+			mod.Version = domain.EffectiveInstalledVersion(mod.Version, filesToDownload) // #94
+```
+
+(Placement: switch — after the `usedFallback` block ending `:1930`, before `var downloadedFileIDs`; import — after the block ending `:3822`, before the download loop at `:3826`.)
+
+- [ ] **Step 4: Re-run — PASS**; `go test ./internal/core/...` bare.
+- [ ] **Step 5: Commit** `git add internal/core/flows.go internal/core/flows_test.go internal/core/flows_import_test.go && git commit -m "fix(core): profile switch and import record file-level version (#94)"`
+
+### Task A5: stamp the two live CLI-side sites
+
+**Files:**
+- Modify: `cmd/lmm/install.go:1040-1079` (`batchInstallMods`), `cmd/lmm/profile.go:1055-1097` (`doProfileApply`)
+- Test: existing cmd-level test files (`cmd/lmm/install_test.go`, `cmd/lmm/profile_test.go`) — follow their established fake-service/temp-dir setup.
+
+**Interfaces:** Consumes `domain.EffectiveInstalledVersion`. Context: `batchInstallMods` selects via `selectPrimaryFile(files)` (returns `*domain.DownloadableFile`, `profile.go:1133`) then saves `InstalledMod{Mod: *mod}` at `install.go:1079` and the profile ref at `:1103`. `doProfileApply` selects via `selectFilesToDownload` at `profile.go:1055`, downloads at `:1074` (cache keyed by `mod.Version`), saves at `:1097`, ref at `:1114`. (The two `cmd/lmm/import.go` sites are LOCAL imports — no `DownloadableFile` exists, version comes from filename parsing — out of #94's scope.)
+
+- [ ] **Step 1: Failing tests**: cmd-level, seeding a source whose primary file version differs from the mod version; run the command path; assert the DB row's version equals the file version. If cmd-level harnessing is disproportionate, test the same behavior through the core flows these paths mirror AND add a minimal cmd assertion on the saved row.
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement.** `batchInstallMods`, after the `selectPrimaryFile` call:
+
+```go
+	mod.Version = domain.EffectiveInstalledVersion(mod.Version, []*domain.DownloadableFile{file}) // #94
+```
+
+`doProfileApply`, after the `usedFallback` warning block (`profile.go:1061-1063`), before the download loop:
+
+```go
+			mod.Version = domain.EffectiveInstalledVersion(mod.Version, filesToDownload) // #94
+```
+
+- [ ] **Step 4: Re-run — PASS**; `go test ./cmd/lmm/...` bare.
+- [ ] **Step 5: Commit** `git add cmd/lmm/install.go cmd/lmm/profile.go cmd/lmm/install_test.go cmd/lmm/profile_test.go && git commit -m "fix(cli): batch install and profile apply record file-level version (#94)"`
+
+### Task A6: `lmm verify` version-record check (report only)
+
+**Files:**
+- Modify: `cmd/lmm/verify.go` (`doVerify` at `:84`, `verifyFileJSON` at `:21-33`, `Long` doc at `:38-67`)
+- Test: `cmd/lmm/verify_test.go`
+
+**Interfaces:**
+- Consumes: `svc.GetInstalledMods(game.ID, profile)` (`service.go:649`), `svc.GetModFiles` (`service.go:371`), `domain.EffectiveInstalledVersion`.
+- Produces: new `verifyFileJSON.Status` literals `"version_mismatch"` (bucket `issues`, fixable in Task A7) and `"version_unverifiable"` (bucket `warnings`, not fixable — stored file IDs no longer exist upstream). Task A7 extends this check with the `--fix` branch.
+
+Check semantics (a pre-pass loop alongside the file-count pre-pass at `verify.go:129`, one entry per installed mod, `FileID` left empty):
+- Skip silently: `SourceID == domain.SourceLocal`, `ManualDownload`, or `len(FileIDs) == 0`.
+- `GetModFiles` error → `warnings++`, text "could not check version (source unreachable)", JSON status `skipped`.
+- Stored `FileIDs` matched against the returned list → `effective := domain.EffectiveInstalledVersion(mod.Version, matched)`. If no stored ID matches → `"version_unverifiable"` + reinstall hint. If `effective != mod.Version` → `"version_mismatch"` (report shows both values). Else `ok` (counted, not printed per-line — matching the existing quiet-ok convention).
+- The `Long` help text gains a paragraph: the version-record check contacts each mod's source; statuses documented incl. which are fixable.
+
+- [ ] **Step 1: Write failing behavioral tests** (the file currently has only cobra-wiring smoke tests — these are the first): seed an installed row with `Version: "1.5"`, `FileIDs: ["2"]` against a fake source whose file `"2"` reports `Version: "1.0"` → expect `version_mismatch` in text and JSON with `issues == 1`; a second case where the source no longer lists `"2"` → `version_unverifiable`, `warnings == 1`. Follow the cmd-package test conventions (TestMain temp-dir flooring from `main_test.go`; build a `core.ServiceConfig` like `install_gameid` tests do).
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** the pre-pass loop + status plumbing + `Long` text.
+- [ ] **Step 4: Re-run — PASS**; `go test ./cmd/lmm/...` bare.
+- [ ] **Step 5: Commit** `git add cmd/lmm/verify.go cmd/lmm/verify_test.go && git commit -m "feat(cli): verify detects version-record mismatches (#94)"`
+
+### Task A7: `verify --fix` repairs version records
+
+**Files:**
+- Modify: `cmd/lmm/verify.go`
+- Test: `cmd/lmm/verify_test.go`
+
+**Interfaces:**
+- Consumes: Task A6's `version_mismatch` detection; `svc.GetGameCache(game).ModPath(...)` (`cache.go:29`) with `os.Rename` (precedent: `cmd/lmm/import.go:160-169`); `svc.GetInstalledMod` + `svc.SaveInstalledMod` (`service.go:884`, `:820` — full-row load-mutate-save, deliberately NOT `UpdateModVersion`, which would shift the wrong value into `previous_version` and poison rollback); `getProfileManager(service)` (as used at `install.go:971`) + `pm.UpsertMod(gameID, profile, domain.ModReference{SourceID, ModID, Version: effective, FileIDs: mod.FileIDs})`; `svc.GetInstaller(game).Install(...)` for the re-link.
+
+Fix sequence per `version_mismatch` row (guarded on `verifyFix && mod.SourceID != domain.SourceLocal`, matching `redownloadModFile`'s gate at `verify.go:296`):
+1. Cache re-key: if `oldPath := ModPath(..., mod.Version)` exists and `newPath := ModPath(..., effective)` does not → `os.Rename(oldPath, newPath)`. If the new path already exists, leave the cache alone and continue (report notes it). Rename failure → the row stays `version_mismatch`, error printed, no DB write (never let the DB and cache disagree in a NEW way).
+2. DB: load the full row, set `Version = effective`, `SaveInstalledMod`.
+3. Profile ref: `pm.UpsertMod` with the corrected version.
+4. Re-link: if the mod is `Deployed` and `LinkMethod == domain.LinkSymlink`, the game-dir symlinks point INTO the renamed cache dir and are now dangling — re-run `installer.Install(ctx, game, &mod.Mod, profile)` to refresh them. Hardlink/copy deployments are untouched by the rename.
+5. On full success: mutate the row's JSON entry to `ok` and decrement `issues` (the existing in-place pattern at `verify.go:206-210`); text prints "Repaired: <old> → <new>".
+
+- [ ] **Step 1: Write failing tests**: (a) mismatch row, not deployed → after `--fix`: DB row shows the file version, cache `Exists` under the new key and not the old, profile YAML ref updated, JSON status `ok`, `issues == 0`; (b) mismatch row, `Deployed` + symlink → additionally assert the deployed symlink resolves post-fix (use `t.TempDir()` game dir); (c) rename-blocked case (pre-create the new-version cache dir) → DB IS still fixed, cache left as-is, note emitted.
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** the repair helper (model: `redownloadModFile`, `verify.go:296`).
+- [ ] **Step 4: Re-run — PASS**; `go test ./cmd/lmm/...` bare; `go vet ./...`.
+- [ ] **Step 5: Commit** `git add cmd/lmm/verify.go cmd/lmm/verify_test.go && git commit -m "feat(cli): verify --fix repairs version records, re-keys cache, re-links (#94)"`
+
+### Task A8: PR A docs, CHANGELOG, version bump, PR
+
+- [ ] **Step 1:** README verify section (if present — `grep -n "verify" README.md`) gains the version-record check + the note that verify now contacts sources; regenerate man pages if help text changed (`make man`, drift test will fail otherwise).
+- [ ] **Step 2:** CHANGELOG: `### Fixed` — #94 record/cache fix; `### Added` — verify version-record check + `--fix` repair. Move `[Unreleased]` → `## [1.23.0] - 2026-07-28` (adjust if the current version differs from v1.22.0; MINOR because of the new verify capability + JSON statuses), update comparison links.
+- [ ] **Step 3:** Bump `version` in `cmd/lmm/root.go` to `1.23.0`. Commit separately: `chore: bump version to 1.23.0`.
+- [ ] **Step 4:** Full gate, each command run bare: `go fmt ./...`, `go vet ./...`, `go test ./...`, `trunk check`. Then push branch, open PR "fix(core): record the installed file's version, not the mod's latest (#94)" referencing EPIC #98; run Copilot triage rounds per repo convention (`gh-await-review` via background Bash).
+
+---
+
+# PR B — #95: no silent primary-file fallback (branch `fix/95-no-silent-fallback`; branch from main AFTER PR A merges — it edits the lines adjacent to A4's stamps)
+
+### Task B1: `selectDeployFiles` fallback becomes a policy
+
+**Files:**
+- Modify: `internal/core/flows.go:993-1026` (+ sentinel above it), call sites `:1321` (deploy), `:1920` (switch), `:2200` (PlanInstall), `:2757` (batch), `:3219` (update), `:3813` (import)
+- Test: `internal/core/flows_test.go`, `flows_import_test.go`, `flows_update_test.go`
+
+**Interfaces:**
+- Produces: `func selectDeployFiles(files []domain.DownloadableFile, storedFileIDs []string, allowFallback bool) ([]*domain.DownloadableFile, bool, error)` and sentinel `errStoredFilesUnavailable`. With `allowFallback == false`, a would-be fallback returns `nil, false, fmt.Errorf("%w (file ID(s): %s) - reinstall the mod or run 'lmm update' to adopt the current version", errStoredFilesUnavailable, strings.Join(storedFileIDs, ", "))`. With `true`, behavior is unchanged (update-apply semantics: falling back to the NEW version's primary file is correct when a source prunes old files — CurseForge routinely does; hard-failing there would break updates. The update path's own silent-substitution subtleties belong to #96).
+- Call-site policy: deploy `:1321` → `false`, existing `skip(err.Error())` at `:1323` already routes the error to `result.Skipped` + `DeploySkipped`; switch `:1920` → `false`, `fail(err.Error())` at `:1922` routes to `SwitchInstallError`; import `:3813` → `false`, `fail(err.Error())` at `:3815` routes to `ImportModFailed` (+`Failed++`); update `:3219` → `true`; nil-ID sites `:2200`/`:2757` → `false` (unreachable branch — no stored IDs means no fallback).
+- Dead phases removed: `DeployFallbackUsed` (`flows.go:306`), `SwitchFallbackUsed` (`:452`), `ImportFallbackUsed` (`:787`) and their emit blocks (`:1325-1329`, `:1925-1930`, `:3818-3822`).
+
+- [ ] **Step 1: Write the failing tests first:**
+  - Deploy (currently UNTESTED fallback — green-field): `TestService_DeployProfile_StoredFileIDsGone_SkipsModWithClearError` mirroring `TestService_DeployProfile_MissingCacheAndDownloadFailure_EmitsDeployDownloadFailedEvent` (`flows_test.go:1093`): stored `FileIDs: ["stale-id"]` vs mock's only file `"1"`; assert `require.NoError` overall (per-mod failure never fails the deploy), exactly one `result.Skipped` entry containing "no longer available upstream" and "stale-id", `DeploySkipped` fired, `DeployFallbackUsed` NOT fired, and the mod NOT deployed.
+  - Switch: convert `TestService_ApplyProfileSwitch_InstallLoop_FallbackUsedWhenStoredFileIDsNotFound` (`flows_test.go:2673`) into `..._StoredFileIDsGone_FailsMod`: expect `SwitchInstallError` with the message, mod not installed, and (add a second mod) the loop continuing.
+  - Import: mirror `TestApplyImportPartialFailure` (`flows_import_test.go:276`): `ImportModFailed` + `Failed == 1`, no substitution.
+  - Update keeps fallback: `TestApplyUpdate_StoredFileIDsGoneUpstream_FallsBackToPrimary` in `flows_update_test.go`: stored IDs absent from the new version's file list and no `FileIDReplacements` → update succeeds using the primary file.
+- [ ] **Step 2: Run all four** — FAIL (first three see substitution; fourth passes only after signature change compiles — expected compile failure counts as the observed failure here).
+- [ ] **Step 3: Implement:** sentinel + signature + branch; update all six call sites; delete the three phases, their emit blocks, and their `usedFallback` locals.
+- [ ] **Step 4:** `go test ./internal/core/...` bare — PASS, including pre-existing pins (the negative-assertion idiom from `flows_test.go:1093`'s family guards double-printing).
+- [ ] **Step 5: Commit** `git add internal/core/flows.go internal/core/flows_test.go internal/core/flows_import_test.go internal/core/flows_update_test.go && git commit -m "fix(core): stored-file-gone is a per-mod failure, not a silent fallback (#95)"`
+
+### Task B2: CLI + TUI renderer cleanup
+
+**Files:**
+- Modify: `cmd/lmm/deploy.go:171-172` (remove `DeployFallbackUsed` case), `cmd/lmm/profile.go:364-366`, `:503-505` (remove `SwitchFallbackUsed`/`ImportFallbackUsed` cases), `internal/tui/service_core.go:1107-1108` (switch line), `:1643-1644` (import line)
+- Test: `internal/tui/service_core_internal_test.go` (`:44-48` pins the fallback rendering — update), plus any cmd test pinning the warning strings (`grep -rn "using primary" cmd internal --include="*_test.go"`)
+
+- [ ] **Step 1:** Update the pinned-rendering tests to expect the fallback lines GONE (compile errors from the removed phase constants guide the sweep — that is the failing state).
+- [ ] **Step 2:** Remove the render cases in CLI and TUI.
+- [ ] **Step 3:** `go test ./cmd/lmm/... ./internal/tui/...` bare — PASS. `go vet ./...`.
+- [ ] **Step 4: Commit** `git add cmd/lmm/deploy.go cmd/lmm/profile.go internal/tui/service_core.go internal/tui/service_core_internal_test.go && git commit -m "fix(tui,cli): drop dead fallback-warning renderers (#95)"`
+
+### Task B3: CLI `selectFilesToDownload` (doProfileApply) same policy
+
+**Files:**
+- Modify: `cmd/lmm/profile.go:1151` (`selectFilesToDownload`) and its only call site `:1055-1063`
+- Test: `cmd/lmm/profile_test.go`
+
+**Interfaces:** Mirror B1 exactly on the CLI copy (it exists for documented duplication reasons — `flows.go:2234`): signature `(files []domain.DownloadableFile, storedFileIDs []string) ([]*domain.DownloadableFile, error)` — single caller is deploy-class, so no `allowFallback` parameter needed; would-be fallback returns the same wrapped error text as core's. Call site replaces the `usedFallback` warning with `fmt.Printf("    Error: %v\n", err)` + `continue` (the pattern already present at `:1056-1058`).
+
+- [ ] **Step 1:** Failing test: profile apply with stale stored FileIDs → mod skipped with the upstream-gone error, no substitution, other mods proceed.
+- [ ] **Step 2:** Run — FAIL.
+- [ ] **Step 3:** Implement.
+- [ ] **Step 4:** `go test ./cmd/lmm/...` bare — PASS.
+- [ ] **Step 5: Commit** `git add cmd/lmm/profile.go cmd/lmm/profile_test.go && git commit -m "fix(cli): profile apply fails mods whose stored files are gone upstream (#95)"`
+
+### Task B4: PR B docs, CHANGELOG, version bump, PR
+
+- [ ] **Step 1:** `grep -rn "using primary" docs README.md` — update any documentation of the old warning to describe the new failure + remediation. Regenerate man pages if help text changed.
+- [ ] **Step 2:** CHANGELOG `### Changed`: deploy/switch/import now fail a mod (with reinstall/update hint) instead of silently substituting the primary file; update-apply intentionally retains the fallback. `## [1.24.0]` + links.
+- [ ] **Step 3:** Bump `cmd/lmm/root.go` to `1.24.0`; separate `chore: bump version to 1.24.0` commit.
+- [ ] **Step 4:** Full gate (bare): `go fmt ./...`, `go vet ./...`, `go test ./...`, `trunk check`. **This PR archives this plan doc** (move to `docs/plans/archive/`) per repo convention. Push, open PR "fix(core): fail deploys when stored files are gone upstream (#95)" referencing EPIC #98, Copilot triage rounds.
+
+---
+
+## Post-merge (both PRs)
+
+- Tag each release on its MERGE COMMIT (repo convention; lightweight tags).
+- Comment on #94 and #95; close them (check them off in EPIC #98's body — they are the "Foundational fixes" tier).
+- #93 remains open (interim guard shipped v1.18.2; real implementation belongs to #96).
+- Note for #96's design: the update-apply path still records `Update.NewVersion` rather than the downloaded file's version — deliberate here (it breaks the sloppy-upstream-metadata update loop: a mod whose author bumps the mod version without new files gets ONE spurious-looking update offer that resolves on apply, instead of looping forever), but #96's version→file resolver should revisit it.
+
+## Self-review notes
+
+- Spec coverage: #94 record fix (A2-A5 cover all six live recording sites; the two `cmd/lmm/import.go` sites are local imports with no file version — out of scope by construction), cache keying (same stamp — verified against the blast-radius list: every cache read keys off the recorded `mod.Version`, so record==key holds by construction), repair (A6-A7 per user decision), update-offer symptom (A2 step 1.6). #95 hard-fail (B1) in all three flows + CLI copy (B3), TUI parity (B2), update exemption tested (B1).
+- Deliberate exclusions: update-apply fallback retained (rationale in B1); local-import version semantics unchanged; `verify` stays CLI-only (no TUI verify surface exists — not a new parity gap).

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -2760,6 +2760,7 @@ func (s *Service) applyInstallBatchMod(ctx context.Context, game *domain.Game, p
 		return nil
 	}
 	file := selected[0]
+	mod.Version = domain.EffectiveInstalledVersion(mod.Version, selected) // #94
 
 	fileEvt := base
 	fileEvt.Phase, fileEvt.File = InstallDepFileSelected, file

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -1928,6 +1928,8 @@ func (s *Service) ApplyProfileSwitch(ctx context.Context, game *domain.Game, pla
 				emit(fallbackEvt)
 			}
 
+			mod.Version = domain.EffectiveInstalledVersion(mod.Version, filesToDownload) // #94
+
 			var downloadedFileIDs []string
 			downloadFailed := false
 			for _, file := range filesToDownload {
@@ -3831,6 +3833,8 @@ func (s *Service) ApplyImport(ctx context.Context, game *domain.Game, plan *Impo
 			fbEvt.Phase = ImportFallbackUsed
 			emit(fbEvt)
 		}
+
+		mod.Version = domain.EffectiveInstalledVersion(mod.Version, filesToDownload) // #94
 
 		var downloadedFileIDs []string
 		downloadFailed := false

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -2888,6 +2888,16 @@ type fileChecksum struct {
 // as a whole, matching doInstall's own early returns.
 func (s *Service) applyInstallPrimary(ctx context.Context, game *domain.Game, plan *InstallPlan, linkMethod domain.LinkMethod, pm *ProfileManager, opts InstallOptions, result *InstallResult, emit func(DeployProgress)) (*DeployProgress, error) {
 	mod := plan.Mod // local, addressable copy - distinct from plan.Mod
+
+	// #94: record what is actually being installed. plan.Files is the final
+	// selection (the CLI --file/picker path overwrites it after PlanInstall),
+	// and mod.Version keys the cache, the DB row, and the profile ref below.
+	selectedFiles := make([]*domain.DownloadableFile, len(plan.Files))
+	for i := range plan.Files {
+		selectedFiles[i] = &plan.Files[i]
+	}
+	mod.Version = domain.EffectiveInstalledVersion(mod.Version, selectedFiles)
+
 	base := DeployProgress{ModName: mod.Name, ModID: mod.ID, SourceID: mod.SourceID}
 
 	hookCtx := opts.HookContext

--- a/internal/core/flows_import_test.go
+++ b/internal/core/flows_import_test.go
@@ -386,6 +386,64 @@ func TestApplyImportRedownloadUsesStoredFileIDs(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "the primary file must NOT have been downloaded/deployed")
 }
 
+// TestApplyImport_InstallLoop_RecordsFileVersion is the #94 regression test
+// for ApplyImport's install loop: like
+// TestApplyImportRedownloadUsesStoredFileIDs above, a prior install recorded
+// FileIDs=["1"] with no matching cache entry (forcing a redownload), but
+// here the source's served file "1" carries its own Version ("1.0"),
+// distinct from the mod-level Version ("1.5"). The saved InstalledMod row
+// and cache dir must be stamped with the file's version, not the mod's -
+// mirroring flows_test.go's TestService_ApplyProfileSwitch_InstallLoop_
+// RecordsFileVersion for this flow. versionedFileSource is defined in
+// flows_test.go (same core_test package).
+func TestApplyImport_InstallLoop_RecordsFileVersion(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	mock := &versionedFileSource{mockSourceWithDownloads: newMockSourceWithDownloads("src")}
+	defer mock.Close()
+	svc.RegisterSource(mock)
+	mock.AddMod("g1", &domain.Mod{ID: "mod1", SourceID: "src", Name: "Mod One", Version: "1.5", GameID: "g1"})
+
+	zipPath := createTestZip(t, t.TempDir(), map[string]string{"mod1.esp": "payload"})
+	zipContent, err := os.ReadFile(zipPath)
+	require.NoError(t, err)
+	mock.AddDownload("1", zipContent)
+
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	// A prior install recorded FileIDs=["1"], but its cache entry is gone -
+	// a cache-miss redownload, matching TestApplyImportRedownloadUsesStoredFileIDs's setup.
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "mod1", SourceID: "src", Name: "Mod One", Version: "1.5", GameID: "g1"},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+		FileIDs:      []string{"1"},
+	}))
+
+	profile := &domain.Profile{Name: "target", GameID: "g1", Mods: []domain.ModReference{{SourceID: "src", ModID: "mod1", Version: "1.5"}}}
+	data, err := config.ExportProfile(profile)
+	require.NoError(t, err)
+
+	plan, err := svc.PlanImport(context.Background(), game, data)
+	require.NoError(t, err)
+	require.Len(t, plan.NeedsRedownload, 1)
+
+	result, err := svc.ApplyImport(context.Background(), game, plan, core.ProfileImportOptions{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Installed)
+
+	installed, err := svc.GetInstalledMod("src", "mod1", "g1", "target")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", installed.Version, "DB row must record the selected file's version, not the mod's latest")
+
+	gameCache := svc.GetGameCache(game)
+	assert.True(t, gameCache.Exists("g1", "src", "mod1", "1.0"), "cache must be keyed by the installed file's version")
+}
+
 // TestApplyImportCtxCancelled covers the loop's cancellation check: it must
 // be honored BETWEEN mods (never mid-file-operation), matching
 // DeployProfile/ApplyProfileSwitch's identical check - the quit-drain

--- a/internal/core/flows_install_test.go
+++ b/internal/core/flows_install_test.go
@@ -565,6 +565,25 @@ func (s *oldFileSource) GetModFiles(ctx context.Context, mod *domain.Mod) ([]dom
 	}, nil
 }
 
+// versionOverrideFileSource is oldFileSource's BATCH-path counterpart: like
+// perModFileSource, its single served file's ID is the mod's own ID (so
+// distinct mods - e.g. a dependency and its primary - each get an
+// unambiguous download key and can be installed together via
+// applyInstallBatchMod), but the file's Version is looked up per mod.ID in
+// fileVersions rather than left blank, so a test can diverge it from the
+// mod's own Version field - see
+// TestApplyInstall_ExplicitOldFile_BatchPath_RecordsFileVersion (#94).
+type versionOverrideFileSource struct {
+	*mockSourceWithDownloads
+	fileVersions map[string]string // mod.ID -> served file's Version
+}
+
+func (s *versionOverrideFileSource) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	return []domain.DownloadableFile{
+		{ID: mod.ID, Name: mod.Name, FileName: mod.ID + ".zip", Version: s.fileVersions[mod.ID], IsPrimary: true},
+	}, nil
+}
+
 // registerDownloadableMod registers mod with mock and stages a one-file zip
 // archive (containing relativePath -> content) as that mod's download,
 // keyed by mod.ID (matching perModFileSource's GetModFiles).
@@ -1317,6 +1336,61 @@ exit 0`)
 	require.NoError(t, err)
 	assert.Equal(t, "install.before_each:mod1:1.0\n", string(logContent),
 		"install.before_each must see the effective (selected-file) version, not the mod-level 1.5")
+}
+
+// TestApplyInstall_ExplicitOldFile_BatchPath_RecordsFileVersion is the #94
+// regression test for the BATCH path (applyInstallBatchMod), which installs
+// dependencies AND the primary identically and - unlike applyInstallPrimary
+// - always re-resolves its own file from the source rather than consulting
+// plan.Files. A dependency mod's source reports a mod-level Version ("2.0")
+// that differs from its actually-served primary file's Version ("2.0.1");
+// the DB row and cache dir must carry the file's version, matching
+// TestApplyInstall_ExplicitOldFile_RecordsFileVersionAndCacheKey's PRIMARY
+// path assertion but exercised via a dependency install instead.
+func TestApplyInstall_ExplicitOldFile_BatchPath_RecordsFileVersion(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	mock := &versionOverrideFileSource{
+		mockSourceWithDownloads: newMockSourceWithDownloads("src"),
+		fileVersions:            map[string]string{"dep1": "2.0.1", "root": "1.0"},
+	}
+	defer mock.Close()
+	svc.RegisterSource(mock)
+
+	dep1 := &domain.Mod{ID: "dep1", SourceID: "src", Name: "Dep One", Version: "2.0", GameID: "g1"}
+	root := &domain.Mod{ID: "root", SourceID: "src", Name: "Root", Version: "1.0", GameID: "g1",
+		Dependencies: []domain.ModReference{{SourceID: "src", ModID: "dep1"}}}
+
+	depZip := createTestZip(t, t.TempDir(), map[string]string{"dep1.esp": "dep-payload"})
+	depContent, err := os.ReadFile(depZip)
+	require.NoError(t, err)
+	mock.AddDownload("dep1", depContent)
+	mock.AddMod(dep1.GameID, dep1)
+
+	rootZip := createTestZip(t, t.TempDir(), map[string]string{"root.esp": "root-payload"})
+	rootContent, err := os.ReadFile(rootZip)
+	require.NoError(t, err)
+	mock.AddDownload("root", rootContent)
+	mock.AddMod(root.GameID, root)
+
+	plan, err := svc.PlanInstall(context.Background(), game, "default", "src", "root", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Dependencies, 1)
+
+	result, err := svc.ApplyInstall(context.Background(), game, plan, core.InstallOptions{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"Dep One", "Root"}, result.Installed)
+
+	got, err := svc.GetInstalledMod("src", "dep1", "g1", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.1", got.Version, "the dependency's DB row must record the selected file's version, not the mod's mod-level 2.0")
+
+	gameCache := svc.GetGameCache(game)
+	assert.True(t, gameCache.Exists("g1", "src", "dep1", "2.0.1"), "cache must be keyed by the installed file's version")
+	assert.False(t, gameCache.Exists("g1", "src", "dep1", "2.0"), "cache must NOT be keyed by the mod's mod-level version when the file's own version differs")
 }
 
 // TestService_ApplyInstall_ContextCancellation proves ApplyInstall checks

--- a/internal/core/flows_install_test.go
+++ b/internal/core/flows_install_test.go
@@ -1267,6 +1267,58 @@ func TestApplyInstall_ExplicitOldFile_RecordsFileVersionAndCacheKey(t *testing.T
 	assert.Equal(t, "1.5", updates[0].NewVersion)
 }
 
+// TestApplyInstall_ExplicitOldFile_BeforeEachHookSeesEffectiveVersion pins
+// the other observable consequence of the #94 stamp: applyInstallPrimary
+// sets hookCtx.ModVersion (flows.go, right after the stamp) from the SAME
+// now-effective mod.Version, so install.before_each - and therefore the
+// LMM_MOD_VERSION env var a hook script sees (hooks.go's Run) - reports the
+// file actually being installed ("1.0"), not the mod's own latest version
+// ("1.5"). Mirrors TestService_ApplyUpdate_HookOrder's callLog pattern
+// (flows_update_test.go) for capturing hook context via a real script.
+func TestApplyInstall_ExplicitOldFile_BeforeEachHookSeesEffectiveVersion(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	mock := &oldFileSource{mockSourceWithDownloads: newMockSourceWithDownloads("src")}
+	defer mock.Close()
+	svc.RegisterSource(mock)
+
+	mod := &domain.Mod{ID: "mod1", SourceID: "src", Name: "Mod One", Version: "1.5", GameID: "g1"}
+	mock.AddMod(mod.GameID, mod)
+
+	oldZip := createTestZip(t, t.TempDir(), map[string]string{"mod1.esp": "old-payload"})
+	oldContent, err := os.ReadFile(oldZip)
+	require.NoError(t, err)
+	mock.AddDownload("2", oldContent)
+
+	callLog := filepath.Join(scriptsDir, "calls.log")
+	beforeEach := createTestScript(t, scriptsDir, "before_each.sh", `#!/bin/bash
+echo "install.before_each:$LMM_MOD_ID:$LMM_MOD_VERSION" >> `+callLog+`
+exit 0`)
+	hooks := &core.ResolvedHooks{Install: domain.HookConfig{BeforeEach: beforeEach}}
+	runner := core.NewHookRunner(5 * time.Second)
+
+	plan, err := svc.PlanInstall(context.Background(), game, "default", "src", "mod1", false)
+	require.NoError(t, err)
+
+	// Caller (CLI's --file override) picks the archived old file instead.
+	plan.Files = []domain.DownloadableFile{
+		{ID: "2", Name: "Old File", FileName: "mod1-old.zip", Version: "1.0"},
+	}
+
+	result, err := svc.ApplyInstall(context.Background(), game, plan, core.InstallOptions{Hooks: hooks, HookRunner: runner}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"Mod One"}, result.Installed)
+
+	logContent, err := os.ReadFile(callLog)
+	require.NoError(t, err)
+	assert.Equal(t, "install.before_each:mod1:1.0\n", string(logContent),
+		"install.before_each must see the effective (selected-file) version, not the mod-level 1.5")
+}
+
 // TestService_ApplyInstall_ContextCancellation proves ApplyInstall checks
 // ctx at least once before doing any work, so an already-cancelled context
 // leaves nothing installed - the seam Phase 5b's cancel-then-drain task will

--- a/internal/core/flows_install_test.go
+++ b/internal/core/flows_install_test.go
@@ -548,6 +548,23 @@ func (s *multiFileDownloadSource) GetModFiles(ctx context.Context, mod *domain.M
 	return s.files, nil
 }
 
+// oldFileSource serves two files: the primary/latest (v1.5) and an archived
+// older file (v1.0) - mockSource's default GetModFiles (a single, Version-
+// less file) is overridden so a test can exercise installing the non-primary
+// file explicitly, mirroring the CLI --file path (cmd/lmm/install.go:
+// 497-513 overwrites plan.Files with a caller-picked file after PlanInstall)
+// - see TestApplyInstall_ExplicitOldFile_RecordsFileVersionAndCacheKey (#94).
+type oldFileSource struct {
+	*mockSourceWithDownloads
+}
+
+func (s *oldFileSource) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	return []domain.DownloadableFile{
+		{ID: "1", Name: "Main File", FileName: mod.ID + ".zip", Version: "1.5", IsPrimary: true},
+		{ID: "2", Name: "Old File", FileName: mod.ID + "-old.zip", Version: "1.0"},
+	}, nil
+}
+
 // registerDownloadableMod registers mod with mock and stages a one-file zip
 // archive (containing relativePath -> content) as that mod's download,
 // keyed by mod.ID (matching perModFileSource's GetModFiles).
@@ -1174,6 +1191,80 @@ func TestService_ApplyInstall_EditedPlanFilesHonored(t *testing.T) {
 	installed, err := svc.GetInstalledMod("src", "mod1", "g1", "default")
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"main", "optional"}, installed.FileIDs)
+}
+
+// TestApplyInstall_ExplicitOldFile_RecordsFileVersionAndCacheKey is the #94
+// regression test: installing an explicitly-picked non-primary (older) file
+// must record THAT FILE's version - not the mod's own (newer) Version - in
+// the DB row and the cache directory key, so a subsequent CheckUpdates still
+// offers the real update instead of the old file silently masquerading as
+// current. Mirrors the CLI --file path (cmd/lmm/install.go:497-513), which
+// overwrites plan.Files with the caller-picked file after PlanInstall.
+func TestApplyInstall_ExplicitOldFile_RecordsFileVersionAndCacheKey(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	mock := &oldFileSource{mockSourceWithDownloads: newMockSourceWithDownloads("src")}
+	defer mock.Close()
+	svc.RegisterSource(mock)
+
+	mod := &domain.Mod{ID: "mod1", SourceID: "src", Name: "Mod One", Version: "1.5", GameID: "g1"}
+	mock.AddMod(mod.GameID, mod)
+
+	oldZip := createTestZip(t, t.TempDir(), map[string]string{"mod1.esp": "old-payload"})
+	oldContent, err := os.ReadFile(oldZip)
+	require.NoError(t, err)
+	mock.AddDownload("2", oldContent)
+
+	plan, err := svc.PlanInstall(context.Background(), game, "default", "src", "mod1", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Files, 1, "PlanInstall's own default picks just the primary file")
+	assert.Equal(t, "1", plan.Files[0].ID)
+
+	// Caller (CLI's --file override) picks the archived old file instead.
+	plan.Files = []domain.DownloadableFile{
+		{ID: "2", Name: "Old File", FileName: "mod1-old.zip", Version: "1.0"},
+	}
+
+	result, err := svc.ApplyInstall(context.Background(), game, plan, core.InstallOptions{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"Mod One"}, result.Installed)
+
+	got, err := svc.GetInstalledMod("src", "mod1", "g1", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", got.Version, "DB row must record the selected file's version, not the mod's latest")
+
+	gameCache := svc.GetGameCache(game)
+	assert.True(t, gameCache.Exists("g1", "src", "mod1", "1.0"), "cache must be keyed by the installed file's version")
+	assert.False(t, gameCache.Exists("g1", "src", "mod1", "1.5"), "cache must NOT be keyed by the mod's latest version when an older file was installed")
+
+	// The user-visible symptom: installing an older file must not suppress
+	// its own update notification. domain.IsNewerVersion backs CheckUpdates'
+	// comparison for sources that use it directly.
+	assert.True(t, domain.IsNewerVersion(got.Version, "1.5"))
+
+	// Confirm at the CheckUpdates level too, via a source mock whose
+	// CheckUpdates is actually wired up (mockSource's always returns nil).
+	registry := source.NewRegistry()
+	updateSrc := &updateMockSource{
+		id: "src",
+		currentMod: &domain.Mod{
+			ID:       "mod1",
+			SourceID: "src",
+			Name:     "Mod One",
+			Version:  "1.5",
+			GameID:   "g1",
+		},
+	}
+	registry.Register(updateSrc)
+	updater := core.NewUpdater(registry)
+
+	updates, err := updater.CheckUpdates(context.Background(), game, []domain.InstalledMod{*got})
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "1.5", updates[0].NewVersion)
 }
 
 // TestService_ApplyInstall_ContextCancellation proves ApplyInstall checks

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -18,6 +18,24 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// versionedFileSource serves a single file under mockSource's default ID
+// ("1" - the same ID both ApplyProfileSwitch and ApplyImport's install
+// loops select via stored FileIDs), but with an explicit Version ("1.0")
+// distinct from the mod-level Version a test passes to AddMod - mirroring
+// flows_install_test.go's oldFileSource/versionOverrideFileSource fixtures
+// for the #94 stamp, applied to the two remaining flows (Task A4). See
+// TestService_ApplyProfileSwitch_InstallLoop_RecordsFileVersion and
+// TestApplyImport_InstallLoop_RecordsFileVersion.
+type versionedFileSource struct {
+	*mockSourceWithDownloads
+}
+
+func (s *versionedFileSource) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	return []domain.DownloadableFile{
+		{ID: "1", Name: "Main File", FileName: mod.ID + ".zip", Version: "1.0", IsPrimary: true},
+	}, nil
+}
+
 // newFlowsTestService returns a *core.Service backed by fresh temp dirs
 // (config/data/cache), matching the construction pattern used throughout
 // service_test.go.
@@ -2713,6 +2731,52 @@ func TestService_ApplyProfileSwitch_InstallLoop_FallbackUsedWhenStoredFileIDsNot
 		}
 	}
 	assert.True(t, sawFallback, "expected a SwitchFallbackUsed event")
+}
+
+// TestService_ApplyProfileSwitch_InstallLoop_RecordsFileVersion is the #94
+// regression test for ApplyProfileSwitch's install loop: the source's served
+// file ("1") carries its own Version ("1.0"), distinct from the mod-level
+// Version ("1.5") GetMod returns. The saved InstalledMod row and the cache
+// dir must be stamped with the file's version, not the mod's, mirroring
+// flows_install_test.go's TestApplyInstall_ExplicitOldFile_
+// RecordsFileVersionAndCacheKey for this flow.
+func TestService_ApplyProfileSwitch_InstallLoop_RecordsFileVersion(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	_, err = pm.Create(game.ID, "target")
+	require.NoError(t, err)
+
+	mock := &versionedFileSource{mockSourceWithDownloads: newMockSourceWithDownloads("src")}
+	defer mock.Close()
+	svc.RegisterSource(mock)
+	tmpDir := t.TempDir()
+	zipPath := createTestZip(t, tmpDir, map[string]string{"mod1.esp": "payload"})
+	zipContent, err := os.ReadFile(zipPath)
+	require.NoError(t, err)
+	mock.AddDownload("1", zipContent)
+	mock.AddMod("g1", &domain.Mod{ID: "mod1", SourceID: "src", Name: "Mod One", Version: "1.5", GameID: "g1"})
+
+	plan := &core.SwitchPlan{
+		GameID: "g1", From: "default", To: "target",
+		ToInstall: []domain.ModReference{{SourceID: "src", ModID: "mod1", Version: "1.5", FileIDs: []string{"1"}}},
+	}
+
+	result, err := svc.ApplyProfileSwitch(context.Background(), game, plan, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Installed)
+
+	installed, err := svc.GetInstalledMod("src", "mod1", "g1", "target")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", installed.Version, "DB row must record the selected file's version, not the mod's latest")
+
+	gameCache := svc.GetGameCache(game)
+	assert.True(t, gameCache.Exists("g1", "src", "mod1", "1.0"), "cache must be keyed by the installed file's version")
 }
 
 // TestService_ApplyProfileSwitch_InstallLoop_SavesWithNormalizedGameID

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -821,6 +821,18 @@ func (s *Service) SaveInstalledMod(mod *domain.InstalledMod) error {
 	return s.db.SaveInstalledMod(mod)
 }
 
+// SetModVersion corrects an installed mod's recorded version without
+// shifting PreviousVersion (unlike a real version update) or re-keying its
+// file-ID rows (unlike SaveInstalledMod's full-row upsert, whose
+// replaceModFileIDsTx would silently wipe stored checksums even when the
+// file IDs themselves haven't changed - see internal/storage/db/mods.go).
+// For repairing a version string known to be WRONG (verify --fix's
+// version-record repair, issue #94), where the file IDs and their
+// checksums are already correct.
+func (s *Service) SetModVersion(sourceID, modID, gameID, profileName, version string) error {
+	return s.db.SetModVersion(sourceID, modID, gameID, profileName, version)
+}
+
 // DeleteInstalledMod removes the installed-mod record from the active profile.
 func (s *Service) DeleteInstalledMod(sourceID, modID, gameID, profileName string) error {
 	return s.db.DeleteInstalledMod(sourceID, modID, gameID, profileName)

--- a/internal/domain/mod.go
+++ b/internal/domain/mod.go
@@ -48,6 +48,27 @@ type DownloadableFile struct {
 	SHA256      string // Expected SHA-256 of the download (hex); empty = source declares no checksum
 }
 
+// EffectiveInstalledVersion resolves the version string that describes what
+// the selected files actually are: the primary selected file's Version when
+// it carries one, else the first selected file with a non-empty Version,
+// else modVersion (the mod-level version). Install-recording flows stamp
+// this onto the mod before downloading so the DB row, the profile
+// ModReference, and the cache directory key all describe the bytes on disk
+// (issue #94) instead of the mod-level latest.
+func EffectiveInstalledVersion(modVersion string, selected []*DownloadableFile) string {
+	for _, f := range selected {
+		if f != nil && f.IsPrimary && f.Version != "" {
+			return f.Version
+		}
+	}
+	for _, f := range selected {
+		if f != nil && f.Version != "" {
+			return f.Version
+		}
+	}
+	return modVersion
+}
+
 // ModReference is a pointer to a mod (used in profiles, dependencies)
 type ModReference struct {
 	SourceID string   `yaml:"source_id"`          // "nexusmods", "curseforge", etc.

--- a/internal/domain/mod_test.go
+++ b/internal/domain/mod_test.go
@@ -96,3 +96,29 @@ func TestExtractVersionFromName(t *testing.T) {
 		})
 	}
 }
+
+func TestEffectiveInstalledVersion(t *testing.T) {
+	f := func(id, version string, primary bool) *DownloadableFile {
+		return &DownloadableFile{ID: id, Version: version, IsPrimary: primary}
+	}
+	tests := []struct {
+		name     string
+		modVer   string
+		selected []*DownloadableFile
+		want     string
+	}{
+		{"no files falls back to mod version", "1.5", nil, "1.5"},
+		{"single file with version wins", "1.5", []*DownloadableFile{f("10", "1.0", false)}, "1.0"},
+		{"file without version falls back", "1.5", []*DownloadableFile{f("10", "", true)}, "1.5"},
+		{"primary file version preferred over earlier non-primary", "1.5",
+			[]*DownloadableFile{f("10", "0.9-patch", false), f("11", "1.0", true)}, "1.0"},
+		{"first non-empty when no primary has a version", "1.5",
+			[]*DownloadableFile{f("10", "", true), f("11", "1.0", false)}, "1.0"},
+		{"nil entries skipped", "1.5", []*DownloadableFile{nil, f("10", "1.0", false)}, "1.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, EffectiveInstalledVersion(tt.modVer, tt.selected))
+		})
+	}
+}

--- a/internal/storage/db/mods.go
+++ b/internal/storage/db/mods.go
@@ -350,7 +350,16 @@ func (d *DB) SetModVersion(sourceID, modID, gameID, profileName, version string)
 		return fmt.Errorf("setting mod version: %w", err)
 	}
 
-	rows, _ := result.RowsAffected()
+	rows, err := result.RowsAffected()
+	if err != nil {
+		// A driver error here must not be read as "0 rows affected" -
+		// doing so would misreport a real DB failure as
+		// domain.ErrModNotFound (Copilot round 6, PR #128), which callers
+		// (e.g. cmd/lmm/verify.go's repair paths) treat as a normal,
+		// non-retryable "not a candidate" case rather than the transient
+		// failure it actually is.
+		return fmt.Errorf("checking rows affected: %w", err)
+	}
 	if rows == 0 {
 		return domain.ErrModNotFound
 	}

--- a/internal/storage/db/mods.go
+++ b/internal/storage/db/mods.go
@@ -329,6 +329,35 @@ func getModFileIDsTx(tx *sql.Tx, sourceID, modID, gameID, profileName string) (f
 	return fileIDs, rows.Err()
 }
 
+// SetModVersion corrects an installed mod's recorded version in place: a
+// plain UPDATE of the version column only. Unlike UpdateModVersion, it does
+// NOT shift the current version into previous_version/previous_file_ids -
+// this is for repairing a WRONG recorded value (issue #94's verify --fix),
+// not a real version change that should be rollback-able. And unlike
+// SaveInstalledMod's full-row upsert, it does NOT touch installed_mod_files
+// at all: SaveInstalledMod always runs replaceModFileIDsTx (DELETE + a
+// checksum-less re-INSERT), so calling it just to fix the version string
+// silently wipes every stored checksum for the mod's files even when the
+// file IDs themselves never changed. SetModVersion exists specifically to
+// avoid that: the version is wrong, the file IDs and their checksums are
+// not, so only the version column should move.
+func (d *DB) SetModVersion(sourceID, modID, gameID, profileName, version string) error {
+	result, err := d.Exec(`
+		UPDATE installed_mods SET version = ?
+		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
+	`, version, sourceID, modID, gameID, profileName)
+	if err != nil {
+		return fmt.Errorf("setting mod version: %w", err)
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return domain.ErrModNotFound
+	}
+
+	return nil
+}
+
 // UpdateModVersion updates a mod's version, preserving the previous version and file IDs for rollback.
 func (d *DB) UpdateModVersion(sourceID, modID, gameID, profileName, newVersion string) error {
 	currentFileIDs, err := d.GetModFileIDs(sourceID, modID, gameID, profileName)

--- a/internal/storage/db/mods_test.go
+++ b/internal/storage/db/mods_test.go
@@ -109,6 +109,60 @@ func TestSetModLinkMethod_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, domain.ErrModNotFound)
 }
 
+// TestSetModVersion guards the epic98 audit's Finding 1 (Critical):
+// SaveInstalledMod's full-row upsert always replaces installed_mod_files
+// via replaceModFileIDsTx (DELETE + re-INSERT with only file_id, no
+// checksum column), so ANY SaveInstalledMod call - even one that only
+// intends to correct the version string, with FileIDs completely unchanged
+// - silently wipes every stored checksum for that mod. SetModVersion is a
+// plain UPDATE of the version column alone: no file-row replacement (so
+// stored checksums survive), and no PreviousVersion/PreviousFileIDs shift
+// either (unlike UpdateModVersion, which is for real version bumps that
+// SHOULD be rollback-able - a version-record *correction* isn't one).
+func TestSetModVersion(t *testing.T) {
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	mod := &domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "12345",
+			SourceID: "nexusmods",
+			Name:     "Test Mod",
+			Version:  "1.5",
+			GameID:   "skyrim-se",
+		},
+		ProfileName: "default",
+		Enabled:     true,
+		FileIDs:     []string{"111"},
+	}
+	require.NoError(t, database.SaveInstalledMod(mod))
+	require.NoError(t, database.SaveFileChecksum("nexusmods", "12345", "skyrim-se", "default", "111", "deadbeef"))
+
+	err = database.SetModVersion("nexusmods", "12345", "skyrim-se", "default", "1.0")
+	require.NoError(t, err)
+
+	retrieved, err := database.GetInstalledMod("nexusmods", "12345", "skyrim-se", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", retrieved.Version, "version must be corrected")
+	assert.Empty(t, retrieved.PreviousVersion, "SetModVersion must not shift PreviousVersion - unlike UpdateModVersion, this is a correction, not an update with a rollback path")
+	assert.Equal(t, []string{"111"}, retrieved.FileIDs, "FileIDs must be untouched")
+
+	files, err := database.GetFilesWithChecksums("skyrim-se", "default")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "deadbeef", files[0].Checksum, "SetModVersion must NOT wipe the stored checksum - unlike SaveInstalledMod's full-row upsert, which replaces installed_mod_files and loses it")
+}
+
+func TestSetModVersion_NotFound(t *testing.T) {
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	err = database.SetModVersion("nexusmods", "nonexistent", "skyrim-se", "default", "1.0")
+	assert.ErrorIs(t, err, domain.ErrModNotFound)
+}
+
 func TestSetModFileIDs(t *testing.T) {
 	database, err := db.New(":memory:")
 	require.NoError(t, err)

--- a/internal/storage/db/mods_test.go
+++ b/internal/storage/db/mods_test.go
@@ -163,6 +163,17 @@ func TestSetModVersion_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, domain.ErrModNotFound)
 }
 
+// Note: SetModVersion's result.RowsAffected() error-classification branch
+// (a driver error there must be returned, not misread as "0 rows affected"
+// -> domain.ErrModNotFound - PR #128 Copilot round 6) is not covered by a
+// dedicated test. modernc.org/sqlite's Result.RowsAffected() is a
+// locally-computed value from the just-executed statement, not a fresh
+// round-trip that can fail independently of Exec's own error return
+// (already checked above it) - there's no realistic way to make it error
+// with the standard driver without a custom sql.Driver mock, which isn't
+// otherwise justified here. Verified by inspection: the fix wraps and
+// returns the error instead of discarding it via `_`.
+
 func TestSetModFileIDs(t *testing.T) {
 	database, err := db.New(":memory:")
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #94. Part of EPIC #98 (version locking) — foundational-fixes tier.

## Problem

When a specific file was installed (`--file` + `--show-archived`, or any path where the selected file's version differs from the mod-level latest), the recorded version was the **mod-level latest**, not the installed file's version. The cache directory was keyed by the same wrong value. Consequence: an archived 1.0 install was recorded and cached as "1.5", `lmm list` lied, and `CheckUpdates` silently suppressed the mod's own update notifications.

## What changed

**Recording fix (forward-only):**
- New pure helper `domain.EffectiveInstalledVersion` — primary selected file's version, else first non-empty file version, else the mod-level version.
- The resolved version is stamped onto the in-flight mod after file selection in all six live install-recording paths (core: `applyInstallPrimary`, `applyInstallBatchMod`, `ApplyProfileSwitch`, `ApplyImport`; CLI: `batchInstallMods`, `doProfileApply`) — one stamp per flow fixes the DB row, the profile `ModReference.Version`, and the cache key together.
- `install.before_each` hooks in the core install path now see the effective file version (pinned by test); the update-apply path deliberately still records `Update.NewVersion` (loop-breaker for sloppy upstream metadata — revisit under #96).

**Repair for pre-existing bad rows (`lmm verify`):**
- New version-record check: re-queries each mod's source for its stored `FileIDs`; reports `version_mismatch` (fixable) and `version_unverifiable` (file gone upstream — reinstall hint). Verify now contacts sources for this check; unreachable sources degrade to a warning.
- `--fix` repairs a mismatch: re-keys the shared cache dir, corrects the DB row (full-row save — never `UpdateModVersion`, which would poison rollback), updates the profile ref, and re-links symlink deployments. Failure ordering is strict: rename failure → no DB write; re-link failure → `Deployed` cleared so the state stays detectable; blocked rename (destination dir already exists) → cache and working symlinks left untouched, DB still corrected, surfaced via a new additive `note` field in `--json`.
- Because the cache is shared across profiles while rows are per-profile, a successful rename also repairs sibling-profile rows recording the same wrong version (their YAML refs included, deployed symlink siblings re-linked); per-sibling failures are surfaced in both text and `--json`, never swallowed.

**Docs:** README verify section, CHANGELOG 1.23.0, regenerated man pages, version bump to 1.23.0 (MINOR: new verify capability + additive JSON contract).

## Notes for review

- Pre-existing wrong-but-consistent rows (record == cache key, both wrong) keep deploying fine without `--fix` — nothing touches deploy-time reads.
- `trunk check` was unavailable in the dev environment; gofmt/vet/full test suite are clean (verified repeatedly, including the man-page drift test).
- Sibling to this PR: #95 (silent primary-file fallback → per-mod failure) branches after this merges, per the committed plan doc (docs/plans/2026-07-28-epic98-foundational-fixes.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)