### PR TITLE
chore: pre-merge hardening + coverage sweep (#136)

### DIFF
--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -940,10 +940,10 @@ func isExmodzFile(fileName string) bool {
 // JSON data tables live in Content/Data/data.pak, NOT in the Content/Paks
 // pakchunks, which carry only cooked .uasset/.uexp assets and no JSON at all.
 //
-// Since rev3 this pak is no longer the source of base table *content* (that
-// comes from the hosted dump — Task 12a); it is still required, because it is
-// the only authority on which tables the installed game has and on which game
-// week is installed. Its parent directory also locates Icarus/Config/version.json.
+// This pak is also the direct source of base table *content* (#175): Compile
+// reads each patched table straight out of it via internal/unrealpak, so a
+// compile is always week-correct by construction (there's no separate dump
+// to go stale relative to the install) and works entirely offline.
 func resolveBasePak(game *domain.Game) (string, error) {
 	candidate := filepath.Join(game.InstallPath, "Icarus", "Content", "Data", "data.pak")
 	if _, err := os.Stat(candidate); err != nil {

--- a/internal/source/icarus/exmodz.go
+++ b/internal/source/icarus/exmodz.go
@@ -91,11 +91,36 @@ func normalizeZipName(name string) string {
 	return strings.ReplaceAll(name, `\`, "/")
 }
 
+// maxZipEntrySize caps a single .EXMODZ entry's declared (and actual)
+// decompressed size, mirroring #136's dump-tar cap (maxTarEntrySize): the
+// largest real Icarus base data table is 7.3 MB, and .EXMODZ manifests and
+// bundled UE assets are smaller still in every real sample seen. 64 MiB
+// leaves generous headroom while refusing to trust an unbounded or lying
+// UncompressedSize64 in a third-party, user-downloaded zip archive.
+const maxZipEntrySize = 64 << 20
+
 func readZipFile(f *zip.File) ([]byte, error) {
+	if f.UncompressedSize64 > maxZipEntrySize {
+		return nil, fmt.Errorf("icarus: zip entry %s declares a %d-byte uncompressed size, "+
+			"exceeding the %d-byte per-entry cap", f.Name, f.UncompressedSize64, uint64(maxZipEntrySize))
+	}
 	rc, err := f.Open()
 	if err != nil {
 		return nil, err
 	}
 	defer rc.Close() //nolint:errcheck
-	return io.ReadAll(rc)
+	// The cap above only guards an honest-but-large size field; a header
+	// that LIES by understating the real decompressed size must not be able
+	// to drive an unbounded read either, so the read itself is bounded one
+	// byte past what was declared — enough to detect an overrun without
+	// reading further than necessary to prove it.
+	data, err := io.ReadAll(io.LimitReader(rc, int64(f.UncompressedSize64)+1))
+	if err != nil {
+		return nil, err
+	}
+	if uint64(len(data)) > f.UncompressedSize64 {
+		return nil, fmt.Errorf("icarus: zip entry %s decompresses past its declared %d-byte size",
+			f.Name, f.UncompressedSize64)
+	}
+	return data, nil
 }

--- a/internal/source/icarus/exmodz.go
+++ b/internal/source/icarus/exmodz.go
@@ -60,7 +60,7 @@ func ParseExmodz(zipData []byte) (*ExmodzBundle, error) {
 	}
 	diff, err := ParseExmod(manifestData)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("icarus: %s: %w", manifestPath, err)
 	}
 	bundle := &ExmodzBundle{Diff: diff, Assets: make(map[string][]byte)}
 

--- a/internal/source/icarus/exmodz_test.go
+++ b/internal/source/icarus/exmodz_test.go
@@ -3,6 +3,7 @@ package icarus
 import (
 	"archive/zip"
 	"bytes"
+	"hash/crc32"
 	"strings"
 	"testing"
 )
@@ -170,5 +171,88 @@ func TestParseExmodz_NoManifest_Errors(t *testing.T) {
 
 	if _, err := ParseExmodz(buf.Bytes()); err == nil {
 		t.Error("expected error when no .EXMOD manifest is present, got nil")
+	}
+}
+
+// An entry (manifest or asset) declaring an uncompressed size over the
+// per-entry cap must be rejected before any content is read — guards
+// against a user-downloaded, third-party .EXMODZ with a corrupt or lying
+// size field driving an unbounded allocation, mirroring #136's dump-tar
+// cap. zw.CreateRaw writes the caller-declared size fields verbatim (unlike
+// zw.Create/CreateHeader, which recompute them from what's actually
+// written), so the fixture never needs 64+ real MiB of content.
+func TestParseExmodz_RejectsOversizedAssetDeclaredSize(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	w, err := zw.Create("Extracted Mods/X.EXMOD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte(`{"name":"X","Rows":[]}`)) //nolint:errcheck
+
+	content := []byte("tiny")
+	rawW, err := zw.CreateRaw(&zip.FileHeader{
+		Name:               "Bear_Mount/huge.uasset",
+		Method:             zip.Store,
+		UncompressedSize64: maxZipEntrySize + 1,
+		CompressedSize64:   uint64(len(content)),
+		CRC32:              crc32.ChecksumIEEE(content),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawW.Write(content) //nolint:errcheck
+
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ParseExmodz(buf.Bytes())
+	if err == nil {
+		t.Fatal("expected an error for an asset declaring an oversized uncompressed size, got nil")
+	}
+	if !strings.Contains(err.Error(), "Bear_Mount/huge.uasset") {
+		t.Errorf("error %q should name the offending entry", err)
+	}
+}
+
+// An entry whose declared size is UNDER the cap (so the pre-check passes)
+// but whose actual decompressed content exceeds that declared size must
+// still be caught — the read itself has to be bounded, not just the
+// pre-check, so a lying-but-small header can't drive an unbounded read.
+func TestParseExmodz_RejectsLyingAssetDeclaredSize(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	w, err := zw.Create("Extracted Mods/X.EXMOD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte(`{"name":"X","Rows":[]}`)) //nolint:errcheck
+
+	content := []byte("hello world") // 11 real bytes
+	rawW, err := zw.CreateRaw(&zip.FileHeader{
+		Name:               "Bear_Mount/lying.uasset",
+		Method:             zip.Store,
+		UncompressedSize64: 3, // lies: declares far less than the 11 real bytes
+		CompressedSize64:   uint64(len(content)),
+		CRC32:              crc32.ChecksumIEEE(content),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawW.Write(content) //nolint:errcheck
+
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ParseExmodz(buf.Bytes())
+	if err == nil {
+		t.Fatal("expected an error for an asset whose real content exceeds its declared uncompressed size, got nil")
+	}
+	if !strings.Contains(err.Error(), "Bear_Mount/lying.uasset") {
+		t.Errorf("error %q should name the offending entry", err)
 	}
 }

--- a/internal/source/icarus/exmodz_test.go
+++ b/internal/source/icarus/exmodz_test.go
@@ -174,6 +174,30 @@ func TestParseExmodz_NoManifest_Errors(t *testing.T) {
 	}
 }
 
+// A present-but-malformed manifest (invalid JSON) must fail loudly, wrapped
+// with the manifest's own path — Task 11 review noted this path returned
+// ParseExmod's error unwrapped, unlike every other error path in this file.
+func TestParseExmodz_MalformedManifest_Errors(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("Extracted Mods/Bad.EXMOD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte("{not valid json")) //nolint:errcheck
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ParseExmodz(buf.Bytes())
+	if err == nil {
+		t.Fatal("expected an error for a malformed manifest, got nil")
+	}
+	if !strings.Contains(err.Error(), "Bad.EXMOD") {
+		t.Errorf("error %q should name the manifest that failed to parse", err)
+	}
+}
+
 // An entry (manifest or asset) declaring an uncompressed size over the
 // per-entry cap must be rejected before any content is read — guards
 // against a user-downloaded, third-party .EXMODZ with a corrupt or lying

--- a/internal/source/icarus/firestore_client.go
+++ b/internal/source/icarus/firestore_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -92,6 +93,12 @@ func (c *firestoreClient) getJSON(ctx context.Context, url string, out any) erro
 	}
 	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode != http.StatusOK {
+		// Drain before Close so the underlying connection stays eligible for
+		// reuse — net/http only pools an HTTP/1.x connection once its body
+		// has been read to EOF; returning immediately here left whatever the
+		// server sent (however small) unread, forcing the transport to
+		// close the connection instead of reusing it for the next request.
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 	return json.NewDecoder(resp.Body).Decode(out)

--- a/internal/source/icarus/firestore_client_test.go
+++ b/internal/source/icarus/firestore_client_test.go
@@ -3,6 +3,7 @@ package icarus
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -105,5 +106,112 @@ func TestFirestoreClient_GetDocument_NotFound(t *testing.T) {
 	_, err := c.getDocument(context.Background(), "mods", "missing")
 	if err == nil {
 		t.Fatal("expected error for 404, got nil")
+	}
+}
+
+func TestFirestoreClient_GetDocument_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		doc := map[string]any{
+			"name":   "projects/p/databases/(default)/documents/mods/abc",
+			"fields": map[string]any{"name": map[string]any{"stringValue": "Bear Mount"}},
+		}
+		json.NewEncoder(w).Encode(doc) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := newFirestoreClient("test-project", srv.Client())
+	c.baseURL = srv.URL
+
+	doc, err := c.getDocument(context.Background(), "mods", "abc")
+	if err != nil {
+		t.Fatalf("getDocument: %v", err)
+	}
+	if doc.ID != "abc" {
+		t.Errorf("doc.ID = %q, want abc", doc.ID)
+	}
+	if doc.Fields["name"] != "Bear Mount" {
+		t.Errorf("doc.Fields[name] = %v, want Bear Mount", doc.Fields["name"])
+	}
+}
+
+// newFirestoreClient(id, nil) must fall back to http.DefaultClient rather
+// than leaving httpClient nil (which would panic the first time getJSON
+// called c.httpClient.Do).
+func TestNewFirestoreClient_NilHTTPClient_FallsBackToDefault(t *testing.T) {
+	c := newFirestoreClient("test-project", nil)
+	if c.httpClient != http.DefaultClient {
+		t.Errorf("httpClient = %v, want http.DefaultClient", c.httpClient)
+	}
+}
+
+// trackingBody wraps a response body to record whether it was read all the
+// way to io.EOF (drained) and whether Close was called, independent of real
+// TCP connection pooling — the property getJSON's error path needs to
+// guarantee is "drain, then close," not any particular transport behavior.
+type trackingBody struct {
+	rc        io.ReadCloser
+	readToEOF bool
+	closed    bool
+}
+
+func (b *trackingBody) Read(p []byte) (int, error) {
+	n, err := b.rc.Read(p)
+	if err == io.EOF {
+		b.readToEOF = true
+	}
+	return n, err
+}
+
+func (b *trackingBody) Close() error {
+	b.closed = true
+	return b.rc.Close()
+}
+
+// drainTrackingTransport substitutes every response's body with a
+// trackingBody, recording the last one seen so a test can inspect it after
+// the request completes.
+type drainTrackingTransport struct {
+	base    http.RoundTripper
+	tracked *trackingBody
+}
+
+func (t *drainTrackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	t.tracked = &trackingBody{rc: resp.Body}
+	resp.Body = t.tracked
+	return resp, nil
+}
+
+// getJSON's non-200 error path must drain the response body to EOF before
+// closing it — an early return without draining leaves bytes unread on the
+// wire, which forces net/http's transport to close the underlying
+// connection instead of pooling it for reuse (connection-reuse hygiene).
+func TestFirestoreClient_GetJSON_DrainsBodyBeforeCloseOnErrorPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"nope, and some padding so there is real body to drain"}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	transport := &drainTrackingTransport{base: http.DefaultTransport}
+	client := &http.Client{Transport: transport}
+	c := newFirestoreClient("test-project", client)
+	c.baseURL = srv.URL
+
+	err := c.getJSON(context.Background(), srv.URL, &struct{}{})
+	if err == nil {
+		t.Fatal("expected an error for a non-200 response, got nil")
+	}
+	if transport.tracked == nil {
+		t.Fatal("transport never saw a request")
+	}
+	if !transport.tracked.readToEOF {
+		t.Error("response body was not drained to EOF before Close on the error path")
+	}
+	if !transport.tracked.closed {
+		t.Error("response body was not closed")
 	}
 }

--- a/internal/source/icarus/firestore_value_test.go
+++ b/internal/source/icarus/firestore_value_test.go
@@ -32,3 +32,50 @@ func TestDecodeFields(t *testing.T) {
 		t.Errorf("decodeFields() = %#v, want %#v", got, want)
 	}
 }
+
+// TestDecodeValue table-drives every value kind decodeValue recognizes,
+// plus its two fallback-to-nil paths (an unrecognized kind, and input that
+// isn't a wrapped {"kind": ...} object at all) — decodeFields' own test
+// above only exercises stringValue/mapValue/nullValue.
+func TestDecodeValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{"stringValue", map[string]any{"stringValue": "hello"}, "hello"},
+		{"booleanValue", map[string]any{"booleanValue": true}, true},
+		// Firestore's REST API encodes integerValue as a decimal STRING
+		// (avoiding int64-precision loss in JSON numbers), not a JSON number.
+		{"integerValue", map[string]any{"integerValue": "42"}, "42"},
+		{"doubleValue", map[string]any{"doubleValue": 3.5}, 3.5},
+		{
+			"mapValue decodes its nested fields recursively",
+			map[string]any{"mapValue": map[string]any{"fields": map[string]any{
+				"inner": map[string]any{"stringValue": "nested"},
+			}}},
+			map[string]any{"inner": "nested"},
+		},
+		{
+			"arrayValue decodes each element recursively",
+			map[string]any{"arrayValue": map[string]any{"values": []any{
+				map[string]any{"stringValue": "a"},
+				map[string]any{"integerValue": "1"},
+				map[string]any{"booleanValue": false},
+			}}},
+			[]any{"a", "1", false},
+		},
+		{"arrayValue with no values key decodes to an empty slice", map[string]any{"arrayValue": map[string]any{}}, []any{}},
+		{"nullValue", map[string]any{"nullValue": nil}, nil},
+		{"unrecognized kind decodes to nil, not a panic", map[string]any{"geoPointValue": map[string]any{"latitude": 1.0}}, nil},
+		{"non-map input decodes to nil", "not a wrapped value", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decodeValue(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("decodeValue(%#v) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/source/icarus/icarus.go
+++ b/internal/source/icarus/icarus.go
@@ -3,6 +3,7 @@ package icarus
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"path"
@@ -104,13 +105,27 @@ func (s *Icarus) Search(ctx context.Context, query source.SearchQuery) (source.S
 	if page < 0 {
 		page = 0
 	}
-	start := page * pageSize
-	if start > len(mods) {
-		start = len(mods)
+	// Both page*pageSize (below) and start+pageSize (for end, further down)
+	// can overflow int for a huge user-supplied Page or PageSize, wrapping
+	// negative instead of landing somewhere past len(mods) — the pre-fix
+	// "start > len(mods)"/"end > len(mods)" clamps never catch a NEGATIVE
+	// value, so a wrapped result panicked the slice below instead of just
+	// clamping to an empty page. Both operations are guarded before they
+	// run rather than trusted to land in range; pageSize > 0 is guaranteed
+	// by the clamp above, so both divisions here are always safe.
+	start := len(mods)
+	if page <= math.MaxInt/pageSize {
+		start = page * pageSize
+		if start > len(mods) {
+			start = len(mods)
+		}
 	}
-	end := start + pageSize
-	if end > len(mods) {
-		end = len(mods)
+	end := len(mods)
+	if pageSize <= math.MaxInt-start {
+		end = start + pageSize
+		if end > len(mods) {
+			end = len(mods)
+		}
 	}
 
 	return source.SearchResult{Mods: mods[start:end], TotalCount: len(mods), Page: page, PageSize: pageSize}, nil

--- a/internal/source/icarus/icarus_test.go
+++ b/internal/source/icarus/icarus_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -104,6 +105,126 @@ func TestIcarus_GetModFiles_ReturnsExmodzAndPak(t *testing.T) {
 	}
 	if !files[0].IsPrimary {
 		t.Error("single file should be marked primary")
+	}
+}
+
+// TestIcarus_GetMod pins the happy path: a single Firestore document maps
+// through mapDoc into the domain.Mod fields Search/GetModFiles callers
+// expect. GetMod's queryGameID parameter is deliberately not exercised here
+// (tracked/accepted elsewhere, per this sweep's scope).
+func TestIcarus_GetMod(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"name": "projects/p/databases/(default)/documents/mods/abc",
+			"fields": map[string]any{
+				"name":    map[string]any{"stringValue": "Bear Mount"},
+				"author":  map[string]any{"stringValue": "Jimk72"},
+				"version": map[string]any{"stringValue": "3.3"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	src := New(srv.Client(), "test-project")
+	src.firestore.baseURL = srv.URL
+
+	mod, err := src.GetMod(context.Background(), "icarus", "abc")
+	if err != nil {
+		t.Fatalf("GetMod: %v", err)
+	}
+	if mod.ID != "abc" || mod.Name != "Bear Mount" || mod.Author != "Jimk72" || mod.Version != "3.3" {
+		t.Errorf("GetMod = %+v, want ID=abc Name=Bear Mount Author=Jimk72 Version=3.3", mod)
+	}
+	if mod.GameID != "icarus" {
+		t.Errorf("GameID = %q, want icarus", mod.GameID)
+	}
+}
+
+// TestIcarus_GetDownloadURL table-drives both the success path (fileID
+// present, either "pak" or "exmodz") and the not-found error path.
+func TestIcarus_GetDownloadURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"name": "projects/p/databases/(default)/documents/mods/abc",
+			"fields": map[string]any{
+				"files": map[string]any{"mapValue": map[string]any{"fields": map[string]any{
+					"pak":    map[string]any{"stringValue": "https://x/bear.pak"},
+					"exmodz": map[string]any{"stringValue": "https://x/bear.exmodz"},
+				}}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	src := New(srv.Client(), "test-project")
+	src.firestore.baseURL = srv.URL
+	mod := &domain.Mod{ID: "abc", GameID: "icarus"}
+
+	tests := []struct {
+		name    string
+		fileID  string
+		want    string
+		wantErr bool
+	}{
+		{name: "pak file ID resolves", fileID: "pak", want: "https://x/bear.pak"},
+		{name: "exmodz file ID resolves", fileID: "exmodz", want: "https://x/bear.exmodz"},
+		{name: "unrecognized file ID errors", fileID: "nope", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := src.GetDownloadURL(context.Background(), mod, tt.fileID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("GetDownloadURL(%q) = %q, nil; want an error", tt.fileID, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetDownloadURL(%q): %v", tt.fileID, err)
+			}
+			if got != tt.want {
+				t.Errorf("GetDownloadURL(%q) = %q, want %q", tt.fileID, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIcarus_CheckUpdates drives two installed mods against a per-ID
+// catalog: one whose stored version is behind the catalog's (an update is
+// expected) and one that already matches (no update).
+func TestIcarus_CheckUpdates(t *testing.T) {
+	catalog := map[string]map[string]any{
+		"abc": {"name": map[string]any{"stringValue": "Bear Mount"}, "version": map[string]any{"stringValue": "3.3"}},
+		"def": {"name": map[string]any{"stringValue": "Wolf Pack"}, "version": map[string]any{"stringValue": "1.0"}},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := path.Base(r.URL.Path)
+		fields, ok := catalog[id]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"name":   "projects/p/databases/(default)/documents/mods/" + id,
+			"fields": fields,
+		})
+	}))
+	defer srv.Close()
+
+	src := New(srv.Client(), "test-project")
+	src.firestore.baseURL = srv.URL
+
+	installed := []domain.InstalledMod{
+		{Mod: domain.Mod{ID: "abc", Version: "3.2"}}, // catalog has 3.3: newer, update expected
+		{Mod: domain.Mod{ID: "def", Version: "1.0"}}, // catalog has 1.0: same, no update
+	}
+
+	updates, err := src.CheckUpdates(context.Background(), installed)
+	if err != nil {
+		t.Fatalf("CheckUpdates: %v", err)
+	}
+	if len(updates) != 1 || updates[0].InstalledMod.ID != "abc" || updates[0].NewVersion != "3.3" {
+		t.Fatalf("updates = %+v, want exactly one update for abc -> 3.3", updates)
 	}
 }
 

--- a/internal/source/icarus/icarus_test.go
+++ b/internal/source/icarus/icarus_test.go
@@ -3,6 +3,7 @@ package icarus
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -76,6 +77,58 @@ func TestIcarus_Search_FiltersClientSide(t *testing.T) {
 		if all.Mods[i].Name != want {
 			t.Errorf("Search(\"\") order[%d] = %q, want %q (deterministic, alphabetical by Name)", i, all.Mods[i].Name, want)
 		}
+	}
+}
+
+// A huge user-supplied Page overflows the page*pageSize multiplication
+// (int wraps to a negative value), which previously produced a negative
+// slice start and panicked instead of just clamping to an empty page past
+// the end of the result set (#136 PR #181 review).
+func TestIcarus_Search_HugePage_ClampsInsteadOfPanicking(t *testing.T) {
+	srv := httptest.NewServer(modsListHandler([]map[string]any{
+		{"id": "abc", "fields": map[string]any{"name": map[string]any{"stringValue": "Bear Mount"}}},
+	}))
+	defer srv.Close()
+
+	src := New(srv.Client(), "test-project")
+	src.firestore.baseURL = srv.URL
+
+	result, err := src.Search(context.Background(), source.SearchQuery{Page: math.MaxInt, PageSize: 20})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(result.Mods) != 0 {
+		t.Errorf("Mods = %+v, want empty (page far beyond the 1-mod result set)", result.Mods)
+	}
+	if result.TotalCount != 1 {
+		t.Errorf("TotalCount = %d, want 1", result.TotalCount)
+	}
+}
+
+// The same overflow class hits start+pageSize (computing "end") once start
+// is non-zero: page*pageSize (1*MaxInt) doesn't itself overflow, and gets
+// clamped down to the small, valid len(mods) — but THAT small start plus a
+// huge PageSize wraps the addition negative, and the existing
+// "end > len(mods)" clamp can't catch an end that's gone negative (Page: 0
+// can't exercise this: 0+anything never overflows).
+func TestIcarus_Search_HugePageSize_ClampsInsteadOfPanicking(t *testing.T) {
+	srv := httptest.NewServer(modsListHandler([]map[string]any{
+		{"id": "abc", "fields": map[string]any{"name": map[string]any{"stringValue": "Bear Mount"}}},
+	}))
+	defer srv.Close()
+
+	src := New(srv.Client(), "test-project")
+	src.firestore.baseURL = srv.URL
+
+	result, err := src.Search(context.Background(), source.SearchQuery{Page: 1, PageSize: math.MaxInt})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(result.Mods) != 0 {
+		t.Errorf("Mods = %+v, want empty (page 1 is past the 1-mod result set)", result.Mods)
+	}
+	if result.TotalCount != 1 {
+		t.Errorf("TotalCount = %d, want 1", result.TotalCount)
 	}
 }
 

--- a/internal/unrealpak/zlib_test.go
+++ b/internal/unrealpak/zlib_test.go
@@ -17,6 +17,14 @@ type zlibFixture struct {
 	path   string
 	blocks [][]byte // each block's PLAINTEXT; each is deflated independently
 	method int32    // 1-based index into the methods table below
+	// declaredUncompressed, when non-zero, overrides the UncompressedSize
+	// this fixture declares in both its on-disk header and its encoded
+	// index record, independent of the real sum of block plaintext lengths
+	// — for fixtures that need to lie about their size (decompression-bomb
+	// and size-cap regression tests) without needing real gigabytes of
+	// content. Zero means "use the real sum," which every genuine fixture
+	// in this file has anyway (none declares a real zero-length entry).
+	declaredUncompressed int64
 }
 
 // writeMethodPak hand-builds a version-11 pak whose footer declares methods and
@@ -53,6 +61,9 @@ func writeMethodPak(t *testing.T, methods []string, fixtures []zlibFixture) stri
 			payload.Write(zbuf.Bytes())
 			spans = append(spans, span{start, hdrSize + int64(payload.Len())})
 			uncompressed += int64(len(plain))
+		}
+		if fx.declaredUncompressed != 0 {
+			uncompressed = fx.declaredUncompressed
 		}
 		size := int64(payload.Len())
 		sum := sha1.Sum(payload.Bytes()) //nolint:gosec
@@ -263,5 +274,97 @@ func TestReadFile_ZlibCorruptPayload_FailsHashGate(t *testing.T) {
 
 	if _, err := r.ReadFile("c/D.json"); err == nil {
 		t.Fatal("expected an error for a corrupted compressed payload, got nil")
+	}
+}
+
+// A block that decompresses to more bytes than the entry's own declared
+// UncompressedSize (a lying header, or an over-inflating compression bomb)
+// must be caught mid-decompress, not silently truncated or allowed to
+// over-allocate — #175 final review ledger item 1. The real block content
+// is genuinely 1000 bytes; the fixture just declares (and the index/header
+// therefore both agree on) a 5-byte size, which is what readZlib actually
+// checks against as it reads.
+func TestReadFile_ZlibBlockExceedsDeclaredSize_Errors(t *testing.T) {
+	huge := bytes.Repeat([]byte("A"), 1000)
+	p := writeMethodPak(t, []string{"Zlib"}, []zlibFixture{
+		{path: "bomb/D.json", blocks: [][]byte{huge}, method: 1, declaredUncompressed: 5},
+	})
+
+	r, err := Open(p)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+
+	_, err = r.ReadFile("bomb/D.json")
+	if err == nil {
+		t.Fatal("expected an error for a block decompressing past the declared uncompressed size, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds the declared uncompressed size") {
+		t.Errorf("error %q should name the size mismatch", err)
+	}
+}
+
+// An entry declaring an UncompressedSize over maxUncompressedEntrySize must
+// be refused before any decompression is attempted — #175 final review
+// ledger item 2. The real block content is tiny; only the declared size
+// needs to be oversized; the cap check runs before the block loop ever
+// touches the payload, so no gigabytes of real content are needed.
+func TestReadFile_ZlibUncompressedSizeExceedsCap_IsUnsupported(t *testing.T) {
+	body := []byte("tiny")
+	p := writeMethodPak(t, []string{"Zlib"}, []zlibFixture{
+		{path: "big/Huge.json", blocks: [][]byte{body}, method: 1, declaredUncompressed: maxUncompressedEntrySize + 1},
+	})
+
+	r, err := Open(p)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+
+	_, err = r.ReadFile("big/Huge.json")
+	if !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("err = %v, want ErrUnsupportedFormat", err)
+	}
+	if !strings.Contains(err.Error(), "exceeds the") {
+		t.Errorf("error %q should name the cap", err)
+	}
+}
+
+// A block whose (start, end) span falls outside the entry's own payload
+// region must be refused, never sliced out of range — #175 final review
+// ledger item 3. Corrupts the single block's "end" field (at header byte
+// offset 60, per readZlib's hdr[60+i*16:68+i*16] for i=0) to 0, which is
+// less than "start" (== hdrSize == compressedHeaderSize(1), unaffected by
+// this edit), tripping the end < start bounds check — independent of the
+// SHA1 hash gate, since only the header's block-span table is touched, not
+// the actual compressed payload bytes the hash covers.
+func TestReadFile_ZlibBlockSpanOutsidePayload_Errors(t *testing.T) {
+	p := writeMethodPak(t, []string{"Zlib"}, []zlibFixture{
+		{path: "c/D.json", blocks: [][]byte{[]byte("hello world")}, method: 1},
+	})
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 60; i < 68; i++ {
+		raw[i] = 0
+	}
+	if err := os.WriteFile(p, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Open(p)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+
+	_, err = r.ReadFile("c/D.json")
+	if err == nil {
+		t.Fatal("expected an error for a block span outside the entry's payload, got nil")
+	}
+	if !strings.Contains(err.Error(), "outside the entry's payload") {
+		t.Errorf("error %q should name the bounds violation", err)
 	}
 }


### PR DESCRIPTION
## Summary

Closes out every deferred item worth shipping before the epic reaches develop, plus the two genuine catches from #181's Copilot round:

- **Security**: `.EXMODZ` zip entries get a 64 MiB per-entry cap + `LimitReader` bound (mirroring the pattern the dump tarball got in #171's review) — the last unbounded untrusted-input read.
- **Fix**: `Search` pagination clamps `page*pageSize` against int wraparound — adversarial `--page`/page-size values can no longer produce negative slice indices (TDD, incl. a huge-PageSize case).
- **Polish**: Firestore response bodies drained before Close on error paths (connection reuse); exmodz error-path wrapping; stale dump-era comment on `resolveBasePak` corrected.
- **Coverage** (test-only): unrealpak's 3 deferred defensive-path regression tests, firestore_value decoder branch table (arrayValue/integer/double), icarus `GetMod`/`GetDownloadURL`/`CheckUpdates` mock-HTTP tests, malformed-manifest case.

Full suite green (19 packages), gofmt/vet/trunk clean; SDD review approved the code with zero findings (independently re-derived the clamp's overflow math).

Refs #136; addresses the two actionable comments on #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)