### PR TITLE
feat: Icarus mod support — Firestore source + .exmodz PAK compilation (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Icarus built-in mod source** (`internal/source/icarus`): a public, unauthenticated Firestore-backed catalog (Project Daedalus) — `lmm search`/`install`/`update` work against it like NexusMods/CurseForge. A `.exmodz` mod file now compiles into a deployable `_P.pak` at download time via a new, game-agnostic `internal/unrealpak` PAK reader/writer and the new `deploy_mode: compile` game setting; a plain `.pak` file from the same catalog is unaffected and deploys through the existing extract/copy pipeline unchanged. An optional per-game `data_dump_path` points compilation at your own unpacked `data.pak` JSON tree instead of fetching the hosted community base-table dump — both are `games.yaml`-only settings, with no new CLI flag or TUI screen (#136)
+
 ## [1.27.1] - 2026-07-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -426,7 +426,9 @@ games:
     name: "Icarus"
     install_path: "/path/to/Steam/steamapps/common/Icarus"
     mod_path: "/path/to/Steam/steamapps/common/Icarus/Icarus/Content/Paks/mods"
-    deploy_mode: compile # added in Task 13
+    deploy_mode: compile
+    # data_dump_path: ~/icarus-data-dump # Optional: compile from your own
+    # unpacked data.pak JSON tree instead of the hosted community dump
     sources:
       icarus: "icarus"
 ```

--- a/README.md
+++ b/README.md
@@ -421,7 +421,17 @@ games:
       nexusmods: "starfield"
     link_method: copy # This game requires file copies instead of symlinks
     cache_path: /mnt/fast-ssd/starfield-mods # Store this game's mods on fast storage
+
+  icarus:
+    name: "Icarus"
+    install_path: "/path/to/Steam/steamapps/common/Icarus"
+    mod_path: "/path/to/Steam/steamapps/common/Icarus/Icarus/Content/Paks/mods"
+    deploy_mode: compile # added in Task 13
+    sources:
+      icarus: "icarus"
 ```
+
+Steam auto-detection (`lmm game detect`) does not yet know about Icarus (App ID `1149460`, confirmed during the research spike) — add this entry to `games.yaml` by hand for now; auto-detection is a separate, smaller follow-up not covered by this plan.
 
 ### Deployment Methods
 
@@ -1085,7 +1095,7 @@ The mod cache location can be customized via `cache_path` in `config.yaml`. Sett
 - [x] Automatic dependency installation (opt out with `--no-deps`)
 - [x] Interactive TUI (Bubble Tea) - see the Terminal UI section above
 - [x] CurseForge integration
-- [ ] Additional first-party built-in sources beyond NexusMods/CurseForge
+- [x] Additional first-party built-in sources beyond NexusMods/CurseForge (Icarus)
 - [ ] Game auto-detection beyond Steam (Lutris, Heroic, Flatpak)
 - [ ] Backup and restore
 

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/curseforge"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/custom"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/icarus"
 	"github.com/DonovanMods/linux-mod-manager/internal/source/nexusmods"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
 
@@ -207,12 +208,19 @@ func initService() (*core.Service, error) {
 	return svc, nil
 }
 
+// icarusFirestoreProjectID is Project Daedalus's Firebase project ID, from
+// the Firebase console. It is public information (Firestore reads are
+// unauthenticated by design, per the research spike) — this constant is the
+// one place it needs to be substituted with the real value.
+const icarusFirestoreProjectID = "projectdaedalus-fb09f"
+
 // builtinSourceFactories constructs each built-in source keyless — the
 // unified pipeline resolves and applies API keys post-construction via
 // registerSource's SetAPIKey seam, the same path custom sources use.
 var builtinSourceFactories = []func() source.ModSource{
 	func() source.ModSource { return nexusmods.New(nil, "") },
 	func() source.ModSource { return curseforge.New(nil, "") },
+	func() source.ModSource { return icarus.New(nil, icarusFirestoreProjectID) },
 }
 
 // registerSources registers all available mod sources with the service

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -242,8 +242,11 @@ func registerSources(svc *core.Service, cfgDir, dataDir string) {
 // wins, warning on customSourceWarnWriter) → API-key resolution (env var via
 // envKeyFor, falling back to the stored DB token) → SetAPIKey when the
 // source accepts one → SetDataDir when the source accepts one (Icarus's
-// Compile needs a cache directory for the base-table dump store, #136 Task
-// 13 — New itself can't take it since Task 8/9 froze its 2-arg signature) →
+// Compile is gated on SetDataDir having been called at all: that call
+// constructs the base-table dump store. dataDir's value itself is currently
+// unused there — that store fetches on demand rather than caching to disk,
+// #136 review round 3 — SetDataDir just fulfils the shared interface. New
+// itself can't take dataDir since Task 8/9 froze its 2-arg signature) →
 // RegisterSource.
 func registerSource(svc *core.Service, src source.ModSource, dataDir string) {
 	id := src.ID()

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -203,7 +203,7 @@ func initService() (*core.Service, error) {
 	}
 
 	// Register mod sources
-	registerSources(svc, cfg.ConfigDir)
+	registerSources(svc, cfg.ConfigDir, cfg.DataDir)
 
 	return svc, nil
 }
@@ -226,21 +226,26 @@ var builtinSourceFactories = []func() source.ModSource{
 // registerSources registers all available mod sources with the service
 // through one ordered pipeline: built-ins first (so the collision rule's
 // "first wins" preserves their identity against a same-id custom
-// definition), then user-defined sources from <configDir>/sources/.
-func registerSources(svc *core.Service, cfgDir string) {
+// definition), then user-defined sources from <configDir>/sources/. dataDir
+// is threaded through to registerSource for DeployCompile sources (#136
+// Task 13) that need it wired via the SetDataDir optional setter.
+func registerSources(svc *core.Service, cfgDir, dataDir string) {
 	for _, factory := range builtinSourceFactories {
-		registerSource(svc, factory())
+		registerSource(svc, factory(), dataDir)
 	}
 
-	registerCustomSources(svc, cfgDir)
+	registerCustomSources(svc, cfgDir, dataDir)
 }
 
 // registerSource runs src through the shared registration steps used for
 // both built-in and custom sources: collision check (first registration
 // wins, warning on customSourceWarnWriter) → API-key resolution (env var via
 // envKeyFor, falling back to the stored DB token) → SetAPIKey when the
-// source accepts one → RegisterSource.
-func registerSource(svc *core.Service, src source.ModSource) {
+// source accepts one → SetDataDir when the source accepts one (Icarus's
+// Compile needs a cache directory for the base-table dump store, #136 Task
+// 13 — New itself can't take it since Task 8/9 froze its 2-arg signature) →
+// RegisterSource.
+func registerSource(svc *core.Service, src source.ModSource, dataDir string) {
 	id := src.ID()
 	// Custom sources are constructed (custom.New) by the caller before this
 	// runs; a definition that both collides with an existing ID AND fails to
@@ -258,6 +263,9 @@ func registerSource(svc *core.Service, src source.ModSource) {
 		if key := getSourceAPIKey(svc, id, envKeyFor(src)); key != "" {
 			setter.SetAPIKey(key)
 		}
+	}
+	if setter, ok := src.(interface{ SetDataDir(string) }); ok {
+		setter.SetDataDir(dataDir)
 	}
 	svc.RegisterSource(src)
 }
@@ -295,7 +303,7 @@ func customSourceWarnWriter() io.Writer {
 // registerCustomSources loads user-defined source definitions and registers
 // the valid ones. Broken definitions warn (via customSourceWarnWriter, normally
 // os.Stderr) and are skipped — a bad file must never prevent lmm from starting.
-func registerCustomSources(svc *core.Service, cfgDir string) {
+func registerCustomSources(svc *core.Service, cfgDir, dataDir string) {
 	defs, loadErrs, err := config.LoadSourceDefinitions(cfgDir)
 	if err != nil {
 		fmt.Fprintf(customSourceWarnWriter(), "warning: loading custom sources: %v\n", err)
@@ -310,7 +318,7 @@ func registerCustomSources(svc *core.Service, cfgDir string) {
 			fmt.Fprintf(customSourceWarnWriter(), "warning: skipping source %q: %v\n", def.ID, err)
 			continue
 		}
-		registerSource(svc, src)
+		registerSource(svc, src, dataDir)
 	}
 }
 

--- a/cmd/lmm/root_test.go
+++ b/cmd/lmm/root_test.go
@@ -192,6 +192,18 @@ directory:
 	assert.Contains(t, warnBuf.String(), `warning: skipping source "nexusmods": id already in use`)
 }
 
+func TestBuiltinSourceFactories_IncludesIcarus(t *testing.T) {
+	found := false
+	for _, factory := range builtinSourceFactories {
+		if factory().ID() == "icarus" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("builtinSourceFactories should include the icarus source")
+	}
+}
+
 func TestInitService_RegistersSources(t *testing.T) {
 	// Use temp directories to avoid polluting real config
 	configDir = t.TempDir()

--- a/cmd/lmm/root_test.go
+++ b/cmd/lmm/root_test.go
@@ -48,7 +48,7 @@ func TestRegisterSources_BuiltinStillAuthenticatesWithEnvAndToken(t *testing.T) 
 	t.Cleanup(func() { require.NoError(t, svc.Close()) })
 	require.NoError(t, svc.SaveSourceToken("nexusmods", "stored-db-key"))
 
-	registerSources(svc, t.TempDir())
+	registerSources(svc, t.TempDir(), t.TempDir())
 
 	src, err := svc.GetSource("nexusmods")
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestRegisterSource_KeyResolutionPrecedence(t *testing.T) {
 			mockAuthSource: mockAuthSource{id: "precedence-src", name: "Precedence Src"},
 			envKey:         envVar,
 		}
-		registerSource(svc, mock)
+		registerSource(svc, mock, t.TempDir())
 
 		assert.Equal(t, "env-value", mock.apiKey, "env var must take precedence over a stored DB token")
 	})
@@ -115,10 +115,40 @@ func TestRegisterSource_KeyResolutionPrecedence(t *testing.T) {
 			mockAuthSource: mockAuthSource{id: "precedence-src", name: "Precedence Src"},
 			envKey:         envVar,
 		}
-		registerSource(svc, mock)
+		registerSource(svc, mock, t.TempDir())
 
 		assert.Equal(t, "token-value", mock.apiKey, "stored token must apply when no env var is set")
 	})
+}
+
+// recordingDataDirSource is a mockAuthSource that also implements the
+// optional SetDataDir(string) setter (icarus.Icarus, #136 Task 13), so
+// TestRegisterSource_WiresDataDir can pin that registerSource calls it with
+// the resolved data directory - the same optional-setter pattern SetAPIKey
+// already uses, just for a different capability.
+type recordingDataDirSource struct {
+	mockAuthSource
+	dataDir string
+}
+
+func (r *recordingDataDirSource) SetDataDir(dataDir string) { r.dataDir = dataDir }
+
+// TestRegisterSource_WiresDataDir pins that registerSource calls SetDataDir
+// on a source that implements it, passing through the exact dataDir it was
+// given - the seam icarus.Icarus.SetDataDir relies on to ever get a working
+// dumps store outside of a test that constructs Icarus directly.
+func TestRegisterSource_WiresDataDir(t *testing.T) {
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	mock := &recordingDataDirSource{mockAuthSource: mockAuthSource{id: "data-dir-src", name: "Data Dir Src"}}
+	wantDataDir := t.TempDir()
+	registerSource(svc, mock, wantDataDir)
+
+	assert.Equal(t, wantDataDir, mock.dataDir, "registerSource must pass its dataDir through to SetDataDir")
 }
 
 // TestRegisterSources_DerivedEnvKeyForCustom pins that a custom source with
@@ -150,7 +180,7 @@ manifest:
 `)
 	t.Setenv("LMM_MY_CUSTOM_API_KEY", "custom-env-key")
 
-	registerSources(svc, cfgDir)
+	registerSources(svc, cfgDir, t.TempDir())
 
 	src, err := svc.GetSource("my-custom")
 	require.NoError(t, err)
@@ -184,7 +214,7 @@ directory:
 	customSourceWarnOut = &warnBuf
 	t.Cleanup(func() { customSourceWarnOut = nil })
 
-	registerSources(svc, cfgDir)
+	registerSources(svc, cfgDir, t.TempDir())
 
 	src, err := svc.GetSource("nexusmods")
 	require.NoError(t, err)
@@ -330,7 +360,7 @@ directory:
   path: /this/path/should/not/exist/lmm-test-fixture
 `) // construction-failure branch: Validate passes, NewDirectory's os.Stat fails
 
-	registerCustomSources(svc, cfgDir)
+	registerCustomSources(svc, cfgDir, t.TempDir())
 
 	sources := svc.ListSources()
 	byID := make(map[string]source.ModSource, len(sources))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,16 +20,17 @@ Defines moddable games. Each game is keyed by a unique slug (e.g. `skyrim-se`).
 
 ### Game options
 
-| Option         | Type   | Required | Description                                                |
-| -------------- | ------ | -------- | ---------------------------------------------------------- |
-| `name`         | string | yes      | Display name                                               |
-| `install_path` | string | yes      | Game installation directory (supports `~`)                 |
-| `mod_path`     | string | yes      | Directory where mods are deployed (supports `~`)           |
-| `sources`      | map    | yes      | Source ID to game ID mapping (see below)                   |
-| `link_method`  | string | no       | Override global link method: `symlink`, `hardlink`, `copy` |
-| `cache_path`   | string | no       | Per-game cache directory override                          |
-| `hooks`        | object | no       | Scripts to run around install/uninstall (see below)        |
-| `deploy_mode`  | string | no       | How to handle mod archives: `extract` (default) or `copy`  |
+| Option           | Type   | Required | Description                                                                                      |
+| ---------------- | ------ | -------- | ------------------------------------------------------------------------------------------------ |
+| `name`           | string | yes      | Display name                                                                                     |
+| `install_path`   | string | yes      | Game installation directory (supports `~`)                                                       |
+| `mod_path`       | string | yes      | Directory where mods are deployed (supports `~`)                                                 |
+| `sources`        | map    | yes      | Source ID to game ID mapping (see below)                                                         |
+| `link_method`    | string | no       | Override global link method: `symlink`, `hardlink`, `copy`                                       |
+| `cache_path`     | string | no       | Per-game cache directory override                                                                |
+| `hooks`          | object | no       | Scripts to run around install/uninstall (see below)                                              |
+| `deploy_mode`    | string | no       | How to handle mod archives: `extract` (default), `copy`, or `compile`                            |
+| `data_dump_path` | string | no       | Compile-mode only: local unpacked data.pak JSON tree, used instead of the hosted base-table dump |
 
 ### Hooks (games.yaml)
 
@@ -57,6 +58,7 @@ The `deploy_mode` option controls how downloaded mod archives are handled:
 
 - **`extract`** (default): Archives are extracted to the mod path. Use for games where mods are loose files (e.g., Skyrim, Fallout).
 - **`copy`**: Archives are copied as-is to the mod path without extraction. Use for games that expect mod files to remain as archives (e.g., Minecraft `.jar` files, some Unity games).
+- **`compile`**: The downloaded file is compiled into a new artifact before caching (currently Icarus only: an `.exmodz` diff is applied to the game's base data tables to produce a deployable `_P.pak`). Only sources that implement compiling support this mode. Optional `data_dump_path` points compilation at your own unpacked `data.pak` JSON tree instead of the hosted community dump; it must match the installed game version, and a mismatch is a hard error.
 
 Example:
 

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -500,7 +500,7 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 	}
 	defer os.RemoveAll(stagePath) //nolint:errcheck
 
-	if game.DeployMode == domain.DeployCompile {
+	if game.DeployMode == domain.DeployCompile && isExmodzFile(file.FileName) {
 		compiler, ok := src.(source.Compiler)
 		if !ok {
 			return nil, fmt.Errorf("source %q: game %q requires DeployCompile but source does not implement Compiler", src.ID(), game.ID)
@@ -918,6 +918,17 @@ func commitStagedCache(cachePath, stagePath string) error {
 		return fmt.Errorf("removing old cache backup: %w", err)
 	}
 	return nil
+}
+
+// isExmodzFile reports whether fileName is a compile-eligible archive
+// (case-insensitive ".exmodz" suffix). DeployCompile games can also serve
+// plain, already-built ".pak" files (icarus.GetModFiles enumerates "pak"
+// before "exmodz") - those must NOT be routed through Compile, which expects
+// an .exmodz diff (#136 review, Task 13 fix round 1): a prebuilt pak falls
+// through to the pre-compile extract/copy logic unchanged, exactly as if
+// DeployMode were not DeployCompile at all.
+func isExmodzFile(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".exmodz")
 }
 
 // resolveBasePak locates the currently-installed game's base pak for

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -499,6 +499,33 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 		return nil, err
 	}
 	defer os.RemoveAll(stagePath) //nolint:errcheck
+
+	if game.DeployMode == domain.DeployCompile {
+		compiler, ok := src.(source.Compiler)
+		if !ok {
+			return nil, fmt.Errorf("source %q: game %q requires DeployCompile but source does not implement Compiler", src.ID(), game.ID)
+		}
+		basePakPath, err := resolveBasePak(game)
+		if err != nil {
+			return nil, err
+		}
+		// Unlike copyFileStreaming (which mkdirs its destination itself),
+		// Compile writes via unrealpak.Create - a bare os.Create - so
+		// stagePath must exist before it's called.
+		if err := os.MkdirAll(stagePath, 0755); err != nil {
+			return nil, fmt.Errorf("preparing compile staging: %w", err)
+		}
+		destName := compiledFileName(file.FileName)
+		destPath := filepath.Join(stagePath, destName)
+		if err := compiler.Compile(ctx, basePakPath, game.BaseDataPath, archivePath, destPath); err != nil {
+			return nil, fmt.Errorf("compiling mod: %w", err)
+		}
+		if err := commitStagedCacheWithMarker(cachePath, stagePath, file.ID, []string{destName}); err != nil {
+			return nil, err
+		}
+		return &DownloadModResult{FilesExtracted: 1, Checksum: downloadResult.Checksum}, nil
+	}
+
 	if game.DeployMode == domain.DeployCopy || !s.extractor.CanExtract(archivePath) {
 		// Copy mode: game wants files as-is (e.g., Hytale .zip mods)
 		// Or not an archive - just copy to cache. copyFileStreaming mkdirs
@@ -891,6 +918,35 @@ func commitStagedCache(cachePath, stagePath string) error {
 		return fmt.Errorf("removing old cache backup: %w", err)
 	}
 	return nil
+}
+
+// resolveBasePak locates the currently-installed game's base pak for
+// DeployCompile sources. v1 scope: Icarus only, one known pak filename
+// pattern — extend this if a second DeployCompile-using game is ever added
+// rather than generalizing speculatively now. The relative path below is
+// Task 1's empirically-confirmed finding (docs/plans/icarus-pak-format-findings.md),
+// recorded before this function was written, not an assumption made here: the
+// JSON data tables live in Content/Data/data.pak, NOT in the Content/Paks
+// pakchunks, which carry only cooked .uasset/.uexp assets and no JSON at all.
+//
+// Since rev3 this pak is no longer the source of base table *content* (that
+// comes from the hosted dump — Task 12a); it is still required, because it is
+// the only authority on which tables the installed game has and on which game
+// week is installed. Its parent directory also locates Icarus/Config/version.json.
+func resolveBasePak(game *domain.Game) (string, error) {
+	candidate := filepath.Join(game.InstallPath, "Icarus", "Content", "Data", "data.pak")
+	if _, err := os.Stat(candidate); err != nil {
+		return "", fmt.Errorf("locating base pak for %q: %w", game.ID, err)
+	}
+	return candidate, nil
+}
+
+// compiledFileName turns a downloaded source filename into the cached
+// output's name: same base name, .pak extension, matching Icarus's "_P.pak"
+// override convention.
+func compiledFileName(sourceFileName string) string {
+	base := strings.TrimSuffix(sourceFileName, filepath.Ext(sourceFileName))
+	return base + "_P.pak"
 }
 
 // GetGame retrieves a game by ID

--- a/internal/core/service_icarus_compile_test.go
+++ b/internal/core/service_icarus_compile_test.go
@@ -1,0 +1,110 @@
+package core_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCompilerSource is a minimal ModSource that also implements
+// source.Compiler, standing in for internal/source/icarus.Icarus (Tasks
+// 8/13) without pulling that package into internal/core's tests — this test
+// only needs to prove Service invokes Compile when DeployMode is
+// DeployCompile, which Task 12 already tests in isolation.
+type fakeCompilerSource struct {
+	downloadURL  string
+	compileCalls int
+}
+
+func (s *fakeCompilerSource) ID() string      { return "fake-compiler" }
+func (s *fakeCompilerSource) Name() string    { return "Fake Compiler Source" }
+func (s *fakeCompilerSource) AuthURL() string { return "" }
+func (s *fakeCompilerSource) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
+	return nil, source.ErrNotSupported
+}
+func (s *fakeCompilerSource) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	return source.SearchResult{}, source.ErrNotSupported
+}
+func (s *fakeCompilerSource) GetMod(ctx context.Context, gameID, modID string) (*domain.Mod, error) {
+	return nil, source.ErrNotSupported
+}
+func (s *fakeCompilerSource) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	return nil, source.ErrNotSupported
+}
+func (s *fakeCompilerSource) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, source.ErrNotSupported
+}
+func (s *fakeCompilerSource) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	return s.downloadURL, nil
+}
+func (s *fakeCompilerSource) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, source.ErrNotSupported
+}
+
+// Compile implements source.Compiler by copying the downloaded source file
+// through unchanged — this test only asserts Service invoked it with the
+// right arguments and used its output, not that it performs real PAK
+// compilation (Task 12 covers that).
+func (s *fakeCompilerSource) Compile(ctx context.Context, basePakPath, baseDataPath, sourceFilePath, outputPath string) error {
+	s.compileCalls++
+	data, err := os.ReadFile(sourceFilePath)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(outputPath, data, 0o644)
+}
+
+var (
+	_ source.ModSource = (*fakeCompilerSource)(nil)
+	_ source.Compiler  = (*fakeCompilerSource)(nil)
+)
+
+func TestDownloadMod_DeployCompile_InvokesCompiler(t *testing.T) {
+	dlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("fake-exmodz-bytes"))
+	}))
+	defer dlSrv.Close()
+
+	installDir := t.TempDir()
+	basePak := filepath.Join(installDir, "Icarus", "Content", "Data", "data.pak")
+	require.NoError(t, os.MkdirAll(filepath.Dir(basePak), 0o755))
+	require.NoError(t, os.WriteFile(basePak, []byte("fake-base-pak"), 0o644))
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	src := &fakeCompilerSource{downloadURL: dlSrv.URL}
+	svc.RegisterSource(src)
+
+	game := &domain.Game{ID: "icarus", InstallPath: installDir, ModPath: t.TempDir(), DeployMode: domain.DeployCompile}
+	require.NoError(t, svc.AddGame(game))
+
+	mod := &domain.Mod{ID: "bear-mount", SourceID: "fake-compiler", GameID: "icarus", Version: "3.3"}
+	file := &domain.DownloadableFile{ID: "exmodz", FileName: "Bear_Mount.exmodz"}
+
+	result, err := svc.DownloadMod(context.Background(), "fake-compiler", game, mod, file, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.FilesExtracted)
+	require.Equal(t, 1, src.compileCalls)
+
+	gameCache := svc.GetGameCache(game)
+	require.True(t, gameCache.Exists(game.ID, mod.SourceID, mod.ID, mod.Version))
+	files, err := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "Bear_Mount_P.pak", files[0])
+
+	data, err := os.ReadFile(gameCache.GetFilePath(game.ID, mod.SourceID, mod.ID, mod.Version, files[0]))
+	require.NoError(t, err)
+	require.Equal(t, "fake-exmodz-bytes", string(data))
+}

--- a/internal/core/service_icarus_compile_test.go
+++ b/internal/core/service_icarus_compile_test.go
@@ -108,3 +108,145 @@ func TestDownloadMod_DeployCompile_InvokesCompiler(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "fake-exmodz-bytes", string(data))
 }
+
+// newCompileTestGame builds a DeployCompile game backed by fakeCompilerSource,
+// serving dlBody for every download - shared setup for
+// TestDownloadMod_DeployCompile_RoutesPerFile's cases.
+func newCompileTestGame(t *testing.T, dlBody string) (*core.Service, *fakeCompilerSource, *domain.Game) {
+	t.Helper()
+
+	dlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(dlBody))
+	}))
+	t.Cleanup(dlSrv.Close)
+
+	installDir := t.TempDir()
+	basePak := filepath.Join(installDir, "Icarus", "Content", "Data", "data.pak")
+	require.NoError(t, os.MkdirAll(filepath.Dir(basePak), 0o755))
+	require.NoError(t, os.WriteFile(basePak, []byte("fake-base-pak"), 0o644))
+
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	src := &fakeCompilerSource{downloadURL: dlSrv.URL}
+	svc.RegisterSource(src)
+
+	game := &domain.Game{ID: "icarus", InstallPath: installDir, ModPath: t.TempDir(), DeployMode: domain.DeployCompile}
+	require.NoError(t, svc.AddGame(game))
+
+	return svc, src, game
+}
+
+// TestDownloadMod_DeployCompile_RoutesPerFile pins the fix-round-1 gap: a
+// DeployCompile game's compile branch must key off the FILE (".exmodz"
+// suffix, case-insensitive), not the game alone - icarus.GetModFiles can
+// serve a mod's already-built ".pak" alongside its ".exmodz" diff, and a pak
+// routed into Compile fails (it isn't a zip ParseExmodz can read).
+func TestDownloadMod_DeployCompile_RoutesPerFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		fileName       string
+		wantCompiled   bool
+		wantCachedName string
+	}{
+		{"exmodz file takes the compile branch", "Bear_Mount.exmodz", true, "Bear_Mount_P.pak"},
+		{"EXMODZ file takes the compile branch case-insensitively", "Bear_Mount.EXMODZ", true, "Bear_Mount_P.pak"},
+		{"pak file skips the compiler entirely", "Bear_Mount.pak", false, "Bear_Mount.pak"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const body = "fake-download-bytes"
+			svc, src, game := newCompileTestGame(t, body)
+
+			mod := &domain.Mod{ID: "bear-mount", SourceID: "fake-compiler", GameID: "icarus", Version: "3.3"}
+			file := &domain.DownloadableFile{ID: "the-file", FileName: tt.fileName}
+
+			result, err := svc.DownloadMod(context.Background(), "fake-compiler", game, mod, file, nil)
+			require.NoError(t, err)
+			require.Equal(t, 1, result.FilesExtracted)
+
+			wantCompileCalls := 0
+			if tt.wantCompiled {
+				wantCompileCalls = 1
+			}
+			require.Equal(t, wantCompileCalls, src.compileCalls)
+
+			gameCache := svc.GetGameCache(game)
+			files, err := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+			require.NoError(t, err)
+			require.Equal(t, []string{tt.wantCachedName}, files)
+
+			data, err := os.ReadFile(gameCache.GetFilePath(game.ID, mod.SourceID, mod.ID, mod.Version, tt.wantCachedName))
+			require.NoError(t, err)
+			require.Equal(t, body, string(data))
+		})
+	}
+
+	// Regression proof for the ".pak" case above: rather than only asserting
+	// "Compile wasn't called" (a fake-tautology that would also pass if
+	// routing were broken some other way), this proves a DeployCompile game
+	// handling a plain ".pak" produces EXACTLY what a DeployExtract game
+	// produces for the identical file through the identical source - the
+	// genuine pre-Task-13 extract/copy path, byte-for-byte.
+	t.Run("pak file on a compile-mode game matches a non-compile game byte-for-byte", func(t *testing.T) {
+		const body = "fake-pak-bytes"
+		mod := &domain.Mod{ID: "bear-mount", SourceID: "fake-compiler", GameID: "icarus", Version: "3.3"}
+		file := &domain.DownloadableFile{ID: "pak", FileName: "Bear_Mount.pak"}
+
+		compileSvc, compileSrc, compileGame := newCompileTestGame(t, body)
+		compileResult, err := compileSvc.DownloadMod(context.Background(), "fake-compiler", compileGame, mod, file, nil)
+		require.NoError(t, err)
+
+		extractSvc, extractSrc, extractGame := newCompileTestGame(t, body)
+		extractGame.DeployMode = domain.DeployExtract
+		extractResult, err := extractSvc.DownloadMod(context.Background(), "fake-compiler", extractGame, mod, file, nil)
+		require.NoError(t, err)
+
+		require.Equal(t, 0, compileSrc.compileCalls)
+		require.Equal(t, 0, extractSrc.compileCalls)
+		require.Equal(t, extractResult, compileResult)
+
+		compileFiles, err := compileSvc.GetGameCache(compileGame).ListFiles(compileGame.ID, mod.SourceID, mod.ID, mod.Version)
+		require.NoError(t, err)
+		extractFiles, err := extractSvc.GetGameCache(extractGame).ListFiles(extractGame.ID, mod.SourceID, mod.ID, mod.Version)
+		require.NoError(t, err)
+		require.Equal(t, extractFiles, compileFiles)
+
+		compileData, err := os.ReadFile(compileSvc.GetGameCache(compileGame).GetFilePath(compileGame.ID, mod.SourceID, mod.ID, mod.Version, compileFiles[0]))
+		require.NoError(t, err)
+		extractData, err := os.ReadFile(extractSvc.GetGameCache(extractGame).GetFilePath(extractGame.ID, mod.SourceID, mod.ID, mod.Version, extractFiles[0]))
+		require.NoError(t, err)
+		require.Equal(t, extractData, compileData)
+	})
+}
+
+// TestDownloadMod_DeployCompile_MixedFileMod pins that a single mod shipping
+// both a prebuilt ".pak" and an ".exmodz" diff (icarus.GetModFiles's "pak"
+// then "exmodz" enumeration, neither marked primary when both are present)
+// gets each file routed independently within the same DeployCompile game:
+// one DownloadMod call per DownloadableFile, exactly as the real CLI/TUI
+// download flow drives it.
+func TestDownloadMod_DeployCompile_MixedFileMod(t *testing.T) {
+	svc, src, game := newCompileTestGame(t, "fake-bytes")
+	mod := &domain.Mod{ID: "bear-mount", SourceID: "fake-compiler", GameID: "icarus", Version: "3.3"}
+
+	exmodzFile := &domain.DownloadableFile{ID: "exmodz", FileName: "Bear_Mount.exmodz"}
+	pakFile := &domain.DownloadableFile{ID: "pak", FileName: "Bear_Mount.pak"}
+
+	_, err := svc.DownloadMod(context.Background(), "fake-compiler", game, mod, exmodzFile, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, src.compileCalls, "exmodz file must compile")
+
+	_, err = svc.DownloadMod(context.Background(), "fake-compiler", game, mod, pakFile, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, src.compileCalls, "pak file must not trigger a second compile")
+
+	gameCache := svc.GetGameCache(game)
+	files, err := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"Bear_Mount_P.pak", "Bear_Mount.pak"}, files,
+		"both the compiled exmodz output and the untouched pak must be cached")
+}

--- a/internal/domain/game.go
+++ b/internal/domain/game.go
@@ -46,6 +46,9 @@ type Game struct {
 	CachePath          string            // Optional: custom cache path for this game's mods
 	Hooks              GameHooks         // Optional: hooks for install/uninstall operations
 	DeployMode         DeployMode        // How to handle downloaded files (extract vs copy)
+	// BaseDataPath is optional: a directory holding an unpacked data.pak JSON
+	// tree, used instead of fetching the hosted base-table dump (compile games only)
+	BaseDataPath string
 }
 
 // DeployMode determines how downloaded mod archives are handled
@@ -54,6 +57,7 @@ type DeployMode int
 const (
 	DeployExtract DeployMode = iota // Default: extract archives to mod path
 	DeployCopy                      // Copy files as-is (for games like Hytale where .zip IS the mod)
+	DeployCompile                   // Compile downloaded file into a new artifact before caching (Icarus .exmodz -> .pak)
 )
 
 func (m DeployMode) String() string {
@@ -62,6 +66,8 @@ func (m DeployMode) String() string {
 		return "extract"
 	case DeployCopy:
 		return "copy"
+	case DeployCompile:
+		return "compile"
 	default:
 		return "extract"
 	}
@@ -72,6 +78,8 @@ func ParseDeployMode(s string) DeployMode {
 	switch s {
 	case "copy":
 		return DeployCopy
+	case "compile":
+		return DeployCompile
 	default:
 		return DeployExtract
 	}

--- a/internal/domain/game_test.go
+++ b/internal/domain/game_test.go
@@ -58,6 +58,7 @@ func TestDeployMode_String(t *testing.T) {
 	}{
 		{"extract", DeployExtract, "extract"},
 		{"copy", DeployCopy, "copy"},
+		{"compile", DeployCompile, "compile"},
 		// Unlike LinkMethod.String, the default branch here also returns
 		// "extract" rather than "unknown" for out-of-range values.
 		{"unknown value falls back to extract", DeployMode(99), "extract"},
@@ -77,6 +78,7 @@ func TestParseDeployMode(t *testing.T) {
 		want  DeployMode
 	}{
 		{"copy", "copy", DeployCopy},
+		{"compile", "compile", DeployCompile},
 		{"extract explicit", "extract", DeployExtract},
 		{"empty defaults to extract", "", DeployExtract},
 		{"unknown defaults to extract", "bogus", DeployExtract},

--- a/internal/source/icarus/compile.go
+++ b/internal/source/icarus/compile.go
@@ -41,7 +41,7 @@ func Compile(ctx context.Context, dumps *DumpStore, basePakPath, localDumpDir, e
 	if err != nil {
 		return fmt.Errorf("icarus: opening base pak %s: %w", basePakPath, err)
 	}
-	defer base.Close()
+	defer base.Close() //nolint:errcheck
 
 	// Loaded and validated before anything is written, so a week mismatch or
 	// an offline machine fails before a half-built pak exists on disk.

--- a/internal/source/icarus/compile.go
+++ b/internal/source/icarus/compile.go
@@ -60,11 +60,15 @@ func Compile(ctx context.Context, dumps *DumpStore, basePakPath, localDumpDir, e
 	// no way to abort without finalizing (Close always serializes and writes
 	// whatever was buffered), so removing the file is the only way to keep
 	// the fail-loud-and-clean contract on this path; the success path
-	// (err == nil here) is untouched.
+	// (err == nil here) is untouched. The writer is closed (best-effort,
+	// error ignored — whatever it wrote is about to be deleted anyway)
+	// before the remove so the fd never leaks and the remove itself works on
+	// platforms (Windows) that refuse to delete a still-open file.
 	defer func() {
 		if err == nil {
 			return
 		}
+		_ = out.Close() //nolint:errcheck
 		if rmErr := os.Remove(outputPakPath); rmErr != nil && !os.IsNotExist(rmErr) {
 			err = fmt.Errorf("%w (additionally, removing partial output %s failed: %v)", err, outputPakPath, rmErr)
 		}

--- a/internal/source/icarus/compile.go
+++ b/internal/source/icarus/compile.go
@@ -27,7 +27,7 @@ import (
 // localDumpDir is the game's optional data_dump_path: when set, base tables
 // are read from that directory instead of being fetched. It is validated
 // identically, so a stale local directory fails just as loudly.
-func Compile(ctx context.Context, dumps *DumpStore, basePakPath, localDumpDir, exmodzPath, outputPakPath string) error {
+func Compile(ctx context.Context, dumps *DumpStore, basePakPath, localDumpDir, exmodzPath, outputPakPath string) (err error) {
 	exmodzData, err := os.ReadFile(exmodzPath)
 	if err != nil {
 		return fmt.Errorf("icarus: reading %s: %w", exmodzPath, err)
@@ -54,6 +54,21 @@ func Compile(ctx context.Context, dumps *DumpStore, basePakPath, localDumpDir, e
 	if err != nil {
 		return fmt.Errorf("icarus: creating %s: %w", outputPakPath, err)
 	}
+	// unrealpak.Create opens the file eagerly, so any error from here on
+	// leaves a partial/incomplete pak at outputPakPath unless removed — a
+	// hazard, since it could be picked up and deployed. unrealpak.Writer has
+	// no way to abort without finalizing (Close always serializes and writes
+	// whatever was buffered), so removing the file is the only way to keep
+	// the fail-loud-and-clean contract on this path; the success path
+	// (err == nil here) is untouched.
+	defer func() {
+		if err == nil {
+			return
+		}
+		if rmErr := os.Remove(outputPakPath); rmErr != nil && !os.IsNotExist(rmErr) {
+			err = fmt.Errorf("%w (additionally, removing partial output %s failed: %v)", err, outputPakPath, rmErr)
+		}
+	}()
 
 	for _, row := range bundle.Diff.Rows {
 		if row.CurrentFile == endOfModSentinel {

--- a/internal/source/icarus/compile.go
+++ b/internal/source/icarus/compile.go
@@ -1,0 +1,181 @@
+package icarus
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"
+)
+
+// Compile reads exmodzPath's .EXMOD diff, applies it to the game's base data
+// tables, bundles in any pre-built assets the .EXMODZ carries, and writes the
+// result as a new pak at outputPakPath ready to deploy as-is.
+//
+// The base tables come from the community per-week dump (Task 12a), not from
+// basePakPath: 258 of the 298 tables in a real data.pak are Oodle-compressed
+// and cannot be read with the stdlib. basePakPath is still opened, for two
+// things it alone can answer — which tables the installed game actually has
+// (so a bare, hyphen-flattened CurrentFile resolves to a real mount path),
+// and whether the dump
+// is for the installed week (DumpForBuild byte-checks it against the tables
+// the pak stores uncompressed). A dump that does not match fails the whole
+// compile; see Task 12a.
+//
+// localDumpDir is the game's optional data_dump_path: when set, base tables
+// are read from that directory instead of being fetched. It is validated
+// identically, so a stale local directory fails just as loudly.
+func Compile(ctx context.Context, dumps *DumpStore, basePakPath, localDumpDir, exmodzPath, outputPakPath string) error {
+	exmodzData, err := os.ReadFile(exmodzPath)
+	if err != nil {
+		return fmt.Errorf("icarus: reading %s: %w", exmodzPath, err)
+	}
+	bundle, err := ParseExmodz(exmodzData)
+	if err != nil {
+		return fmt.Errorf("icarus: %s: %w", exmodzPath, err)
+	}
+
+	base, err := unrealpak.Open(basePakPath)
+	if err != nil {
+		return fmt.Errorf("icarus: opening base pak %s: %w", basePakPath, err)
+	}
+	defer base.Close()
+
+	// Loaded and validated before anything is written, so a week mismatch or
+	// an offline machine fails before a half-built pak exists on disk.
+	dump, err := dumps.DumpForBuild(ctx, basePakPath, localDumpDir)
+	if err != nil {
+		return err
+	}
+
+	out, err := unrealpak.Create(outputPakPath)
+	if err != nil {
+		return fmt.Errorf("icarus: creating %s: %w", outputPakPath, err)
+	}
+
+	for _, row := range bundle.Diff.Rows {
+		if row.CurrentFile == endOfModSentinel {
+			// A known .EXMOD ecosystem terminator row: no File_Items, no
+			// corresponding data table. Not a row to resolve or patch.
+			continue
+		}
+		if len(row.FileItems) == 0 {
+			return fmt.Errorf("icarus: %s: row has no File_Items to apply (malformed .EXMOD manifest)", row.CurrentFile)
+		}
+		mountPath, err := resolveCurrentFile(base, row.CurrentFile)
+		if err != nil {
+			return err
+		}
+		baseData, ok := dump.Table(mountPath)
+		if !ok {
+			return fmt.Errorf("icarus: base data table %s is present in the installed game "+
+				"but missing from the base-table dump", mountPath)
+		}
+		patched, err := ApplyRowPatch(baseData, row)
+		if err != nil {
+			return err
+		}
+		if err := out.AddFile(mountPath, patched); err != nil {
+			return fmt.Errorf("icarus: writing patched %s: %w", mountPath, err)
+		}
+	}
+
+	for assetPath, data := range bundle.Assets {
+		safePath, err := sanitizeAssetPath(assetPath)
+		if err != nil {
+			return err
+		}
+		if err := out.AddFile(safePath, data); err != nil {
+			return fmt.Errorf("icarus: writing bundled asset %s: %w", safePath, err)
+		}
+	}
+
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("icarus: finalizing %s: %w", outputPakPath, err)
+	}
+	return nil
+}
+
+// endOfModSentinel is a known .EXMOD ecosystem terminator row: real-world
+// manifests end their Rows array with {"CurrentFile":"EndOfMod"} and no
+// File_Items key at all. It targets no data table and carries no patch, so
+// Compile skips it rather than trying (and failing) to resolve it.
+const endOfModSentinel = "EndOfMod"
+
+// resolveCurrentFile finds the base-pak file a row's bare CurrentFile refers
+// to. The .EXMOD schema flattens the mount-relative directory path into
+// CurrentFile by replacing every "/" with "-" (e.g. the real base pak path
+// "Audio/MusicConditions/D_MusicLocationConditions.json" is recorded as
+// "Audio-MusicConditions-D_MusicLocationConditions.json"); reversing that
+// substitution reconstructs the mount path exactly. This was verified
+// against a real install and a real .EXMODZ: none of Icarus's 298 real base
+// table paths contain a literal hyphen, so the reverse mapping is
+// unambiguous. Fails loudly on zero or multiple matches — see this task's
+// header note; guessing which one is correct is exactly the kind of silent
+// fallback repo precedent #95 forbids.
+func resolveCurrentFile(base *unrealpak.Reader, currentFile string) (string, error) {
+	files := base.Files()
+	paths := make([]string, len(files))
+	for i, f := range files {
+		paths[i] = f.Path
+	}
+	return matchMountPath(paths, currentFile)
+}
+
+// matchMountPath resolves currentFile against paths, isolated from
+// *unrealpak.Reader so the zero/ambiguous-match error paths can be tested
+// directly without needing a base pak with (unreachable in valid data)
+// duplicate mount entries.
+func matchMountPath(paths []string, currentFile string) (string, error) {
+	candidate := strings.ReplaceAll(currentFile, "-", "/")
+	var matches []string
+	for _, p := range paths {
+		if p == candidate {
+			matches = append(matches, p)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf("icarus: %s: no matching file in base pak "+
+			"(expected mount path %s, from CurrentFile with '-' converted to '/')", currentFile, candidate)
+	default:
+		return "", fmt.Errorf("icarus: %s: ambiguous, matches %v", currentFile, matches)
+	}
+}
+
+// sanitizeAssetPath validates a bundled asset's mount path before it is
+// written into the output pak. .EXMODZ archives are third-party zip files,
+// and ParseExmodz (Task 11) carries each entry's raw zip name through
+// unchanged as the Assets map key. Without this gate, a crafted entry name
+// (a "../" parent traversal, an absolute path, or a Windows drive path) could
+// escape the mod's own namespace once the pak is deployed or unpacked
+// elsewhere — the pak equivalent of a zip-slip. Rejecting it here, before
+// AddFile, keeps that malformed-archive class of input a loud compile
+// failure rather than a written-then-discovered problem.
+func sanitizeAssetPath(rawZipName string) (string, error) {
+	normalized := strings.ReplaceAll(rawZipName, `\`, "/")
+	if strings.Contains(normalized, "\x00") {
+		return "", fmt.Errorf("icarus: bundled asset %q: contains a NUL byte", rawZipName)
+	}
+	if strings.HasPrefix(normalized, "/") || isWindowsDriveAbsolute(normalized) {
+		return "", fmt.Errorf("icarus: bundled asset %q: absolute paths are not allowed", rawZipName)
+	}
+	cleaned := path.Clean(normalized)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("icarus: bundled asset %q: escapes the mod's own path", rawZipName)
+	}
+	return cleaned, nil
+}
+
+// isWindowsDriveAbsolute reports whether p starts with a Windows drive letter
+// (e.g. "C:/evil"). Checked on the slash-normalized form, since a zip entry
+// written by a Windows tool may carry "C:\evil" — backslashes normalize to
+// forward slashes before this check runs.
+func isWindowsDriveAbsolute(p string) bool {
+	return len(p) >= 2 && p[1] == ':' &&
+		((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z'))
+}

--- a/internal/source/icarus/compile_test.go
+++ b/internal/source/icarus/compile_test.go
@@ -194,6 +194,38 @@ func TestCompile_UnsafeAssetPath_Errors(t *testing.T) {
 	if !strings.Contains(err.Error(), "../evil.uasset") {
 		t.Errorf("error %q should name the offending asset path", err)
 	}
+	if _, statErr := os.Stat(outputPath); statErr == nil {
+		t.Error("no partial output pak should exist after an unsafe-asset-path failure")
+	}
+}
+
+// A failure that happens after unrealpak.Create(outputPakPath) has already
+// created the file on disk (here: an unresolvable row, mid row-loop) must
+// not leave a partial/incomplete pak behind — a stray partial _P.pak is a
+// hazard (it could be picked up and deployed) and contradicts the
+// fail-loud-and-clean philosophy. See task-12-report.md "plan delta" (fix
+// round 1).
+func TestCompile_MidCompileFailure_LeavesNoOutputFile(t *testing.T) {
+	baseTables := map[string][]byte{
+		"AI/D_AIGrowth.json": []byte(`{"Mount_Bear":{"BaseMovementSpeed":200}}`),
+	}
+	basePak := writeTestBasePak(t, baseTables)
+	dumps := testDumpStore(t, baseTables)
+	// CurrentFile has no matching base-pak file: resolveCurrentFile fails
+	// inside the row loop, after out has already been created.
+	manifest := `{"name":"X","Rows":[{"CurrentFile":"AI-D_Nonexistent.json","File_Items":[{"Name":"Mount_Bear","X":1}]}]}`
+	exmodzPath := writeTestExmodzFile(t, manifest, nil)
+	outputPath := filepath.Join(t.TempDir(), "out.pak")
+
+	err := Compile(context.Background(), dumps, basePak, "", exmodzPath, outputPath)
+	if err == nil {
+		t.Fatal("expected an error for an unresolvable row, got nil")
+	}
+	if _, statErr := os.Stat(outputPath); statErr == nil {
+		t.Error("no partial output pak should exist after a mid-compile failure")
+	} else if !os.IsNotExist(statErr) {
+		t.Errorf("unexpected error stat-ing output path: %v", statErr)
+	}
 }
 
 func TestMatchMountPath(t *testing.T) {

--- a/internal/source/icarus/compile_test.go
+++ b/internal/source/icarus/compile_test.go
@@ -76,7 +76,7 @@ func TestCompile_AppliesDiffAndBundlesAssets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("opening compiled output: %v", err)
 	}
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 
 	patched, err := r.ReadFile("AI/D_AIGrowth.json")
 	if err != nil {
@@ -118,7 +118,7 @@ func TestCompile_SkipsEndOfModSentinelRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("opening compiled output: %v", err)
 	}
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 	patched, err := r.ReadFile("AI/D_AIGrowth.json")
 	if err != nil {
 		t.Fatalf("ReadFile patched data table: %v", err)

--- a/internal/source/icarus/compile_test.go
+++ b/internal/source/icarus/compile_test.go
@@ -1,0 +1,285 @@
+package icarus
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"
+)
+
+// testDumpStore serves a dump containing exactly files, so validateDump agrees
+// it matches the base pak built from the same map. Reuses tarGz from
+// datadump_test.go (same package).
+func testDumpStore(t *testing.T, files map[string][]byte) *DumpStore {
+	t.Helper()
+	entries := make(map[string]string, len(files))
+	for name, data := range files {
+		entries[name] = string(data)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(tarGz(t, "IcarusData-test", entries))
+	}))
+	t.Cleanup(srv.Close)
+	store := newDumpStore(t.TempDir(), srv.Client())
+	store.treeURL = srv.URL
+	return store
+}
+
+func writeTestExmodzFile(t *testing.T, manifestJSON string, assets map[string][]byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "mod.exmodz")
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, _ := zw.Create("Extracted Mods/Test.EXMOD")
+	w.Write([]byte(manifestJSON)) //nolint:errcheck
+	for name, data := range assets {
+		aw, _ := zw.Create(name)
+		aw.Write(data) //nolint:errcheck
+	}
+	zw.Close() //nolint:errcheck
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// Base table paths and CurrentFile values below mirror the real shape found
+// against a live install + a real Bear_Mount.EXMODZ during Step 5b
+// verification: CurrentFile flattens the mount-relative directory path with
+// "-" in place of "/" (e.g. "AI-D_AIGrowth.json" for base pak path
+// "AI/D_AIGrowth.json"), not a bare filename living at a hyphenated leaf as
+// the original brief's fixtures assumed. See task-12-report.md "plan delta".
+func TestCompile_AppliesDiffAndBundlesAssets(t *testing.T) {
+	baseTables := map[string][]byte{
+		"AI/D_AIGrowth.json": []byte(`{"Mount_Bear":{"BaseMovementSpeed":200}}`),
+	}
+	basePak := writeTestBasePak(t, baseTables)
+	dumps := testDumpStore(t, baseTables)
+	manifest := `{"name":"Bear Mount","Rows":[{"CurrentFile":"AI-D_AIGrowth.json","File_Items":[{"Name":"Mount_Bear","BaseMovementSpeed":235}]}]}`
+	exmodzPath := writeTestExmodzFile(t, manifest, map[string][]byte{
+		"Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset": []byte("fake-asset"),
+	})
+	outputPath := filepath.Join(t.TempDir(), "Bear_Mount_P.pak")
+
+	if err := Compile(context.Background(), dumps, basePak, "", exmodzPath, outputPath); err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	r, err := unrealpak.Open(outputPath)
+	if err != nil {
+		t.Fatalf("opening compiled output: %v", err)
+	}
+	defer r.Close()
+
+	patched, err := r.ReadFile("AI/D_AIGrowth.json")
+	if err != nil {
+		t.Fatalf("ReadFile patched data table: %v", err)
+	}
+	if !bytes.Contains(patched, []byte(`"BaseMovementSpeed":235`)) {
+		t.Errorf("patched data table = %s, want BaseMovementSpeed 235", patched)
+	}
+
+	asset, err := r.ReadFile("Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset")
+	if err != nil {
+		t.Fatalf("ReadFile bundled asset: %v", err)
+	}
+	if string(asset) != "fake-asset" {
+		t.Errorf("bundled asset content = %q", asset)
+	}
+}
+
+// The real .EXMOD ecosystem terminates Rows with {"CurrentFile":"EndOfMod"}
+// and no File_Items key — Compile must skip it, not try to resolve it as a
+// data table (it has none).
+func TestCompile_SkipsEndOfModSentinelRow(t *testing.T) {
+	baseTables := map[string][]byte{
+		"AI/D_AIGrowth.json": []byte(`{"Mount_Bear":{"BaseMovementSpeed":200}}`),
+	}
+	basePak := writeTestBasePak(t, baseTables)
+	dumps := testDumpStore(t, baseTables)
+	manifest := `{"name":"X","Rows":[` +
+		`{"CurrentFile":"AI-D_AIGrowth.json","File_Items":[{"Name":"Mount_Bear","BaseMovementSpeed":235}]},` +
+		`{"CurrentFile":"EndOfMod"}]}`
+	exmodzPath := writeTestExmodzFile(t, manifest, nil)
+	outputPath := filepath.Join(t.TempDir(), "out.pak")
+
+	if err := Compile(context.Background(), dumps, basePak, "", exmodzPath, outputPath); err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	r, err := unrealpak.Open(outputPath)
+	if err != nil {
+		t.Fatalf("opening compiled output: %v", err)
+	}
+	defer r.Close()
+	patched, err := r.ReadFile("AI/D_AIGrowth.json")
+	if err != nil {
+		t.Fatalf("ReadFile patched data table: %v", err)
+	}
+	if !bytes.Contains(patched, []byte(`"BaseMovementSpeed":235`)) {
+		t.Errorf("patched data table = %s, want BaseMovementSpeed 235", patched)
+	}
+}
+
+// A real (non-sentinel) row with no File_Items is a malformed manifest, not
+// something to silently skip — only the EndOfMod sentinel gets that pass.
+func TestCompile_RowWithoutFileItems_Errors(t *testing.T) {
+	baseTables := map[string][]byte{
+		"AI/D_AIGrowth.json": []byte(`{"Mount_Bear":{"BaseMovementSpeed":200}}`),
+	}
+	basePak := writeTestBasePak(t, baseTables)
+	dumps := testDumpStore(t, baseTables)
+	manifest := `{"name":"X","Rows":[{"CurrentFile":"AI-D_AIGrowth.json"}]}`
+	exmodzPath := writeTestExmodzFile(t, manifest, nil)
+	outputPath := filepath.Join(t.TempDir(), "out.pak")
+
+	err := Compile(context.Background(), dumps, basePak, "", exmodzPath, outputPath)
+	if err == nil {
+		t.Fatal("expected an error for a non-sentinel row with no File_Items, got nil")
+	}
+	if !strings.Contains(err.Error(), "AI-D_AIGrowth.json") {
+		t.Errorf("error %q should name the offending row", err)
+	}
+}
+
+// A stale dump must stop the compile before any output pak is written — this
+// is the live case today, where the newest dump lags the installed game.
+func TestCompile_DumpWeekMismatch_FailsBeforeWriting(t *testing.T) {
+	basePak := writeTestBasePak(t, map[string][]byte{
+		"AI/D_AIGrowth.json": []byte(`{"Mount_Bear":{"BaseMovementSpeed":200}}`),
+	})
+	dumps := testDumpStore(t, map[string][]byte{ // different week's content
+		"AI/D_AIGrowth.json": []byte(`{"Mount_Bear":{"BaseMovementSpeed":150}}`),
+	})
+	manifest := `{"name":"X","Rows":[{"CurrentFile":"AI-D_AIGrowth.json","File_Items":[{"Name":"Mount_Bear","BaseMovementSpeed":235}]}]}`
+	exmodzPath := writeTestExmodzFile(t, manifest, nil)
+	outputPath := filepath.Join(t.TempDir(), "out.pak")
+
+	err := Compile(context.Background(), dumps, basePak, "", exmodzPath, outputPath)
+	if err == nil {
+		t.Fatal("expected an error when the dump is for a different game week, got nil")
+	}
+	if _, statErr := os.Stat(outputPath); statErr == nil {
+		t.Error("no output pak should exist after a week-mismatch failure")
+	}
+}
+
+// A malicious .EXMODZ whose bundled asset entry escapes the mod's own path
+// must fail loudly rather than write outside the pak's intended namespace —
+// see task-12-report.md "plan delta" for the exact semantics agreed with the
+// coordinator.
+func TestCompile_UnsafeAssetPath_Errors(t *testing.T) {
+	baseTables := map[string][]byte{
+		"AI/D_AIGrowth.json": []byte(`{"Mount_Bear":{"BaseMovementSpeed":200}}`),
+	}
+	basePak := writeTestBasePak(t, baseTables)
+	dumps := testDumpStore(t, baseTables)
+	manifest := `{"name":"X","Rows":[]}`
+	exmodzPath := writeTestExmodzFile(t, manifest, map[string][]byte{
+		"../evil.uasset": []byte("payload"),
+	})
+	outputPath := filepath.Join(t.TempDir(), "out.pak")
+
+	err := Compile(context.Background(), dumps, basePak, "", exmodzPath, outputPath)
+	if err == nil {
+		t.Fatal("expected an error for an asset path escaping the mod's own namespace, got nil")
+	}
+	if !strings.Contains(err.Error(), "../evil.uasset") {
+		t.Errorf("error %q should name the offending asset path", err)
+	}
+}
+
+func TestMatchMountPath(t *testing.T) {
+	paths := []string{
+		"AI/D_AIGrowth.json",
+		"Audio/MusicConditions/D_MusicLocationConditions.json",
+		"D_Factions.json",
+	}
+
+	t.Run("single-level directory", func(t *testing.T) {
+		got, err := matchMountPath(paths, "AI-D_AIGrowth.json")
+		if err != nil {
+			t.Fatalf("matchMountPath: %v", err)
+		}
+		if got != "AI/D_AIGrowth.json" {
+			t.Errorf("matchMountPath = %q, want AI/D_AIGrowth.json", got)
+		}
+	})
+
+	t.Run("multi-level directory", func(t *testing.T) {
+		got, err := matchMountPath(paths, "Audio-MusicConditions-D_MusicLocationConditions.json")
+		if err != nil {
+			t.Fatalf("matchMountPath: %v", err)
+		}
+		if got != "Audio/MusicConditions/D_MusicLocationConditions.json" {
+			t.Errorf("matchMountPath = %q, want Audio/MusicConditions/D_MusicLocationConditions.json", got)
+		}
+	})
+
+	t.Run("root-level file, no hyphen to convert", func(t *testing.T) {
+		got, err := matchMountPath(paths, "D_Factions.json")
+		if err != nil {
+			t.Fatalf("matchMountPath: %v", err)
+		}
+		if got != "D_Factions.json" {
+			t.Errorf("matchMountPath = %q, want D_Factions.json", got)
+		}
+	})
+
+	t.Run("no match is a loud, actionable error", func(t *testing.T) {
+		_, err := matchMountPath(paths, "AI-D_Nonexistent.json")
+		if err == nil {
+			t.Fatal("expected an error for a CurrentFile with no matching base pak file, got nil")
+		}
+		if !strings.Contains(err.Error(), "AI-D_Nonexistent.json") || !strings.Contains(err.Error(), "AI/D_Nonexistent.json") {
+			t.Errorf("error %q should name both the CurrentFile and the expected mount path", err)
+		}
+	})
+
+	t.Run("ambiguous match is a loud error", func(t *testing.T) {
+		dup := []string{"AI/D_AIGrowth.json", "AI/D_AIGrowth.json"}
+		_, err := matchMountPath(dup, "AI-D_AIGrowth.json")
+		if err == nil {
+			t.Fatal("expected an error for an ambiguous match, got nil")
+		}
+	})
+}
+
+func TestSanitizeAssetPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "parent traversal", raw: "../evil.json", wantErr: true},
+		{name: "absolute unix path", raw: "/evil", wantErr: true},
+		{name: "windows drive absolute", raw: `C:\evil`, wantErr: true},
+		{name: "backslash-normalized nested path", raw: `Good\Nested\file.uasset`, want: "Good/Nested/file.uasset"},
+		{name: "benign nested path", raw: "Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset", want: "Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sanitizeAssetPath(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("sanitizeAssetPath(%q) = %q, nil; want error", tt.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("sanitizeAssetPath(%q): %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Errorf("sanitizeAssetPath(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/source/icarus/compile_test.go
+++ b/internal/source/icarus/compile_test.go
@@ -27,7 +27,7 @@ func testDumpStore(t *testing.T, files map[string][]byte) *DumpStore {
 		_, _ = w.Write(tarGz(t, "IcarusData-test", entries))
 	}))
 	t.Cleanup(srv.Close)
-	store := newDumpStore(t.TempDir(), srv.Client())
+	store := newDumpStore(srv.Client())
 	store.treeURL = srv.URL
 	return store
 }

--- a/internal/source/icarus/datadump.go
+++ b/internal/source/icarus/datadump.go
@@ -90,15 +90,17 @@ func (d *Dump) Table(rel string) ([]byte, bool) {
 	return b, ok
 }
 
-// DumpStore fetches and caches base-table dumps.
+// DumpStore fetches base-table dumps (hosted, or from a local directory
+// override — see DumpForBuild). It does not cache to disk: every call that
+// doesn't supply a localDumpDir re-fetches the tree over the network. Adding
+// caching is a real, tracked follow-up, not implemented here (YAGNI).
 type DumpStore struct {
-	cacheDir   string
 	httpClient *http.Client
 	treeURL    string // overridable in tests
 }
 
-func newDumpStore(cacheDir string, httpClient *http.Client) *DumpStore {
-	return &DumpStore{cacheDir: cacheDir, httpClient: httpClient, treeURL: defaultDumpTreeURL}
+func newDumpStore(httpClient *http.Client) *DumpStore {
+	return &DumpStore{httpClient: httpClient, treeURL: defaultDumpTreeURL}
 }
 
 // DumpForBuild loads the base data tables and returns them only if they match

--- a/internal/source/icarus/datadump.go
+++ b/internal/source/icarus/datadump.go
@@ -1,0 +1,291 @@
+package icarus
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"
+)
+
+// defaultDumpTreeURL is the community per-week unpack of Icarus's data.pak:
+// https://github.com/GODOFMINECRAFT4/IcarusData. The tree is committed as
+// loose JSON at the repo root, one commit per game week, with the week
+// recorded only in the commit message — there are no tags or releases. This
+// URL is HEAD; a specific week is addressed by substituting its commit SHA.
+const defaultDumpTreeURL = "https://codeload.github.com/GODOFMINECRAFT4/IcarusData/tar.gz/refs/heads/master"
+
+// maxDumpBytes caps the download. The real tree is ~36 MB; this leaves room to
+// grow while refusing to stream an unbounded body into memory.
+const maxDumpBytes = 256 << 20
+
+// Build identifies the installed game, read from Icarus/Config/version.json.
+// Note this carries no week number — nothing in the install does. Week
+// agreement is established by content comparison, not by this value.
+type Build struct {
+	Major, Minor, Patch int
+	Changelist          int
+	DataChangelist      int
+	FeatureLevel        string
+}
+
+func (b Build) String() string {
+	return fmt.Sprintf("%d.%d.%d.%d", b.Major, b.Minor, b.Patch, b.Changelist)
+}
+
+// detectBuild reads <installRoot>/Icarus/Config/version.json.
+func detectBuild(installRoot string) (Build, error) {
+	p := filepath.Join(installRoot, "Icarus", "Config", "version.json")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		return Build{}, fmt.Errorf("icarus: reading game version from %s: %w", p, err)
+	}
+	var doc struct {
+		Version struct {
+			Major, Minor, Patch int
+			Changelist          int
+			FeatureLevel        string
+		}
+		Data struct{ Changelist int }
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return Build{}, fmt.Errorf("icarus: parsing %s: %w", p, err)
+	}
+	return Build{
+		Major: doc.Version.Major, Minor: doc.Version.Minor, Patch: doc.Version.Patch,
+		Changelist:     doc.Version.Changelist,
+		DataChangelist: doc.Data.Changelist,
+		FeatureLevel:   doc.Version.FeatureLevel,
+	}, nil
+}
+
+// Dump is a fetched set of base data tables, keyed by mount-relative path
+// (e.g. "Factions/D_Factions.json") with values already converted back to the
+// game's CRLF line endings.
+type Dump struct {
+	tables map[string][]byte
+}
+
+// Table returns one table's shipped bytes.
+func (d *Dump) Table(rel string) ([]byte, bool) {
+	b, ok := d.tables[rel]
+	return b, ok
+}
+
+// DumpStore fetches and caches base-table dumps.
+type DumpStore struct {
+	cacheDir   string
+	httpClient *http.Client
+	treeURL    string // overridable in tests
+}
+
+func newDumpStore(cacheDir string, httpClient *http.Client) *DumpStore {
+	return &DumpStore{cacheDir: cacheDir, httpClient: httpClient, treeURL: defaultDumpTreeURL}
+}
+
+// DumpForBuild loads the base data tables and returns them only if they match
+// the installed game, proven by byte-comparing every table basePakPath stores
+// uncompressed. A mismatch means the tables are for a different game week:
+// that is a hard error naming the offending tables, never a silent
+// best-effort.
+//
+// localDumpDir, when non-empty, is a user-supplied directory holding an
+// unpacked data.pak JSON tree (QuickBMS output and the like); it replaces the
+// network fetch entirely. Validation is the same either way — a local
+// directory from the wrong week is rejected exactly like a stale hosted dump.
+func (s *DumpStore) DumpForBuild(ctx context.Context, basePakPath, localDumpDir string) (*Dump, error) {
+	var (
+		dump *Dump
+		err  error
+	)
+	if localDumpDir != "" {
+		dump, err = loadLocalDump(localDumpDir)
+	} else {
+		dump, err = s.fetchTree(ctx, s.treeURL)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := validateDump(dump, basePakPath); err != nil {
+		if localDumpDir != "" {
+			return nil, fmt.Errorf("%w (tables were read from the configured data_dump_path %s)", err, localDumpDir)
+		}
+		return nil, err
+	}
+	return dump, nil
+}
+
+// loadLocalDump reads an unpacked data.pak JSON tree from disk. The layout is
+// the same one the hosted dump ships — table paths relative to the directory
+// root, e.g. "Factions/D_Factions.json" — so a user can point this at QuickBMS
+// output without rearranging anything.
+func loadLocalDump(dir string) (*Dump, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("icarus: reading the configured data_dump_path %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("icarus: the configured data_dump_path %s is not a directory", dir)
+	}
+
+	dump := &Dump{tables: make(map[string][]byte)}
+	err = filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".json") {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			return err
+		}
+		body, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		dump.tables[filepath.ToSlash(rel)] = toCRLF(body)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("icarus: scanning the configured data_dump_path %s: %w", dir, err)
+	}
+	if len(dump.tables) == 0 {
+		return nil, fmt.Errorf("icarus: the configured data_dump_path %s contains no JSON tables "+
+			"(expected an unpacked data.pak tree, e.g. Factions/D_Factions.json)", dir)
+	}
+	return dump, nil
+}
+
+// fetchTree downloads a dump tarball and ingests its JSON tables, restoring
+// the CRLF line endings the game ships (the repo stores LF).
+func (s *DumpStore) fetchTree(ctx context.Context, url string) (*Dump, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("icarus: building dump request: %w", err)
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("icarus: fetching base-table dump: %w "+
+			"(compiling Icarus mods requires network access — see the plan's Global Constraints)", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("icarus: fetching base-table dump from %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	zr, err := gzip.NewReader(io.LimitReader(resp.Body, maxDumpBytes))
+	if err != nil {
+		return nil, fmt.Errorf("icarus: base-table dump is not valid gzip: %w", err)
+	}
+	defer zr.Close() //nolint:errcheck
+
+	dump := &Dump{tables: make(map[string][]byte)}
+	tr := tar.NewReader(zr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("icarus: reading base-table dump: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg || !strings.HasSuffix(hdr.Name, ".json") {
+			continue
+		}
+		// Strip the archive's single top-level directory (e.g.
+		// "IcarusData-<sha>/") to get the mount-relative table path.
+		rel := hdr.Name
+		if i := strings.Index(rel, "/"); i >= 0 {
+			rel = rel[i+1:]
+		}
+		// The repo also carries a stale "data/" copy of the tree; the
+		// authoritative tables are the root-level ones.
+		if rel == "" || strings.HasPrefix(rel, "data/") {
+			continue
+		}
+		body, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("icarus: reading %s from base-table dump: %w", rel, err)
+		}
+		dump.tables[path.Clean(rel)] = toCRLF(body)
+	}
+	if len(dump.tables) == 0 {
+		return nil, fmt.Errorf("icarus: base-table dump from %s contained no JSON tables", url)
+	}
+	return dump, nil
+}
+
+// toCRLF restores the game's line endings. The dump repo stores LF (committed
+// with autocrlf); the shipped pak stores CRLF, and the two are otherwise
+// byte-identical. Existing CRLFs are left alone so the conversion is
+// idempotent.
+func toCRLF(b []byte) []byte {
+	return []byte(strings.ReplaceAll(strings.ReplaceAll(string(b), "\r\n", "\n"), "\n", "\r\n"))
+}
+
+// validateDump proves a dump belongs to the installed game.
+//
+// Only the tables data.pak stores *uncompressed* can be checked — the rest are
+// Oodle-compressed and unreadable here, which is the whole reason the dump
+// exists. That is enough: a dump built from a different week's data.pak
+// disagrees on some of them, and in practice it disagrees loudly (the spike saw
+// 3 differing stored tables and 6 missing tables across a 7-week gap).
+func validateDump(dump *Dump, basePakPath string) error {
+	pak, err := unrealpak.Open(basePakPath)
+	if err != nil {
+		return fmt.Errorf("icarus: opening base pak %s for dump validation: %w", basePakPath, err)
+	}
+	defer pak.Close() //nolint:errcheck
+
+	var missing, differing []string
+	checked := 0
+	for _, f := range pak.Files() {
+		shipped, err := pak.ReadFile(f.Path)
+		if err != nil {
+			continue // Oodle-compressed: not readable here, and not our gate
+		}
+		checked++
+		got, ok := dump.Table(f.Path)
+		if !ok {
+			missing = append(missing, f.Path)
+			continue
+		}
+		if !bytes.Equal(got, shipped) {
+			differing = append(differing, f.Path)
+		}
+	}
+	if checked == 0 {
+		return fmt.Errorf("icarus: %s exposed no uncompressed tables to validate the dump against", basePakPath)
+	}
+	if len(missing) == 0 && len(differing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	sort.Strings(differing)
+	return fmt.Errorf(
+		"icarus: the available base-table dump does not match the installed game "+
+			"(%d/%d uncompressed tables disagree: %s). The dump is for a different game week. "+
+			"Wait for the dump to be updated for your game version, or roll the game back to a "+
+			"matching week; compiling against a mismatched week would silently corrupt mod data",
+		len(missing)+len(differing), checked, summarize(append(differing, missing...)))
+}
+
+func summarize(paths []string) string {
+	const max = 3
+	if len(paths) <= max {
+		return strings.Join(paths, ", ")
+	}
+	return fmt.Sprintf("%s and %d more", strings.Join(paths[:max], ", "), len(paths)-max)
+}

--- a/internal/source/icarus/datadump.go
+++ b/internal/source/icarus/datadump.go
@@ -31,6 +31,12 @@ const defaultDumpTreeURL = "https://codeload.github.com/GODOFMINECRAFT4/IcarusDa
 // grow while refusing to stream an unbounded body into memory.
 const maxDumpBytes = 256 << 20
 
+// maxTarEntrySize caps a single table's decompressed size. The largest real
+// table (Items/D_ItemsStatic.json, per the base pak) is 7.3 MB; 64 MiB leaves
+// generous headroom while refusing to trust an unbounded or lying size field
+// in a tar header from a third-party, network-fetched archive.
+const maxTarEntrySize = 64 << 20
+
 // Build identifies the installed game, read from Icarus/Config/version.json.
 // Note this carries no week number — nothing in the install does. Week
 // agreement is established by content comparison, not by this value.
@@ -216,7 +222,11 @@ func (s *DumpStore) fetchTree(ctx context.Context, url string) (*Dump, error) {
 		if rel == "" || strings.HasPrefix(rel, "data/") {
 			continue
 		}
-		body, err := io.ReadAll(tr)
+		if hdr.Size > maxTarEntrySize {
+			return nil, fmt.Errorf("icarus: base-table dump entry %s declares a %d-byte size, "+
+				"exceeding the %d-byte per-table cap", rel, hdr.Size, maxTarEntrySize)
+		}
+		body, err := io.ReadAll(io.LimitReader(tr, hdr.Size))
 		if err != nil {
 			return nil, fmt.Errorf("icarus: reading %s from base-table dump: %w", rel, err)
 		}

--- a/internal/source/icarus/datadump.go
+++ b/internal/source/icarus/datadump.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -254,7 +255,14 @@ func validateDump(dump *Dump, basePakPath string) error {
 	for _, f := range pak.Files() {
 		shipped, err := pak.ReadFile(f.Path)
 		if err != nil {
-			continue // Oodle-compressed: not readable here, and not our gate
+			if errors.Is(err, unrealpak.ErrUnsupportedFormat) {
+				continue // Oodle-compressed (or similar): not readable here, and not our gate
+			}
+			// Any other ReadFile failure — corruption, a truncated payload, an
+			// I/O error — is not an expected skip. Silently excluding it here
+			// would quietly narrow what this gate actually verified, exactly
+			// the "no silent fallbacks" failure this function exists to prevent.
+			return fmt.Errorf("icarus: validating base pak %s: reading %s: %w", basePakPath, f.Path, err)
 		}
 		checked++
 		got, ok := dump.Table(f.Path)

--- a/internal/source/icarus/datadump_test.go
+++ b/internal/source/icarus/datadump_test.go
@@ -295,6 +295,48 @@ func TestDumpStore_DumpForBuild_NetworkFailure_IsActionable(t *testing.T) {
 	}
 }
 
+// A tar entry whose declared header size exceeds the per-table cap must be
+// rejected before any content is read — guards against a network-fetched,
+// third-party archive with a corrupt or lying size field driving an
+// unbounded allocation. The fixture never writes real content matching the
+// declared size (impractical at 64+ MiB): tw.WriteHeader alone already
+// produces a header a tar.Reader can parse, and the cap fires on hdr.Size
+// alone, before fetchTree ever attempts to read the entry's body.
+func TestDumpStore_DumpForBuild_RejectsOversizedTarEntry(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name: "IcarusData-test/Huge/D_Huge.json",
+		Mode: 0o644,
+		Size: maxTarEntrySize + 1,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately not calling tw.Close() or writing the declared body.
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer srv.Close()
+
+	store := newDumpStore(t.TempDir(), srv.Client())
+	store.treeURL = srv.URL
+
+	pak := writeTestBasePak(t, map[string][]byte{"a/B.json": []byte("{}")})
+	_, err := store.DumpForBuild(context.Background(), pak, "")
+	if err == nil {
+		t.Fatal("expected an error for an oversized tar entry, got nil")
+	}
+	if !strings.Contains(err.Error(), "Huge/D_Huge.json") {
+		t.Errorf("error %q should name the offending entry", err)
+	}
+}
+
 // A base pak entry that fails to read for a reason OTHER than
 // unrealpak.ErrUnsupportedFormat (corruption, a truncated payload, an I/O
 // error) must fail validateDump loudly, not be silently folded into the

--- a/internal/source/icarus/datadump_test.go
+++ b/internal/source/icarus/datadump_test.go
@@ -148,7 +148,7 @@ func TestDumpStore_DumpForBuild_AcceptsMatchingDump(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := newDumpStore(t.TempDir(), srv.Client())
+	store := newDumpStore(srv.Client())
 	store.treeURL = srv.URL // test seam
 
 	dump, err := store.DumpForBuild(context.Background(), pak, "")
@@ -174,7 +174,7 @@ func TestDumpStore_DumpForBuild_RejectsWrongWeek(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := newDumpStore(t.TempDir(), srv.Client())
+	store := newDumpStore(srv.Client())
 	store.treeURL = srv.URL
 
 	_, err := store.DumpForBuild(context.Background(), pak, "")
@@ -215,7 +215,7 @@ func TestDumpStore_DumpForBuild_LocalDirOverridesFetch(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer srv.Close()
-	store := newDumpStore(t.TempDir(), srv.Client())
+	store := newDumpStore(srv.Client())
 	store.treeURL = srv.URL
 
 	dump, err := store.DumpForBuild(context.Background(), pak, local)
@@ -239,7 +239,7 @@ func TestDumpStore_DumpForBuild_LocalDirAlreadyCRLF(t *testing.T) {
 	pak := writeTestBasePak(t, map[string][]byte{rel: []byte(shipped)})
 	local := writeLocalDump(t, map[string]string{rel: shipped})
 
-	store := newDumpStore(t.TempDir(), http.DefaultClient)
+	store := newDumpStore(http.DefaultClient)
 	store.treeURL = "http://127.0.0.1:0/never-used"
 
 	if _, err := store.DumpForBuild(context.Background(), pak, local); err != nil {
@@ -254,7 +254,7 @@ func TestDumpStore_DumpForBuild_LocalDirWrongWeek_Rejected(t *testing.T) {
 	pak := writeTestBasePak(t, map[string][]byte{rel: []byte("{\r\n    \"Rows\": [1]\r\n}")})
 	local := writeLocalDump(t, map[string]string{rel: "{\n    \"Rows\": []\n}"})
 
-	store := newDumpStore(t.TempDir(), http.DefaultClient)
+	store := newDumpStore(http.DefaultClient)
 	store.treeURL = "http://127.0.0.1:0/never-used"
 
 	_, err := store.DumpForBuild(context.Background(), pak, local)
@@ -271,7 +271,7 @@ func TestDumpStore_DumpForBuild_LocalDirWrongWeek_Rejected(t *testing.T) {
 
 func TestDumpStore_DumpForBuild_LocalDirEmpty_IsActionable(t *testing.T) {
 	pak := writeTestBasePak(t, map[string][]byte{"a/B.json": []byte("{}")})
-	store := newDumpStore(t.TempDir(), http.DefaultClient)
+	store := newDumpStore(http.DefaultClient)
 
 	_, err := store.DumpForBuild(context.Background(), pak, t.TempDir())
 	if err == nil {
@@ -285,7 +285,7 @@ func TestDumpStore_DumpForBuild_NetworkFailure_IsActionable(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := newDumpStore(t.TempDir(), srv.Client())
+	store := newDumpStore(srv.Client())
 	store.treeURL = srv.URL
 
 	pak := writeTestBasePak(t, map[string][]byte{"a/B.json": []byte("{}")})
@@ -324,7 +324,7 @@ func TestDumpStore_DumpForBuild_RejectsOversizedTarEntry(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := newDumpStore(t.TempDir(), srv.Client())
+	store := newDumpStore(srv.Client())
 	store.treeURL = srv.URL
 
 	pak := writeTestBasePak(t, map[string][]byte{"a/B.json": []byte("{}")})

--- a/internal/source/icarus/datadump_test.go
+++ b/internal/source/icarus/datadump_test.go
@@ -1,0 +1,254 @@
+package icarus
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"
+)
+
+// writeTestBasePak builds a stored, unencrypted version-11 pak holding one
+// entry per (mount-relative path, content) pair, via the Task 4 Writer. It
+// stands in for Task 12's identically-named helper, which does not exist yet
+// at this point in the plan's task order.
+func writeTestBasePak(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+	pakPath := filepath.Join(t.TempDir(), "data.pak")
+	w, err := unrealpak.Create(pakPath)
+	if err != nil {
+		t.Fatalf("creating test base pak: %v", err)
+	}
+	for rel, data := range files {
+		if err := w.AddFile(rel, data); err != nil {
+			t.Fatalf("AddFile(%q): %v", rel, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing test base pak: %v", err)
+	}
+	return pakPath
+}
+
+// tarGz builds a dump-shaped tarball: a single top-level directory, then the
+// table tree beneath it, LF-terminated exactly as the real repo stores it.
+func tarGz(t *testing.T, root string, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(zw)
+	for name, body := range files {
+		hdr := &tar.Header{Name: root + "/" + name, Mode: 0o644, Size: int64(len(body))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestDetectBuild_ReadsVersionJSON(t *testing.T) {
+	root := t.TempDir()
+	cfg := filepath.Join(root, "Icarus", "Config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const vjson = `{"Name":"Icarus","Version":{"Major":3,"Minor":0,"Patch":21,` +
+		`"Changelist":155335,"BuildType":"Shipping","FeatureLevel":"DangerousHorizons"},` +
+		`"Data":{"Changelist":155151}}`
+	if err := os.WriteFile(filepath.Join(cfg, "version.json"), []byte(vjson), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := detectBuild(root)
+	if err != nil {
+		t.Fatalf("detectBuild: %v", err)
+	}
+	if got := b.String(); got != "3.0.21.155335" {
+		t.Errorf("Build.String() = %q, want 3.0.21.155335", got)
+	}
+	if b.DataChangelist != 155151 {
+		t.Errorf("DataChangelist = %d, want 155151", b.DataChangelist)
+	}
+}
+
+func TestDetectBuild_MissingVersionFile_Errors(t *testing.T) {
+	if _, err := detectBuild(t.TempDir()); err == nil {
+		t.Fatal("expected error when version.json is absent, got nil")
+	}
+}
+
+// A dump whose stored tables match the local pak byte-for-byte (after CRLF
+// restoration) is accepted, and its tables are exposed with shipped bytes.
+func TestDumpStore_DumpForBuild_AcceptsMatchingDump(t *testing.T) {
+	const rel = "Factions/D_Factions.json"
+	shipped := []byte("{\r\n    \"Rows\": []\r\n}") // CRLF, as the pak stores it
+	dumped := "{\n    \"Rows\": []\n}"              // LF, as the repo stores it
+
+	pak := writeTestBasePak(t, map[string][]byte{rel: shipped}) // Task 12's helper
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(tarGz(t, "IcarusData-abc123", map[string]string{rel: dumped}))
+	}))
+	defer srv.Close()
+
+	store := newDumpStore(t.TempDir(), srv.Client())
+	store.treeURL = srv.URL // test seam
+
+	dump, err := store.DumpForBuild(context.Background(), pak, "")
+	if err != nil {
+		t.Fatalf("DumpForBuild: %v", err)
+	}
+	got, ok := dump.Table(rel)
+	if !ok {
+		t.Fatalf("dump has no table %q", rel)
+	}
+	if !bytes.Equal(got, shipped) {
+		t.Errorf("table bytes = %q, want the shipped CRLF form %q", got, shipped)
+	}
+}
+
+// The case that is live today: the newest dump is an older week than the
+// install. Must fail loudly and name what disagreed.
+func TestDumpStore_DumpForBuild_RejectsWrongWeek(t *testing.T) {
+	const rel = "Factions/D_Factions.json"
+	pak := writeTestBasePak(t, map[string][]byte{rel: []byte("{\r\n    \"Rows\": [1]\r\n}")})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(tarGz(t, "IcarusData-old", map[string]string{rel: "{\n    \"Rows\": []\n}"}))
+	}))
+	defer srv.Close()
+
+	store := newDumpStore(t.TempDir(), srv.Client())
+	store.treeURL = srv.URL
+
+	_, err := store.DumpForBuild(context.Background(), pak, "")
+	if err == nil {
+		t.Fatal("expected an error for a dump that does not match the install, got nil")
+	}
+	if !strings.Contains(err.Error(), rel) {
+		t.Errorf("error %q should name the table that disagreed (%s)", err, rel)
+	}
+}
+
+// writeLocalDump lays out an unpacked-data.pak-shaped directory on disk.
+func writeLocalDump(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, body := range files {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// With a local dump directory configured, the network is never touched.
+func TestDumpStore_DumpForBuild_LocalDirOverridesFetch(t *testing.T) {
+	const rel = "Factions/D_Factions.json"
+	shipped := []byte("{\r\n    \"Rows\": []\r\n}")
+	pak := writeTestBasePak(t, map[string][]byte{rel: shipped})
+	local := writeLocalDump(t, map[string]string{rel: "{\n    \"Rows\": []\n}"})
+
+	fetched := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetched = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	store := newDumpStore(t.TempDir(), srv.Client())
+	store.treeURL = srv.URL
+
+	dump, err := store.DumpForBuild(context.Background(), pak, local)
+	if err != nil {
+		t.Fatalf("DumpForBuild with a local dump dir: %v", err)
+	}
+	if fetched {
+		t.Error("the hosted dump was fetched even though a local dump dir was configured")
+	}
+	got, ok := dump.Table(rel)
+	if !ok || !bytes.Equal(got, shipped) {
+		t.Errorf("table bytes = %q (found=%v), want the shipped CRLF form %q", got, ok, shipped)
+	}
+}
+
+// A local directory already storing CRLF must load unchanged — QuickBMS writes
+// whatever the pak stored, so the conversion has to be idempotent.
+func TestDumpStore_DumpForBuild_LocalDirAlreadyCRLF(t *testing.T) {
+	const rel = "Factions/D_Factions.json"
+	shipped := "{\r\n    \"Rows\": []\r\n}"
+	pak := writeTestBasePak(t, map[string][]byte{rel: []byte(shipped)})
+	local := writeLocalDump(t, map[string]string{rel: shipped})
+
+	store := newDumpStore(t.TempDir(), http.DefaultClient)
+	store.treeURL = "http://127.0.0.1:0/never-used"
+
+	if _, err := store.DumpForBuild(context.Background(), pak, local); err != nil {
+		t.Fatalf("DumpForBuild with a CRLF local dump dir: %v", err)
+	}
+}
+
+// A local dir from the wrong week is rejected exactly like a stale hosted
+// dump, and the error points at the configured path.
+func TestDumpStore_DumpForBuild_LocalDirWrongWeek_Rejected(t *testing.T) {
+	const rel = "Factions/D_Factions.json"
+	pak := writeTestBasePak(t, map[string][]byte{rel: []byte("{\r\n    \"Rows\": [1]\r\n}")})
+	local := writeLocalDump(t, map[string]string{rel: "{\n    \"Rows\": []\n}"})
+
+	store := newDumpStore(t.TempDir(), http.DefaultClient)
+	store.treeURL = "http://127.0.0.1:0/never-used"
+
+	_, err := store.DumpForBuild(context.Background(), pak, local)
+	if err == nil {
+		t.Fatal("expected an error for a local dump dir from a different week, got nil")
+	}
+	if !strings.Contains(err.Error(), rel) {
+		t.Errorf("error %q should name the disagreeing table (%s)", err, rel)
+	}
+	if !strings.Contains(err.Error(), local) {
+		t.Errorf("error %q should name the configured data_dump_path (%s)", err, local)
+	}
+}
+
+func TestDumpStore_DumpForBuild_LocalDirEmpty_IsActionable(t *testing.T) {
+	pak := writeTestBasePak(t, map[string][]byte{"a/B.json": []byte("{}")})
+	store := newDumpStore(t.TempDir(), http.DefaultClient)
+
+	_, err := store.DumpForBuild(context.Background(), pak, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for a data_dump_path holding no JSON tables, got nil")
+	}
+}
+
+func TestDumpStore_DumpForBuild_NetworkFailure_IsActionable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	store := newDumpStore(t.TempDir(), srv.Client())
+	store.treeURL = srv.URL
+
+	pak := writeTestBasePak(t, map[string][]byte{"a/B.json": []byte("{}")})
+	_, err := store.DumpForBuild(context.Background(), pak, "")
+	if err == nil {
+		t.Fatal("expected an error when the dump host fails, got nil")
+	}
+}

--- a/internal/source/icarus/datadump_test.go
+++ b/internal/source/icarus/datadump_test.go
@@ -15,6 +15,48 @@ import (
 	"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"
 )
 
+// testStoredHeaderSize mirrors unrealpak's unexported storedHeaderSize (the
+// 53-byte FPakEntry header preceding a stored file's payload). Duplicated
+// here because these fixture-corruption helpers need to reach into pak bytes
+// unrealpak itself does not expose, the same way reader_test.go pokes at raw
+// offsets from inside package unrealpak.
+const testStoredHeaderSize = 53
+
+// corruptFirstEntryPayload flips the first byte of the alphabetically-first
+// entry's payload (which the Writer always places at file offset
+// testStoredHeaderSize, since entries are packed with no gap starting at 0).
+// This breaks the entry's stored SHA1 without touching its header, producing
+// a genuinely unexpected ReadFile error distinct from ErrUnsupportedFormat.
+func corruptFirstEntryPayload(t *testing.T, pakPath string) {
+	t.Helper()
+	data, err := os.ReadFile(pakPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[testStoredHeaderSize] ^= 0xFF
+	if err := os.WriteFile(pakPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// corruptFirstEntryCompressionMethod patches the alphabetically-first entry's
+// on-disk header CompressionMethodIndex field (bytes 24:28 of the 53-byte
+// header at file offset 0) to a nonzero value. This simulates the
+// compression-refusal ReadFile takes for real Oodle-compressed entries
+// without needing the Writer to emit actual compressed data, which it never
+// does (it only ever produces stored, method-0 entries).
+func corruptFirstEntryCompressionMethod(t *testing.T, pakPath string) {
+	t.Helper()
+	data, err := os.ReadFile(pakPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[24] = 1
+	if err := os.WriteFile(pakPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // writeTestBasePak builds a stored, unencrypted version-11 pak holding one
 // entry per (mount-relative path, content) pair, via the Task 4 Writer. It
 // stands in for Task 12's identically-named helper, which does not exist yet
@@ -250,5 +292,49 @@ func TestDumpStore_DumpForBuild_NetworkFailure_IsActionable(t *testing.T) {
 	_, err := store.DumpForBuild(context.Background(), pak, "")
 	if err == nil {
 		t.Fatal("expected an error when the dump host fails, got nil")
+	}
+}
+
+// A base pak entry that fails to read for a reason OTHER than
+// unrealpak.ErrUnsupportedFormat (corruption, a truncated payload, an I/O
+// error) must fail validateDump loudly, not be silently folded into the
+// "not our gate" skip that Oodle-compressed entries get.
+func TestValidateDump_CorruptedStoredEntry_FailsLoudly(t *testing.T) {
+	const rel = "a/B.json"
+	pak := writeTestBasePak(t, map[string][]byte{rel: []byte("{\r\n}")})
+	corruptFirstEntryPayload(t, pak)
+
+	dump := &Dump{tables: map[string][]byte{rel: []byte("{\r\n}")}}
+	err := validateDump(dump, pak)
+	if err == nil {
+		t.Fatal("expected an error for a corrupted stored entry, got nil")
+	}
+	if strings.Contains(err.Error(), "different game week") {
+		t.Errorf("error %q should report the read failure, not the mismatch/wrong-week message "+
+			"(a corrupted entry is not evidence of a stale dump)", err)
+	}
+	if !strings.Contains(err.Error(), rel) {
+		t.Errorf("error %q should name the unreadable table (%s)", err, rel)
+	}
+}
+
+// An entry that refuses with unrealpak.ErrUnsupportedFormat (the real-world
+// case: Oodle compression) must still be skipped, not treated as a
+// validateDump failure — it is excluded from the check, not a reason to
+// reject the dump.
+func TestValidateDump_SkipsUnsupportedFormatEntry_NotAnError(t *testing.T) {
+	const compressedRel = "a/Apple.json" // sorts first -> lands at file offset 0
+	const okRel = "z/Zebra.json"
+	okShipped := []byte("{\r\n    \"Rows\": []\r\n}")
+
+	pak := writeTestBasePak(t, map[string][]byte{
+		compressedRel: []byte("{\r\n}"),
+		okRel:         okShipped,
+	})
+	corruptFirstEntryCompressionMethod(t, pak)
+
+	dump := &Dump{tables: map[string][]byte{okRel: okShipped}}
+	if err := validateDump(dump, pak); err != nil {
+		t.Fatalf("validateDump with one ErrUnsupportedFormat entry and one matching entry: %v", err)
 	}
 }

--- a/internal/source/icarus/exmod.go
+++ b/internal/source/icarus/exmod.go
@@ -1,0 +1,93 @@
+package icarus
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ExmodDiff is the parsed .EXMOD manifest — a diff against the base game's
+// JSON data tables, not a binary/compiled-asset diff (confirmed against a
+// real sample; see docs/plans/2026-07-29-icarus-exmod-pak-research.md).
+type ExmodDiff struct {
+	Name        string
+	Author      string
+	Version     string
+	Description string
+	Rows        []ExmodRow
+}
+
+// ExmodRow targets one base data-table file (e.g. "AI-D_AIGrowth.json").
+type ExmodRow struct {
+	CurrentFile string
+	FileItems   []ExmodFileItem
+}
+
+// ExmodFileItem overrides fields on the base row named Name. Fields holds
+// every key from the source JSON except "Name" itself, generically — the
+// real schema nests arbitrary game-data shapes here (see package doc
+// comment), so this deliberately does not enumerate them.
+type ExmodFileItem struct {
+	Name   string
+	Fields map[string]any
+}
+
+func ParseExmod(data []byte) (*ExmodDiff, error) {
+	var raw struct {
+		Name        string `json:"name"`
+		Author      string `json:"author"`
+		Version     string `json:"version"`
+		Description string `json:"description"`
+		Rows        []struct {
+			CurrentFile string           `json:"CurrentFile"`
+			FileItems   []map[string]any `json:"File_Items"`
+		} `json:"Rows"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("icarus: parsing .EXMOD: %w", err)
+	}
+
+	diff := &ExmodDiff{Name: raw.Name, Author: raw.Author, Version: raw.Version, Description: raw.Description}
+	for _, r := range raw.Rows {
+		row := ExmodRow{CurrentFile: r.CurrentFile}
+		for _, item := range r.FileItems {
+			name, _ := item["Name"].(string)
+			if name == "" {
+				return nil, fmt.Errorf("icarus: .EXMOD row in %s: File_Items entry missing Name", r.CurrentFile)
+			}
+			fields := make(map[string]any, len(item)-1)
+			for k, v := range item {
+				if k == "Name" {
+					continue
+				}
+				fields[k] = v
+			}
+			row.FileItems = append(row.FileItems, ExmodFileItem{Name: name, Fields: fields})
+		}
+		diff.Rows = append(diff.Rows, row)
+	}
+	return diff, nil
+}
+
+// ApplyRowPatch merges row's named-row field overrides into baseJSON (a base
+// game data-table file keyed by row name, e.g. {"Mount_Bear": {...}, ...})
+// and returns the patched document. Fails loudly (no silent fallback, repo
+// precedent #95) if a targeted row name doesn't exist in the base — that
+// means either the base version is stale relative to the mod, or the exmod
+// targets a file this function was called with by mistake.
+func ApplyRowPatch(baseJSON []byte, row ExmodRow) ([]byte, error) {
+	var doc map[string]map[string]any
+	if err := json.Unmarshal(baseJSON, &doc); err != nil {
+		return nil, fmt.Errorf("icarus: parsing base data table %s: %w", row.CurrentFile, err)
+	}
+	for _, item := range row.FileItems {
+		target, ok := doc[item.Name]
+		if !ok {
+			return nil, fmt.Errorf("icarus: %s: row %q not found in base data table", row.CurrentFile, item.Name)
+		}
+		for k, v := range item.Fields {
+			target[k] = v
+		}
+		doc[item.Name] = target
+	}
+	return json.Marshal(doc)
+}

--- a/internal/source/icarus/exmod_test.go
+++ b/internal/source/icarus/exmod_test.go
@@ -1,0 +1,81 @@
+package icarus
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+const sampleExmod = `{
+  "name": "Bear Mount",
+  "author": "Jimk72",
+  "version": "3.3",
+  "description": "Allows raising cubs",
+  "Rows": [
+    {
+      "CurrentFile": "AI-D_AIGrowth.json",
+      "File_Items": [
+        {"Name": "Mount_Bear", "BaseMovementSpeed": 235, "BaseSwimSpeed": 300}
+      ]
+    }
+  ]
+}`
+
+func TestParseExmod(t *testing.T) {
+	diff, err := ParseExmod([]byte(sampleExmod))
+	if err != nil {
+		t.Fatalf("ParseExmod: %v", err)
+	}
+	if diff.Name != "Bear Mount" || diff.Version != "3.3" {
+		t.Errorf("Name/Version = %q/%q, want Bear Mount/3.3", diff.Name, diff.Version)
+	}
+	if len(diff.Rows) != 1 || diff.Rows[0].CurrentFile != "AI-D_AIGrowth.json" {
+		t.Fatalf("Rows = %+v", diff.Rows)
+	}
+	if len(diff.Rows[0].FileItems) != 1 || diff.Rows[0].FileItems[0].Name != "Mount_Bear" {
+		t.Fatalf("FileItems = %+v", diff.Rows[0].FileItems)
+	}
+	if diff.Rows[0].FileItems[0].Fields["BaseMovementSpeed"] != float64(235) {
+		t.Errorf("BaseMovementSpeed = %v, want 235", diff.Rows[0].FileItems[0].Fields["BaseMovementSpeed"])
+	}
+}
+
+func TestApplyRowPatch_OverwritesNamedRowFieldsOnly(t *testing.T) {
+	base := []byte(`{
+		"Mount_Bear": {"BaseMovementSpeed": 200, "BaseSwimSpeed": 150, "Untouched": "keep-me"},
+		"Other_Row": {"BaseMovementSpeed": 999}
+	}`)
+	row := ExmodRow{
+		CurrentFile: "AI-D_AIGrowth.json",
+		FileItems: []ExmodFileItem{
+			{Name: "Mount_Bear", Fields: map[string]any{"BaseMovementSpeed": float64(235)}},
+		},
+	}
+
+	got, err := ApplyRowPatch(base, row)
+	if err != nil {
+		t.Fatalf("ApplyRowPatch: %v", err)
+	}
+
+	var result map[string]map[string]any
+	if err := json.Unmarshal(got, &result); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if result["Mount_Bear"]["BaseMovementSpeed"] != float64(235) {
+		t.Errorf("BaseMovementSpeed not patched: %v", result["Mount_Bear"]["BaseMovementSpeed"])
+	}
+	if result["Mount_Bear"]["Untouched"] != "keep-me" {
+		t.Errorf("unrelated field was clobbered: %v", result["Mount_Bear"]["Untouched"])
+	}
+	if result["Other_Row"]["BaseMovementSpeed"] != float64(999) {
+		t.Errorf("unrelated row was modified: %v", result["Other_Row"])
+	}
+}
+
+func TestApplyRowPatch_UnknownRowName_Errors(t *testing.T) {
+	base := []byte(`{"Mount_Bear": {}}`)
+	row := ExmodRow{FileItems: []ExmodFileItem{{Name: "Does_Not_Exist", Fields: map[string]any{"X": 1}}}}
+
+	if _, err := ApplyRowPatch(base, row); err == nil {
+		t.Error("expected error for unknown row name (no silent fallback), got nil")
+	}
+}

--- a/internal/source/icarus/exmodz.go
+++ b/internal/source/icarus/exmodz.go
@@ -1,0 +1,74 @@
+package icarus
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ExmodzBundle is a parsed .EXMODZ: the diff manifest plus any pre-built
+// asset files the mod author already compiled (placed as-is into the output
+// pak — never recompiled by LMM).
+type ExmodzBundle struct {
+	Diff   *ExmodDiff
+	Assets map[string][]byte // zip-internal path -> raw content, manifest/readme/image excluded
+}
+
+// ParseExmodz unpacks zipData (an in-memory .EXMODZ) into its manifest and
+// bundled assets. The manifest lives at "Extracted Mods/<name>.EXMOD" in
+// every sample seen so far; this looks for any "*.EXMOD" file under an
+// "Extracted Mods/" prefix rather than hard-coding the mod name, since that
+// varies per mod.
+func ParseExmodz(zipData []byte) (*ExmodzBundle, error) {
+	zr, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		return nil, fmt.Errorf("icarus: opening .EXMODZ: %w", err)
+	}
+
+	bundle := &ExmodzBundle{Assets: make(map[string][]byte)}
+	var manifestPath string
+	for _, f := range zr.File {
+		if strings.HasPrefix(f.Name, "Extracted Mods/") && strings.HasSuffix(f.Name, ".EXMOD") {
+			manifestPath = f.Name
+			data, err := readZipFile(f)
+			if err != nil {
+				return nil, fmt.Errorf("icarus: reading %s: %w", f.Name, err)
+			}
+			bundle.Diff, err = ParseExmod(data)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+	}
+	if manifestPath == "" {
+		return nil, fmt.Errorf("icarus: .EXMODZ has no Extracted Mods/*.EXMOD manifest")
+	}
+
+	for _, f := range zr.File {
+		if f.Name == manifestPath || f.FileInfo().IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(f.Name, ".uasset") && !strings.HasSuffix(f.Name, ".uexp") {
+			continue // skip readme/image/other non-asset files — never placed into the output pak
+		}
+		data, err := readZipFile(f)
+		if err != nil {
+			return nil, fmt.Errorf("icarus: reading asset %s: %w", f.Name, err)
+		}
+		bundle.Assets[f.Name] = data
+	}
+
+	return bundle, nil
+}
+
+func readZipFile(f *zip.File) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close() //nolint:errcheck
+	return io.ReadAll(rc)
+}

--- a/internal/source/icarus/exmodz.go
+++ b/internal/source/icarus/exmodz.go
@@ -20,48 +20,75 @@ type ExmodzBundle struct {
 // bundled assets. The manifest lives at "Extracted Mods/<name>.EXMOD" in
 // every sample seen so far; this looks for any "*.EXMOD" file under an
 // "Extracted Mods/" prefix rather than hard-coding the mod name, since that
-// varies per mod.
+// varies per mod. Matching (both the manifest's prefix/suffix and the asset
+// extensions below) is done on the entry name with backslashes normalized to
+// forward slashes and case folded — some .EXMODZ producers are Windows tools
+// and zip entry casing is not guaranteed — but stored asset keys keep their
+// original case, only the slash direction is normalized.
 func ParseExmodz(zipData []byte) (*ExmodzBundle, error) {
 	zr, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
 	if err != nil {
 		return nil, fmt.Errorf("icarus: opening .EXMODZ: %w", err)
 	}
 
-	bundle := &ExmodzBundle{Assets: make(map[string][]byte)}
-	var manifestPath string
+	var manifests []*zip.File
 	for _, f := range zr.File {
-		if strings.HasPrefix(f.Name, "Extracted Mods/") && strings.HasSuffix(f.Name, ".EXMOD") {
-			manifestPath = f.Name
-			data, err := readZipFile(f)
-			if err != nil {
-				return nil, fmt.Errorf("icarus: reading %s: %w", f.Name, err)
-			}
-			bundle.Diff, err = ParseExmod(data)
-			if err != nil {
-				return nil, err
-			}
-			continue
+		lower := strings.ToLower(normalizeZipName(f.Name))
+		if strings.HasPrefix(lower, "extracted mods/") && strings.HasSuffix(lower, ".exmod") {
+			manifests = append(manifests, f)
 		}
 	}
-	if manifestPath == "" {
+	switch len(manifests) {
+	case 0:
 		return nil, fmt.Errorf("icarus: .EXMODZ has no Extracted Mods/*.EXMOD manifest")
+	case 1:
+		// exactly one candidate — proceed below
+	default:
+		names := make([]string, len(manifests))
+		for i, f := range manifests {
+			names[i] = f.Name
+		}
+		return nil, fmt.Errorf("icarus: .EXMODZ has %d ambiguous Extracted Mods/*.EXMOD manifests: %v",
+			len(manifests), names)
 	}
+	manifestFile := manifests[0]
+	manifestPath := manifestFile.Name // original (un-normalized) name, used only to exclude this entry below
+
+	manifestData, err := readZipFile(manifestFile)
+	if err != nil {
+		return nil, fmt.Errorf("icarus: reading %s: %w", manifestPath, err)
+	}
+	diff, err := ParseExmod(manifestData)
+	if err != nil {
+		return nil, err
+	}
+	bundle := &ExmodzBundle{Diff: diff, Assets: make(map[string][]byte)}
 
 	for _, f := range zr.File {
 		if f.Name == manifestPath || f.FileInfo().IsDir() {
 			continue
 		}
-		if !strings.HasSuffix(f.Name, ".uasset") && !strings.HasSuffix(f.Name, ".uexp") {
+		normalized := normalizeZipName(f.Name)
+		lower := strings.ToLower(normalized)
+		if !strings.HasSuffix(lower, ".uasset") && !strings.HasSuffix(lower, ".uexp") {
 			continue // skip readme/image/other non-asset files — never placed into the output pak
 		}
 		data, err := readZipFile(f)
 		if err != nil {
 			return nil, fmt.Errorf("icarus: reading asset %s: %w", f.Name, err)
 		}
-		bundle.Assets[f.Name] = data
+		bundle.Assets[normalized] = data
 	}
 
 	return bundle, nil
+}
+
+// normalizeZipName converts a zip entry's backslashes to forward slashes.
+// Zip is a forward-slash format, but some Windows-built .EXMODZ archives
+// store entries with backslashes anyway; this makes matching and asset keys
+// consistent regardless of which the producing tool used.
+func normalizeZipName(name string) string {
+	return strings.ReplaceAll(name, `\`, "/")
 }
 
 func readZipFile(f *zip.File) ([]byte, error) {

--- a/internal/source/icarus/exmodz_test.go
+++ b/internal/source/icarus/exmodz_test.go
@@ -1,0 +1,71 @@
+package icarus
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+)
+
+// buildTestExmodz mirrors the real Bear_Mount.EXMODZ layout: a manifest
+// under "Extracted Mods/<name>.EXMOD" plus loose asset files at paths that
+// mirror in-game mount structure.
+func buildTestExmodz(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	manifest := `{"name":"Bear Mount","Rows":[{"CurrentFile":"AI-D_AIGrowth.json","File_Items":[{"Name":"Mount_Bear","BaseMovementSpeed":235}]}]}`
+	w, err := zw.Create("Extracted Mods/Bear_Mount.EXMOD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte(manifest)) //nolint:errcheck
+
+	assetW, err := zw.Create("Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assetW.Write([]byte("fake-uasset-bytes")) //nolint:errcheck
+
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestParseExmodz(t *testing.T) {
+	bundle, err := ParseExmodz(buildTestExmodz(t))
+	if err != nil {
+		t.Fatalf("ParseExmodz: %v", err)
+	}
+	if bundle.Diff == nil || bundle.Diff.Name != "Bear Mount" {
+		t.Fatalf("Diff = %+v", bundle.Diff)
+	}
+	asset, ok := bundle.Assets["Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset"]
+	if !ok {
+		t.Fatalf("Assets missing expected key; got keys: %v", mapKeys(bundle.Assets))
+	}
+	if string(asset) != "fake-uasset-bytes" {
+		t.Errorf("asset content = %q", asset)
+	}
+}
+
+func mapKeys(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestParseExmodz_NoManifest_Errors(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, _ := zw.Create("readme.txt")
+	w.Write([]byte("no manifest here")) //nolint:errcheck
+	zw.Close()                          //nolint:errcheck
+
+	if _, err := ParseExmodz(buf.Bytes()); err == nil {
+		t.Error("expected error when no .EXMOD manifest is present, got nil")
+	}
+}

--- a/internal/source/icarus/exmodz_test.go
+++ b/internal/source/icarus/exmodz_test.go
@@ -3,6 +3,7 @@ package icarus
 import (
 	"archive/zip"
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -56,6 +57,108 @@ func mapKeys(m map[string][]byte) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// Some .EXMODZ producers are Windows tools and store entry names with
+// backslashes; ParseExmodz must normalize them for matching and store asset
+// keys under the normalized (forward-slash) form (#136 review round 3).
+func TestParseExmodz_NormalizesBackslashNames(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	manifest := `{"name":"Bear Mount","Rows":[]}`
+	w, err := zw.Create(`Extracted Mods\Bear_Mount.EXMOD`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte(manifest)) //nolint:errcheck
+
+	assetW, err := zw.Create(`Bear_Mount\ASS\ITM\SK_ITM_Saddle_Bear.uasset`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assetW.Write([]byte("fake-uasset-bytes")) //nolint:errcheck
+
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	bundle, err := ParseExmodz(buf.Bytes())
+	if err != nil {
+		t.Fatalf("ParseExmodz: %v", err)
+	}
+	if bundle.Diff == nil || bundle.Diff.Name != "Bear Mount" {
+		t.Fatalf("Diff = %+v", bundle.Diff)
+	}
+	asset, ok := bundle.Assets["Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset"]
+	if !ok {
+		t.Fatalf("Assets missing expected forward-slash key; got keys: %v", mapKeys(bundle.Assets))
+	}
+	if string(asset) != "fake-uasset-bytes" {
+		t.Errorf("asset content = %q", asset)
+	}
+}
+
+// The manifest's "Extracted Mods/" prefix + ".EXMOD" suffix, and an asset's
+// .uasset/.uexp extension, must match regardless of case — a differently
+// cased but otherwise valid entry must not be silently dropped.
+func TestParseExmodz_MatchesCaseInsensitively(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	manifest := `{"name":"Bear Mount","Rows":[]}`
+	w, err := zw.Create("extracted mods/Bear_Mount.exmod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte(manifest)) //nolint:errcheck
+
+	assetW, err := zw.Create("Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.UASSET")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assetW.Write([]byte("fake-uasset-bytes")) //nolint:errcheck
+
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	bundle, err := ParseExmodz(buf.Bytes())
+	if err != nil {
+		t.Fatalf("ParseExmodz: %v", err)
+	}
+	if bundle.Diff == nil || bundle.Diff.Name != "Bear Mount" {
+		t.Fatalf("Diff = %+v", bundle.Diff)
+	}
+	if _, ok := bundle.Assets["Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.UASSET"]; !ok {
+		t.Fatalf("Assets missing case-varying key (original case preserved); got keys: %v", mapKeys(bundle.Assets))
+	}
+}
+
+// Two candidate manifests is ambiguous and must fail loudly, naming both —
+// not silently pick whichever the zip directory happened to list last.
+func TestParseExmodz_MultipleManifests_Errors(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	for _, name := range []string{"Extracted Mods/A.EXMOD", "Extracted Mods/B.EXMOD"} {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.Write([]byte(`{"name":"X","Rows":[]}`)) //nolint:errcheck
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ParseExmodz(buf.Bytes())
+	if err == nil {
+		t.Fatal("expected an error for multiple candidate manifests, got nil")
+	}
+	if !strings.Contains(err.Error(), "A.EXMOD") || !strings.Contains(err.Error(), "B.EXMOD") {
+		t.Errorf("error %q should name both ambiguous manifests", err)
+	}
 }
 
 func TestParseExmodz_NoManifest_Errors(t *testing.T) {

--- a/internal/source/icarus/firestore_client.go
+++ b/internal/source/icarus/firestore_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -42,9 +43,9 @@ func (c *firestoreClient) listCollection(ctx context.Context, collection string)
 	var all []firestoreDoc
 	pageToken := ""
 	for {
-		url := fmt.Sprintf("%s/%s?pageSize=200", c.documentsURL(), collection)
+		reqURL := fmt.Sprintf("%s/%s?pageSize=200", c.documentsURL(), collection)
 		if pageToken != "" {
-			url += "&pageToken=" + pageToken
+			reqURL += "&pageToken=" + url.QueryEscape(pageToken)
 		}
 		var page struct {
 			Documents []struct {
@@ -53,7 +54,7 @@ func (c *firestoreClient) listCollection(ctx context.Context, collection string)
 			} `json:"documents"`
 			NextPageToken string `json:"nextPageToken"`
 		}
-		if err := c.getJSON(ctx, url, &page); err != nil {
+		if err := c.getJSON(ctx, reqURL, &page); err != nil {
 			return nil, fmt.Errorf("listing %s: %w", collection, err)
 		}
 		for _, d := range page.Documents {

--- a/internal/source/icarus/firestore_client.go
+++ b/internal/source/icarus/firestore_client.go
@@ -1,0 +1,102 @@
+package icarus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const defaultFirestoreBaseURL = "https://firestore.googleapis.com/v1"
+
+// firestoreDoc is a decoded Firestore document: ID is the last path segment
+// of its resource name, Fields is already unwrapped via decodeFields.
+type firestoreDoc struct {
+	ID     string
+	Fields map[string]any
+}
+
+type firestoreClient struct {
+	projectID  string
+	httpClient *http.Client
+	baseURL    string // overridable in tests; defaults to defaultFirestoreBaseURL
+}
+
+func newFirestoreClient(projectID string, httpClient *http.Client) *firestoreClient {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &firestoreClient{projectID: projectID, httpClient: httpClient, baseURL: defaultFirestoreBaseURL}
+}
+
+func (c *firestoreClient) documentsURL() string {
+	return fmt.Sprintf("%s/projects/%s/databases/(default)/documents", c.baseURL, c.projectID)
+}
+
+// listCollection fetches every document in collection, following
+// nextPageToken until exhausted (the catalog reads Firestore unauthenticated
+// and public, with no server-side query support in play — see the design
+// doc's "fetch-all + filter client-side" decision).
+func (c *firestoreClient) listCollection(ctx context.Context, collection string) ([]firestoreDoc, error) {
+	var all []firestoreDoc
+	pageToken := ""
+	for {
+		url := fmt.Sprintf("%s/%s?pageSize=200", c.documentsURL(), collection)
+		if pageToken != "" {
+			url += "&pageToken=" + pageToken
+		}
+		var page struct {
+			Documents []struct {
+				Name   string         `json:"name"`
+				Fields map[string]any `json:"fields"`
+			} `json:"documents"`
+			NextPageToken string `json:"nextPageToken"`
+		}
+		if err := c.getJSON(ctx, url, &page); err != nil {
+			return nil, fmt.Errorf("listing %s: %w", collection, err)
+		}
+		for _, d := range page.Documents {
+			all = append(all, firestoreDoc{ID: lastPathSegment(d.Name), Fields: decodeFields(d.Fields)})
+		}
+		if page.NextPageToken == "" {
+			break
+		}
+		pageToken = page.NextPageToken
+	}
+	return all, nil
+}
+
+// getDocument fetches a single document by ID.
+func (c *firestoreClient) getDocument(ctx context.Context, collection, docID string) (*firestoreDoc, error) {
+	url := fmt.Sprintf("%s/%s/%s", c.documentsURL(), collection, docID)
+	var doc struct {
+		Name   string         `json:"name"`
+		Fields map[string]any `json:"fields"`
+	}
+	if err := c.getJSON(ctx, url, &doc); err != nil {
+		return nil, fmt.Errorf("fetching %s/%s: %w", collection, docID, err)
+	}
+	return &firestoreDoc{ID: lastPathSegment(doc.Name), Fields: decodeFields(doc.Fields)}, nil
+}
+
+func (c *firestoreClient) getJSON(ctx context.Context, url string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func lastPathSegment(resourceName string) string {
+	parts := strings.Split(resourceName, "/")
+	return parts[len(parts)-1]
+}

--- a/internal/source/icarus/firestore_client_test.go
+++ b/internal/source/icarus/firestore_client_test.go
@@ -51,6 +51,48 @@ func TestFirestoreClient_ListCollection_Paginates(t *testing.T) {
 	}
 }
 
+// nextPageToken is opaque server-issued data, not guaranteed URL-safe as-is;
+// listCollection must query-escape it before appending it to the request URL
+// rather than concatenating it raw. Round-trips a token containing
+// characters ("&", "=", "+", "/", "?") that would corrupt the query string
+// if not escaped, and asserts the mock server decodes it back to the exact
+// original value.
+func TestFirestoreClient_ListCollection_EscapesPageToken(t *testing.T) {
+	const rawToken = "page&two=x+y/z?w"
+	pages := []map[string]any{
+		{
+			"documents": []map[string]any{
+				{"name": "projects/p/databases/(default)/documents/mods/abc", "fields": map[string]any{}},
+			},
+			"nextPageToken": rawToken,
+		},
+		{
+			"documents": []map[string]any{},
+		},
+	}
+	callCount := 0
+	var gotPageToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if callCount == 1 {
+			gotPageToken = r.URL.Query().Get("pageToken")
+		}
+		page := pages[callCount]
+		callCount++
+		json.NewEncoder(w).Encode(page) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := newFirestoreClient("test-project", srv.Client())
+	c.baseURL = srv.URL
+
+	if _, err := c.listCollection(context.Background(), "mods"); err != nil {
+		t.Fatalf("listCollection: %v", err)
+	}
+	if gotPageToken != rawToken {
+		t.Errorf("server decoded pageToken = %q, want %q (round-trip through query-escaping)", gotPageToken, rawToken)
+	}
+}
+
 func TestFirestoreClient_GetDocument_NotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/source/icarus/firestore_client_test.go
+++ b/internal/source/icarus/firestore_client_test.go
@@ -1,0 +1,67 @@
+package icarus
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFirestoreClient_ListCollection_Paginates(t *testing.T) {
+	pages := []map[string]any{
+		{
+			"documents": []map[string]any{
+				{"name": "projects/p/databases/(default)/documents/mods/abc", "fields": map[string]any{"name": map[string]any{"stringValue": "Bear Mount"}}},
+			},
+			"nextPageToken": "page2",
+		},
+		{
+			"documents": []map[string]any{
+				{"name": "projects/p/databases/(default)/documents/mods/def", "fields": map[string]any{"name": map[string]any{"stringValue": "Wolf Mount"}}},
+			},
+		},
+	}
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := pages[callCount]
+		callCount++
+		json.NewEncoder(w).Encode(page) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := newFirestoreClient("test-project", srv.Client())
+	c.baseURL = srv.URL // test seam, see Step 3
+
+	docs, err := c.listCollection(context.Background(), "mods")
+	if err != nil {
+		t.Fatalf("listCollection: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("got %d docs, want 2 (pagination should have followed nextPageToken)", len(docs))
+	}
+	if docs[0].ID != "abc" || docs[1].ID != "def" {
+		t.Errorf("doc IDs = %q, %q, want abc, def", docs[0].ID, docs[1].ID)
+	}
+	if docs[0].Fields["name"] != "Bear Mount" {
+		t.Errorf("docs[0].Fields[name] = %v, want Bear Mount", docs[0].Fields["name"])
+	}
+	if callCount != 2 {
+		t.Errorf("callCount = %d, want 2 (one per page)", callCount)
+	}
+}
+
+func TestFirestoreClient_GetDocument_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newFirestoreClient("test-project", srv.Client())
+	c.baseURL = srv.URL
+
+	_, err := c.getDocument(context.Background(), "mods", "missing")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+}

--- a/internal/source/icarus/firestore_value.go
+++ b/internal/source/icarus/firestore_value.go
@@ -1,0 +1,51 @@
+package icarus
+
+// decodeFields unwraps a Firestore REST document's typed-value "fields"
+// object (each value wrapped as {"stringValue": ...} / {"mapValue": {...}} /
+// etc.) into plain Go values. Only the value kinds this catalog's schema
+// actually uses are handled; anything else decodes to nil rather than
+// panicking, since an unrecognized field should be ignorable, not fatal.
+func decodeFields(fields map[string]any) map[string]any {
+	out := make(map[string]any, len(fields))
+	for k, v := range fields {
+		out[k] = decodeValue(v)
+	}
+	return out
+}
+
+func decodeValue(v any) any {
+	wrapped, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if s, ok := wrapped["stringValue"]; ok {
+		return s
+	}
+	if b, ok := wrapped["booleanValue"]; ok {
+		return b
+	}
+	if i, ok := wrapped["integerValue"]; ok {
+		return i
+	}
+	if d, ok := wrapped["doubleValue"]; ok {
+		return d
+	}
+	if m, ok := wrapped["mapValue"]; ok {
+		mv, _ := m.(map[string]any)
+		inner, _ := mv["fields"].(map[string]any)
+		return decodeFields(inner)
+	}
+	if a, ok := wrapped["arrayValue"]; ok {
+		av, _ := a.(map[string]any)
+		values, _ := av["values"].([]any)
+		out := make([]any, len(values))
+		for i, item := range values {
+			out[i] = decodeValue(item)
+		}
+		return out
+	}
+	if _, ok := wrapped["nullValue"]; ok {
+		return nil
+	}
+	return nil
+}

--- a/internal/source/icarus/firestore_value_test.go
+++ b/internal/source/icarus/firestore_value_test.go
@@ -1,0 +1,34 @@
+package icarus
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDecodeFields(t *testing.T) {
+	// Shape of a real Firestore REST document's "fields" object.
+	raw := map[string]any{
+		"name":    map[string]any{"stringValue": "Bear Mount"},
+		"version": map[string]any{"stringValue": "3.3"},
+		"files": map[string]any{"mapValue": map[string]any{"fields": map[string]any{
+			"pak":    map[string]any{"stringValue": "https://example.com/mod.pak"},
+			"exmodz": map[string]any{"stringValue": "https://example.com/mod.exmodz"},
+		}}},
+		"missing": map[string]any{"nullValue": nil},
+	}
+
+	got := decodeFields(raw)
+
+	want := map[string]any{
+		"name":    "Bear Mount",
+		"version": "3.3",
+		"files": map[string]any{
+			"pak":    "https://example.com/mod.pak",
+			"exmodz": "https://example.com/mod.exmodz",
+		},
+		"missing": nil,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("decodeFields() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/source/icarus/icarus.go
+++ b/internal/source/icarus/icarus.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -105,6 +106,19 @@ func (s *Icarus) Search(ctx context.Context, query source.SearchQuery) (source.S
 			mods = append(mods, m)
 		}
 	}
+
+	// Firestore's listCollection order is not guaranteed stable across runs,
+	// so the same page could otherwise return different mods on different
+	// requests. Sort deterministically before slicing, matching the custom
+	// api/manifest/directory sources' name-based ordering convention
+	// (internal/source/custom/search.go), with an ID tiebreak for the rare
+	// case of two mods sharing a name.
+	sort.SliceStable(mods, func(i, j int) bool {
+		if mods[i].Name != mods[j].Name {
+			return mods[i].Name < mods[j].Name
+		}
+		return mods[i].ID < mods[j].ID
+	})
 
 	pageSize := query.PageSize
 	if pageSize <= 0 {

--- a/internal/source/icarus/icarus.go
+++ b/internal/source/icarus/icarus.go
@@ -1,0 +1,209 @@
+package icarus
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+)
+
+// gameID is fixed: the Firestore database this source reads is Icarus-only.
+const gameID = "icarus"
+
+// Icarus is a ModSource backed by the public, unauthenticated Firestore REST
+// API described in docs/plans/2026-07-29-icarus-exmod-pak-research.md.
+type Icarus struct {
+	firestore *firestoreClient
+}
+
+// New constructs an Icarus source. projectID is the Firestore project ID
+// (from the Firebase console) — passed explicitly rather than hard-coded so
+// tests can point at an httptest server and so the real value lives in one
+// place at the call site (Task 9), not buried in this package.
+func New(httpClient *http.Client, projectID string) *Icarus {
+	return &Icarus{firestore: newFirestoreClient(projectID, httpClient)}
+}
+
+var (
+	_ source.ModSource          = (*Icarus)(nil)
+	_ source.CapabilityReporter = (*Icarus)(nil)
+)
+
+func (s *Icarus) ID() string   { return "icarus" }
+func (s *Icarus) Name() string { return "Icarus (Project Daedalus)" }
+
+// AuthURL/ExchangeToken: unsupported — Firestore reads here are public.
+func (s *Icarus) AuthURL() string { return "" }
+func (s *Icarus) ExchangeToken(ctx context.Context, code string) (*source.Token, error) {
+	return nil, fmt.Errorf("source %q: authentication: %w", s.ID(), source.ErrNotSupported)
+}
+
+// GetDependencies: the modinfo.json v2 schema has no dependency field.
+func (s *Icarus) GetDependencies(ctx context.Context, mod *domain.Mod) ([]domain.ModReference, error) {
+	return nil, fmt.Errorf("source %q: dependencies: %w", s.ID(), source.ErrNotSupported)
+}
+
+func (s *Icarus) Capabilities() source.Capabilities {
+	return source.Capabilities{Search: true, Dependencies: false, Updates: true, Auth: false}
+}
+
+func (s *Icarus) TypeLabel() string { return "built-in" }
+
+// Search fetches the whole mods collection and filters client-side — this
+// catalog has no server-side query support to speak of, matching
+// project_daedalus's own ModsController#find_mods approach.
+func (s *Icarus) Search(ctx context.Context, query source.SearchQuery) (source.SearchResult, error) {
+	docs, err := s.firestore.listCollection(ctx, "mods")
+	if err != nil {
+		return source.SearchResult{}, fmt.Errorf("source %q: searching: %w", s.ID(), err)
+	}
+
+	var mods []domain.Mod
+	q := strings.ToLower(query.Query)
+	for _, d := range docs {
+		m := mapDoc(d)
+		if q == "" || strings.Contains(strings.ToLower(m.Name), q) ||
+			strings.Contains(strings.ToLower(m.Author), q) ||
+			strings.Contains(strings.ToLower(m.Description), q) {
+			mods = append(mods, m)
+		}
+	}
+
+	pageSize := query.PageSize
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	page := query.Page
+	if page < 0 {
+		page = 0
+	}
+	start := page * pageSize
+	if start > len(mods) {
+		start = len(mods)
+	}
+	end := start + pageSize
+	if end > len(mods) {
+		end = len(mods)
+	}
+
+	return source.SearchResult{Mods: mods[start:end], TotalCount: len(mods), Page: page, PageSize: pageSize}, nil
+}
+
+func (s *Icarus) GetMod(ctx context.Context, queryGameID, modID string) (*domain.Mod, error) {
+	doc, err := s.firestore.getDocument(ctx, "mods", modID)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: fetching mod %s: %w", s.ID(), modID, err)
+	}
+	m := mapDoc(*doc)
+	return &m, nil
+}
+
+// GetModFiles returns the mod's downloadable files (pak and/or exmodz — see
+// modinfo.json v2 schema). A single file is marked primary, matching the
+// existing custom.API convention.
+func (s *Icarus) GetModFiles(ctx context.Context, mod *domain.Mod) ([]domain.DownloadableFile, error) {
+	doc, err := s.firestore.getDocument(ctx, "mods", mod.ID)
+	if err != nil {
+		return nil, fmt.Errorf("source %q: listing files for %s: %w", s.ID(), mod.ID, err)
+	}
+	filesField, _ := doc.Fields["files"].(map[string]any)
+	var out []domain.DownloadableFile
+	for _, kind := range []string{"pak", "exmodz"} {
+		rawURL, ok := filesField[kind].(string)
+		if !ok || rawURL == "" {
+			continue
+		}
+		out = append(out, domain.DownloadableFile{
+			ID:       kind,
+			Name:     kind,
+			FileName: fileNameFromURL(rawURL, kind),
+			Category: strings.ToUpper(kind),
+		})
+	}
+	if len(out) == 1 {
+		out[0].IsPrimary = true
+	}
+	return out, nil
+}
+
+// GetDownloadURL re-fetches the mod document and returns the stored URL for
+// fileID ("pak" or "exmodz") directly — no signing, matching a static-URL
+// catalog rather than an OAuth-gated one.
+func (s *Icarus) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	doc, err := s.firestore.getDocument(ctx, "mods", mod.ID)
+	if err != nil {
+		return "", fmt.Errorf("source %q: download URL for %s: %w", s.ID(), fileID, err)
+	}
+	filesField, _ := doc.Fields["files"].(map[string]any)
+	rawURL, ok := filesField[fileID].(string)
+	if !ok || rawURL == "" {
+		return "", fmt.Errorf("source %q: file %s: no download URL", s.ID(), fileID)
+	}
+	return rawURL, nil
+}
+
+// CheckUpdates compares each installed mod's stored version against the
+// catalog's current version string (semantic-ish, per modinfo.json's
+// "recommended" versioning note — not guaranteed strictly semver, so this
+// uses domain.IsNewerVersion the same way custom.API does).
+func (s *Icarus) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {
+	var updates []domain.Update
+	var errs []error
+	for _, inst := range installed {
+		select {
+		case <-ctx.Done():
+			return updates, ctx.Err()
+		default:
+		}
+		current, err := s.GetMod(ctx, gameID, inst.ID)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if domain.IsNewerVersion(inst.Version, current.Version) {
+			updates = append(updates, domain.Update{InstalledMod: inst, NewVersion: current.Version})
+		}
+	}
+	if len(errs) > 0 {
+		return updates, fmt.Errorf("source %q: %d update check(s) failed: %v", s.ID(), len(errs), errs[0])
+	}
+	return updates, nil
+}
+
+// mapDoc converts a decoded Firestore document into domain.Mod per the
+// modinfo.json v2 schema (docs/plans/2026-07-29-icarus-exmod-pak-research.md).
+func mapDoc(d firestoreDoc) domain.Mod {
+	str := func(key string) string {
+		s, _ := d.Fields[key].(string)
+		return s
+	}
+	return domain.Mod{
+		ID:          d.ID,
+		SourceID:    "icarus",
+		GameID:      gameID,
+		Name:        str("name"),
+		Author:      str("author"),
+		Version:     str("version"),
+		Category:    str("compatibility"), // Icarus week-build string, e.g. "w57"
+		Description: str("description"),
+		PictureURL:  str("imageURL"),
+		SourceURL:   str("readmeURL"),
+	}
+}
+
+func fileNameFromURL(rawURL, fallbackExt string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Path == "" {
+		return fallbackExt
+	}
+	base := path.Base(u.Path)
+	if base == "." || base == "/" {
+		return fallbackExt
+	}
+	return base
+}

--- a/internal/source/icarus/icarus.go
+++ b/internal/source/icarus/icarus.go
@@ -223,14 +223,27 @@ func mapDoc(d firestoreDoc) domain.Mod {
 	}
 }
 
+// fileNameFromURL derives a download's file name from its URL, falling back
+// to a synthesized "mod.<fallbackExt>" name (never a bare, dot-less
+// fallbackExt) when the URL yields nothing usable. A dot-less fallback would
+// silently defeat both isExmodzFile's case-insensitive ".exmodz" suffix
+// check and compiledFileName's filepath.Ext-based rename in Service — a
+// downloaded file named e.g. "exmodz" would never route through Compile.
+// A parsed basename that exists but carries no extension of its own gets
+// fallbackExt appended rather than being discarded outright, preserving
+// whatever real name the URL offered.
 func fileNameFromURL(rawURL, fallbackExt string) string {
+	fallback := "mod." + fallbackExt
 	u, err := url.Parse(rawURL)
 	if err != nil || u.Path == "" {
-		return fallbackExt
+		return fallback
 	}
 	base := path.Base(u.Path)
-	if base == "." || base == "/" {
-		return fallbackExt
+	if base == "." || base == "/" || base == ".." {
+		return fallback
+	}
+	if path.Ext(base) == "" {
+		return base + "." + fallbackExt
 	}
 	return base
 }

--- a/internal/source/icarus/icarus.go
+++ b/internal/source/icarus/icarus.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -19,6 +20,7 @@ const gameID = "icarus"
 // API described in docs/plans/2026-07-29-icarus-exmod-pak-research.md.
 type Icarus struct {
 	firestore *firestoreClient
+	dumps     *DumpStore // nil until SetDataDir is called
 }
 
 // New constructs an Icarus source. projectID is the Firestore project ID
@@ -29,10 +31,35 @@ func New(httpClient *http.Client, projectID string) *Icarus {
 	return &Icarus{firestore: newFirestoreClient(projectID, httpClient)}
 }
 
+// SetDataDir wires the base-table dump store's cache directory once the
+// service's data directory is known. This is a post-construction setter
+// rather than a New parameter because Task 8 froze New(httpClient, projectID)
+// at exactly those two params — Task 9's call site already depends on that
+// signature — so the data dir arrives the same way API keys do: an optional
+// setter the registration pipeline calls when present (cmd/lmm/root.go's
+// registerSource, mirroring its existing SetAPIKey wiring).
+func (s *Icarus) SetDataDir(dataDir string) {
+	s.dumps = newDumpStore(filepath.Join(dataDir, "icarus", "datadump"), s.firestore.httpClient)
+}
+
 var (
 	_ source.ModSource          = (*Icarus)(nil)
 	_ source.CapabilityReporter = (*Icarus)(nil)
+	_ source.Compiler           = (*Icarus)(nil)
 )
+
+// Compile implements source.Compiler by delegating to the package-level
+// Compile function (Task 12) — basePakPath/baseDataPath/sourceFilePath/
+// outputPath map directly onto Compile's basePakPath/localDumpDir/exmodzPath/
+// outputPakPath parameters. The base-table dump store (Task 12a) is supplied
+// from the source itself; the per-game dump-directory override arrives as
+// baseDataPath, since only the caller has the game's config.
+func (s *Icarus) Compile(ctx context.Context, basePakPath, baseDataPath, sourceFilePath, outputPath string) error {
+	if s.dumps == nil {
+		return fmt.Errorf("source %q: not initialized with a data directory (SetDataDir was never called)", s.ID())
+	}
+	return Compile(ctx, s.dumps, basePakPath, baseDataPath, sourceFilePath, outputPath)
+}
 
 func (s *Icarus) ID() string   { return "icarus" }
 func (s *Icarus) Name() string { return "Icarus (Project Daedalus)" }

--- a/internal/source/icarus/icarus.go
+++ b/internal/source/icarus/icarus.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -31,15 +30,21 @@ func New(httpClient *http.Client, projectID string) *Icarus {
 	return &Icarus{firestore: newFirestoreClient(projectID, httpClient)}
 }
 
-// SetDataDir wires the base-table dump store's cache directory once the
-// service's data directory is known. This is a post-construction setter
-// rather than a New parameter because Task 8 froze New(httpClient, projectID)
-// at exactly those two params — Task 9's call site already depends on that
-// signature — so the data dir arrives the same way API keys do: an optional
-// setter the registration pipeline calls when present (cmd/lmm/root.go's
-// registerSource, mirroring its existing SetAPIKey wiring).
+// SetDataDir constructs the base-table dump store once the service's data
+// directory is known, gating Compile on it having been called at all (see
+// TestIcarus_Compile_WithoutDataDir_FailsLoudly) — DumpStore itself has no
+// current use for dataDir's value (it fetches on demand rather than caching
+// to disk, see DumpStore's doc comment), so the parameter exists only to
+// satisfy the shared `interface{ SetDataDir(string) }` duck-typed contract
+// cmd/lmm/root.go's registerSource calls uniformly across sources. This is a
+// post-construction setter rather than a New parameter because Task 8 froze
+// New(httpClient, projectID) at exactly those two params — Task 9's call
+// site already depends on that signature — so the data dir arrives the same
+// way API keys do: an optional setter the registration pipeline calls when
+// present (mirroring its existing SetAPIKey wiring).
 func (s *Icarus) SetDataDir(dataDir string) {
-	s.dumps = newDumpStore(filepath.Join(dataDir, "icarus", "datadump"), s.firestore.httpClient)
+	_ = dataDir // unused: see doc comment above
+	s.dumps = newDumpStore(s.firestore.httpClient)
 }
 
 var (

--- a/internal/source/icarus/icarus_test.go
+++ b/internal/source/icarus/icarus_test.go
@@ -1,0 +1,85 @@
+package icarus
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+)
+
+func modsListHandler(mods []map[string]any) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		docs := make([]map[string]any, len(mods))
+		for i, m := range mods {
+			docs[i] = map[string]any{
+				"name":   "projects/p/databases/(default)/documents/mods/" + m["id"].(string),
+				"fields": m["fields"],
+			}
+		}
+		json.NewEncoder(w).Encode(map[string]any{"documents": docs}) //nolint:errcheck
+	}
+}
+
+func TestIcarus_Search_FiltersClientSide(t *testing.T) {
+	srv := httptest.NewServer(modsListHandler([]map[string]any{
+		{"id": "abc", "fields": map[string]any{
+			"name": map[string]any{"stringValue": "Bear Mount"}, "author": map[string]any{"stringValue": "Jimk72"},
+			"description": map[string]any{"stringValue": "Ride a bear"}, "version": map[string]any{"stringValue": "3.3"},
+			"compatibility": map[string]any{"stringValue": "w57"},
+			"files":         map[string]any{"mapValue": map[string]any{"fields": map[string]any{"exmodz": map[string]any{"stringValue": "https://x/bear.exmodz"}}}},
+		}},
+		{"id": "def", "fields": map[string]any{
+			"name": map[string]any{"stringValue": "Wolf Pack"}, "author": map[string]any{"stringValue": "Someone"},
+			"description": map[string]any{"stringValue": "Tame wolves"}, "version": map[string]any{"stringValue": "1.0"},
+			"files": map[string]any{"mapValue": map[string]any{"fields": map[string]any{"pak": map[string]any{"stringValue": "https://x/wolf.pak"}}}},
+		}},
+	}))
+	defer srv.Close()
+
+	src := New(srv.Client(), "test-project")
+	src.firestore.baseURL = srv.URL
+
+	result, err := src.Search(context.Background(), source.SearchQuery{Query: "bear"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(result.Mods) != 1 || result.Mods[0].Name != "Bear Mount" {
+		t.Fatalf("Search(%q) = %+v, want exactly Bear Mount", "bear", result.Mods)
+	}
+	if result.Mods[0].GameID != "icarus" {
+		t.Errorf("GameID = %q, want icarus", result.Mods[0].GameID)
+	}
+}
+
+func TestIcarus_GetModFiles_ReturnsExmodzAndPak(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"name": "projects/p/databases/(default)/documents/mods/abc",
+			"fields": map[string]any{
+				"name": map[string]any{"stringValue": "Bear Mount"},
+				"files": map[string]any{"mapValue": map[string]any{"fields": map[string]any{
+					"exmodz": map[string]any{"stringValue": "https://x/bear.exmodz"},
+				}}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	src := New(srv.Client(), "test-project")
+	src.firestore.baseURL = srv.URL
+
+	files, err := src.GetModFiles(context.Background(), &domain.Mod{ID: "abc", GameID: "icarus"})
+	if err != nil {
+		t.Fatalf("GetModFiles: %v", err)
+	}
+	if len(files) != 1 || files[0].FileName != "bear.exmodz" {
+		t.Fatalf("files = %+v, want one bear.exmodz entry", files)
+	}
+	if !files[0].IsPrimary {
+		t.Error("single file should be marked primary")
+	}
+}

--- a/internal/source/icarus/icarus_test.go
+++ b/internal/source/icarus/icarus_test.go
@@ -85,6 +85,34 @@ func TestIcarus_GetModFiles_ReturnsExmodzAndPak(t *testing.T) {
 	}
 }
 
+// The fallback must always be a dotted name (never a bare "exmodz"/"pak"),
+// or isExmodzFile's ".exmodz" suffix check and compiledFileName's
+// filepath.Ext-based rename in Service would both silently misroute the
+// download instead of failing loudly (#136 review round 2).
+func TestFileNameFromURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		rawURL      string
+		fallbackExt string
+		want        string
+	}{
+		{"basename with extension is used as-is", "https://x/mods/Bear_Mount.exmodz", "exmodz", "Bear_Mount.exmodz"},
+		{"basename without an extension gets fallbackExt appended", "https://x/mods/Bear_Mount", "exmodz", "Bear_Mount.exmodz"},
+		{"root path falls back to a dotted name", "https://x/", "pak", "mod.pak"},
+		{"empty path falls back to a dotted name", "https://x", "pak", "mod.pak"},
+		{"a path of exactly '..' falls back to a dotted name", "https://x/mods/..", "exmodz", "mod.exmodz"},
+		{"an unparseable URL falls back to a dotted name", "://not a url", "pak", "mod.pak"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fileNameFromURL(tt.rawURL, tt.fallbackExt)
+			if got != tt.want {
+				t.Errorf("fileNameFromURL(%q, %q) = %q, want %q", tt.rawURL, tt.fallbackExt, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestIcarus_Compile_WithoutDataDir_FailsLoudly pins that a source
 // constructed via New but never wired with SetDataDir (e.g. a registration
 // path that forgets the optional-setter call) fails loudly instead of

--- a/internal/source/icarus/icarus_test.go
+++ b/internal/source/icarus/icarus_test.go
@@ -25,18 +25,27 @@ func modsListHandler(mods []map[string]any) http.HandlerFunc {
 	}
 }
 
+// The mock server deliberately returns documents in non-alphabetical order
+// (Wolf, Bear, Aardvark) — Firestore's listCollection order isn't guaranteed
+// stable across runs, so Search must sort before paginating rather than
+// trusting (or accidentally reproducing) whatever order the server used.
 func TestIcarus_Search_FiltersClientSide(t *testing.T) {
 	srv := httptest.NewServer(modsListHandler([]map[string]any{
+		{"id": "def", "fields": map[string]any{
+			"name": map[string]any{"stringValue": "Wolf Pack"}, "author": map[string]any{"stringValue": "Someone"},
+			"description": map[string]any{"stringValue": "Tame wolves"}, "version": map[string]any{"stringValue": "1.0"},
+			"files": map[string]any{"mapValue": map[string]any{"fields": map[string]any{"pak": map[string]any{"stringValue": "https://x/wolf.pak"}}}},
+		}},
 		{"id": "abc", "fields": map[string]any{
 			"name": map[string]any{"stringValue": "Bear Mount"}, "author": map[string]any{"stringValue": "Jimk72"},
 			"description": map[string]any{"stringValue": "Ride a bear"}, "version": map[string]any{"stringValue": "3.3"},
 			"compatibility": map[string]any{"stringValue": "w57"},
 			"files":         map[string]any{"mapValue": map[string]any{"fields": map[string]any{"exmodz": map[string]any{"stringValue": "https://x/bear.exmodz"}}}},
 		}},
-		{"id": "def", "fields": map[string]any{
-			"name": map[string]any{"stringValue": "Wolf Pack"}, "author": map[string]any{"stringValue": "Someone"},
-			"description": map[string]any{"stringValue": "Tame wolves"}, "version": map[string]any{"stringValue": "1.0"},
-			"files": map[string]any{"mapValue": map[string]any{"fields": map[string]any{"pak": map[string]any{"stringValue": "https://x/wolf.pak"}}}},
+		{"id": "ghi", "fields": map[string]any{
+			"name": map[string]any{"stringValue": "Aardvark Delight"}, "author": map[string]any{"stringValue": "Someone"},
+			"description": map[string]any{"stringValue": "Burrowing companion"}, "version": map[string]any{"stringValue": "1.0"},
+			"files": map[string]any{"mapValue": map[string]any{"fields": map[string]any{"pak": map[string]any{"stringValue": "https://x/aardvark.pak"}}}},
 		}},
 	}))
 	defer srv.Close()
@@ -53,6 +62,20 @@ func TestIcarus_Search_FiltersClientSide(t *testing.T) {
 	}
 	if result.Mods[0].GameID != "icarus" {
 		t.Errorf("GameID = %q, want icarus", result.Mods[0].GameID)
+	}
+
+	all, err := src.Search(context.Background(), source.SearchQuery{Query: ""})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	wantOrder := []string{"Aardvark Delight", "Bear Mount", "Wolf Pack"}
+	if len(all.Mods) != len(wantOrder) {
+		t.Fatalf("Search(\"\") returned %d mods, want %d", len(all.Mods), len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if all.Mods[i].Name != want {
+			t.Errorf("Search(\"\") order[%d] = %q, want %q (deterministic, alphabetical by Name)", i, all.Mods[i].Name, want)
+		}
 	}
 }
 

--- a/internal/source/icarus/icarus_test.go
+++ b/internal/source/icarus/icarus_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -81,5 +82,32 @@ func TestIcarus_GetModFiles_ReturnsExmodzAndPak(t *testing.T) {
 	}
 	if !files[0].IsPrimary {
 		t.Error("single file should be marked primary")
+	}
+}
+
+// TestIcarus_Compile_WithoutDataDir_FailsLoudly pins that a source
+// constructed via New but never wired with SetDataDir (e.g. a registration
+// path that forgets the optional-setter call) fails loudly instead of
+// panicking on a nil dumps store.
+func TestIcarus_Compile_WithoutDataDir_FailsLoudly(t *testing.T) {
+	src := New(nil, "test-project")
+
+	err := src.Compile(context.Background(), "/base.pak", "", "/mod.exmodz", "/out.pak")
+	if err == nil {
+		t.Fatal("Compile: expected an error when SetDataDir was never called")
+	}
+	if !strings.Contains(err.Error(), "SetDataDir") {
+		t.Errorf("Compile error = %q, want it to mention SetDataDir", err.Error())
+	}
+}
+
+// TestIcarus_SetDataDir_ConstructsDumpStore pins that SetDataDir wires a
+// non-nil dumps store, so a real registration call unblocks Compile.
+func TestIcarus_SetDataDir_ConstructsDumpStore(t *testing.T) {
+	src := New(nil, "test-project")
+	src.SetDataDir(t.TempDir())
+
+	if src.dumps == nil {
+		t.Fatal("SetDataDir: dumps store still nil")
 	}
 }

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -142,3 +142,19 @@ func CapabilitiesOf(src ModSource) Capabilities {
 type DownloadHeaderProvider interface {
 	DownloadHeaders(fileURL string) map[string]string
 }
+
+// Compiler is implemented by sources whose downloaded files need
+// transforming into a different artifact before deployment (Icarus's
+// .exmodz -> .pak). Service consults it, when DeployMode is DeployCompile,
+// after downloading but before committing the file to cache — the result
+// replaces the downloaded file in cache, so everything downstream (Install,
+// the linker) treats it exactly like a DeployCopy file.
+//
+// basePakPath and baseDataPath are both resolved by the caller from the game's
+// config: basePakPath from game.InstallPath, baseDataPath from the game's
+// optional data_dump_path ("" when unset — see Step 6b). sourceFilePath is the
+// just-downloaded file; outputPath is where the compiled result must be
+// written.
+type Compiler interface {
+	Compile(ctx context.Context, basePakPath, baseDataPath, sourceFilePath, outputPath string) error
+}

--- a/internal/storage/config/games.go
+++ b/internal/storage/config/games.go
@@ -49,14 +49,15 @@ type GameHooksYAML struct {
 
 // GameConfig is the YAML representation of a game
 type GameConfig struct {
-	Name        string            `yaml:"name"`
-	InstallPath string            `yaml:"install_path"`
-	ModPath     string            `yaml:"mod_path"`
-	Sources     map[string]string `yaml:"sources"`
-	LinkMethod  string            `yaml:"link_method,omitempty"`
-	CachePath   string            `yaml:"cache_path,omitempty"`
-	Hooks       GameHooksYAML     `yaml:"hooks,omitempty"`
-	DeployMode  string            `yaml:"deploy_mode,omitempty"`
+	Name         string            `yaml:"name"`
+	InstallPath  string            `yaml:"install_path"`
+	ModPath      string            `yaml:"mod_path"`
+	Sources      map[string]string `yaml:"sources"`
+	LinkMethod   string            `yaml:"link_method,omitempty"`
+	CachePath    string            `yaml:"cache_path,omitempty"`
+	Hooks        GameHooksYAML     `yaml:"hooks,omitempty"`
+	DeployMode   string            `yaml:"deploy_mode,omitempty"`
+	BaseDataPath string            `yaml:"data_dump_path,omitempty"`
 }
 
 // GamesFile is the top-level games.yaml structure
@@ -97,6 +98,7 @@ func loadGamesLocked(configDir string) (map[string]*domain.Game, error) {
 			LinkMethodExplicit: cfg.LinkMethod != "",
 			CachePath:          ExpandPath(cfg.CachePath),
 			DeployMode:         domain.ParseDeployMode(cfg.DeployMode),
+			BaseDataPath:       ExpandPath(cfg.BaseDataPath),
 			Hooks: domain.GameHooks{
 				Install: domain.HookConfig{
 					BeforeAll:  ExpandPath(cfg.Hooks.Install.BeforeAll),
@@ -134,11 +136,12 @@ func saveGamesLocked(configDir string, games map[string]*domain.Game) error {
 
 	for id, game := range games {
 		cfg := GameConfig{
-			Name:        game.Name,
-			InstallPath: game.InstallPath,
-			ModPath:     game.ModPath,
-			Sources:     game.SourceIDs,
-			CachePath:   game.CachePath,
+			Name:         game.Name,
+			InstallPath:  game.InstallPath,
+			ModPath:      game.ModPath,
+			Sources:      game.SourceIDs,
+			CachePath:    game.CachePath,
+			BaseDataPath: game.BaseDataPath,
 			Hooks: GameHooksYAML{
 				Install: HookConfigYAML{
 					BeforeAll:  game.Hooks.Install.BeforeAll,

--- a/internal/storage/config/games_test.go
+++ b/internal/storage/config/games_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadGames_DataDumpPath(t *testing.T) {
+	dir := t.TempDir()
+	yaml := "games:\n  icarus:\n    name: Icarus\n    install_path: /games/icarus\n" +
+		"    mod_path: /games/icarus/mods\n    data_dump_path: /dumps/week243\n"
+	if err := os.WriteFile(filepath.Join(dir, "games.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	games, err := LoadGames(dir)
+	if err != nil {
+		t.Fatalf("LoadGames: %v", err)
+	}
+	if got := games["icarus"].BaseDataPath; got != "/dumps/week243" {
+		t.Errorf("BaseDataPath = %q, want /dumps/week243", got)
+	}
+}

--- a/internal/unrealpak/pak.go
+++ b/internal/unrealpak/pak.go
@@ -1,0 +1,166 @@
+package unrealpak
+
+import (
+	"bytes"
+	"crypto/sha1" //nolint:gosec // pak format uses SHA1, not our choice
+	"encoding/binary"
+	"errors"
+	"strings"
+	"unicode/utf16"
+)
+
+// ErrUnsupportedFormat indicates the pak uses a feature this package
+// deliberately does not support (compression, encryption, exotic FString
+// encodings) rather than a genuine parse failure. Callers should fail loudly
+// on this, not silently degrade (repo precedent: #95).
+var ErrUnsupportedFormat = errors.New("unrealpak: unsupported pak feature")
+
+const magic uint32 = 0x5A6F12E1
+
+// footerSize is the only footer shape this package supports: the version>=8
+// layout, EncryptionKeyGuid(16)+bEncryptedIndex(1)+Magic(4)+Version(4)+
+// IndexOffset(8)+IndexSize(8)+IndexHash(20)+CompressionMethods(5x32) = 221.
+// Note EncryptionKeyGuid and bEncryptedIndex precede Magic — not after
+// IndexHash, as some public docs describe. Confirmed on all 34 paks in a real
+// Icarus install (Task 1); see docs/plans/icarus-pak-format-findings.md.
+const footerSize = 221
+
+// minVersion is the oldest pak version this package reads. Version 10
+// (PakFile_Version_PathHashIndex) introduced the three-part index — primary
+// index + path-hash index + full directory index — that this package parses.
+// Older paks use a flat index with a completely different shape; rather than
+// carry a second parser for a layout Icarus does not ship, they are a hard
+// ErrUnsupportedFormat (repo precedent #95: no silent fallbacks).
+const minVersion int32 = 10
+
+// writeVersion is what Writer emits: the same version Icarus's own paks use,
+// so the engine loads our output through the exact code path it already uses.
+const writeVersion int32 = 11
+
+// storedHeaderSize is the on-disk size of the per-entry FPakEntry header that
+// precedes each stored (uncompressed) file's payload:
+// Offset(8)+Size(8)+UncompressedSize(8)+CompressionMethodIndex(4)+Hash(20)+
+// Flags(1)+CompressionBlockSize(4) = 53. Compressed entries add
+// BlockCount(4)+16*blocks between Hash and Flags; this package never writes
+// those and refuses to read their payloads.
+const storedHeaderSize = 53
+
+// FileEntry describes one file inside a pak, as returned by Reader.Files.
+type FileEntry struct {
+	Path string // Mount-relative path, e.g. "Icarus/Content/Data/AI-D_AIGrowth.json"
+	Size int64  // Uncompressed size in bytes
+}
+
+// hashPath computes a path's key in the pak's path-hash index: FNV-1a 64 over
+// the UTF-16LE bytes of the lowercased mount-relative path (no NUL
+// terminator), seeded by ADDING the pak's PathHashSeed to the FNV offset
+// basis. Any leading "/" is stripped first — the full directory index stores
+// root-level files under a "/" directory, and the hash is taken over the path
+// without it.
+//
+// This recipe was not guessed: it was recovered by brute-forcing seed/
+// encoding/case/prefix combinations until computed hashes matched stored keys,
+// then verified against all 173,078 entries across all 34 paks in a real
+// install. See docs/plans/icarus-pak-format-findings.md.
+//
+// strings.ToLower is full-Unicode where UE's FChar::ToLower is not, but no
+// non-ASCII path exists in any shipped Icarus pak and this package controls
+// the paths it writes, so the two agree for everything we handle.
+func hashPath(mountRelative string, seed uint64) uint64 {
+	const (
+		offsetBasis uint64 = 0xCBF29CE484222325
+		prime       uint64 = 0x00000100000001B3
+	)
+	h := offsetBasis + seed
+	for _, u := range utf16.Encode([]rune(strings.ToLower(strings.TrimPrefix(mountRelative, "/")))) {
+		h ^= uint64(byte(u))
+		h *= prime
+		h ^= uint64(byte(u >> 8))
+		h *= prime
+	}
+	return h
+}
+
+// defaultMountPoint is the mount point Writer stamps into the primary index.
+// Icarus's own data.pak uses an absolute cook-machine path
+// ("C:/BA/work/.../Temp/Data/"); "../../../" is the conventional relative form
+// used by its pakchunks. Confirming which one a _P.pak needs to override
+// Content/Data/data.pak in-game is a post-plan validation item.
+const defaultMountPoint = "../../../"
+
+// writeFString writes a length-prefixed ANSI Unreal FString (length includes
+// the trailing NUL).
+func writeFString(buf *bytes.Buffer, s string) {
+	b := append([]byte(s), 0)
+	binary.Write(buf, binary.LittleEndian, int32(len(b))) //nolint:errcheck // bytes.Buffer writes never fail
+	buf.Write(b)
+}
+
+// splitMountPath splits a mount-relative path into the directory-index key
+// (trailing "/", or exactly "/" for a root-level file) and the leaf name,
+// matching how real paks key their directory indexes.
+func splitMountPath(rel string) (dir, file string) {
+	if i := strings.LastIndex(rel, "/"); i >= 0 {
+		return rel[:i+1], rel[i+1:]
+	}
+	return "/", rel
+}
+
+// storedEntryHeader builds the 53-byte FPakEntry header that precedes a stored
+// file's payload on disk. The Offset field is always 0 in this local copy —
+// real paks write 0 there too, the authoritative offset lives in the index.
+// Hash is the SHA1 of the on-disk payload bytes.
+func storedEntryHeader(size int64, content []byte) []byte {
+	var b bytes.Buffer
+	binary.Write(&b, binary.LittleEndian, int64(0)) //nolint:errcheck // Offset
+	binary.Write(&b, binary.LittleEndian, size)     //nolint:errcheck // Size
+	binary.Write(&b, binary.LittleEndian, size)     //nolint:errcheck // UncompressedSize
+	binary.Write(&b, binary.LittleEndian, int32(0)) //nolint:errcheck // CompressionMethodIndex: stored
+	h := sha1.Sum(content)                          //nolint:gosec
+	b.Write(h[:])
+	b.WriteByte(0)                                   // Flags: not encrypted, not deleted
+	binary.Write(&b, binary.LittleEndian, uint32(0)) //nolint:errcheck // CompressionBlockSize
+	return b.Bytes()
+}
+
+// buildPrimaryIndex serializes the primary index. Callers build it twice: the
+// sub-index offsets it records point past its own end, but its length does not
+// depend on their values (they are fixed-width int64), so a first pass with
+// zero offsets measures it and a second pass writes the real ones.
+func buildPrimaryIndex(numEntries int32, seed uint64,
+	phiOffset, phiSize int64, phiHash [20]byte,
+	fdiOffset, fdiSize int64, fdiHash [20]byte, encoded []byte) []byte {
+	var b bytes.Buffer
+	writeFString(&b, defaultMountPoint)
+	binary.Write(&b, binary.LittleEndian, numEntries) //nolint:errcheck
+	binary.Write(&b, binary.LittleEndian, seed)       //nolint:errcheck // PathHashSeed
+	binary.Write(&b, binary.LittleEndian, int32(1))   //nolint:errcheck // bHasPathHashIndex
+	binary.Write(&b, binary.LittleEndian, phiOffset)  //nolint:errcheck
+	binary.Write(&b, binary.LittleEndian, phiSize)    //nolint:errcheck
+	b.Write(phiHash[:])
+	binary.Write(&b, binary.LittleEndian, int32(1))  //nolint:errcheck // bHasFullDirectoryIndex
+	binary.Write(&b, binary.LittleEndian, fdiOffset) //nolint:errcheck
+	binary.Write(&b, binary.LittleEndian, fdiSize)   //nolint:errcheck
+	b.Write(fdiHash[:])
+	binary.Write(&b, binary.LittleEndian, int32(len(encoded))) //nolint:errcheck // EncodedPakEntriesSize
+	b.Write(encoded)
+	binary.Write(&b, binary.LittleEndian, int32(0)) //nolint:errcheck // NumNonEncodedFiles: none
+	return b.Bytes()
+}
+
+// buildFooter serializes the 221-byte version>=8 footer.
+func buildFooter(version int32, indexOffset, indexSize int64, indexHash [20]byte) []byte {
+	var b bytes.Buffer
+	b.Write(make([]byte, 16))                          // EncryptionKeyGuid: zero
+	b.WriteByte(0)                                     // bEncryptedIndex: false
+	binary.Write(&b, binary.LittleEndian, magic)       //nolint:errcheck
+	binary.Write(&b, binary.LittleEndian, version)     //nolint:errcheck
+	binary.Write(&b, binary.LittleEndian, indexOffset) //nolint:errcheck
+	binary.Write(&b, binary.LittleEndian, indexSize)   //nolint:errcheck
+	b.Write(indexHash[:])
+	// CompressionMethods: 5 fixed-width 32-byte name slots, all empty since
+	// this package only ever writes stored entries. Real paks name "Oodle"
+	// and "Zlib" here; an all-zero table is the correct shape for method 0.
+	b.Write(make([]byte, 160))
+	return b.Bytes()
+}

--- a/internal/unrealpak/reader.go
+++ b/internal/unrealpak/reader.go
@@ -1,0 +1,339 @@
+package unrealpak
+
+import (
+	"bytes"
+	"crypto/sha1" //nolint:gosec // pak format uses SHA1, not our choice
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// Reader provides read access to an uncompressed, unencrypted UE4-range pak.
+type Reader struct {
+	f       *os.File
+	entries []readerEntry
+}
+
+type readerEntry struct {
+	FileEntry
+	offset int64 // absolute offset of the entry's on-disk header
+	method int32 // CompressionMethodIndex; 0 = stored. Non-zero entries are
+	// enumerated but their payloads cannot be read (see ReadFile, Task 3).
+}
+
+// Open parses path's footer and index. It does not read file contents —
+// call ReadFile for that (Task 3).
+func Open(path string) (*Reader, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("unrealpak: opening %s: %w", path, err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		f.Close() //nolint:errcheck
+		return nil, fmt.Errorf("unrealpak: stat %s: %w", path, err)
+	}
+
+	ft, err := readFooter(f, info.Size())
+	if err != nil {
+		f.Close() //nolint:errcheck
+		return nil, err
+	}
+	if ft.encryptedIndex {
+		f.Close() //nolint:errcheck
+		return nil, fmt.Errorf("unrealpak: %s: %w: encrypted index", path, ErrUnsupportedFormat)
+	}
+
+	indexBuf, err := readRegion(f, ft.indexOffset, ft.indexSize, ft.indexHash)
+	if err != nil {
+		f.Close() //nolint:errcheck
+		return nil, fmt.Errorf("unrealpak: %s: primary index: %w", path, err)
+	}
+
+	entries, err := parseIndex(f, indexBuf)
+	if err != nil {
+		f.Close() //nolint:errcheck
+		return nil, fmt.Errorf("unrealpak: %s: parsing index: %w", path, err)
+	}
+
+	return &Reader{f: f, entries: entries}, nil
+}
+
+// readRegion reads size bytes at offset and verifies them against want. Every
+// index region in a version-11 pak is SHA1-gated: the footer covers the
+// primary index, and the primary index covers each sub-index. All three gates
+// are enforced — a mismatch is corruption or an unrecognized layout, never
+// something to parse through.
+func readRegion(r io.ReaderAt, offset, size int64, want [20]byte) ([]byte, error) {
+	if offset < 0 || size < 0 {
+		return nil, fmt.Errorf("%w: negative region offset/size", ErrUnsupportedFormat)
+	}
+	buf := make([]byte, size)
+	if _, err := r.ReadAt(buf, offset); err != nil {
+		return nil, fmt.Errorf("reading region at %d: %w", offset, err)
+	}
+	if sum := sha1.Sum(buf); !bytes.Equal(sum[:], want[:]) { //nolint:gosec
+		return nil, fmt.Errorf("hash mismatch (corrupt or unsupported format)")
+	}
+	return buf, nil
+}
+
+// Close releases the underlying file handle.
+func (r *Reader) Close() error { return r.f.Close() }
+
+// Files returns every file this pak's index describes.
+func (r *Reader) Files() []FileEntry {
+	out := make([]FileEntry, len(r.entries))
+	for i, e := range r.entries {
+		out[i] = e.FileEntry
+	}
+	return out
+}
+
+type footer struct {
+	version        int32
+	indexOffset    int64
+	indexSize      int64
+	indexHash      [20]byte
+	encryptedIndex bool
+}
+
+// readFooter parses the single 221-byte footer shape this package supports.
+// The footer is fixed-size and sits flush against EOF, so there is nothing to
+// search for and no alternate width to try: if Magic isn't where it must be,
+// this is not a pak we handle.
+func readFooter(r io.ReaderAt, fileSize int64) (footer, error) {
+	if fileSize < footerSize {
+		return footer{}, fmt.Errorf("%w: file of %d bytes is smaller than a %d-byte footer",
+			ErrUnsupportedFormat, fileSize, footerSize)
+	}
+	buf := make([]byte, footerSize)
+	if _, err := r.ReadAt(buf, fileSize-footerSize); err != nil {
+		return footer{}, fmt.Errorf("reading footer: %w", err)
+	}
+	// Layout: EncryptionKeyGuid(0:16) bEncryptedIndex(16) Magic(17:21)
+	// Version(21:25) IndexOffset(25:33) IndexSize(33:41) IndexHash(41:61)
+	// CompressionMethods(61:221).
+	if binary.LittleEndian.Uint32(buf[17:21]) != magic {
+		return footer{}, fmt.Errorf("%w: no pak magic at the expected footer offset", ErrUnsupportedFormat)
+	}
+	ft := footer{
+		encryptedIndex: buf[16] != 0,
+		version:        int32(binary.LittleEndian.Uint32(buf[21:25])),
+		indexOffset:    int64(binary.LittleEndian.Uint64(buf[25:33])),
+		indexSize:      int64(binary.LittleEndian.Uint64(buf[33:41])),
+	}
+	copy(ft.indexHash[:], buf[41:61])
+	if ft.version < minVersion {
+		return footer{}, fmt.Errorf("%w: pak version %d (this package requires >= %d)",
+			ErrUnsupportedFormat, ft.version, minVersion)
+	}
+	// The trailing CompressionMethods name table is intentionally left
+	// unparsed: entries carry a method *index*, and this package only ever
+	// reads payloads whose index is 0 (stored), which needs no name.
+	return ft, nil
+}
+
+// parseIndex parses the primary index, then the full directory index it points
+// at, resolving every path to its bit-packed entry record.
+//
+// Version-11 paks have no flat entry array. The primary index holds a blob of
+// bit-packed records plus SHA1-gated offsets to two sub-indexes: a path-hash
+// index (hash -> record offset) and a full directory index
+// (directory -> file -> record offset). Enumeration uses the directory index,
+// which is the only one that carries real path strings.
+func parseIndex(f io.ReaderAt, index []byte) ([]readerEntry, error) {
+	c := &cursor{b: index}
+	c.fstring() // MountPoint: recorded for the engine's benefit, unused here
+	numEntries := c.i32()
+	seed := c.u64()
+	_ = seed // only the writer needs the seed; enumeration goes via the directory index
+
+	pathHash, err := readSubIndexRef(c, "path hash index")
+	if err != nil {
+		return nil, err
+	}
+	fullDir, err := readSubIndexRef(c, "full directory index")
+	if err != nil {
+		return nil, err
+	}
+	encoded := c.bytes(int(c.i32())) // EncodedPakEntriesSize, then the blob
+	if nonEncoded := c.i32(); nonEncoded != 0 {
+		return nil, fmt.Errorf("%w: %d non-encoded index entries", ErrUnsupportedFormat, nonEncoded)
+	}
+	if c.err != nil {
+		return nil, fmt.Errorf("primary index: %w", c.err)
+	}
+
+	// Verify the path-hash index's hash even though enumeration does not use
+	// it: it is part of the format's integrity chain, and a pak whose
+	// sub-index hashes don't hold is not one to trust.
+	if _, err := readRegion(f, pathHash.offset, pathHash.size, pathHash.hash); err != nil {
+		return nil, fmt.Errorf("path hash index: %w", err)
+	}
+	dirBuf, err := readRegion(f, fullDir.offset, fullDir.size, fullDir.hash)
+	if err != nil {
+		return nil, fmt.Errorf("full directory index: %w", err)
+	}
+
+	entries, err := parseDirectoryIndex(dirBuf, encoded)
+	if err != nil {
+		return nil, err
+	}
+	if int32(len(entries)) != numEntries {
+		return nil, fmt.Errorf("directory index lists %d files, index header says %d",
+			len(entries), numEntries)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	return entries, nil
+}
+
+type subIndexRef struct {
+	offset, size int64
+	hash         [20]byte
+}
+
+// readSubIndexRef reads a `bHas<X>Index` flag and, when set, the offset/size/
+// hash triple that follows. Both sub-indexes are required: every pak version
+// this package accepts writes both, and a reader that limped along without the
+// directory index would have no paths to report.
+func readSubIndexRef(c *cursor, name string) (subIndexRef, error) {
+	if c.i32() == 0 {
+		return subIndexRef{}, fmt.Errorf("%w: pak has no %s", ErrUnsupportedFormat, name)
+	}
+	ref := subIndexRef{offset: c.i64(), size: c.i64()}
+	copy(ref.hash[:], c.bytes(20))
+	return ref, c.err
+}
+
+// parseDirectoryIndex walks directory -> file -> entry-location and decodes the
+// bit-packed record each location points at.
+func parseDirectoryIndex(dir, encoded []byte) ([]readerEntry, error) {
+	c := &cursor{b: dir}
+	dirCount := c.i32()
+	var entries []readerEntry
+	for i := int32(0); i < dirCount && c.err == nil; i++ {
+		dirName := c.fstring()
+		fileCount := c.i32()
+		for j := int32(0); j < fileCount && c.err == nil; j++ {
+			fileName := c.fstring()
+			loc := c.i32()
+			// Root-level files live under a "/" directory key, so the naive
+			// join yields a leading slash; the canonical mount-relative path
+			// (and the one hashPath consumes) has none.
+			full := strings.TrimPrefix(dirName+fileName, "/")
+			if loc < 0 {
+				// Negative locations index a non-encoded FPakEntry array. No
+				// pak in a real Icarus install uses them.
+				return nil, fmt.Errorf("entry %q: %w: non-encoded entry location", full, ErrUnsupportedFormat)
+			}
+			e, err := decodeEntry(encoded, int(loc))
+			if err != nil {
+				return nil, fmt.Errorf("entry %q: %w", full, err)
+			}
+			e.Path = full
+			entries = append(entries, e)
+		}
+	}
+	if c.err != nil {
+		return nil, fmt.Errorf("directory index: %w", c.err)
+	}
+	return entries, nil
+}
+
+// decodeEntry decodes one bit-packed FPakEntry from the encoded blob.
+//
+// The leading uint32 packs: bit31 offset-is-32-bit, bit30 uncompressed-size-
+// is-32-bit, bit29 size-is-32-bit, bits28-23 CompressionMethodIndex, bit22
+// encrypted, bits21-6 compression block count, bits5-0 CompressionBlockSize>>11
+// (0x3f = escape, an explicit uint32 follows). Fields then appear in this
+// order: [CompressionBlockSize] Offset, UncompressedSize, [Size], [block
+// sizes]. Size is omitted for stored entries (it equals UncompressedSize), and
+// the per-block size table is omitted for a lone unencrypted block.
+//
+// The block-size-before-Offset ordering is easy to get wrong; it was pinned
+// down empirically and this decoder reproduces all 173,078 records across a
+// real install exactly. See docs/plans/icarus-pak-format-findings.md.
+func decodeEntry(b []byte, at int) (readerEntry, error) {
+	c := &cursor{b: b, pos: at}
+	flags := c.u32()
+	var (
+		method     = int32((flags >> 23) & 0x3F)
+		blockCount = int((flags >> 6) & 0xFFFF)
+		encrypted  = flags&(1<<22) != 0
+	)
+	if flags&0x3F == 0x3F {
+		c.u32() // explicit CompressionBlockSize
+	}
+	read := func(is32 bool) int64 {
+		if is32 {
+			return int64(c.u32())
+		}
+		return int64(c.u64())
+	}
+	offset := read(flags&(1<<31) != 0)
+	uncompressed := read(flags&(1<<30) != 0)
+	if method != 0 {
+		read(flags&(1<<29) != 0) // Size on disk; unused, we refuse to read these payloads
+	}
+	if blockCount > 0 && (blockCount > 1 || encrypted) {
+		c.bytes(4 * blockCount)
+	}
+	if c.err != nil {
+		return readerEntry{}, fmt.Errorf("decoding entry at blob offset %d: %w", at, c.err)
+	}
+	if encrypted {
+		return readerEntry{}, fmt.Errorf("%w: encrypted entry", ErrUnsupportedFormat)
+	}
+	return readerEntry{
+		FileEntry: FileEntry{Size: uncompressed},
+		offset:    offset,
+		method:    method,
+	}, nil
+}
+
+// cursor is a bounds-checked little-endian cursor over an in-memory index
+// region. It latches the first error so parse code can read a whole structure
+// and check once, rather than wrapping every field.
+type cursor struct {
+	b   []byte
+	pos int
+	err error
+}
+
+func (c *cursor) take(n int) []byte {
+	if c.err != nil {
+		return make([]byte, n)
+	}
+	if n < 0 || c.pos+n > len(c.b) {
+		c.err = io.ErrUnexpectedEOF
+		return make([]byte, max(n, 0))
+	}
+	v := c.b[c.pos : c.pos+n]
+	c.pos += n
+	return v
+}
+
+func (c *cursor) bytes(n int) []byte { return c.take(n) }
+func (c *cursor) u32() uint32        { return binary.LittleEndian.Uint32(c.take(4)) }
+func (c *cursor) i32() int32         { return int32(c.u32()) }
+func (c *cursor) u64() uint64        { return binary.LittleEndian.Uint64(c.take(8)) }
+func (c *cursor) i64() int64         { return int64(c.u64()) }
+
+// fstring reads a length-prefixed Unreal FString. A negative length signals
+// UTF-16, which no pak in a real Icarus install uses and this package does not
+// decode.
+func (c *cursor) fstring() string {
+	n := c.i32()
+	if n == 0 || c.err != nil {
+		return ""
+	}
+	if n < 0 {
+		c.err = fmt.Errorf("%w: UTF-16 FString", ErrUnsupportedFormat)
+		return ""
+	}
+	return string(bytes.TrimRight(c.take(int(n)), "\x00"))
+}

--- a/internal/unrealpak/reader.go
+++ b/internal/unrealpak/reader.go
@@ -93,6 +93,51 @@ func (r *Reader) Files() []FileEntry {
 	return out
 }
 
+// ReadFile returns the bytes of the entry at mount-relative path.
+//
+// On-disk entry data is preceded by a full FPakEntry header — 53 bytes for a
+// stored entry (Offset, Size, UncompressedSize, CompressionMethodIndex, Hash,
+// Flags, CompressionBlockSize) — and the index's offset points at that header,
+// not the payload. The header is re-read and cross-checked rather than trusted:
+// its method and size must agree with the index, and its Hash must match the
+// payload's SHA1. Real paks satisfy all three (verified across a whole install),
+// so a disagreement means corruption or a layout this package misread.
+func (r *Reader) ReadFile(path string) ([]byte, error) {
+	for _, e := range r.entries {
+		if e.Path != path {
+			continue
+		}
+		// Compression is refused here rather than at index-parse time so that
+		// Files() can still enumerate real paks, most of whose entries are
+		// Oodle-compressed. No caller can obtain wrong bytes either way.
+		if e.method != 0 {
+			return nil, fmt.Errorf("unrealpak: %s: %w: compressed entry (method %d)",
+				path, ErrUnsupportedFormat, e.method)
+		}
+		hdr := make([]byte, storedHeaderSize)
+		if _, err := r.f.ReadAt(hdr, e.offset); err != nil {
+			return nil, fmt.Errorf("unrealpak: %s: reading entry header: %w", path, err)
+		}
+		if m := int32(binary.LittleEndian.Uint32(hdr[24:28])); m != 0 {
+			return nil, fmt.Errorf("unrealpak: %s: %w: compressed entry data (method %d)",
+				path, ErrUnsupportedFormat, m)
+		}
+		if size := int64(binary.LittleEndian.Uint64(hdr[8:16])); size != e.Size {
+			return nil, fmt.Errorf("unrealpak: %s: entry header size %d disagrees with index size %d",
+				path, size, e.Size)
+		}
+		buf := make([]byte, e.Size)
+		if _, err := r.f.ReadAt(buf, e.offset+storedHeaderSize); err != nil {
+			return nil, fmt.Errorf("unrealpak: reading %s: %w", path, err)
+		}
+		if sum := sha1.Sum(buf); !bytes.Equal(sum[:], hdr[28:48]) { //nolint:gosec
+			return nil, fmt.Errorf("unrealpak: %s: content hash mismatch", path)
+		}
+		return buf, nil
+	}
+	return nil, fmt.Errorf("unrealpak: %s: %w", path, os.ErrNotExist)
+}
+
 type footer struct {
 	version        int32
 	indexOffset    int64

--- a/internal/unrealpak/reader.go
+++ b/internal/unrealpak/reader.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"sort"
 	"strings"
@@ -66,14 +67,18 @@ func Open(path string) (*Reader, error) {
 }
 
 // validateAllocSize checks a length field read from pak data before it is
-// used to size a make([]byte, ...) allocation: it must be non-negative and
+// used to size a make([]byte, ...) allocation: it must be non-negative,
 // cannot exceed the pak file's own size — no genuine region or payload can be
-// larger than the file that contains it. A field outside that range is
-// corruption or a layout this package doesn't understand, never something to
-// allocate for (a 64-bit size field with its top bit set becomes negative
-// once cast to int64, which is exactly the case this exists to catch).
+// larger than the file that contains it — and cannot exceed math.MaxInt,
+// since the caller immediately casts the result to int (a no-op check on a
+// 64-bit build, where int is 64 bits, but load-bearing on a 32-bit one,
+// where a size that passed the fileSize check could still overflow int and
+// wrap negative on the cast). A field outside that range is corruption or a
+// layout this package doesn't understand, never something to allocate for (a
+// 64-bit size field with its top bit set becomes negative once cast to
+// int64, which is exactly the case the negative check exists to catch).
 func validateAllocSize(size, fileSize int64) (int, error) {
-	if size < 0 || size > fileSize {
+	if size < 0 || size > fileSize || size > math.MaxInt {
 		return 0, fmt.Errorf("%w: size field %d is invalid for a %d-byte pak", ErrUnsupportedFormat, size, fileSize)
 	}
 	return int(size), nil

--- a/internal/unrealpak/reader.go
+++ b/internal/unrealpak/reader.go
@@ -13,8 +13,9 @@ import (
 
 // Reader provides read access to an uncompressed, unencrypted UE4-range pak.
 type Reader struct {
-	f       *os.File
-	entries []readerEntry
+	f        *os.File
+	entries  []readerEntry
+	fileSize int64 // total size of the underlying file, for validateAllocSize
 }
 
 type readerEntry struct {
@@ -37,7 +38,9 @@ func Open(path string) (*Reader, error) {
 		return nil, fmt.Errorf("unrealpak: stat %s: %w", path, err)
 	}
 
-	ft, err := readFooter(f, info.Size())
+	fileSize := info.Size()
+
+	ft, err := readFooter(f, fileSize)
 	if err != nil {
 		f.Close() //nolint:errcheck
 		return nil, err
@@ -47,19 +50,33 @@ func Open(path string) (*Reader, error) {
 		return nil, fmt.Errorf("unrealpak: %s: %w: encrypted index", path, ErrUnsupportedFormat)
 	}
 
-	indexBuf, err := readRegion(f, ft.indexOffset, ft.indexSize, ft.indexHash)
+	indexBuf, err := readRegion(f, ft.indexOffset, ft.indexSize, fileSize, ft.indexHash)
 	if err != nil {
 		f.Close() //nolint:errcheck
 		return nil, fmt.Errorf("unrealpak: %s: primary index: %w", path, err)
 	}
 
-	entries, err := parseIndex(f, indexBuf)
+	entries, err := parseIndex(f, indexBuf, fileSize)
 	if err != nil {
 		f.Close() //nolint:errcheck
 		return nil, fmt.Errorf("unrealpak: %s: parsing index: %w", path, err)
 	}
 
-	return &Reader{f: f, entries: entries}, nil
+	return &Reader{f: f, entries: entries, fileSize: fileSize}, nil
+}
+
+// validateAllocSize checks a length field read from pak data before it is
+// used to size a make([]byte, ...) allocation: it must be non-negative and
+// cannot exceed the pak file's own size — no genuine region or payload can be
+// larger than the file that contains it. A field outside that range is
+// corruption or a layout this package doesn't understand, never something to
+// allocate for (a 64-bit size field with its top bit set becomes negative
+// once cast to int64, which is exactly the case this exists to catch).
+func validateAllocSize(size, fileSize int64) (int, error) {
+	if size < 0 || size > fileSize {
+		return 0, fmt.Errorf("%w: size field %d is invalid for a %d-byte pak", ErrUnsupportedFormat, size, fileSize)
+	}
+	return int(size), nil
 }
 
 // readRegion reads size bytes at offset and verifies them against want. Every
@@ -67,11 +84,15 @@ func Open(path string) (*Reader, error) {
 // primary index, and the primary index covers each sub-index. All three gates
 // are enforced — a mismatch is corruption or an unrecognized layout, never
 // something to parse through.
-func readRegion(r io.ReaderAt, offset, size int64, want [20]byte) ([]byte, error) {
-	if offset < 0 || size < 0 {
-		return nil, fmt.Errorf("%w: negative region offset/size", ErrUnsupportedFormat)
+func readRegion(r io.ReaderAt, offset, size, fileSize int64, want [20]byte) ([]byte, error) {
+	if offset < 0 {
+		return nil, fmt.Errorf("%w: negative region offset", ErrUnsupportedFormat)
 	}
-	buf := make([]byte, size)
+	n, err := validateAllocSize(size, fileSize)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, n)
 	if _, err := r.ReadAt(buf, offset); err != nil {
 		return nil, fmt.Errorf("reading region at %d: %w", offset, err)
 	}
@@ -126,7 +147,11 @@ func (r *Reader) ReadFile(path string) ([]byte, error) {
 			return nil, fmt.Errorf("unrealpak: %s: entry header size %d disagrees with index size %d",
 				path, size, e.Size)
 		}
-		buf := make([]byte, e.Size)
+		n, err := validateAllocSize(e.Size, r.fileSize)
+		if err != nil {
+			return nil, fmt.Errorf("unrealpak: %s: %w", path, err)
+		}
+		buf := make([]byte, n)
 		if _, err := r.f.ReadAt(buf, e.offset+storedHeaderSize); err != nil {
 			return nil, fmt.Errorf("unrealpak: reading %s: %w", path, err)
 		}
@@ -190,7 +215,7 @@ func readFooter(r io.ReaderAt, fileSize int64) (footer, error) {
 // index (hash -> record offset) and a full directory index
 // (directory -> file -> record offset). Enumeration uses the directory index,
 // which is the only one that carries real path strings.
-func parseIndex(f io.ReaderAt, index []byte) ([]readerEntry, error) {
+func parseIndex(f io.ReaderAt, index []byte, fileSize int64) ([]readerEntry, error) {
 	c := &cursor{b: index}
 	c.fstring() // MountPoint: recorded for the engine's benefit, unused here
 	numEntries := c.i32()
@@ -216,10 +241,10 @@ func parseIndex(f io.ReaderAt, index []byte) ([]readerEntry, error) {
 	// Verify the path-hash index's hash even though enumeration does not use
 	// it: it is part of the format's integrity chain, and a pak whose
 	// sub-index hashes don't hold is not one to trust.
-	if _, err := readRegion(f, pathHash.offset, pathHash.size, pathHash.hash); err != nil {
+	if _, err := readRegion(f, pathHash.offset, pathHash.size, fileSize, pathHash.hash); err != nil {
 		return nil, fmt.Errorf("path hash index: %w", err)
 	}
-	dirBuf, err := readRegion(f, fullDir.offset, fullDir.size, fullDir.hash)
+	dirBuf, err := readRegion(f, fullDir.offset, fullDir.size, fileSize, fullDir.hash)
 	if err != nil {
 		return nil, fmt.Errorf("full directory index: %w", err)
 	}
@@ -351,7 +376,10 @@ type cursor struct {
 
 func (c *cursor) take(n int) []byte {
 	if c.err != nil {
-		return make([]byte, n)
+		// A corrupted length field can make n negative even on this
+		// already-failed path; make([]byte, negative) panics, so clamp here
+		// too rather than only on the fresh-error branch below.
+		return make([]byte, max(n, 0))
 	}
 	if n < 0 || c.pos+n > len(c.b) {
 		c.err = io.ErrUnexpectedEOF

--- a/internal/unrealpak/reader_test.go
+++ b/internal/unrealpak/reader_test.go
@@ -1,0 +1,189 @@
+package unrealpak
+
+import (
+	"bytes"
+	"crypto/sha1" //nolint:gosec // pak format uses SHA1, not our choice
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fixtureSeed is an arbitrary PathHashSeed for fixture paks. Readers take the
+// seed from the index, so any value works — real paks use a different one per
+// chunk.
+const fixtureSeed uint64 = 0x0123456789ABCDEF
+
+// writeMinimalPak builds a hand-crafted but fully valid version-11 pak holding
+// a single stored entry: data section, primary index, path-hash index, full
+// directory index, then the 221-byte footer. It deliberately does not use the
+// Task 4 Writer — the reader's tests must be able to fail independently of the
+// writer, and vice versa.
+func writeMinimalPak(t *testing.T, mountPath string, content []byte) string {
+	t.Helper()
+	return writeMinimalPakMethod(t, mountPath, content, 0)
+}
+
+// writeMinimalPakMethod builds a fixture whose entry claims CompressionMethodIndex
+// method. Only method 0 produces a genuinely readable pak; non-zero values exist
+// to exercise the reader's refusal path (Task 3), which is the case that matters
+// in practice — 74% of real Icarus entries are Oodle-compressed.
+func writeMinimalPakMethod(t *testing.T, mountPath string, content []byte, method int32) string {
+	t.Helper()
+	pakPath := filepath.Join(t.TempDir(), "test.pak")
+	if err := os.WriteFile(pakPath, buildFixturePak(mountPath, content, method), 0o644); err != nil {
+		t.Fatalf("writing test pak: %v", err)
+	}
+	return pakPath
+}
+
+func buildFixturePak(mountPath string, content []byte, method int32) []byte {
+	rel := strings.TrimPrefix(mountPath, "/")
+
+	// Data section: the 53-byte per-entry header, then the payload, at offset 0.
+	var data bytes.Buffer
+	hdr := storedEntryHeader(int64(len(content)), content)
+	binary.LittleEndian.PutUint32(hdr[24:28], uint32(method)) // CompressionMethodIndex
+	data.Write(hdr)
+	data.Write(content)
+
+	// One encoded index record. For method 0 that is the 12-byte stored shape:
+	// flags 0xE0000000 (offset/uncompressed-size/size all 32-bit-safe, no
+	// blocks), then uint32 Offset and uint32 UncompressedSize — Size is not
+	// serialized for method 0, it equals UncompressedSize. A non-zero method
+	// adds the uint32 Size field, per the encoded-record layout.
+	var encoded bytes.Buffer
+	binary.Write(&encoded, binary.LittleEndian, uint32(0xE0000000)|uint32(method)<<23) //nolint:errcheck
+	binary.Write(&encoded, binary.LittleEndian, uint32(0))                             //nolint:errcheck
+	binary.Write(&encoded, binary.LittleEndian, uint32(len(content)))                  //nolint:errcheck
+	if method != 0 {
+		binary.Write(&encoded, binary.LittleEndian, uint32(len(content))) //nolint:errcheck // Size
+	}
+
+	// Full directory index: one directory, one file, pointing at blob offset 0.
+	dirName, fileName := splitMountPath(rel)
+	var fdi bytes.Buffer
+	binary.Write(&fdi, binary.LittleEndian, int32(1)) //nolint:errcheck // DirCount
+	writeFString(&fdi, dirName)
+	binary.Write(&fdi, binary.LittleEndian, int32(1)) //nolint:errcheck // FileCount
+	writeFString(&fdi, fileName)
+	binary.Write(&fdi, binary.LittleEndian, int32(0)) //nolint:errcheck // PakEntryLocation
+
+	// Path-hash index: the hash->location map, then an EMPTY pruned directory
+	// index. 33 of the 34 paks in a real install ship it empty, so a bare
+	// int32(0) is a shape the engine demonstrably accepts.
+	var phi bytes.Buffer
+	binary.Write(&phi, binary.LittleEndian, int32(1))                   //nolint:errcheck // Count
+	binary.Write(&phi, binary.LittleEndian, hashPath(rel, fixtureSeed)) //nolint:errcheck
+	binary.Write(&phi, binary.LittleEndian, int32(0))                   //nolint:errcheck // location
+	binary.Write(&phi, binary.LittleEndian, int32(0))                   //nolint:errcheck // pruned index: 0 dirs
+
+	phiHash := sha1.Sum(phi.Bytes()) //nolint:gosec
+	fdiHash := sha1.Sum(fdi.Bytes()) //nolint:gosec
+
+	indexOffset := int64(data.Len())
+	sizing := buildPrimaryIndex(1, fixtureSeed, 0, 0, phiHash, 0, 0, fdiHash, encoded.Bytes())
+	phiOffset := indexOffset + int64(len(sizing))
+	fdiOffset := phiOffset + int64(phi.Len())
+	index := buildPrimaryIndex(1, fixtureSeed,
+		phiOffset, int64(phi.Len()), phiHash,
+		fdiOffset, int64(fdi.Len()), fdiHash, encoded.Bytes())
+	indexHash := sha1.Sum(index) //nolint:gosec
+
+	var out bytes.Buffer
+	out.Write(data.Bytes())
+	out.Write(index)
+	out.Write(phi.Bytes())
+	out.Write(fdi.Bytes())
+	out.Write(buildFooter(writeVersion, indexOffset, int64(len(index)), indexHash))
+	return out.Bytes()
+}
+
+func TestReader_Open_ListsFiles(t *testing.T) {
+	content := []byte(`{"hello":"world"}`)
+	path := writeMinimalPak(t, "Icarus/Content/Data/Test.json", content)
+
+	r, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer r.Close()
+
+	files := r.Files()
+	if len(files) != 1 {
+		t.Fatalf("got %d files, want 1", len(files))
+	}
+	if files[0].Path != "Icarus/Content/Data/Test.json" {
+		t.Errorf("Path = %q, want Icarus/Content/Data/Test.json", files[0].Path)
+	}
+	if files[0].Size != int64(len(content)) {
+		t.Errorf("Size = %d, want %d", files[0].Size, len(content))
+	}
+}
+
+// A root-level file is keyed under the "/" directory in the directory index;
+// Files must report it without the leading slash, matching what hashPath uses.
+func TestReader_Open_RootLevelFile(t *testing.T) {
+	path := writeMinimalPak(t, "x.json", []byte("{}"))
+	r, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer r.Close()
+
+	files := r.Files()
+	if len(files) != 1 || files[0].Path != "x.json" {
+		t.Fatalf("Files() = %+v, want one entry with Path %q", files, "x.json")
+	}
+}
+
+func TestReader_Open_RejectsEncryptedIndex(t *testing.T) {
+	path := writeMinimalPak(t, "x.json", []byte("{}"))
+	data, _ := os.ReadFile(path)
+	// bEncryptedIndex sits at offset 16 from footer start — right after the
+	// 16-byte EncryptionKeyGuid, immediately before Magic.
+	data[len(data)-footerSize+16] = 1
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Open(path)
+	if !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("Open error = %v, want ErrUnsupportedFormat", err)
+	}
+}
+
+// Versions below 10 use a flat index this package deliberately does not parse:
+// a hard error, never a fallback.
+func TestReader_Open_RejectsPreVersion10(t *testing.T) {
+	path := writeMinimalPak(t, "x.json", []byte("{}"))
+	data, _ := os.ReadFile(path)
+	// Version is the int32 at footer offset 21 (after Guid+flag+Magic).
+	binary.LittleEndian.PutUint32(data[len(data)-footerSize+21:], uint32(9))
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Open(path)
+	if !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("Open error = %v, want ErrUnsupportedFormat", err)
+	}
+}
+
+// Corruption anywhere in the index must trip a SHA1 gate rather than be
+// parsed. The full directory index is the last region before the footer, so
+// flipping the byte just before it exercises the primary->sub-index gate.
+func TestReader_Open_RejectsCorruptedDirectoryIndex(t *testing.T) {
+	path := writeMinimalPak(t, "x.json", []byte("{}"))
+	data, _ := os.ReadFile(path)
+	data[len(data)-footerSize-1] ^= 0xFF
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Open(path); err == nil {
+		t.Fatal("expected error for corrupted directory index, got nil")
+	}
+}

--- a/internal/unrealpak/reader_test.go
+++ b/internal/unrealpak/reader_test.go
@@ -229,3 +229,120 @@ func TestReader_ReadFile_RejectsCompressedEntry(t *testing.T) {
 		t.Fatalf("ReadFile error = %v, want ErrUnsupportedFormat", err)
 	}
 }
+
+func TestValidateAllocSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		size     int64
+		fileSize int64
+		wantErr  bool
+		want     int
+	}{
+		{"valid, well within file", 10, 1000, false, 10},
+		{"valid, exactly file size", 1000, 1000, false, 1000},
+		{"negative (e.g. a 64-bit field with its top bit set, cast to int64)", -1, 1000, true, 0},
+		{"exceeds file size", 1001, 1000, true, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateAllocSize(tt.size, tt.fileSize)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("validateAllocSize(%d, %d) = %d, nil; want error", tt.size, tt.fileSize, got)
+				}
+				if !errors.Is(err, ErrUnsupportedFormat) {
+					t.Errorf("error = %v, want ErrUnsupportedFormat", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateAllocSize(%d, %d): %v", tt.size, tt.fileSize, err)
+			}
+			if got != tt.want {
+				t.Errorf("validateAllocSize(%d, %d) = %d, want %d", tt.size, tt.fileSize, got, tt.want)
+			}
+		})
+	}
+}
+
+// readRegion must reject an invalid size (or offset) before ever attempting
+// to read — a corrupted size field must not drive an unbounded allocation or
+// even a spurious I/O attempt. panicReaderAt fails the test if readRegion
+// reaches the ReadAt call at all.
+type readerAtFunc func([]byte, int64) (int, error)
+
+func (f readerAtFunc) ReadAt(p []byte, off int64) (int, error) { return f(p, off) }
+
+func TestReadRegion_RejectsInvalidSizeOrOffsetBeforeReading(t *testing.T) {
+	panicReader := readerAtFunc(func(p []byte, off int64) (int, error) {
+		panic("readRegion must not read when offset/size is invalid")
+	})
+	var want [20]byte
+
+	if _, err := readRegion(panicReader, 0, -1, 1000, want); !errors.Is(err, ErrUnsupportedFormat) {
+		t.Errorf("negative size: error = %v, want ErrUnsupportedFormat", err)
+	}
+	if _, err := readRegion(panicReader, 0, 2000, 1000, want); !errors.Is(err, ErrUnsupportedFormat) {
+		t.Errorf("oversized size: error = %v, want ErrUnsupportedFormat", err)
+	}
+	if _, err := readRegion(panicReader, -1, 10, 1000, want); !errors.Is(err, ErrUnsupportedFormat) {
+		t.Errorf("negative offset: error = %v, want ErrUnsupportedFormat", err)
+	}
+}
+
+// ReadFile must reject a corrupted entry-size field before allocating the
+// payload buffer, whether the corruption makes the field negative (a 64-bit
+// UncompressedSize with its top bit set, cast to int64) or merely larger
+// than the file that supposedly contains it. Constructed directly against a
+// Reader/readerEntry rather than through a full on-disk fixture: the
+// interesting case is an internally-consistent header+index pair that still
+// disagrees with reality, not a hash-gated corruption (which a different,
+// already-tested path already catches).
+func TestReader_ReadFile_RejectsInvalidSizeField(t *testing.T) {
+	tests := []struct {
+		name     string
+		size     int64
+		fileSize int64
+	}{
+		{"negative size", -1, 1000},
+		{"size exceeding the file it's claimed to live in", 1 << 40, 1000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hdr := storedEntryHeader(tt.size, []byte("irrelevant")) // payload is never read: the guard fires first
+			pakPath := filepath.Join(t.TempDir(), "test.pak")
+			if err := os.WriteFile(pakPath, hdr, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			f, err := os.Open(pakPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close() //nolint:errcheck
+
+			r := &Reader{
+				f:        f,
+				fileSize: tt.fileSize,
+				entries: []readerEntry{
+					{FileEntry: FileEntry{Path: "x.json", Size: tt.size}, offset: 0, method: 0},
+				},
+			}
+
+			if _, err := r.ReadFile("x.json"); !errors.Is(err, ErrUnsupportedFormat) {
+				t.Fatalf("ReadFile error = %v, want ErrUnsupportedFormat", err)
+			}
+		})
+	}
+}
+
+// A cursor that has already latched an error must not panic when asked to
+// take a negative length (reachable via a corrupted length field parsed
+// earlier in the same structure, e.g. fstring's negative-length check
+// latches c.err and later cursor calls in the same parse can still run).
+func TestCursor_Take_ClampsNegativeLengthOnErrLatchedPath(t *testing.T) {
+	c := &cursor{b: []byte{1, 2, 3}, err: errors.New("boom")}
+	got := c.take(-5) // must not panic
+	if len(got) != 0 {
+		t.Errorf("take(-5) on an err-latched cursor = %v, want empty", got)
+	}
+}

--- a/internal/unrealpak/reader_test.go
+++ b/internal/unrealpak/reader_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1" //nolint:gosec // pak format uses SHA1, not our choice
 	"encoding/binary"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -242,6 +243,15 @@ func TestValidateAllocSize(t *testing.T) {
 		{"valid, exactly file size", 1000, 1000, false, 1000},
 		{"negative (e.g. a 64-bit field with its top bit set, cast to int64)", -1, 1000, true, 0},
 		{"exceeds file size", 1001, 1000, true, 0},
+		// math.MaxInt itself must still be accepted (inclusive boundary, not
+		// an off-by-one) -- guards the int(size) cast that follows against
+		// overflow on a 32-bit build, where int is narrower than int64. On a
+		// 64-bit build (this test's normal target) math.MaxInt == MaxInt64,
+		// so size can never actually exceed it: size is itself int64, and
+		// there is no larger int64 value to construct a "just past the
+		// boundary" case with. The check is a genuine no-op here and only
+		// load-bearing on 32-bit -- see validateAllocSize's doc comment.
+		{"exactly math.MaxInt is still valid (boundary, not exceeded)", math.MaxInt, math.MaxInt, false, math.MaxInt},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/unrealpak/reader_test.go
+++ b/internal/unrealpak/reader_test.go
@@ -187,3 +187,45 @@ func TestReader_Open_RejectsCorruptedDirectoryIndex(t *testing.T) {
 		t.Fatal("expected error for corrupted directory index, got nil")
 	}
 }
+
+func TestReader_ReadFile(t *testing.T) {
+	content := []byte(`{"hello":"world"}`)
+	path := writeMinimalPak(t, "Icarus/Content/Data/Test.json", content)
+
+	r, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer r.Close()
+
+	got, err := r.ReadFile("Icarus/Content/Data/Test.json")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("got %q, want %q", got, content)
+	}
+
+	if _, err := r.ReadFile("does/not/exist.json"); err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestReader_ReadFile_RejectsCompressedEntry(t *testing.T) {
+	const name = "Items/D_ItemsStatic.json"
+	path := writeMinimalPakMethod(t, name, []byte(`{"a":1}`), 1) // 1 = Oodle
+
+	r, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer r.Close()
+
+	// Enumeration must still work — the reader lists compressed entries.
+	if files := r.Files(); len(files) != 1 || files[0].Path != name {
+		t.Fatalf("Files() = %+v, want one entry named %q", files, name)
+	}
+	if _, err := r.ReadFile(name); !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("ReadFile error = %v, want ErrUnsupportedFormat", err)
+	}
+}

--- a/internal/unrealpak/reader_test.go
+++ b/internal/unrealpak/reader_test.go
@@ -109,7 +109,7 @@ func TestReader_Open_ListsFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 
 	files := r.Files()
 	if len(files) != 1 {
@@ -131,7 +131,7 @@ func TestReader_Open_RootLevelFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 
 	files := r.Files()
 	if len(files) != 1 || files[0].Path != "x.json" {
@@ -196,7 +196,7 @@ func TestReader_ReadFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 
 	got, err := r.ReadFile("Icarus/Content/Data/Test.json")
 	if err != nil {
@@ -219,7 +219,7 @@ func TestReader_ReadFile_RejectsCompressedEntry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 
 	// Enumeration must still work — the reader lists compressed entries.
 	if files := r.Files(); len(files) != 1 || files[0].Path != name {

--- a/internal/unrealpak/roundtrip_test.go
+++ b/internal/unrealpak/roundtrip_test.go
@@ -33,7 +33,7 @@ func TestRoundTrip_WriteThenRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 
 	got := r.Files()
 	if len(got) != len(files) {

--- a/internal/unrealpak/roundtrip_test.go
+++ b/internal/unrealpak/roundtrip_test.go
@@ -1,0 +1,100 @@
+package unrealpak
+
+import (
+	"crypto/sha1" //nolint:gosec // pak format uses SHA1, not our choice
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRoundTrip_WriteThenRead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "roundtrip.pak")
+	files := map[string][]byte{
+		"Icarus/Content/Data/AI-D_AIGrowth.json": []byte(`{"Mount_Bear":{"BaseMovementSpeed":235}}`),
+		"Icarus/Content/Data/Other.json":         []byte(`{"foo":"bar"}`),
+		"DataTableMetadata.json":                 []byte(`{"root":true}`), // root-level: "/" directory key
+	}
+
+	w, err := Create(path)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for name, data := range files {
+		if err := w.AddFile(name, data); err != nil {
+			t.Fatalf("AddFile(%s): %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	r, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer r.Close()
+
+	got := r.Files()
+	if len(got) != len(files) {
+		t.Fatalf("got %d files, want %d", len(got), len(files))
+	}
+	for name, want := range files {
+		data, err := r.ReadFile(name)
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", name, err)
+		}
+		if string(data) != string(want) {
+			t.Errorf("ReadFile(%s) = %q, want %q", name, data, want)
+		}
+	}
+}
+
+// Structural assertions on the bytes themselves. Open() proves the Reader
+// accepts what the Writer emits, but the Reader is not the audience that
+// matters most — Icarus's engine is. These check the properties every real pak
+// exhibits, so a drift away from the engine-proven shape fails here rather than
+// silently in-game.
+func TestRoundTrip_StructuralShape(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "shape.pak")
+	w, err := Create(path)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	content := []byte(`{"a":1}`)
+	if err := w.AddFile("Icarus/Content/Data/Test.json", content); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	ft := data[len(data)-footerSize:]
+	indexOffset := int64(binary.LittleEndian.Uint64(ft[25:33]))
+	indexSize := int64(binary.LittleEndian.Uint64(ft[33:41]))
+
+	// The footer's SHA1 must cover the primary index exactly.
+	indexSum := sha1.Sum(data[indexOffset : indexOffset+indexSize]) //nolint:gosec
+	if string(indexSum[:]) != string(ft[41:61]) {
+		t.Error("footer IndexHash does not match the primary index bytes")
+	}
+
+	// The data section holds one 53-byte header plus the payload, and the
+	// index starts immediately after it — regions tile with no gap.
+	if want := int64(storedHeaderSize + len(content)); indexOffset != want {
+		t.Errorf("index starts at %d, want %d (53-byte header + %d-byte payload)",
+			indexOffset, want, len(content))
+	}
+	// The per-entry header's Hash field must be the payload's SHA1.
+	if sum := sha1.Sum(content); string(sum[:]) != string(data[28:48]) { //nolint:gosec
+		t.Error("per-entry header Hash does not match the payload SHA1")
+	}
+	// Its Offset field is zero, as in every real pak.
+	if got := binary.LittleEndian.Uint64(data[0:8]); got != 0 {
+		t.Errorf("per-entry header Offset = %d, want 0", got)
+	}
+}

--- a/internal/unrealpak/writer.go
+++ b/internal/unrealpak/writer.go
@@ -1,0 +1,162 @@
+package unrealpak
+
+import (
+	"bytes"
+	"crypto/sha1" //nolint:gosec // pak format uses SHA1, not our choice
+	"encoding/binary"
+	"fmt"
+	"math"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// writerSeed is the PathHashSeed stamped into written paks. Any value works —
+// readers take the seed from the index, and real paks use a different one per
+// chunk — but a fixed one keeps output deterministic.
+const writerSeed uint64 = 0x9E3779B97F4A7C15
+
+// Writer produces a stored (uncompressed), unencrypted version-11 pak carrying
+// the full three-part index: primary index, path-hash index and full directory
+// index, then the 221-byte footer.
+//
+// AddFile buffers content in memory and Close emits everything sorted by path,
+// so identical inputs produce byte-identical output regardless of AddFile call
+// order. Mod paks are small — Icarus's entire base data.pak is 2.4 MB — so
+// buffering costs little, and deterministic output is worth more: it makes the
+// round-trip test able to assert on bytes and keeps compiled paks stable across
+// recompiles.
+type Writer struct {
+	f      *os.File
+	closed bool
+	files  []writerFile
+	seen   map[string]bool
+}
+
+type writerFile struct {
+	path string
+	data []byte
+}
+
+// Create opens path for writing. Call AddFile for each entry, then Close.
+func Create(path string) (*Writer, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("unrealpak: creating %s: %w", path, err)
+	}
+	return &Writer{f: f, seen: make(map[string]bool)}, nil
+}
+
+// AddFile records one entry. Nothing reaches disk until Close.
+func (w *Writer) AddFile(mountPath string, data []byte) error {
+	if w.closed {
+		return fmt.Errorf("unrealpak: AddFile on closed writer")
+	}
+	// Root-level files are keyed under "/" in the directory index, but the
+	// canonical path — and the one hashPath consumes — carries no leading slash.
+	rel := strings.TrimPrefix(mountPath, "/")
+	if rel == "" {
+		return fmt.Errorf("unrealpak: AddFile: empty mount path")
+	}
+	if w.seen[rel] {
+		return fmt.Errorf("unrealpak: AddFile: duplicate path %q", rel)
+	}
+	w.seen[rel] = true
+	w.files = append(w.files, writerFile{path: rel, data: slices.Clone(data)})
+	return nil
+}
+
+// Close assembles the data section and all three index structures, writes them
+// with the footer, and closes the file.
+func (w *Writer) Close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+
+	sort.Slice(w.files, func(i, j int) bool { return w.files[i].path < w.files[j].path })
+
+	// Data section and encoded index records, in one pass. Each payload is
+	// preceded by its 53-byte header; entries are packed with no padding.
+	var data, encoded bytes.Buffer
+	locations := make(map[string]int32, len(w.files))
+	for _, file := range w.files {
+		offset, size := int64(data.Len()), int64(len(file.data))
+		if offset > math.MaxUint32 || size > math.MaxUint32 {
+			w.f.Close() //nolint:errcheck
+			return fmt.Errorf("unrealpak: %s: offset/size exceeds the 32-bit encoded-entry form this writer emits", file.path)
+		}
+		data.Write(storedEntryHeader(size, file.data))
+		data.Write(file.data)
+
+		locations[file.path] = int32(encoded.Len())
+		// The 12-byte stored record: offset/uncompressed-size/size all
+		// 32-bit-safe, method 0, no compression blocks.
+		binary.Write(&encoded, binary.LittleEndian, uint32(0xE0000000)) //nolint:errcheck
+		binary.Write(&encoded, binary.LittleEndian, uint32(offset))     //nolint:errcheck
+		binary.Write(&encoded, binary.LittleEndian, uint32(size))       //nolint:errcheck
+	}
+
+	// Full directory index: directory -> file -> encoded-record location.
+	byDir := make(map[string][]string)
+	for _, file := range w.files {
+		dir, name := splitMountPath(file.path)
+		byDir[dir] = append(byDir[dir], name)
+	}
+	dirNames := make([]string, 0, len(byDir))
+	for dir := range byDir {
+		dirNames = append(dirNames, dir)
+	}
+	sort.Strings(dirNames)
+
+	var fdi bytes.Buffer
+	binary.Write(&fdi, binary.LittleEndian, int32(len(dirNames))) //nolint:errcheck
+	for _, dir := range dirNames {
+		writeFString(&fdi, dir)
+		names := byDir[dir]
+		sort.Strings(names)
+		binary.Write(&fdi, binary.LittleEndian, int32(len(names))) //nolint:errcheck
+		for _, name := range names {
+			writeFString(&fdi, name)
+			binary.Write(&fdi, binary.LittleEndian, locations[strings.TrimPrefix(dir+name, "/")]) //nolint:errcheck
+		}
+	}
+
+	// Path-hash index, then an empty pruned directory index.
+	var phi bytes.Buffer
+	binary.Write(&phi, binary.LittleEndian, int32(len(w.files))) //nolint:errcheck
+	for _, file := range w.files {
+		binary.Write(&phi, binary.LittleEndian, hashPath(file.path, writerSeed)) //nolint:errcheck
+		binary.Write(&phi, binary.LittleEndian, locations[file.path])            //nolint:errcheck
+	}
+	binary.Write(&phi, binary.LittleEndian, int32(0)) //nolint:errcheck // pruned index: 0 directories
+
+	// The primary index records absolute offsets of the two sub-indexes that
+	// follow it; its own length is independent of those values, so measure it
+	// with zeros first, then rebuild with the real offsets.
+	phiHash := sha1.Sum(phi.Bytes()) //nolint:gosec
+	fdiHash := sha1.Sum(fdi.Bytes()) //nolint:gosec
+	count := int32(len(w.files))
+	indexOffset := int64(data.Len())
+	sizing := buildPrimaryIndex(count, writerSeed, 0, 0, phiHash, 0, 0, fdiHash, encoded.Bytes())
+	phiOffset := indexOffset + int64(len(sizing))
+	fdiOffset := phiOffset + int64(phi.Len())
+	index := buildPrimaryIndex(count, writerSeed,
+		phiOffset, int64(phi.Len()), phiHash,
+		fdiOffset, int64(fdi.Len()), fdiHash, encoded.Bytes())
+	indexHash := sha1.Sum(index) //nolint:gosec
+
+	// Regions tile the file exactly, as they do in every real pak:
+	// data | primary index | path-hash index | full directory index | footer.
+	for _, chunk := range [][]byte{
+		data.Bytes(), index, phi.Bytes(), fdi.Bytes(),
+		buildFooter(writeVersion, indexOffset, int64(len(index)), indexHash),
+	} {
+		if _, err := w.f.Write(chunk); err != nil {
+			w.f.Close() //nolint:errcheck
+			return fmt.Errorf("unrealpak: writing pak: %w", err)
+		}
+	}
+	return w.f.Close()
+}

--- a/internal/unrealpak/writer.go
+++ b/internal/unrealpak/writer.go
@@ -67,6 +67,20 @@ func (w *Writer) AddFile(mountPath string, data []byte) error {
 	return nil
 }
 
+// checkEncodedLocationFits validates that encodedLen — the offset the next
+// entry's record is about to be stored at within the encoded index blob —
+// still fits the int32 location field the format stores in the path-hash and
+// full directory indexes. Extracted from Close so the boundary can be tested
+// without constructing a >2 GiB fixture: encoded.Len() growing past
+// math.MaxInt32 would otherwise silently wrap (even go negative) when cast to
+// int32, corrupting every location recorded from that point on.
+func checkEncodedLocationFits(encodedLen int) error {
+	if encodedLen > math.MaxInt32 {
+		return fmt.Errorf("encoded index exceeds the 32-bit location field this writer emits (%d bytes)", encodedLen)
+	}
+	return nil
+}
+
 // Close assembles the data section and all three index structures, writes them
 // with the footer, and closes the file.
 func (w *Writer) Close() error {
@@ -90,6 +104,10 @@ func (w *Writer) Close() error {
 		data.Write(storedEntryHeader(size, file.data))
 		data.Write(file.data)
 
+		if err := checkEncodedLocationFits(encoded.Len()); err != nil {
+			w.f.Close() //nolint:errcheck
+			return fmt.Errorf("unrealpak: %s: %w", file.path, err)
+		}
 		locations[file.path] = int32(encoded.Len())
 		// The 12-byte stored record: offset/uncompressed-size/size all
 		// 32-bit-safe, method 0, no compression blocks.

--- a/internal/unrealpak/writer_test.go
+++ b/internal/unrealpak/writer_test.go
@@ -1,0 +1,100 @@
+package unrealpak
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriter_CreateAndClose_ProducesValidFooter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.pak")
+	w, err := Create(path)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := w.AddFile("Icarus/Content/Data/Test.json", []byte(`{"a":1}`)); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if len(data) <= footerSize {
+		t.Fatalf("output is %d bytes, want more than a bare %d-byte footer", len(data), footerSize)
+	}
+	ft := data[len(data)-footerSize:]
+	if got := binary.LittleEndian.Uint32(ft[17:21]); got != magic {
+		t.Errorf("footer magic = %#x, want %#x", got, magic)
+	}
+	if got := int32(binary.LittleEndian.Uint32(ft[21:25])); got != writeVersion {
+		t.Errorf("footer version = %d, want %d", got, writeVersion)
+	}
+	if ft[16] != 0 {
+		t.Errorf("bEncryptedIndex = %d, want 0", ft[16])
+	}
+}
+
+// Output must not depend on AddFile ordering — Close sorts by path.
+func TestWriter_Close_IsDeterministic(t *testing.T) {
+	build := func(order []string) []byte {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "out.pak")
+		w, err := Create(path)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		for _, name := range order {
+			if err := w.AddFile(name, []byte(name)); err != nil {
+				t.Fatalf("AddFile(%s): %v", name, err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading output: %v", err)
+		}
+		return data
+	}
+
+	a := build([]string{"a/one.json", "b/two.json", "root.json"})
+	b := build([]string{"root.json", "b/two.json", "a/one.json"})
+	if !bytes.Equal(a, b) {
+		t.Error("output differs with AddFile order; Close must be deterministic")
+	}
+}
+
+func TestWriter_AddFile_RejectsDuplicatePath(t *testing.T) {
+	w, err := Create(filepath.Join(t.TempDir(), "out.pak"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer w.Close() //nolint:errcheck
+	if err := w.AddFile("x.json", []byte("{}")); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	if err := w.AddFile("x.json", []byte("{}")); err == nil {
+		t.Error("expected error adding a duplicate path, got nil")
+	}
+}
+
+func TestWriter_AddFile_AfterClose_Errors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.pak")
+	w, err := Create(path)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := w.AddFile("x.json", []byte("{}")); err == nil {
+		t.Error("expected error adding file after Close, got nil")
+	}
+}

--- a/internal/unrealpak/writer_test.go
+++ b/internal/unrealpak/writer_test.go
@@ -3,6 +3,7 @@ package unrealpak
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -96,5 +97,20 @@ func TestWriter_AddFile_AfterClose_Errors(t *testing.T) {
 	}
 	if err := w.AddFile("x.json", []byte("{}")); err == nil {
 		t.Error("expected error adding file after Close, got nil")
+	}
+}
+
+// checkEncodedLocationFits is tested directly on the boundary rather than by
+// constructing a >2 GiB encoded-index fixture, which would be impractically
+// slow and memory-hungry for a unit test.
+func TestCheckEncodedLocationFits(t *testing.T) {
+	if err := checkEncodedLocationFits(0); err != nil {
+		t.Errorf("checkEncodedLocationFits(0): %v", err)
+	}
+	if err := checkEncodedLocationFits(math.MaxInt32); err != nil {
+		t.Errorf("checkEncodedLocationFits(MaxInt32): %v", err)
+	}
+	if err := checkEncodedLocationFits(math.MaxInt32 + 1); err == nil {
+		t.Error("checkEncodedLocationFits(MaxInt32+1) = nil, want error")
 	}
 }


### PR DESCRIPTION
## Summary

Implements EPIC #136: full Icarus mod support — browsing/installing mods from the community Firestore catalog, and compiling `.exmodz` mods into engine-loadable `_P.pak` files natively on Linux (no Unreal Editor, no Wine).

- **`internal/unrealpak`** (game-agnostic, zero lmm imports): UE v11 PAK reader + writer — 221-byte footer, primary index with bit-packed encoded entries, path-hash index (FNV-1a-64, seeded), full directory index, 53-byte local headers. Every structural constant was empirically verified against the real game's 34 paks / 173,078 entries before implementation; the reader opens the shipping game's files, and the writer's output is byte-round-trip-verified.
- **`internal/source/icarus`**: Firestore REST catalog client (public read-only, project `projectdaedalus-fb09f`, live-verified against 538 real mods), registered as a built-in source beside NexusMods/CurseForge; `.EXMOD` diff engine (hyphen→slash mount-path resolution, `EndOfMod` sentinel handling — both corrected against a real mod after the planned algorithm resolved 0/14 real rows); `.EXMODZ` unpacking with traversal-safe asset paths; hybrid base-table provider (hosted per-week community dumps + `data_dump_path` local-dir override, byte-compare validation against the install's 40 uncompressed-stored tables).
- **Core wiring**: `domain.DeployCompile`, `source.Compiler` capability, per-`.exmodz`-file compile gating in `Service`'s cache-population path (plain `.pak` mods keep the existing extract/copy path), `data_dump_path` in games.yaml, README/configuration docs, CHANGELOG under `[Unreleased]`. No linker changes; no new dependencies (`go.mod` untouched, stdlib only); CLI and TUI both pick the source up through the shared registry.

## Verification

- Full suite green (19 packages), gofmt/vet clean, trunk check: 0 new findings.
- SDD per-task reviews on all 14 tasks + final whole-branch review (clean after one mechanical lint fix); three empirical spikes recorded in the findings doc on the `docs/icarus-exmod-pak-research` branch.
- Real-data checks: reader enumerates the real `pakchunk0` (9,295 entries) and `data.pak` (298 tables); real `Bear_Mount.EXMODZ` resolves 14/14 rows and 26/26 assets.

## Known limitations (by design, fail-loud)

- A real end-to-end compile is currently blocked by ecosystem state: the hosted dump repo's newest week (236) trails the installed game (week 243), and the pipeline loudly refuses mismatched base data (verified against the real install). It unblocks when the dump repo updates or via a user-supplied `data_dump_path`.
- Oodle-compressed base tables are never decompressed locally (no Go decoder exists); base truth comes from the dumps.
- Follow-up issues to be filed: unknown `deploy_mode`/`link_method` values silently fall back (pre-existing convention, needs a repo-wide decision); `lmm import` local ingest doesn't compile `DeployCompile` files.

Closes #136 (pending post-merge in-game validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)