### PR TITLE
docs(cli): document the vacuous version pass for versionless sources (#94)

### DIFF
--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -307,6 +307,14 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 			continue
 		}
 
+		// When every matched file reports an empty Version (custom sources
+		// whose mappings carry no per-file versions), the fallback inside
+		// EffectiveInstalledVersion returns mod.Version and this comparison
+		// passes vacuously. That is a deliberate quiet OK, not a missed
+		// VERSION UNVERIFIABLE (PR #128 triage): install-time stamping
+		// applies the same fallback, so a per-file version mis-stamp cannot
+		// exist for versionless sources - there is nothing to verify, and
+		// warning would flag every mod on every verify for such sources.
 		effective := domain.EffectiveInstalledVersion(mod.Version, matched)
 		if effective != mod.Version {
 			recorded := mod.Version


### PR DESCRIPTION
## Summary

Follow-up to #128: a suppressed low-confidence Copilot finding (review 4803471832) flagged that the verify version-record pre-pass silently counts a mod as OK when every matched upstream file has an empty `Version` field (custom sources whose mappings carry no per-file versions) — `EffectiveInstalledVersion` falls back to the recorded `mod.Version`, so the comparison passes vacuously.

Triage conclusion: this is **not** a correctness false-negative. Install-time stamping applies the same fallback rule, so a per-file version mis-stamp cannot occur for versionless sources — the check is vacuous there, not broken. The remaining question was reporting honesty vs noise, and the decision (product call, confirmed with @DonovanMods) was to keep the quiet OK rather than emit a VERSION UNVERIFIABLE warning for every mod on every `lmm verify` for custom-source users.

This PR documents that decision with a comment at the comparison site so the next reader (or the next Copilot round) doesn't re-litigate it. No behavior change, no JSON contract change.

## Test plan

- [x] `gofmt` / `go vet` / `go build` clean — comment-only change, no behavior to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)