### PR TITLE
fix: persist local-ingest checksums so verify --fix converges (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `lmm verify --fix` no longer reports "OK (checksum populated)" — and `--json` no longer flips the row to `"ok"` — for a repair that persisted nothing: success is only claimed when a checksum was actually written, and a re-download that yields no checksum to store keeps the NO CHECKSUM warning (counted in the summary) with an honest note saying why; the MISSING repair path gets the same honesty one step removed. The root cause is also fixed: local ingests now produce a checksum for the install/verify paths to record — the MD5 of the source file for file/archive ingests (matching the download path's MD5-of-archive), and a deterministic member-set digest (sorted relative path + content MD5 per member) for directory ingests, so re-ingesting an unchanged source reproduces the stored value and directory-source mods (file ID `main`) converge to a clean `verify` instead of warning NO CHECKSUM — and being redundantly re-copied into the cache — on every run, forever. Install-time recording benefits automatically, so newly installed directory-source mods start with checksums. Latent hardening: the checksum DB write now errors when it matches no installed-file row instead of silently no-opping (#164)
+
 ## [1.27.0] - 2026-07-30
 
 ### Added

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -54,8 +54,12 @@ Each file is reported with one of:
     ? Unknown mod ID - SKIPPED          checksum row references a mod no longer installed
 
 Use --fix to re-download files that are MISSING or have NO CHECKSUM,
-storing a fresh checksum afterwards. FILE COUNT MISMATCH and SKIPPED
-are not repaired by --fix.
+storing a fresh checksum afterwards. "OK (checksum populated)" is only
+reported when a checksum was actually written; if the re-download
+succeeds but yields no checksum to store (e.g. a directory-source mod
+whose directory holds no regular files), the NO CHECKSUM warning remains
+with a note explaining why. FILE COUNT MISMATCH and SKIPPED are not
+repaired by --fix.
 
 verify also contacts each installed mod's source to check its recorded
 version against what the stored file ID(s) actually are upstream (issue
@@ -113,9 +117,10 @@ status, note}], issues, warnings}; status is one of "ok", "missing",
 "no_checksum", "file_count_mismatch", "skipped", "version_mismatch", or
 "version_unverifiable"; note adds detail where there's something extra to
 say - a blocked cache rename, sibling-repair results, a --fix repair or
-redownload failure's reason, a file-count-check lookup failure, a --fix
-refusal on a locked record ("locked"), or a locked record's pending
-convergence detail - and is omitted otherwise. issues counts MISSING files
+redownload failure's reason, why a successful re-download stored no
+checksum, a file-count-check lookup failure, a --fix refusal on a locked
+record ("locked"), or a locked record's pending convergence detail - and
+is omitted otherwise. issues counts MISSING files
 and VERSION MISMATCH rows (a successful --fix repair of either decrements
 it back out; a locked VERSION MISMATCH stays counted since --fix refuses
 it); warnings counts everything else that isn't OK. Lock-pending-
@@ -476,7 +481,9 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 			}
 			issues++
 			if verifyFix && mod.SourceID != domain.SourceLocal {
-				if err := redownloadModFile(cmd, svc, game, profile, mod, f.FileID); err != nil {
+				persisted, err := redownloadModFile(cmd, svc, game, profile, mod, f.FileID)
+				switch {
+				case err != nil:
 					if jsonOutput {
 						// audit Finding 7: the row was already appended
 						// above (Status "missing") - the failure reason
@@ -485,13 +492,27 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 					} else {
 						fmt.Printf("  Re-download failed: %v\n", err)
 					}
-				} else {
+				case persisted:
 					if !jsonOutput {
 						fmt.Printf("  %s\n", colorGreen("Re-downloaded OK"))
 					} else {
 						jsonFiles[len(jsonFiles)-1].Status = "ok"
 					}
 					issues--
+				default:
+					// The re-download restored the cache - the MISSING issue
+					// is genuinely repaired - but no checksum was available
+					// to store, so the row remains a NO CHECKSUM warning
+					// (#164: don't report "ok" for a write that never
+					// happened).
+					if jsonOutput {
+						jsonFiles[len(jsonFiles)-1].Status = "no_checksum"
+						jsonFiles[len(jsonFiles)-1].Note = "re-downloaded, but no checksum was available to store"
+					} else {
+						fmt.Printf("  Re-downloaded, but no checksum was available to store - NO CHECKSUM remains\n")
+					}
+					issues--
+					warnings++
 				}
 			}
 			continue
@@ -500,7 +521,9 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 		// Check if checksum stored
 		if f.Checksum == "" {
 			if verifyFix && mod.SourceID != domain.SourceLocal {
-				if err := redownloadModFile(cmd, svc, game, profile, mod, f.FileID); err != nil {
+				persisted, err := redownloadModFile(cmd, svc, game, profile, mod, f.FileID)
+				switch {
+				case err != nil:
 					if jsonOutput {
 						// audit Finding 7: the failure reason must reach
 						// --json, not just the text-mode line below.
@@ -510,12 +533,24 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 						fmt.Printf("  Re-download to populate checksum failed: %v\n", err)
 					}
 					warnings++
-				} else {
+				case persisted:
 					if jsonOutput {
 						jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: f.FileID, Status: "ok"})
 					} else {
 						fmt.Printf("%s %s (%s) - %s (checksum populated)\n", colorGreen("+"), mod.Name, f.FileID, colorGreen("OK"))
 					}
+				default:
+					// The download succeeded but produced no checksum to
+					// store - nothing was written, so the warning stands
+					// with an honest reason (#164: "checksum populated" was
+					// a lie here, and the summary lied with it).
+					if jsonOutput {
+						jsonFiles = append(jsonFiles, verifyFileJSON{ModID: mod.ID, ModName: mod.Name, FileID: f.FileID, Status: "no_checksum", Note: "re-downloaded, but no checksum was available to store"})
+					} else {
+						fmt.Printf("%s %s (%s) - NO CHECKSUM\n", colorYellow("?"), mod.Name, f.FileID)
+						fmt.Printf("  Re-downloaded, but no checksum was available to store\n")
+					}
+					warnings++
 				}
 				continue
 			}
@@ -1121,12 +1156,17 @@ func relinkDeployedRow(cmd *cobra.Command, svc *core.Service, game *domain.Game,
 	return nil, nil, undeployErr
 }
 
-// redownloadModFile re-downloads a single mod file and extracts to cache, then updates checksum in DB.
-func redownloadModFile(cmd *cobra.Command, svc *core.Service, game *domain.Game, profile string, mod *domain.InstalledMod, fileID string) error {
+// redownloadModFile re-downloads a single mod file and extracts it to the
+// cache, then updates the checksum in the DB. persisted reports whether a
+// checksum row was actually written: a download can succeed while yielding no
+// checksum to store (e.g. a directory-source mod whose directory holds no
+// regular files), and callers must not report "checksum populated" on the
+// strength of a nil error alone (#164) - only when persisted is true.
+func redownloadModFile(cmd *cobra.Command, svc *core.Service, game *domain.Game, profile string, mod *domain.InstalledMod, fileID string) (persisted bool, err error) {
 	ctx := cmd.Context()
 	files, err := svc.GetModFiles(ctx, mod.SourceID, sourceMappedMod(game, &mod.Mod))
 	if err != nil {
-		return fmt.Errorf("getting mod files: %w", err)
+		return false, fmt.Errorf("getting mod files: %w", err)
 	}
 	var downloadFile *domain.DownloadableFile
 	for i := range files {
@@ -1136,16 +1176,17 @@ func redownloadModFile(cmd *cobra.Command, svc *core.Service, game *domain.Game,
 		}
 	}
 	if downloadFile == nil {
-		return fmt.Errorf("file %s not found in mod", fileID)
+		return false, fmt.Errorf("file %s not found in mod", fileID)
 	}
 	result, err := svc.DownloadMod(ctx, mod.SourceID, game, &mod.Mod, downloadFile, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
-	if result.Checksum != "" {
-		if err := svc.SaveFileChecksum(mod.SourceID, mod.ID, game.ID, profile, fileID, result.Checksum); err != nil {
-			return fmt.Errorf("saving checksum: %w", err)
-		}
+	if result.Checksum == "" {
+		return false, nil
 	}
-	return nil
+	if err := svc.SaveFileChecksum(mod.SourceID, mod.ID, game.ID, profile, fileID, result.Checksum); err != nil {
+		return false, fmt.Errorf("saving checksum: %w", err)
+	}
+	return true, nil
 }

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 
 	"github.com/spf13/cobra"
@@ -1740,6 +1741,222 @@ func TestDoVerify_Fix_NoChecksum_JSONNotesRedownloadFailure(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected a mod1 file entry in JSON files: %+v", result.Files)
+}
+
+// --- doVerify --fix checksum persistence for directory sources (#164) ---
+//
+// setupDoVerifyDirectorySourceTest reproduces the live #164 state: a real
+// custom directory source (file ID "main", file:// download URL → local
+// ingest) with one installed mod whose installed_mod_files row has a NULL
+// checksum. memberFiles maps member-relative paths to contents; an empty map
+// yields a mod directory with no regular files (no content to fingerprint).
+// When ingest is true the mod is pre-ingested into the cache the same way
+// install did - on the broken build that stores content but never a checksum.
+func setupDoVerifyDirectorySourceTest(t *testing.T, modDirName string, memberFiles map[string]string, ingest bool) (*cobra.Command, *core.Service, *domain.Game, *domain.Mod) {
+	t.Helper()
+
+	root := t.TempDir()
+	modDir := filepath.Join(root, modDirName)
+	require.NoError(t, os.MkdirAll(modDir, 0755))
+	for name, content := range memberFiles {
+		require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(modDir, name)), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(modDir, name), []byte(content), 0644))
+	}
+
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	src, err := custom.New(custom.SourceDefinition{
+		ID:        "my-mods",
+		Name:      "My Mods",
+		Type:      custom.TypeDirectory,
+		Directory: &custom.DirectoryConfig{Path: root},
+	})
+	require.NoError(t, err)
+	svc.RegisterSource(src)
+
+	game := &domain.Game{
+		ID: "7dtd", Name: "7 Days to Die", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink,
+		SourceIDs:  map[string]string{"my-mods": ""}, // README-documented empty mapping for directory sources
+		DeployMode: domain.DeployExtract,
+	}
+
+	ctx := context.Background()
+	mod, err := svc.GetMod(ctx, "my-mods", game.ID, modDirName)
+	require.NoError(t, err)
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: *mod, ProfileName: "default", Enabled: true, FileIDs: []string{"main"},
+	}))
+
+	if ingest {
+		files, err := svc.GetModFiles(ctx, "my-mods", mod)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		_, err = svc.DownloadMod(ctx, "my-mods", game, mod, &files[0], nil)
+		require.NoError(t, err)
+	}
+
+	verifyProfile = "default"
+	t.Cleanup(func() { verifyProfile = "" })
+	verifyFix = true
+	t.Cleanup(func() { verifyFix = false })
+	oldNoColor := noColor
+	noColor = true
+	t.Cleanup(func() { noColor = oldNoColor })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	return cmd, svc, game, mod
+}
+
+// storedChecksum returns the checksum recorded for (sourceID, modID, fileID)
+// in the given game/profile, failing the test if the row is absent.
+func storedChecksum(t *testing.T, svc *core.Service, gameID, profile, sourceID, modID, fileID string) string {
+	t.Helper()
+	files, err := svc.GetFilesWithChecksums(gameID, profile)
+	require.NoError(t, err)
+	for _, f := range files {
+		if f.SourceID == sourceID && f.ModID == modID && f.FileID == fileID {
+			return f.Checksum
+		}
+	}
+	t.Fatalf("no installed file row for %s/%s file %s in %+v", sourceID, modID, fileID, files)
+	return ""
+}
+
+// TestDoVerify_Fix_DirectorySource_PersistsChecksum_SecondRunClean is THE
+// #164 regression test: `verify --fix` on a directory-source mod (NULL
+// checksum) must actually persist a checksum - re-read from the DB, not
+// trusted from stdout - and a second verify run must come back clean instead
+// of warning NO CHECKSUM forever.
+func TestDoVerify_Fix_DirectorySource_PersistsChecksum_SecondRunClean(t *testing.T) {
+	cmd, svc, game, _ := setupDoVerifyDirectorySourceTest(t, "BiggerBackpack",
+		map[string]string{"ModInfo.xml": `<?xml version="1.0"?><xml><Name value="BiggerBackpack"/><Version value="1.2.0"/></xml>`}, true)
+
+	require.Empty(t, storedChecksum(t, svc, game.ID, "default", "my-mods", "BiggerBackpack", "main"),
+		"fixture must start with a NULL checksum")
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "checksum populated")
+
+	assert.NotEmpty(t, storedChecksum(t, svc, game.ID, "default", "my-mods", "BiggerBackpack", "main"),
+		"--fix claimed 'checksum populated', so a checksum must actually be in the DB")
+
+	secondRun := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.NotContains(t, secondRun, "NO CHECKSUM", "the fix must converge - no permanent NO CHECKSUM loop")
+	assert.Contains(t, secondRun, "All files verified OK.")
+}
+
+// TestDoVerify_Fix_NoChecksum_NotPersisted_HonestWarning covers the honesty
+// half of #164 when there is genuinely no checksum to store (a directory mod
+// with no regular files): --fix must NOT claim "checksum populated" - the
+// NO CHECKSUM warning stays, with a note saying why, and is still counted.
+func TestDoVerify_Fix_NoChecksum_NotPersisted_HonestWarning(t *testing.T) {
+	cmd, svc, game, _ := setupDoVerifyDirectorySourceTest(t, "EmptyMod-1.0", nil, true)
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	assert.NotContains(t, out, "checksum populated", "no write happened - claiming success is the #164 lie")
+	assert.Contains(t, out, "NO CHECKSUM", "the warning must survive an unproductive --fix attempt")
+	assert.Contains(t, out, "no checksum was available", "the user must learn why --fix could not populate it")
+	// 2 warnings: the honest NO CHECKSUM one under test, plus the
+	// pre-existing FILE COUNT MISMATCH a fileless mod's empty cache entry
+	// legitimately draws from the file-count pre-pass.
+	assert.Contains(t, out, "2 warning(s)", "an unpersisted checksum must still be counted as a warning")
+}
+
+// TestDoVerify_Fix_NoChecksum_NotPersisted_JSONStaysNoChecksum is the --json
+// counterpart: status must stay "no_checksum" (not flip to "ok") with a note,
+// and the warnings counter must reflect it.
+func TestDoVerify_Fix_NoChecksum_NotPersisted_JSONStaysNoChecksum(t *testing.T) {
+	cmd, svc, game, _ := setupDoVerifyDirectorySourceTest(t, "EmptyMod-1.0", nil, true)
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "EmptyMod-1.0" && f.FileID == "main" {
+			found = true
+			assert.Equal(t, "no_checksum", f.Status, "no write happened, so the row must not claim ok")
+			assert.NotEmpty(t, f.Note, "the reason no checksum was stored must reach --json")
+		}
+	}
+	assert.True(t, found, "expected an EmptyMod-1.0 file entry in JSON files: %+v", result.Files)
+	// 2 warnings: the honest no_checksum one under test, plus the
+	// pre-existing file_count_mismatch a fileless mod's empty cache entry
+	// legitimately draws from the file-count pre-pass.
+	assert.Equal(t, 2, result.Warnings, "an unpersisted checksum must still be counted as a warning")
+}
+
+// TestDoVerify_Fix_Missing_NotPersisted_JSONStaysNoChecksum covers the
+// MISSING branch's honesty (#164, "one step removed"): the re-ingest restores
+// the cache (so the MISSING issue is genuinely resolved) but stores no
+// checksum, so the row must surface as no_checksum with a note - not "ok".
+func TestDoVerify_Fix_Missing_NotPersisted_JSONStaysNoChecksum(t *testing.T) {
+	cmd, svc, game, _ := setupDoVerifyDirectorySourceTest(t, "EmptyMod-1.0", nil, false)
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+
+	found := false
+	for _, f := range result.Files {
+		if f.ModID == "EmptyMod-1.0" && f.FileID == "main" {
+			found = true
+			assert.Equal(t, "no_checksum", f.Status, "cache was restored but no checksum stored - the row must say so, not claim ok")
+			assert.NotEmpty(t, f.Note, "the reason no checksum was stored must reach --json")
+		}
+	}
+	assert.True(t, found, "expected an EmptyMod-1.0 file entry in JSON files: %+v", result.Files)
+	assert.Equal(t, 0, result.Issues, "the MISSING issue itself was genuinely repaired")
+	assert.Equal(t, 1, result.Warnings, "the unpersisted checksum must still be counted as a warning")
+}
+
+// TestDoVerify_Fix_Missing_DirectorySource_RedownloadPersistsChecksum: the
+// MISSING branch's success path for a real directory mod - the re-ingest both
+// restores the cache AND persists a checksum, so the run repairs completely.
+func TestDoVerify_Fix_Missing_DirectorySource_RedownloadPersistsChecksum(t *testing.T) {
+	cmd, svc, game, _ := setupDoVerifyDirectorySourceTest(t, "BiggerBackpack",
+		map[string]string{"ModInfo.xml": `<?xml version="1.0"?><xml><Name value="BiggerBackpack"/><Version value="1.2.0"/></xml>`}, false)
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "MISSING")
+	assert.Contains(t, out, "Re-downloaded OK")
+
+	assert.NotEmpty(t, storedChecksum(t, svc, game.ID, "default", "my-mods", "BiggerBackpack", "main"),
+		"a MISSING repair for a directory mod must persist the checksum too")
+
+	secondRun := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, secondRun, "All files verified OK.")
 }
 
 // --- doVerify lock-awareness (#97, Task 8) ---

--- a/docs/man/man1/lmm-verify.1
+++ b/docs/man/man1/lmm-verify.1
@@ -29,8 +29,12 @@ X NAME (FILE) - MISSING             version not present in cache
 
 .PP
 Use --fix to re-download files that are MISSING or have NO CHECKSUM,
-storing a fresh checksum afterwards. FILE COUNT MISMATCH and SKIPPED
-are not repaired by --fix.
+storing a fresh checksum afterwards. "OK (checksum populated)" is only
+reported when a checksum was actually written; if the re-download
+succeeds but yields no checksum to store (e.g. a directory-source mod
+whose directory holds no regular files), the NO CHECKSUM warning remains
+with a note explaining why. FILE COUNT MISMATCH and SKIPPED are not
+repaired by --fix.
 
 .PP
 verify also contacts each installed mod's source to check its recorded
@@ -95,9 +99,10 @@ status, note}], issues, warnings}; status is one of "ok", "missing",
 "no_checksum", "file_count_mismatch", "skipped", "version_mismatch", or
 "version_unverifiable"; note adds detail where there's something extra to
 say - a blocked cache rename, sibling-repair results, a --fix repair or
-redownload failure's reason, a file-count-check lookup failure, a --fix
-refusal on a locked record ("locked"), or a locked record's pending
-convergence detail - and is omitted otherwise. issues counts MISSING files
+redownload failure's reason, why a successful re-download stored no
+checksum, a file-count-check lookup failure, a --fix refusal on a locked
+record ("locked"), or a locked record's pending convergence detail - and
+is omitted otherwise. issues counts MISSING files
 and VERSION MISMATCH rows (a successful --fix repair of either decrements
 it back out; a locked VERSION MISMATCH stays counted since --fix refuses
 it); warnings counts everything else that isn't OK. Lock-pending-

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -2,8 +2,11 @@ package core
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -535,7 +538,15 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 
 // ingestLocalToCache copies a local mod (directory or archive) into the cache
 // using the same staging/commit flow as downloaded mods. Local ingests have no
-// download checksum, so DownloadModResult.Checksum is empty.
+// HTTP download checksum, so DownloadModResult.Checksum is computed from the
+// SOURCE instead (#164): the MD5 of the local file for file/archive ingests
+// (the same fingerprint the download path records for a fetched archive), or
+// a deterministic digest over the member set for directory ingests
+// (digestDirectoryMembers). Both are pure functions of the source content, so
+// a later re-ingest of an unchanged source reproduces the stored value and
+// install/verify --fix converge instead of looping on NO CHECKSUM. A
+// directory with no regular files yields an empty checksum - nothing to
+// fingerprint - and callers must report that honestly.
 func (s *Service) ingestLocalToCache(gameCache *cache.Cache, game *domain.Game, mod *domain.Mod, file *domain.DownloadableFile, localPath string) (*DownloadModResult, error) {
 	info, err := os.Stat(localPath)
 	if err != nil {
@@ -549,6 +560,7 @@ func (s *Service) ingestLocalToCache(gameCache *cache.Cache, game *domain.Game, 
 	defer os.RemoveAll(stagePath) //nolint:errcheck
 
 	var members []string
+	var checksum string
 	switch {
 	case info.IsDir():
 		if err := copyDir(localPath, stagePath); err != nil {
@@ -559,6 +571,9 @@ func (s *Service) ingestLocalToCache(gameCache *cache.Cache, game *domain.Game, 
 		// members belong to other file IDs.
 		if members, err = relativeFileMembers(localPath); err != nil {
 			return nil, fmt.Errorf("listing mod directory: %w", err)
+		}
+		if checksum, err = digestDirectoryMembers(localPath, members); err != nil {
+			return nil, fmt.Errorf("fingerprinting mod directory: %w", err)
 		}
 	case game.DeployMode == domain.DeployCopy || !s.extractor.CanExtract(localPath):
 		// file.FileName is the declared name for this mod file - use it so
@@ -575,9 +590,15 @@ func (s *Service) ingestLocalToCache(gameCache *cache.Cache, game *domain.Game, 
 			return nil, fmt.Errorf("copying to cache: %w", err)
 		}
 		members = []string{destName}
+		if checksum, err = md5File(localPath); err != nil {
+			return nil, fmt.Errorf("hashing local mod file: %w", err)
+		}
 	default:
 		if members, err = s.extractIntoStaging(localPath, cachePath, stagePath); err != nil {
 			return nil, fmt.Errorf("extracting mod: %w", err)
+		}
+		if checksum, err = md5File(localPath); err != nil {
+			return nil, fmt.Errorf("hashing local mod archive: %w", err)
 		}
 	}
 
@@ -589,7 +610,48 @@ func (s *Service) ingestLocalToCache(gameCache *cache.Cache, game *domain.Game, 
 	if err != nil {
 		return nil, err
 	}
-	return &DownloadModResult{FilesExtracted: len(files)}, nil
+	return &DownloadModResult{FilesExtracted: len(files), Checksum: checksum}, nil
+}
+
+// md5File returns the hex MD5 of the file at path - the same fingerprint the
+// HTTP download path records for a fetched archive (Downloader), so local
+// file/archive ingests store values with identical semantics.
+func md5File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close() //nolint:errcheck
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// digestDirectoryMembers returns a deterministic hex MD5 fingerprint of a
+// directory ingest's member set: each member's root-relative slash path plus
+// the MD5 of its content, folded in sorted path order. Re-ingesting an
+// unchanged source directory reproduces the value bit-for-bit (#164: verify
+// --fix and reinstalls must converge on the stored value), while any member
+// edit, rename, addition, or removal changes it - a real drift fingerprint.
+// An empty member set returns "": there is nothing to fingerprint, and
+// recording a meaningless constant would defeat the honesty guarantee.
+func digestDirectoryMembers(root string, members []string) (string, error) {
+	if len(members) == 0 {
+		return "", nil
+	}
+	sorted := append([]string(nil), members...)
+	sort.Strings(sorted)
+	h := md5.New()
+	for _, m := range sorted {
+		fileSum, err := md5File(filepath.Join(root, m))
+		if err != nil {
+			return "", fmt.Errorf("hashing member %s: %w", m, err)
+		}
+		_, _ = fmt.Fprintf(h, "%s\x00%s\n", filepath.ToSlash(m), fileSum) // hash.Hash writes never fail
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // prepareStaging computes the cache/staging paths for (game, mod) and readies

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -572,7 +572,11 @@ func (s *Service) ingestLocalToCache(gameCache *cache.Cache, game *domain.Game, 
 		if members, err = relativeFileMembers(localPath); err != nil {
 			return nil, fmt.Errorf("listing mod directory: %w", err)
 		}
-		if checksum, err = digestDirectoryMembers(localPath, members); err != nil {
+		// Digest the STAGED copies, not localPath: staging holds the exact
+		// bytes the commit below publishes, while the live source directory
+		// can change mid-ingest - hashing it here could persist a checksum
+		// for content that was never cached (review finding on #164).
+		if checksum, err = digestDirectoryMembers(stagePath, members); err != nil {
 			return nil, fmt.Errorf("fingerprinting mod directory: %w", err)
 		}
 	case game.DeployMode == domain.DeployCopy || !s.extractor.CanExtract(localPath):
@@ -631,7 +635,10 @@ func md5File(path string) (string, error) {
 
 // digestDirectoryMembers returns a deterministic hex MD5 fingerprint of a
 // directory ingest's member set: each member's root-relative slash path plus
-// the MD5 of its content, folded in sorted path order. Re-ingesting an
+// the MD5 of its content under root, folded in sorted path order. root is
+// the directory holding the bytes to fingerprint - for ingests, the STAGING
+// copy, so the stored value describes exactly what gets committed to the
+// cache even if the live source changes mid-ingest. Re-ingesting an
 // unchanged source directory reproduces the value bit-for-bit (#164: verify
 // --fix and reinstalls must converge on the stored value), while any member
 // edit, rename, addition, or removal changes it - a real drift fingerprint.

--- a/internal/core/service_download_local_test.go
+++ b/internal/core/service_download_local_test.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"crypto/md5"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,11 +34,71 @@ func TestIngestLocalToCacheDirectory(t *testing.T) {
 	result, err := svc.ingestLocalToCache(gameCache, game, mod, file, modDir)
 	require.NoError(t, err)
 	assert.Equal(t, 2, result.FilesExtracted)
-	assert.Empty(t, result.Checksum)
+	assert.NotEmpty(t, result.Checksum, "#164: a directory ingest must produce a checksum so installs/verify can persist it")
 
 	files, err := gameCache.ListFiles("7dtd", "my-mods", "BiggerBackpack", "1.2.0")
 	require.NoError(t, err)
 	assert.Len(t, files, 2)
+}
+
+// TestIngestLocalToCacheDirectory_ChecksumDeterministicAndDriftSensitive pins
+// the #164 symmetry requirement for the directory-ingest digest: re-ingesting
+// an UNCHANGED source directory must reproduce the stored value bit-for-bit
+// (so a later `verify --fix` or reinstall converges instead of looping), and
+// changing a member's content - or the member set itself - must change it (so
+// the stored value is a real drift fingerprint, not a constant).
+func TestIngestLocalToCacheDirectory_ChecksumDeterministicAndDriftSensitive(t *testing.T) {
+	svc, gameCache := newLocalIngestService(t)
+
+	modDir := filepath.Join(t.TempDir(), "BiggerBackpack")
+	require.NoError(t, os.MkdirAll(filepath.Join(modDir, "Config"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "ModInfo.xml"), []byte("<xml/>"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "Config", "items.xml"), []byte("<items/>"), 0644))
+
+	game := &domain.Game{ID: "7dtd", DeployMode: domain.DeployExtract}
+	mod := &domain.Mod{ID: "BiggerBackpack", SourceID: "my-mods", Version: "1.2.0"}
+	file := &domain.DownloadableFile{ID: "main", FileName: "BiggerBackpack"}
+
+	first, err := svc.ingestLocalToCache(gameCache, game, mod, file, modDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, first.Checksum)
+
+	unchanged, err := svc.ingestLocalToCache(gameCache, game, mod, file, modDir)
+	require.NoError(t, err)
+	assert.Equal(t, first.Checksum, unchanged.Checksum,
+		"re-ingesting an unchanged source directory must reproduce the same digest")
+
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "Config", "items.xml"), []byte("<items changed/>"), 0644))
+	contentDrift, err := svc.ingestLocalToCache(gameCache, game, mod, file, modDir)
+	require.NoError(t, err)
+	assert.NotEqual(t, first.Checksum, contentDrift.Checksum,
+		"changing a member file's content must change the digest")
+
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "extra.txt"), []byte("new member"), 0644))
+	memberDrift, err := svc.ingestLocalToCache(gameCache, game, mod, file, modDir)
+	require.NoError(t, err)
+	assert.NotEqual(t, contentDrift.Checksum, memberDrift.Checksum,
+		"adding a member file must change the digest")
+}
+
+// TestIngestLocalToCacheDirectory_EmptyMemberSet_NoChecksum: a directory with
+// no regular files has no content to fingerprint - the ingest still succeeds
+// but reports no checksum, and callers (verify --fix, install) must then stay
+// honest about NOT having persisted one rather than claiming success (#164).
+func TestIngestLocalToCacheDirectory_EmptyMemberSet_NoChecksum(t *testing.T) {
+	svc, gameCache := newLocalIngestService(t)
+
+	modDir := filepath.Join(t.TempDir(), "EmptyMod-1.0")
+	require.NoError(t, os.MkdirAll(modDir, 0755))
+
+	game := &domain.Game{ID: "7dtd", DeployMode: domain.DeployExtract}
+	mod := &domain.Mod{ID: "EmptyMod-1.0", SourceID: "my-mods", Version: "1.0"}
+	file := &domain.DownloadableFile{ID: "main", FileName: "EmptyMod-1.0"}
+
+	result, err := svc.ingestLocalToCache(gameCache, game, mod, file, modDir)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.FilesExtracted)
+	assert.Empty(t, result.Checksum, "an empty member set has nothing to fingerprint - no digest")
 }
 
 func TestIngestLocalToCacheArchiveCopyMode(t *testing.T) {
@@ -52,6 +114,8 @@ func TestIngestLocalToCacheArchiveCopyMode(t *testing.T) {
 	result, err := svc.ingestLocalToCache(gameCache, game, mod, file, archive)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.FilesExtracted)
+	assert.Equal(t, fmt.Sprintf("%x", md5.Sum([]byte("zipbytes"))), result.Checksum,
+		"#164: a file/archive ingest must report the MD5 of the source file, matching the HTTP download path's MD5-of-archive semantics")
 
 	cached := gameCache.GetFilePath("hytale", "my-mods", "coolmod-2.0", "2.0", "coolmod-2.0.zip")
 	_, err = os.Stat(cached)

--- a/internal/storage/db/db_test.go
+++ b/internal/storage/db/db_test.go
@@ -510,6 +510,20 @@ func TestSaveFileChecksum(t *testing.T) {
 	assert.Equal(t, "a1b2c3d4e5f6", checksum)
 }
 
+// TestSaveFileChecksum_NoMatchingRow_ReturnsError guards the latent defect
+// from #164: SaveFileChecksum is an UPDATE, and with no RowsAffected check a
+// write against a row that doesn't exist silently no-ops - the caller
+// believes the checksum was persisted when nothing happened.
+func TestSaveFileChecksum_NoMatchingRow_ReturnsError(t *testing.T) {
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+
+	err = database.SaveFileChecksum("nexusmods", "nonexistent", "skyrim-se", "default", "99999", "a1b2c3d4e5f6")
+	require.Error(t, err, "updating a nonexistent installed_mod_files row must fail loudly, not silently no-op")
+	assert.Contains(t, err.Error(), "no installed file row")
+}
+
 func TestGetFileChecksum_NotFound(t *testing.T) {
 	database, err := db.New(":memory:")
 	require.NoError(t, err)

--- a/internal/storage/db/db_test.go
+++ b/internal/storage/db/db_test.go
@@ -508,6 +508,13 @@ func TestSaveFileChecksum(t *testing.T) {
 	checksum, err := database.GetFileChecksum("nexusmods", "12345", "skyrim-se", "default", "67890")
 	require.NoError(t, err)
 	assert.Equal(t, "a1b2c3d4e5f6", checksum)
+
+	// Re-saving the SAME value must stay a success: SQLite's changes()
+	// counts rows matched by the UPDATE even when the new value equals the
+	// old (unlike MySQL), so the RowsAffected guard added for #164 must not
+	// misread an idempotent re-save as "row missing".
+	err = database.SaveFileChecksum("nexusmods", "12345", "skyrim-se", "default", "67890", "a1b2c3d4e5f6")
+	require.NoError(t, err, "idempotent same-value checksum re-save must not trip the 0-rows guard")
 }
 
 // TestSaveFileChecksum_NoMatchingRow_ReturnsError guards the latent defect

--- a/internal/storage/db/mods.go
+++ b/internal/storage/db/mods.go
@@ -554,14 +554,25 @@ type FileWithChecksum struct {
 	Checksum string
 }
 
-// SaveFileChecksum stores the MD5 checksum for a downloaded file
+// SaveFileChecksum stores the MD5 checksum for a downloaded file. The target
+// installed_mod_files row must already exist: an UPDATE matching no row would
+// otherwise succeed as a silent no-op while the caller believes the checksum
+// was persisted (#164), so 0 affected rows is an error.
 func (d *DB) SaveFileChecksum(sourceID, modID, gameID, profileName, fileID, checksum string) error {
-	_, err := d.Exec(`
+	res, err := d.Exec(`
 		UPDATE installed_mod_files SET checksum = ?
 		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ? AND file_id = ?
 	`, checksum, sourceID, modID, gameID, profileName, fileID)
 	if err != nil {
 		return fmt.Errorf("saving file checksum: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("saving file checksum: rows affected: %w", err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("saving file checksum: no installed file row for %s/%s file %s (game %s, profile %s)",
+			sourceID, modID, fileID, gameID, profileName)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #164.

`lmm verify --fix` printed `OK (checksum populated)` (and `--json` flipped the row to `"ok"`) for directory-source mods while persisting nothing — the local-ingest path never produced a checksum, so the "fix" looped forever, re-copying the mod directory into the cache on every run.

## Changes

**1. Honesty (`cmd/lmm/verify.go`)** — `redownloadModFile` now returns a `persisted` flag alongside the error. `checksum populated` / JSON `"ok"` only appear when a DB write actually happened. A successful re-download with no checksum to store keeps the NO CHECKSUM warning (counted in the summary) with the note `re-downloaded, but no checksum was available to store`. The MISSING branch gets the same honesty one step removed: a checksum-less re-ingest still repairs the MISSING issue (`issues--`) but surfaces the row as `no_checksum` + note and counts a warning, instead of `"ok"`. JSON stays within the existing status vocabulary (`ok`/`no_checksum`) — no shape change, only honest values plus a new `note` string.

**2. Make it fixable (`internal/core/service.go`)** — `ingestLocalToCache` now populates `DownloadModResult.Checksum`:
- **file/archive ingests**: MD5 of the source file — identical semantics to the HTTP path's MD5-of-downloaded-archive.
- **directory ingests**: deterministic digest over the ingested member set — each member's root-relative slash path plus its content MD5, folded into an outer MD5 in sorted path order. Re-ingesting an unchanged source reproduces the stored value bit-for-bit (symmetry: `verify --fix` and reinstalls converge), and any member edit/rename/add/remove changes it, giving directory mods a real drift fingerprint. An empty member set yields no checksum, reported honestly per (1). Note: plain `verify` today validates checksum *presence* only (it never re-hashes), so determinism-under-re-ingest is the operative symmetry contract.

Install-time recording benefits automatically: `cmd/lmm/install.go:1176` and `internal/core/flows.go:3765`/`:3995` all guard on non-empty `Checksum` after `SaveInstalledMod` created the file rows — newly installed directory-source mods now start with checksums (verified by reading; the verify-level regression test covers the persist path end-to-end).

**3. Latent (`internal/storage/db/mods.go`)** — `SaveFileChecksum` now checks `RowsAffected` and errors on 0 rows instead of silently no-opping. All call sites write after the installed-file rows exist, so no legitimate path trips it.

## CLI/TUI parity

The TUI has no verify/fix surface, and its install flow goes through `flows.ApplyInstall`, which picks up the core fix automatically — no TUI change needed.

## Tests (TDD — all written first and watched fail)

- `TestDoVerify_Fix_DirectorySource_PersistsChecksum_SecondRunClean` — the issue's specified regression: real `custom.Directory` source, file ID `main`, NULL checksum → `--fix` → checksum re-read from DB via `GetFilesWithChecksums` is non-empty AND a second run prints `All files verified OK.` with no NO CHECKSUM.
- `TestDoVerify_Fix_NoChecksum_NotPersisted_HonestWarning` / `_JSONStaysNoChecksum` — honest not-persisted branch (text + JSON), warning counted.
- `TestDoVerify_Fix_Missing_NotPersisted_JSONStaysNoChecksum` and `TestDoVerify_Fix_Missing_DirectorySource_RedownloadPersistsChecksum` — both MISSING-branch outcomes.
- `TestIngestLocalToCacheDirectory_ChecksumDeterministicAndDriftSensitive`, `_EmptyMemberSet_NoChecksum`, plus MD5 assertions on the existing ingest tests.
- `TestSaveFileChecksum_NoMatchingRow_ReturnsError`.

`go test ./...` (all 17 packages ok), `go vet ./...`, `trunk check` all clean. Man page regenerated for the updated `verify` help text (genman test enforced). No version bump; CHANGELOG entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)