### PR TITLE
fix: mount compiled Icarus paks at the game's data loader path (#178)

### DIFF
--- a/internal/source/icarus/compile.go
+++ b/internal/source/icarus/compile.go
@@ -23,6 +23,13 @@ import (
 // There is no ctx parameter: every step is local file I/O over a ~2 MB pak,
 // with no network call and no long-running loop to cancel. The
 // source.Compiler interface still takes one, for implementations that need it.
+//
+// The compiled pak's mount point and table-entry paths (icarusContentMountPoint,
+// icarusDataTablePrefix below) are Icarus-specific and deliberately live here
+// rather than in internal/unrealpak, which stays game-agnostic — see
+// unrealpak.Writer's WithMountPoint. They are not guessed: both were
+// confirmed against two real, working prebuilt Icarus mod paks (#178; see
+// docs/plans/2026-08-01-icarus-zlib-pivot.md's pak-divergence-report.md).
 func Compile(basePakPath, exmodzPath, outputPakPath string) (err error) {
 	exmodzData, err := os.ReadFile(exmodzPath)
 	if err != nil {
@@ -39,7 +46,7 @@ func Compile(basePakPath, exmodzPath, outputPakPath string) (err error) {
 	}
 	defer base.Close() //nolint:errcheck
 
-	out, err := unrealpak.Create(outputPakPath)
+	out, err := unrealpak.Create(outputPakPath, unrealpak.WithMountPoint(icarusContentMountPoint))
 	if err != nil {
 		return fmt.Errorf("icarus: creating %s: %w", outputPakPath, err)
 	}
@@ -84,8 +91,9 @@ func Compile(basePakPath, exmodzPath, outputPakPath string) (err error) {
 		if err != nil {
 			return err
 		}
-		if err := out.AddFile(mountPath, patched); err != nil {
-			return fmt.Errorf("icarus: writing patched %s: %w", mountPath, err)
+		tablePath := icarusDataTablePrefix + mountPath
+		if err := out.AddFile(tablePath, patched); err != nil {
+			return fmt.Errorf("icarus: writing patched %s: %w", tablePath, err)
 		}
 	}
 
@@ -94,6 +102,11 @@ func Compile(basePakPath, exmodzPath, outputPakPath string) (err error) {
 		if err != nil {
 			return err
 		}
+		// No icarusDataTablePrefix here: bundled assets are content packages,
+		// not JSON data-table overrides. They need only icarusContentMountPoint
+		// (via the Writer's mount point) to land under Icarus/Content/ at
+		// their own namespace path — confirmed against a real asset-only
+		// prebuilt mod pak (TurretVariants; see pak-divergence-report.md).
 		if err := out.AddFile(safePath, data); err != nil {
 			return fmt.Errorf("icarus: writing bundled asset %s: %w", safePath, err)
 		}
@@ -104,6 +117,26 @@ func Compile(basePakPath, exmodzPath, outputPakPath string) (err error) {
 	}
 	return nil
 }
+
+// icarusContentMountPoint is the mount point a compiled _P.pak must declare
+// for Icarus's own data-table mod loader to find it. "../../../" (this
+// package's own default — see unrealpak.defaultMountPoint) resolves to the
+// Steam install's outer game folder; real Icarus mods redescend from there
+// with a literal "Icarus/Content/" — the game's UProject-root folder name is
+// itself "Icarus" (confirmed both by real prebuilt mods' own mount strings
+// and by data.pak's own on-disk nesting: .../Icarus/Icarus/Content/Data/data.pak).
+// Confirmed against two independent real, working prebuilt mod paks
+// (FloofLevelCap, Intreeg's 4XP) — see pak-divergence-report.md.
+const icarusContentMountPoint = "../../../Icarus/Content/"
+
+// icarusDataTablePrefix is prepended to a patched base table's own
+// mount-relative path (as read from data.pak, e.g. "Experience/D_ExperienceEvents.json")
+// before it is written into the compiled pak. Real prebuilt mods land their
+// table overrides at "Icarus/Content/data/<same-path>" — confirmed
+// byte-for-byte against FloofLevelCap.pak and Intreeg's 4XP.pak. It must NOT
+// be applied to bundled assets (see the asset loop below): a single pak
+// can't correctly address both classes with the same prefix.
+const icarusDataTablePrefix = "data/"
 
 // endOfModSentinel is a known .EXMOD ecosystem terminator row: real-world
 // manifests end their Rows array with {"CurrentFile":"EndOfMod"} and no

--- a/internal/source/icarus/compile_test.go
+++ b/internal/source/icarus/compile_test.go
@@ -56,7 +56,7 @@ func TestCompile_AppliesDiffAndBundlesAssets(t *testing.T) {
 	}
 	defer r.Close() //nolint:errcheck
 
-	patched, err := r.ReadFile("AI/D_AIGrowth.json")
+	patched, err := r.ReadFile("data/AI/D_AIGrowth.json")
 	if err != nil {
 		t.Fatalf("ReadFile patched data table: %v", err)
 	}
@@ -70,6 +70,49 @@ func TestCompile_AppliesDiffAndBundlesAssets(t *testing.T) {
 	}
 	if string(asset) != "fake-asset" {
 		t.Errorf("bundled asset content = %q", asset)
+	}
+}
+
+// TestCompile_MountsAtTheGamesDataLoaderPath pins #178: the compiled pak's
+// MountPoint and patched-table entry paths must land where Icarus's own
+// data-table mod loader actually looks (confirmed against two real prebuilt
+// mod paks — see pak-divergence-report.md), not at the bare base-pak-relative
+// path Compile previously wrote (which mounted fine but had no effect).
+// Bundled assets keep their own unprefixed path; only table entries get the
+// "data/" prefix — a single pak can't correctly address both classes with
+// the same prefix, since assets need the mount point alone to reach
+// Icarus/Content/, while tables additionally need "data/" beneath that.
+func TestCompile_MountsAtTheGamesDataLoaderPath(t *testing.T) {
+	basePak := writeTestBasePak(t, map[string][]byte{
+		"AI/D_AIGrowth.json": []byte(`{"Rows":[{"Name":"Mount_Bear","BaseMovementSpeed":200}]}`),
+	})
+	manifest := `{"name":"X","Rows":[{"CurrentFile":"AI-D_AIGrowth.json","File_Items":[{"Name":"Mount_Bear","BaseMovementSpeed":235}]}]}`
+	exmodzPath := writeTestExmodzFile(t, manifest, map[string][]byte{
+		"Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset": []byte("fake-asset"),
+	})
+	outputPath := filepath.Join(t.TempDir(), "out.pak")
+
+	if err := Compile(basePak, exmodzPath, outputPath); err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	r, err := unrealpak.Open(outputPath)
+	if err != nil {
+		t.Fatalf("opening compiled output: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+
+	const wantMount = "../../../Icarus/Content/"
+	if got := r.MountPoint(); got != wantMount {
+		t.Errorf("MountPoint = %q, want %q", got, wantMount)
+	}
+	if _, err := r.ReadFile("data/AI/D_AIGrowth.json"); err != nil {
+		t.Errorf("patched table must live at the data/-prefixed path: %v", err)
+	}
+	if _, err := r.ReadFile("AI/D_AIGrowth.json"); err == nil {
+		t.Error("patched table must NOT also exist at the unprefixed path")
+	}
+	if _, err := r.ReadFile("Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset"); err != nil {
+		t.Errorf("bundled asset must keep its own unprefixed path: %v", err)
 	}
 }
 
@@ -96,7 +139,7 @@ func TestCompile_SkipsEndOfModSentinelRow(t *testing.T) {
 		t.Fatalf("opening compiled output: %v", err)
 	}
 	defer r.Close() //nolint:errcheck
-	patched, err := r.ReadFile("AI/D_AIGrowth.json")
+	patched, err := r.ReadFile("data/AI/D_AIGrowth.json")
 	if err != nil {
 		t.Fatalf("ReadFile patched data table: %v", err)
 	}
@@ -144,7 +187,7 @@ func TestCompile_PatchesTheBasePaksOwnTable(t *testing.T) {
 		t.Fatalf("opening compiled output: %v", err)
 	}
 	defer r.Close() //nolint:errcheck
-	got, err := r.ReadFile("AI/D_AIGrowth.json")
+	got, err := r.ReadFile("data/AI/D_AIGrowth.json")
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}

--- a/internal/unrealpak/pak.go
+++ b/internal/unrealpak/pak.go
@@ -105,11 +105,13 @@ func hashPath(mountRelative string, seed uint64) uint64 {
 	return h
 }
 
-// defaultMountPoint is the mount point Writer stamps into the primary index.
-// Icarus's own data.pak uses an absolute cook-machine path
-// ("C:/BA/work/.../Temp/Data/"); "../../../" is the conventional relative form
-// used by its pakchunks. Confirming which one a _P.pak needs to override
-// Content/Data/data.pak in-game is a post-plan validation item.
+// defaultMountPoint is the mount point Writer stamps into the primary index
+// when the caller doesn't override it via WithMountPoint. It is the bare
+// UE4 convention ("../../../", relative to <UProject>/Binaries/Win64/"),
+// deliberately game-agnostic — this package has no opinion on any specific
+// game's directory layout. A caller writing paks for a real game (see
+// internal/source/icarus's Writer usage, #178) supplies the mount point its
+// own game's mod loader actually expects.
 const defaultMountPoint = "../../../"
 
 // writeFString writes a length-prefixed ANSI Unreal FString (length includes
@@ -151,11 +153,11 @@ func storedEntryHeader(size int64, content []byte) []byte {
 // sub-index offsets it records point past its own end, but its length does not
 // depend on their values (they are fixed-width int64), so a first pass with
 // zero offsets measures it and a second pass writes the real ones.
-func buildPrimaryIndex(numEntries int32, seed uint64,
+func buildPrimaryIndex(mountPoint string, numEntries int32, seed uint64,
 	phiOffset, phiSize int64, phiHash [20]byte,
 	fdiOffset, fdiSize int64, fdiHash [20]byte, encoded []byte) []byte {
 	var b bytes.Buffer
-	writeFString(&b, defaultMountPoint)
+	writeFString(&b, mountPoint)
 	binary.Write(&b, binary.LittleEndian, numEntries) //nolint:errcheck
 	binary.Write(&b, binary.LittleEndian, seed)       //nolint:errcheck // PathHashSeed
 	binary.Write(&b, binary.LittleEndian, int32(1))   //nolint:errcheck // bHasPathHashIndex

--- a/internal/unrealpak/reader.go
+++ b/internal/unrealpak/reader.go
@@ -17,10 +17,11 @@ import (
 // and Zlib-compressed entries are readable; any other compression method is a
 // loud ErrUnsupportedFormat.
 type Reader struct {
-	f        *os.File
-	entries  []readerEntry
-	fileSize int64                         // total size of the underlying file, for validateAllocSize
-	methods  [maxCompressionMethods]string // this pak's own CompressionMethods table
+	f          *os.File
+	entries    []readerEntry
+	fileSize   int64                         // total size of the underlying file, for validateAllocSize
+	methods    [maxCompressionMethods]string // this pak's own CompressionMethods table
+	mountPoint string                        // this pak's own primary-index MountPoint (see Writer's WithMountPoint)
 }
 
 type readerEntry struct {
@@ -64,13 +65,13 @@ func Open(path string) (*Reader, error) {
 		return nil, fmt.Errorf("unrealpak: %s: primary index: %w", path, err)
 	}
 
-	entries, err := parseIndex(f, indexBuf, fileSize)
+	mountPoint, entries, err := parseIndex(f, indexBuf, fileSize)
 	if err != nil {
 		f.Close() //nolint:errcheck
 		return nil, fmt.Errorf("unrealpak: %s: parsing index: %w", path, err)
 	}
 
-	return &Reader{f: f, entries: entries, fileSize: fileSize, methods: ft.methods}, nil
+	return &Reader{f: f, entries: entries, fileSize: fileSize, methods: ft.methods, mountPoint: mountPoint}, nil
 }
 
 // methodName resolves a 1-based CompressionMethodIndex against this pak's own
@@ -127,6 +128,13 @@ func readRegion(r io.ReaderAt, offset, size, fileSize int64, want [20]byte) ([]b
 
 // Close releases the underlying file handle.
 func (r *Reader) Close() error { return r.f.Close() }
+
+// MountPoint returns this pak's primary-index MountPoint string — where the
+// engine roots Files' mount-relative paths once the pak is mounted. Real
+// paks vary this: Icarus's own data.pak declares an absolute cook-machine
+// path, while mod paks conventionally declare a relative "../../../..."
+// form (see Writer's WithMountPoint, #178).
+func (r *Reader) MountPoint() string { return r.mountPoint }
 
 // Files returns every file this pak's index describes.
 func (r *Reader) Files() []FileEntry {
@@ -359,50 +367,50 @@ func readFooter(r io.ReaderAt, fileSize int64) (footer, error) {
 // index (hash -> record offset) and a full directory index
 // (directory -> file -> record offset). Enumeration uses the directory index,
 // which is the only one that carries real path strings.
-func parseIndex(f io.ReaderAt, index []byte, fileSize int64) ([]readerEntry, error) {
+func parseIndex(f io.ReaderAt, index []byte, fileSize int64) (string, []readerEntry, error) {
 	c := &cursor{b: index}
-	c.fstring() // MountPoint: recorded for the engine's benefit, unused here
+	mountPoint := c.fstring()
 	numEntries := c.i32()
 	seed := c.u64()
 	_ = seed // only the writer needs the seed; enumeration goes via the directory index
 
 	pathHash, err := readSubIndexRef(c, "path hash index")
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	fullDir, err := readSubIndexRef(c, "full directory index")
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	encoded := c.bytes(int(c.i32())) // EncodedPakEntriesSize, then the blob
 	if nonEncoded := c.i32(); nonEncoded != 0 {
-		return nil, fmt.Errorf("%w: %d non-encoded index entries", ErrUnsupportedFormat, nonEncoded)
+		return "", nil, fmt.Errorf("%w: %d non-encoded index entries", ErrUnsupportedFormat, nonEncoded)
 	}
 	if c.err != nil {
-		return nil, fmt.Errorf("primary index: %w", c.err)
+		return "", nil, fmt.Errorf("primary index: %w", c.err)
 	}
 
 	// Verify the path-hash index's hash even though enumeration does not use
 	// it: it is part of the format's integrity chain, and a pak whose
 	// sub-index hashes don't hold is not one to trust.
 	if _, err := readRegion(f, pathHash.offset, pathHash.size, fileSize, pathHash.hash); err != nil {
-		return nil, fmt.Errorf("path hash index: %w", err)
+		return "", nil, fmt.Errorf("path hash index: %w", err)
 	}
 	dirBuf, err := readRegion(f, fullDir.offset, fullDir.size, fileSize, fullDir.hash)
 	if err != nil {
-		return nil, fmt.Errorf("full directory index: %w", err)
+		return "", nil, fmt.Errorf("full directory index: %w", err)
 	}
 
 	entries, err := parseDirectoryIndex(dirBuf, encoded)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	if int32(len(entries)) != numEntries {
-		return nil, fmt.Errorf("directory index lists %d files, index header says %d",
+		return "", nil, fmt.Errorf("directory index lists %d files, index header says %d",
 			len(entries), numEntries)
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
-	return entries, nil
+	return mountPoint, entries, nil
 }
 
 type subIndexRef struct {

--- a/internal/unrealpak/reader_test.go
+++ b/internal/unrealpak/reader_test.go
@@ -85,10 +85,10 @@ func buildFixturePak(mountPath string, content []byte, method int32) []byte {
 	fdiHash := sha1.Sum(fdi.Bytes()) //nolint:gosec
 
 	indexOffset := int64(data.Len())
-	sizing := buildPrimaryIndex(1, fixtureSeed, 0, 0, phiHash, 0, 0, fdiHash, encoded.Bytes())
+	sizing := buildPrimaryIndex(defaultMountPoint, 1, fixtureSeed, 0, 0, phiHash, 0, 0, fdiHash, encoded.Bytes())
 	phiOffset := indexOffset + int64(len(sizing))
 	fdiOffset := phiOffset + int64(phi.Len())
-	index := buildPrimaryIndex(1, fixtureSeed,
+	index := buildPrimaryIndex(defaultMountPoint, 1, fixtureSeed,
 		phiOffset, int64(phi.Len()), phiHash,
 		fdiOffset, int64(fdi.Len()), fdiHash, encoded.Bytes())
 	indexHash := sha1.Sum(index) //nolint:gosec

--- a/internal/unrealpak/writer.go
+++ b/internal/unrealpak/writer.go
@@ -28,10 +28,11 @@ const writerSeed uint64 = 0x9E3779B97F4A7C15
 // round-trip test able to assert on bytes and keeps compiled paks stable across
 // recompiles.
 type Writer struct {
-	f      *os.File
-	closed bool
-	files  []writerFile
-	seen   map[string]bool
+	f          *os.File
+	closed     bool
+	files      []writerFile
+	seen       map[string]bool
+	mountPoint string
 }
 
 type writerFile struct {
@@ -39,13 +40,34 @@ type writerFile struct {
 	data []byte
 }
 
+// Option configures a Writer at construction time (see Create). The set is
+// deliberately tiny and additive: new options can be introduced without
+// breaking existing Create(path) call sites, since opts is variadic.
+type Option func(*Writer)
+
+// WithMountPoint overrides the mount point Writer stamps into the primary
+// index (see defaultMountPoint). This package stays game-agnostic — it has
+// no built-in notion of any specific game's directory layout — so a caller
+// that knows what its target game's mod loader expects (e.g.
+// internal/source/icarus, #178) supplies it here rather than this package
+// guessing or hard-coding one game's convention.
+func WithMountPoint(mountPoint string) Option {
+	return func(w *Writer) { w.mountPoint = mountPoint }
+}
+
 // Create opens path for writing. Call AddFile for each entry, then Close.
-func Create(path string) (*Writer, error) {
+// With no options, the written pak uses defaultMountPoint, matching every
+// existing caller's prior behavior exactly.
+func Create(path string, opts ...Option) (*Writer, error) {
 	f, err := os.Create(path)
 	if err != nil {
 		return nil, fmt.Errorf("unrealpak: creating %s: %w", path, err)
 	}
-	return &Writer{f: f, seen: make(map[string]bool)}, nil
+	w := &Writer{f: f, seen: make(map[string]bool), mountPoint: defaultMountPoint}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w, nil
 }
 
 // AddFile records one entry. Nothing reaches disk until Close.
@@ -157,10 +179,10 @@ func (w *Writer) Close() error {
 	fdiHash := sha1.Sum(fdi.Bytes()) //nolint:gosec
 	count := int32(len(w.files))
 	indexOffset := int64(data.Len())
-	sizing := buildPrimaryIndex(count, writerSeed, 0, 0, phiHash, 0, 0, fdiHash, encoded.Bytes())
+	sizing := buildPrimaryIndex(w.mountPoint, count, writerSeed, 0, 0, phiHash, 0, 0, fdiHash, encoded.Bytes())
 	phiOffset := indexOffset + int64(len(sizing))
 	fdiOffset := phiOffset + int64(phi.Len())
-	index := buildPrimaryIndex(count, writerSeed,
+	index := buildPrimaryIndex(w.mountPoint, count, writerSeed,
 		phiOffset, int64(phi.Len()), phiHash,
 		fdiOffset, int64(fdi.Len()), fdiHash, encoded.Bytes())
 	indexHash := sha1.Sum(index) //nolint:gosec

--- a/internal/unrealpak/writer_test.go
+++ b/internal/unrealpak/writer_test.go
@@ -100,6 +100,60 @@ func TestWriter_AddFile_AfterClose_Errors(t *testing.T) {
 	}
 }
 
+// TestWriter_Create_DefaultMountPoint pins that Create with no options
+// preserves every prior caller's behavior exactly: the written pak's
+// MountPoint is the package's own defaultMountPoint.
+func TestWriter_Create_DefaultMountPoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.pak")
+	w, err := Create(path)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := w.AddFile("x.json", []byte("{}")); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	r, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+	if got := r.MountPoint(); got != defaultMountPoint {
+		t.Errorf("MountPoint = %q, want default %q", got, defaultMountPoint)
+	}
+}
+
+// TestWriter_Create_WithMountPoint pins that WithMountPoint overrides the
+// stamped mount point — this package stays game-agnostic (#178), so a
+// caller like internal/source/icarus supplies its own game's mount point
+// through this seam rather than this package hard-coding one.
+func TestWriter_Create_WithMountPoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.pak")
+	const custom = "../../../Icarus/Content/"
+	w, err := Create(path, WithMountPoint(custom))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := w.AddFile("data/x.json", []byte("{}")); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	r, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+	if got := r.MountPoint(); got != custom {
+		t.Errorf("MountPoint = %q, want %q", got, custom)
+	}
+}
+
 // checkEncodedLocationFits is tested directly on the boundary rather than by
 // constructing a >2 GiB encoded-index fixture, which would be impractically
 // slow and memory-hungry for a unit test.

--- a/internal/unrealpak/zlib_test.go
+++ b/internal/unrealpak/zlib_test.go
@@ -114,10 +114,10 @@ func writeMethodPak(t *testing.T, methods []string, fixtures []zlibFixture) stri
 	fdiHash := sha1.Sum(fdi.Bytes()) //nolint:gosec
 	count := int32(len(fixtures))
 	indexOffset := int64(data.Len())
-	sizing := buildPrimaryIndex(count, seed, 0, 0, phiHash, 0, 0, fdiHash, encoded.Bytes())
+	sizing := buildPrimaryIndex(defaultMountPoint, count, seed, 0, 0, phiHash, 0, 0, fdiHash, encoded.Bytes())
 	phiOffset := indexOffset + int64(len(sizing))
 	fdiOffset := phiOffset + int64(phi.Len())
-	index := buildPrimaryIndex(count, seed, phiOffset, int64(phi.Len()), phiHash,
+	index := buildPrimaryIndex(defaultMountPoint, count, seed, phiOffset, int64(phi.Len()), phiHash,
 		fdiOffset, int64(fdi.Len()), fdiHash, encoded.Bytes())
 	indexHash := sha1.Sum(index) //nolint:gosec
 


### PR DESCRIPTION
## Summary

Fixes #178 — the last gap between "the engine mounts our paks" and "the mods actually work."

Real-world validation showed compiled paks mounted cleanly but their table patches had no effect. Forensic comparison against three real author-built mod paks isolated the cause: working mods mount at `../../../Icarus/Content/` with tables under a `data/` prefix; ours used bare `../../../` with unprefixed paths — three segments away from where the game's data loader looks.

- `internal/unrealpak`: `Writer` gains a backward-compatible `WithMountPoint` functional option (+ `Reader.MountPoint()`); default unchanged, package stays game-agnostic (verified no Icarus leakage into production code).
- `internal/source/icarus`: the compiler sets the game's mount point and prefixes `data/` on table entries (assets keep their zip-derived shape, corroborated against an asset-only prebuilt mod).

## Verification

- TDD (writer + compile-level tests), full suite green, gofmt/vet/trunk clean; SDD review approved (0 must-fix).
- Recompiled output is byte-for-byte identical in mount + table paths to a real prebuilt mod pak.
- **Confirmed in-game:** the recompiled stack-size mod's patches now take effect (Wood 500 / Stone 250 vs vanilla 100) — first fully-working lmm-compiled Icarus mod, exercising the row-patch path on real content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)