### PR TITLE
fix: preserve update policy when re-saving an installed mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.1] - 2026-07-29
+
+### Fixed
+
+- Reinstalling or importing over an already-installed mod no longer silently resets its update policy to `notify` — a policy set via `lmm mod set-update` (`--pin`/`--auto`) now survives every reinstall/import path, since the database upsert preserves the existing policy when updating an existing record (#134)
+
 ## [1.24.0] - 2026-07-28
 
 ### Changed
@@ -1072,7 +1078,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.24.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.24.1...HEAD
+[1.24.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.24.0...v1.24.1
 [1.24.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.23.1...v1.24.0
 [1.23.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.23.0...v1.23.1
 [1.23.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.22.0...v1.23.0

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -35,7 +35,7 @@ var ErrCancelled = errors.New("cancelled")
 var ErrReported = errors.New("already reported")
 
 var (
-	version = "1.24.0"
+	version = "1.24.1"
 
 	// Global flags
 	configDir  string

--- a/cmd/lmm/update_test.go
+++ b/cmd/lmm/update_test.go
@@ -340,17 +340,15 @@ func TestDoUpdate_BatchAutoAndAll_MidBatchFailureContinues(t *testing.T) {
 	updateAll = true
 
 	// mod1: auto-policy, succeeds.
-	mod1 := seedInstalledForUpdate(t, svc, game, "test-src", "mod1", "Mod One", "1.0", []string{"m1-old"}, map[string][]byte{"mod1-old.esp": []byte("old1")})
-	mod1.UpdatePolicy = domain.UpdateAuto
-	require.NoError(t, svc.SaveInstalledMod(mod1))
+	seedInstalledForUpdate(t, svc, game, "test-src", "mod1", "Mod One", "1.0", []string{"m1-old"}, map[string][]byte{"mod1-old.esp": []byte("old1")})
+	require.NoError(t, svc.SetModUpdatePolicy("test-src", "mod1", "g1", "default", domain.UpdateAuto))
 	src.AddMod(&domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: "2.0", GameID: "g1"},
 		[]domain.DownloadableFile{{ID: "m1-new", FileName: "mod1-new.esp", IsPrimary: true}})
 	src.AddDownload("m1-new", []byte("new1"))
 
 	// mod2: auto-policy, download fails (no AddDownload registered).
-	mod2 := seedInstalledForUpdate(t, svc, game, "test-src", "mod2", "Mod Two", "1.0", []string{"m2-old"}, map[string][]byte{"mod2-old.esp": []byte("old2")})
-	mod2.UpdatePolicy = domain.UpdateAuto
-	require.NoError(t, svc.SaveInstalledMod(mod2))
+	seedInstalledForUpdate(t, svc, game, "test-src", "mod2", "Mod Two", "1.0", []string{"m2-old"}, map[string][]byte{"mod2-old.esp": []byte("old2")})
+	require.NoError(t, svc.SetModUpdatePolicy("test-src", "mod2", "g1", "default", domain.UpdateAuto))
 	src.AddMod(&domain.Mod{ID: "mod2", SourceID: "test-src", Name: "Mod Two", Version: "2.0", GameID: "g1"},
 		[]domain.DownloadableFile{{ID: "m2-new", FileName: "mod2-new.esp", IsPrimary: true}})
 
@@ -392,9 +390,8 @@ func TestDoUpdate_DryRun_ZeroSideEffectsAndOutputUnchanged(t *testing.T) {
 	svc, game, src := setupDoUpdateTest(t)
 	updateDryRun = true
 
-	mod := seedInstalledForUpdate(t, svc, game, "test-src", "mod1", "Mod One", "1.0", []string{"old-1"}, map[string][]byte{"mod1-old.esp": []byte("old-content")})
-	mod.UpdatePolicy = domain.UpdateAuto
-	require.NoError(t, svc.SaveInstalledMod(mod))
+	seedInstalledForUpdate(t, svc, game, "test-src", "mod1", "Mod One", "1.0", []string{"old-1"}, map[string][]byte{"mod1-old.esp": []byte("old-content")})
+	require.NoError(t, svc.SetModUpdatePolicy("test-src", "mod1", "g1", "default", domain.UpdateAuto))
 	src.AddMod(&domain.Mod{ID: "mod1", SourceID: "test-src", Name: "Mod One", Version: "2.0", GameID: "g1"},
 		[]domain.DownloadableFile{{ID: "new-1", FileName: "mod1-new.esp", IsPrimary: true}})
 	// Deliberately no AddDownload - if ApplyUpdate were ever called, the

--- a/docs/man/man1/lmm-auth-login.1
+++ b/docs/man/man1/lmm-auth-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-auth-login - Authenticate with a mod source

--- a/docs/man/man1/lmm-auth-logout.1
+++ b/docs/man/man1/lmm-auth-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-auth-logout - Remove stored credentials for a mod source

--- a/docs/man/man1/lmm-auth-status.1
+++ b/docs/man/man1/lmm-auth-status.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-auth-status - Show authentication status for all sources

--- a/docs/man/man1/lmm-auth.1
+++ b/docs/man/man1/lmm-auth.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-auth - Manage authentication for mod sources

--- a/docs/man/man1/lmm-completion-bash.1
+++ b/docs/man/man1/lmm-completion-bash.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-completion-bash - Generate the autocompletion script for bash

--- a/docs/man/man1/lmm-completion-fish.1
+++ b/docs/man/man1/lmm-completion-fish.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-completion-fish - Generate the autocompletion script for fish

--- a/docs/man/man1/lmm-completion-powershell.1
+++ b/docs/man/man1/lmm-completion-powershell.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-completion-powershell - Generate the autocompletion script for powershell

--- a/docs/man/man1/lmm-completion-zsh.1
+++ b/docs/man/man1/lmm-completion-zsh.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-completion-zsh - Generate the autocompletion script for zsh

--- a/docs/man/man1/lmm-completion.1
+++ b/docs/man/man1/lmm-completion.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-completion - Generate the autocompletion script for the specified shell

--- a/docs/man/man1/lmm-conflicts.1
+++ b/docs/man/man1/lmm-conflicts.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-conflicts - Show all file conflicts in the current profile

--- a/docs/man/man1/lmm-deploy.1
+++ b/docs/man/man1/lmm-deploy.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-deploy - Deploy mods to game directory

--- a/docs/man/man1/lmm-game-add.1
+++ b/docs/man/man1/lmm-game-add.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-game-add - Add a game interactively

--- a/docs/man/man1/lmm-game-clear-default.1
+++ b/docs/man/man1/lmm-game-clear-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-game-clear-default - Clear the default game setting

--- a/docs/man/man1/lmm-game-detect.1
+++ b/docs/man/man1/lmm-game-detect.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-game-detect - Detect Steam games and add them to config

--- a/docs/man/man1/lmm-game-set-default.1
+++ b/docs/man/man1/lmm-game-set-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-game-set-default - Set the default game

--- a/docs/man/man1/lmm-game-show-default.1
+++ b/docs/man/man1/lmm-game-show-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-game-show-default - Show the current default game

--- a/docs/man/man1/lmm-game.1
+++ b/docs/man/man1/lmm-game.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-game - Game management commands

--- a/docs/man/man1/lmm-import.1
+++ b/docs/man/man1/lmm-import.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-import - Import mods from local files or scan mod_path

--- a/docs/man/man1/lmm-install.1
+++ b/docs/man/man1/lmm-install.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-install - Install a mod

--- a/docs/man/man1/lmm-list.1
+++ b/docs/man/man1/lmm-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-list - List installed mods

--- a/docs/man/man1/lmm-mod-disable.1
+++ b/docs/man/man1/lmm-mod-disable.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-mod-disable - Disable a mod without uninstalling

--- a/docs/man/man1/lmm-mod-edit.1
+++ b/docs/man/man1/lmm-mod-edit.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-mod-edit - Edit mod details (name, version, author, source, ID)

--- a/docs/man/man1/lmm-mod-enable.1
+++ b/docs/man/man1/lmm-mod-enable.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-mod-enable - Enable a disabled mod

--- a/docs/man/man1/lmm-mod-files.1
+++ b/docs/man/man1/lmm-mod-files.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-mod-files - List files deployed by a mod

--- a/docs/man/man1/lmm-mod-set-update.1
+++ b/docs/man/man1/lmm-mod-set-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-mod-set-update - Set update policy for a mod

--- a/docs/man/man1/lmm-mod-show.1
+++ b/docs/man/man1/lmm-mod-show.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-mod-show - Show mod details

--- a/docs/man/man1/lmm-mod.1
+++ b/docs/man/man1/lmm-mod.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-mod - Manage mod settings

--- a/docs/man/man1/lmm-profile-apply.1
+++ b/docs/man/man1/lmm-profile-apply.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-profile-apply - Apply profile to system

--- a/docs/man/man1/lmm-profile-create.1
+++ b/docs/man/man1/lmm-profile-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-profile-create - Create a new profile

--- a/docs/man/man1/lmm-profile-delete.1
+++ b/docs/man/man1/lmm-profile-delete.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-profile-delete - Delete a profile

--- a/docs/man/man1/lmm-profile-export.1
+++ b/docs/man/man1/lmm-profile-export.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-profile-export - Export a profile

--- a/docs/man/man1/lmm-profile-import.1
+++ b/docs/man/man1/lmm-profile-import.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-profile-import - Import a profile

--- a/docs/man/man1/lmm-profile-list.1
+++ b/docs/man/man1/lmm-profile-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-profile-list - List all profiles

--- a/docs/man/man1/lmm-profile-reorder.1
+++ b/docs/man/man1/lmm-profile-reorder.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-profile-reorder - View or change load order

--- a/docs/man/man1/lmm-profile-switch.1
+++ b/docs/man/man1/lmm-profile-switch.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-profile-switch - Switch to a different profile

--- a/docs/man/man1/lmm-profile-sync.1
+++ b/docs/man/man1/lmm-profile-sync.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-profile-sync - Sync profile to match installed mods

--- a/docs/man/man1/lmm-profile.1
+++ b/docs/man/man1/lmm-profile.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-profile - Manage mod profiles

--- a/docs/man/man1/lmm-purge.1
+++ b/docs/man/man1/lmm-purge.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-purge - Remove all deployed mods from game directory

--- a/docs/man/man1/lmm-search.1
+++ b/docs/man/man1/lmm-search.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-search - Search for mods

--- a/docs/man/man1/lmm-source-list.1
+++ b/docs/man/man1/lmm-source-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-source-list - List all mod sources

--- a/docs/man/man1/lmm-source-validate.1
+++ b/docs/man/man1/lmm-source-validate.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-source-validate - Validate a source definition file

--- a/docs/man/man1/lmm-source.1
+++ b/docs/man/man1/lmm-source.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-source - Manage mod sources

--- a/docs/man/man1/lmm-status.1
+++ b/docs/man/man1/lmm-status.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-status - Show current status

--- a/docs/man/man1/lmm-tui.1
+++ b/docs/man/man1/lmm-tui.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-tui - Launch the interactive terminal UI

--- a/docs/man/man1/lmm-uninstall.1
+++ b/docs/man/man1/lmm-uninstall.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-uninstall - Uninstall a mod

--- a/docs/man/man1/lmm-update-rollback.1
+++ b/docs/man/man1/lmm-update-rollback.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-update-rollback - Rollback a mod to its previous version

--- a/docs/man/man1/lmm-update.1
+++ b/docs/man/man1/lmm-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-update - Check for or apply mod updates

--- a/docs/man/man1/lmm-verify.1
+++ b/docs/man/man1/lmm-verify.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm-verify - Verify cached mod files

--- a/docs/man/man1/lmm.1
+++ b/docs/man/man1/lmm.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.24.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.24.1" "User Commands"
 
 .SH NAME
 lmm - Linux Mod Manager \- Terminal-based mod manager for Linux

--- a/internal/storage/db/mods.go
+++ b/internal/storage/db/mods.go
@@ -34,6 +34,10 @@ func decodeFileIDs(raw *string) ([]string, error) {
 
 // SaveInstalledMod inserts or updates an installed mod record.
 // The mod upsert and file ID replacement are performed atomically within a transaction.
+// On update of an existing record, the existing update_policy is preserved:
+// callers always pass the default policy, so honoring it here would silently
+// reset a user-set --pin/--auto policy on reinstall. Policy changes go through
+// UpdateModPolicy. A first-time insert still uses the policy passed in.
 func (d *DB) SaveInstalledMod(mod *domain.InstalledMod) error {
 	tx, err := d.Begin()
 	if err != nil {
@@ -57,7 +61,6 @@ func (d *DB) SaveInstalledMod(mod *domain.InstalledMod) error {
 			name = excluded.name,
 			version = excluded.version,
 			author = excluded.author,
-			update_policy = excluded.update_policy,
 			enabled = excluded.enabled,
 			deployed = excluded.deployed,
 			previous_version = excluded.previous_version,

--- a/internal/storage/db/mods_test.go
+++ b/internal/storage/db/mods_test.go
@@ -59,6 +59,42 @@ func TestUpdateModPolicy(t *testing.T) {
 	assert.Equal(t, domain.UpdateAuto, retrieved.UpdatePolicy)
 }
 
+// TestSaveInstalledMod_PreservesUpdatePolicyOnResave guards against issue
+// #134: every SaveInstalledMod caller hardcodes UpdatePolicy: UpdateNotify, so
+// re-saving an existing row (reinstall/import) must not clobber a policy the
+// user set via UpdateModPolicy (--pin/--auto). A fresh first-time insert still
+// takes the policy passed in (covered by TestGetInstalledMod in db_test.go).
+func TestSaveInstalledMod_PreservesUpdatePolicyOnResave(t *testing.T) {
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	installTestMod(t, database) // saved with domain.UpdateNotify
+
+	err = database.UpdateModPolicy("nexusmods", "12345", "skyrim-se", "default", domain.UpdatePinned)
+	require.NoError(t, err)
+
+	// Simulate a reinstall: callers always pass UpdateNotify.
+	mod := &domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "12345",
+			SourceID: "nexusmods",
+			Name:     "Test Mod",
+			Version:  "1.0.0",
+			GameID:   "skyrim-se",
+		},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}
+	require.NoError(t, database.SaveInstalledMod(mod))
+
+	retrieved, err := database.GetInstalledMod("nexusmods", "12345", "skyrim-se", "default")
+	require.NoError(t, err)
+	assert.Equal(t, domain.UpdatePinned, retrieved.UpdatePolicy,
+		"resaving an installed mod must preserve the existing update policy")
+}
+
 func TestUpdateModPolicy_NotFound(t *testing.T) {
 	database, err := db.New(":memory:")
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #134.

## Problem

`SaveInstalledMod` is an upsert whose `ON CONFLICT` clause included `update_policy = excluded.update_policy`, and every caller (install, reinstall flows, import, profile apply) hardcodes `UpdatePolicy: domain.UpdateNotify`. So a policy set via `lmm mod set-update <id> --pin`/`--auto` was silently reset to `notify` by any reinstall or import over the same row.

## Fix

Single-point fix in the upsert: `update_policy` is dropped from the `DO UPDATE SET` list, so re-saving an existing record preserves its policy while a first-time insert still takes the policy from the inserted values. Policy changes continue to go through the dedicated `UpdateModPolicy` setter — no caller legitimately relied on `SaveInstalledMod` to change an existing row's policy.

Two tests in `cmd/lmm/update_test.go` were using the old overwrite behavior as a setup convenience (mutate `mod.UpdatePolicy` + re-save); they now use `svc.SetModUpdatePolicy` instead. Their assertions are unchanged.

## TDD

- RED: `TestSaveInstalledMod_PreservesUpdatePolicyOnResave` (internal/storage/db) — pin via `UpdateModPolicy`, re-save with `notify`, assert pin survives; failed with `expected: 2, actual: 0` before the fix
- GREEN: full suite passes; `gofmt` clean, `go vet` clean; man pages regenerated for the 1.24.1 bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)