### PR TITLE
fix: record deployed state on mod disable/enable (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `lmm mod disable` undeployed a mod's files and cleared `enabled`, but never cleared `deployed` — `lmm list -v` kept showing DEPLOYED yes after disable. The disable flow now clears `deployed` unconditionally after the undeploy attempt, even when the undeploy itself only partially succeeds (already a non-fatal, Note-reported condition), so the flag always reflects disable-intent rather than lagging behind a best-effort file cleanup. The symmetric enable path had the same gap — enabling a disabled mod re-deployed its files without ever setting `deployed` back to true — and is fixed the same way. Both `SetModDeployed` calls follow the same non-fatal Note convention already used by `DeployProfile`/`PurgeProfile` for this same setter: a failure to record the flag doesn't block the primary enable/disable outcome (#183)
+
 ## [1.27.1] - 2026-07-30
 
 ### Fixed

--- a/cmd/lmm/mod.go
+++ b/cmd/lmm/mod.go
@@ -405,11 +405,10 @@ func doModEnable(ctx context.Context, service *core.Service, game *domain.Game, 
 		// accumulated before the fatal error alongside it (mirrors
 		// UninstallMod's own convention - see uninstall.go's
 		// printUninstallDiagnostics); print them now, or they'd otherwise be
-		// lost even though they already happened. result is nil on every
-		// EnableMod error path today, but is guarded here anyway, for parity
-		// with doModDisable below and because EnableResult.Notes is kept
-		// specifically so a future EnableMod diagnostic wouldn't need
-		// another signature change (see its doc comment in flows.go).
+		// lost even though they already happened (e.g. a SetModDeployed
+		// failure Note recorded, then a later SetModEnabled failure, #183).
+		// result is nil only when EnableMod failed before it could allocate
+		// the result struct, exactly like doModDisable below.
 		if result != nil {
 			printModNotes(result.Notes)
 		}

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -22,29 +22,42 @@ import (
 // error) return. Notes carries operational diagnostics using the same
 // display-contract convention as UninstallResult/DeployResult (Task 2's
 // convention, extended here in Task 6 item a for result-struct
-// convergence): always empty today — EnableMod has no diagnostic-producing
-// step — kept for parity with DisableResult and so a future EnableMod
-// diagnostic wouldn't need another signature change.
+// convergence, and by #183's SetModDeployed note below): a caller wanting
+// byte-identical pre-5a output should print each entry to stdout ONLY
+// under --verbose, verbatim, e.g. `fmt.Printf("  %s\n", n)`.
 type EnableResult struct {
 	Changed bool
 	Notes   []string
 }
 
 // DisableResult reports the outcome of DisableMod. Changed mirrors
-// EnableResult.Changed. Notes carries the sole diagnostic DisableMod can
-// produce — a non-fatal undeploy failure (see DisableMod's doc comment) —
-// using the same historical-prefix-baked-into-the-text convention
-// UninstallResult's doc comment documents: a caller wanting byte-identical
-// pre-5a output should print each entry to stdout ONLY under --verbose,
-// verbatim, e.g. `fmt.Printf("  %s\n", n)`.
+// EnableResult.Changed. Notes carries the diagnostics DisableMod can
+// produce — a non-fatal undeploy failure (see DisableMod's doc comment) and
+// (#183) a non-fatal SetModDeployed failure — using the same
+// historical-prefix-baked-into-the-text convention UninstallResult's doc
+// comment documents: a caller wanting byte-identical pre-5a output should
+// print each entry to stdout ONLY under --verbose, verbatim, e.g.
+// `fmt.Printf("  %s\n", n)`.
 type DisableResult struct {
 	Changed bool
 	Notes   []string
 }
 
 // EnableMod deploys an installed-but-disabled mod's files from the cache to
-// the game directory and marks it enabled in the database. Returns a result
-// with Changed false — not an error — if the mod was already enabled.
+// the game directory and marks it enabled (and deployed, #183) in the
+// database. Returns a result with Changed false — not an error — if the
+// mod was already enabled.
+//
+// A SetModDeployed failure is non-fatal (recorded in Notes) — mirroring
+// both DisableMod's own treatment of the identical call and
+// DeployProfile's/PurgeProfile's existing SetModDeployed call sites: the
+// files are already live on disk at this point, and refusing to record the
+// user's intent to enable the mod over a secondary bookkeeping-write
+// failure would leave it stuck exactly like the undeploy-failure case
+// DisableMod already accepts. SetModEnabled's own failure, in contrast,
+// stays fatal (pre-existing behavior, unchanged) — it is the write that
+// makes "the mod is enabled" true at all, unlike the deployed flag, which
+// is a cache of already-true, already-observable state.
 func (s *Service) EnableMod(ctx context.Context, game *domain.Game, profileName, sourceID, modID string) (*EnableResult, error) {
 	mod, err := s.GetInstalledMod(sourceID, modID, game.ID, profileName)
 	if err != nil {
@@ -64,17 +77,24 @@ func (s *Service) EnableMod(ctx context.Context, game *domain.Game, profileName,
 		return nil, fmt.Errorf("failed to deploy mod: %w", err)
 	}
 
-	if err := s.SetModEnabled(sourceID, modID, game.ID, profileName, true); err != nil {
-		return nil, fmt.Errorf("failed to update mod status: %w", err)
+	result := &EnableResult{}
+	if err := s.SetModDeployed(sourceID, modID, game.ID, profileName, true); err != nil {
+		result.Notes = append(result.Notes, fmt.Sprintf("Warning: could not mark as deployed: %v", err))
 	}
 
-	return &EnableResult{Changed: true}, nil
+	if err := s.SetModEnabled(sourceID, modID, game.ID, profileName, true); err != nil {
+		return result, fmt.Errorf("failed to update mod status: %w", err)
+	}
+
+	result.Changed = true
+	return result, nil
 }
 
 // DisableMod undeploys the mod's files from the game directory — the cache
 // entry is kept so the mod can be re-enabled later without downloading again
-// — and marks it disabled in the database. Returns a result with Changed
-// false — not an error — if the mod was already disabled.
+// — and marks it disabled (and not-deployed, #183) in the database. Returns
+// a result with Changed false — not an error — if the mod was already
+// disabled.
 //
 // Undeploy failures are treated as non-fatal: the game files may already
 // have been removed manually, and refusing to record the user's intent to
@@ -83,6 +103,18 @@ func (s *Service) EnableMod(ctx context.Context, game *domain.Game, profileName,
 // — DisableResult.Notes (Task 6 item a) restores that diagnostic for
 // callers that want it, rather than discarding it as the (bool, error)
 // signature this replaces was forced to.
+//
+// A SetModDeployed failure gets the identical non-fatal treatment (#183),
+// for the identical reason and matching DeployProfile's/PurgeProfile's own
+// SetModDeployed call sites: it is attempted unconditionally, even when the
+// undeploy above already failed, because the deployed flag should reflect
+// "disable was requested" regardless of whether the file-level undeploy
+// itself succeeded — an undeploy failure already means the flag may not
+// match reality either way, and the alternative (skipping the write
+// because undeploy failed) would leave the mod stuck reporting DEPLOYED
+// forever, which is #183 itself. SetModEnabled's own failure stays fatal,
+// unchanged: it is the write that makes "the mod is disabled" true at all,
+// not a cache of already-true state.
 func (s *Service) DisableMod(ctx context.Context, game *domain.Game, profileName, sourceID, modID string) (*DisableResult, error) {
 	mod, err := s.GetInstalledMod(sourceID, modID, game.ID, profileName)
 	if err != nil {
@@ -99,6 +131,10 @@ func (s *Service) DisableMod(ctx context.Context, game *domain.Game, profileName
 		// Non-fatal — see doc comment. Historical "Warning: " prefix baked
 		// into the text itself, matching UninstallResult's own convention.
 		result.Notes = append(result.Notes, fmt.Sprintf("Warning: failed to undeploy some files: %v", err))
+	}
+
+	if err := s.SetModDeployed(sourceID, modID, game.ID, profileName, false); err != nil {
+		result.Notes = append(result.Notes, fmt.Sprintf("Warning: could not mark as not deployed: %v", err))
 	}
 
 	if err := s.SetModEnabled(sourceID, modID, game.ID, profileName, false); err != nil {

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -94,7 +94,10 @@ func (s *Service) EnableMod(ctx context.Context, game *domain.Game, profileName,
 // entry is kept so the mod can be re-enabled later without downloading again
 // — and marks it disabled (and not-deployed, #183) in the database. Returns
 // a result with Changed false — not an error — if the mod was already
-// disabled.
+// disabled. That already-disabled path still self-heals a stale
+// deployed=true left behind by a pre-#183 disable (or any other drift):
+// it clears the flag, non-fatally, before returning, so calling disable
+// again converges deployed state even when enabled was already false.
 //
 // Undeploy failures are treated as non-fatal: the game files may already
 // have been removed manually, and refusing to record the user's intent to
@@ -122,7 +125,19 @@ func (s *Service) DisableMod(ctx context.Context, game *domain.Game, profileName
 	}
 
 	if !mod.Enabled {
-		return &DisableResult{}, nil
+		// Self-heal (#183): a mod disabled before this fix shipped can be
+		// stuck with enabled=false but deployed=true forever, since nothing
+		// else clears the flag once the mod is already disabled. Clear it
+		// here too, under the same non-fatal Note convention as the
+		// already-enabled path below, so disable converges the flag even
+		// when called on an already-disabled mod.
+		result := &DisableResult{}
+		if mod.Deployed {
+			if err := s.SetModDeployed(sourceID, modID, game.ID, profileName, false); err != nil {
+				result.Notes = append(result.Notes, fmt.Sprintf("Warning: could not mark as not deployed: %v", err))
+			}
+		}
+		return result, nil
 	}
 
 	result := &DisableResult{}

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -284,6 +284,8 @@ func TestService_DisableMod_UndeployFailureIsNonFatal(t *testing.T) {
 
 	installer := svc.GetInstaller(game)
 	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+	require.NoError(t, svc.SetModDeployed("src", "1", "g1", "default", true),
+		"seed Deployed=true so the post-disable assertion below actually proves a transition")
 
 	// Corrupt the deployed file into a plain file (not a symlink) so the
 	// symlink linker's Undeploy fails deterministically ("not a symlink").

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -128,6 +128,7 @@ func TestService_EnableMod_DeploysDisabledMod(t *testing.T) {
 	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
 	require.NoError(t, err)
 	assert.True(t, mod.Enabled)
+	assert.True(t, mod.Deployed, "#183: enabling a mod must also record it as deployed")
 }
 
 func TestService_EnableMod_AlreadyEnabledIsNoop(t *testing.T) {
@@ -214,9 +215,12 @@ func TestService_DisableMod_UndeploysEnabledMod(t *testing.T) {
 	})
 
 	// Deploy the files first so there's something to undeploy (mirrors an
-	// install that happened earlier).
+	// install that happened earlier), and record the DB's deployed flag to
+	// match — seedInstalledMod doesn't set it, so this mirrors the real
+	// precondition DisableMod actually sees for a genuinely-deployed mod.
 	installer := svc.GetInstaller(game)
 	require.NoError(t, installer.Install(context.Background(), game, &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g1"}, "default"))
+	require.NoError(t, svc.SetModDeployed("src", "1", "g1", "default", true))
 
 	result, err := svc.DisableMod(context.Background(), game, "default", "src", "1")
 	require.NoError(t, err)
@@ -232,6 +236,7 @@ func TestService_DisableMod_UndeploysEnabledMod(t *testing.T) {
 	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
 	require.NoError(t, err)
 	assert.False(t, mod.Enabled)
+	assert.False(t, mod.Deployed, "#183: disabling a mod must also clear the deployed flag")
 }
 
 func TestService_DisableMod_AlreadyDisabledIsNoop(t *testing.T) {
@@ -297,6 +302,73 @@ func TestService_DisableMod_UndeployFailureIsNonFatal(t *testing.T) {
 	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
 	require.NoError(t, err)
 	assert.False(t, mod.Enabled, "DB should still flip to disabled even when undeploy is best-effort")
+	assert.False(t, mod.Deployed, "#183: the deployed flag must still clear to record intent, even when the undeploy itself was best-effort")
+}
+
+// TestService_DisableMod_SetModDeployedFailure_NonFatalNote pins the #183
+// fix's own failure-handling decision: a SetModDeployed(false) failure is
+// non-fatal, recorded as a Note, exactly like DisableMod's existing
+// Uninstall-failure handling and like PurgeProfile's own SetModDeployed
+// call (see TestService_PurgeProfile_SetModDeployedFailure_NonFatalNote) —
+// not escalated to a hard error the way SetModEnabled's own failure still
+// is. installBlockingTrigger blocks only the "deployed" column, so
+// SetModEnabled (a different column) still succeeds.
+func TestService_DisableMod_SetModDeployedFailure_NonFatalNote(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{"plugin.esp": []byte("data")})
+	installSeededMod(t, svc, game, "1")
+	installBlockingTrigger(t, filepath.Join(dataDir, "lmm.db"))
+
+	result, err := svc.DisableMod(context.Background(), game, "default", "src", "1")
+	require.NoError(t, err, "a SetModDeployed failure must not fail DisableMod")
+	require.NotNil(t, result)
+	assert.True(t, result.Changed)
+	require.NotEmpty(t, result.Notes)
+	assert.Contains(t, strings.Join(result.Notes, "\n"), "could not mark as not deployed",
+		"Notes = %v, want one mentioning the SetModDeployed failure", result.Notes)
+
+	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+	assert.False(t, mod.Enabled, "SetModEnabled touches a different column and must still succeed")
+}
+
+// TestService_EnableMod_SetModDeployedFailure_NonFatalNote is
+// TestService_DisableMod_SetModDeployedFailure_NonFatalNote's mirror for
+// the enable path.
+func TestService_EnableMod_SetModDeployedFailure_NonFatalNote(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(), DataDir: dataDir, CacheDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", false, map[string][]byte{"plugin.esp": []byte("data")})
+	installBlockingTrigger(t, filepath.Join(dataDir, "lmm.db"))
+
+	result, err := svc.EnableMod(context.Background(), game, "default", "src", "1")
+	require.NoError(t, err, "a SetModDeployed failure must not fail EnableMod")
+	require.NotNil(t, result)
+	assert.True(t, result.Changed)
+	require.NotEmpty(t, result.Notes)
+	assert.Contains(t, strings.Join(result.Notes, "\n"), "could not mark as deployed",
+		"Notes = %v, want one mentioning the SetModDeployed failure", result.Notes)
+
+	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+	assert.True(t, mod.Enabled, "SetModEnabled touches a different column and must still succeed")
 }
 
 // --- UninstallMod ---

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -254,6 +254,34 @@ func TestService_DisableMod_AlreadyDisabledIsNoop(t *testing.T) {
 	assert.False(t, result.Changed)
 }
 
+// TestService_DisableMod_AlreadyDisabledSelfHealsStaleDeployedFlag pins
+// #183's self-heal follow-up: a mod disabled before the #183 fix shipped
+// (or otherwise drifted) can be stuck at enabled=false, deployed=true
+// forever, since nothing else clears the flag once a mod is already
+// disabled. Calling DisableMod again on it must converge deployed to
+// false, still succeed, and still report Changed=false (the enabled
+// status itself didn't change).
+func TestService_DisableMod_AlreadyDisabledSelfHealsStaleDeployedFlag(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", false, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
+	require.NoError(t, svc.SetModDeployed("src", "1", "g1", "default", true),
+		"simulate a pre-#183 disable that left the stale deployed=true flag behind")
+
+	result, err := svc.DisableMod(context.Background(), game, "default", "src", "1")
+	require.NoError(t, err, "self-healing the stale flag must still report success")
+	require.NotNil(t, result)
+	assert.False(t, result.Changed, "enabled status itself didn't change")
+
+	mod, err := svc.GetInstalledMod("src", "1", "g1", "default")
+	require.NoError(t, err)
+	assert.False(t, mod.Deployed, "#183: re-disabling an already-disabled mod must self-heal a stale deployed=true")
+}
+
 func TestService_DisableMod_UnknownModReturnsErrModNotFound(t *testing.T) {
 	svc := newFlowsTestService(t)
 	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}


### PR DESCRIPTION
## Summary

- `DisableMod` undeployed a mod's files and cleared `enabled`, but never cleared `deployed` — `lmm list -v` kept showing `DEPLOYED yes` after disable.
- Audited the symmetric path: `EnableMod` had the same gap — re-deploying a disabled mod never set `deployed` back to `true`.
- Both flows now call `SetModDeployed` right after the (un)deploy step, using the same non-fatal "Note" convention `DeployProfile`/`PurgeProfile` already use for this exact setter: a failure to persist the flag is recorded as a warning Note, not returned as a fatal error, since it's secondary bookkeeping rather than the primary enable/disable intent (`SetModEnabled` failures remain fatal, unchanged).
- `DisableMod` clears `deployed` unconditionally after the undeploy attempt, even when `Uninstall` only partially succeeds — that failure mode was already treated as non-fatal (Note) before this fix, so the deployed flag should track disable-*intent*, not depend on every file cleanup landing perfectly.
- `EnableMod`'s `SetModEnabled`-failure return changed from `nil` to `result` so an earlier `SetModDeployed` Note isn't silently dropped; verified both CLI (`cmd/lmm/mod.go`) and TUI (`internal/tui/service_core.go`) callers already nil-guard `result` before use, so this is safe.

## Repro (pre-fix)

```
lmm mod disable <mod>
lmm list -v
# -> DEPLOYED yes (should be no)
```

## Test plan

- [x] RED: extended `TestService_DisableMod_UndeploysEnabledMod` / `TestService_EnableMod_DeploysDisabledMod` with `Deployed` assertions — failed before the fix, proving the stale flag.
- [x] GREEN: same tests pass after the fix.
- [x] New `TestService_DisableMod_SetModDeployedFailure_NonFatalNote` / `TestService_EnableMod_SetModDeployedFailure_NonFatalNote` use the existing `installBlockingTrigger` fault-injection helper to force `SetModDeployed` to fail on its own DB column, proving the Note is recorded and the primary enable/disable outcome still succeeds.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` — all packages green
- [x] `trunk check` — no new issues
- [x] CHANGELOG `[Unreleased]` → Fixed entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)