### PR TITLE
fix: release-review hardening batch (#203 review)

### DIFF
--- a/cmd/lmm/game.go
+++ b/cmd/lmm/game.go
@@ -270,7 +270,7 @@ func gameFromDetected(g steam.DetectedGame) (*domain.Game, error) {
 			domain.ErrInvalidDeployMode, g.Slug, g.DeployMode, domain.ValidDeployModes)
 	}
 	sources := g.Sources
-	if sources == nil {
+	if len(sources) == 0 {
 		if g.NexusID == "" {
 			return nil, fmt.Errorf("game %q: known-games entry has no sources and no nexus_id - set at least one", g.Slug)
 		}

--- a/cmd/lmm/game.go
+++ b/cmd/lmm/game.go
@@ -254,20 +254,27 @@ func runGameDetect(cmd *cobra.Command, args []string) error {
 // wins outright; otherwise this derives the single-entry {nexusmods:
 // g.NexusID} map every detected game produced before Sources existed, so
 // every pre-#177 known game generates byte-for-byte the same games.yaml
-// block it always has. g.DeployMode goes through domain.ParseDeployMode,
-// which already treats "" as DeployExtract (today's default); an
-// unrecognized non-empty value in the known-games schema (steam-games.yaml,
-// built-in or user override) is a load-time error rather than a silent
-// fallback (#172).
+// block it always has. A known-games entry setting NEITHER is
+// misconfigured - every legitimate entry sets at least one - and used to
+// silently produce {"nexusmods": ""}, a garbage source mapping that would
+// propagate into games.yaml unnoticed; that is now a fail-loud error naming
+// the game instead (#203 release review). g.DeployMode goes through
+// domain.ParseDeployMode, which already treats "" as DeployExtract (today's
+// default); an unrecognized non-empty value in the known-games schema
+// (steam-games.yaml, built-in or user override) is a load-time error rather
+// than a silent fallback (#172).
 func gameFromDetected(g steam.DetectedGame) (*domain.Game, error) {
-	sources := g.Sources
-	if sources == nil {
-		sources = map[string]string{"nexusmods": g.NexusID}
-	}
 	deployMode, ok := domain.ParseDeployMode(g.DeployMode)
 	if !ok {
 		return nil, fmt.Errorf("%w: steam-games.yaml: game %q: deploy_mode %q (valid: %s)",
 			domain.ErrInvalidDeployMode, g.Slug, g.DeployMode, domain.ValidDeployModes)
+	}
+	sources := g.Sources
+	if sources == nil {
+		if g.NexusID == "" {
+			return nil, fmt.Errorf("game %q: known-games entry has no sources and no nexus_id - set at least one", g.Slug)
+		}
+		sources = map[string]string{"nexusmods": g.NexusID}
 	}
 	return &domain.Game{
 		ID:          g.Slug,

--- a/cmd/lmm/game_detect_test.go
+++ b/cmd/lmm/game_detect_test.go
@@ -129,6 +129,21 @@ func TestGameFromDetected_RequiresSourcesOrNexusID(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{"icarus": "icarus"}, game.SourceIDs)
 	})
+
+	// #204 round-2 review: YAML unmarshaling an explicit `sources: {}` line
+	// produces map[string]string{} (empty, non-nil), which the original
+	// `sources == nil` check let slide through, still landing at
+	// {"nexusmods": ""} when NexusID is also unset. Empty must be treated
+	// identically to nil.
+	t.Run("empty-but-non-nil Sources map fails the same as nil", func(t *testing.T) {
+		_, err := gameFromDetected(steam.DetectedGame{
+			Slug:    "empty-sources-game",
+			Name:    "Empty Sources Game",
+			Sources: map[string]string{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty-sources-game")
+	})
 }
 
 // TestGameFromDetected_Icarus_ProducesReadmeEquivalentValues proves the

--- a/cmd/lmm/game_detect_test.go
+++ b/cmd/lmm/game_detect_test.go
@@ -92,6 +92,45 @@ func TestGameFromDetected_RejectsUnknownDeployMode(t *testing.T) {
 	assert.Contains(t, err.Error(), "compil")
 }
 
+// TestGameFromDetected_RequiresSourcesOrNexusID guards a Copilot release-
+// review finding on #203: a known-games entry with neither Sources NOR a
+// non-empty NexusID used to silently produce {"nexusmods": ""} - a garbage
+// source mapping (an empty NexusMods game ID) that would propagate into
+// games.yaml unnoticed. This is a misconfigured known-games entry (every
+// legitimate one sets at least one of the two), so it must fail loud,
+// naming the game, instead. Both legs: the failing case, and the two
+// success cases (Sources-only, NexusID-only) that must remain unaffected.
+func TestGameFromDetected_RequiresSourcesOrNexusID(t *testing.T) {
+	t.Run("neither Sources nor NexusID fails loud", func(t *testing.T) {
+		_, err := gameFromDetected(steam.DetectedGame{
+			Slug: "misconfigured-game",
+			Name: "Misconfigured Game",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "misconfigured-game")
+	})
+
+	t.Run("NexusID alone is sufficient", func(t *testing.T) {
+		game, err := gameFromDetected(steam.DetectedGame{
+			Slug:    "skyrim-se",
+			Name:    "Skyrim Special Edition",
+			NexusID: "skyrimspecialedition",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"nexusmods": "skyrimspecialedition"}, game.SourceIDs)
+	})
+
+	t.Run("Sources alone is sufficient", func(t *testing.T) {
+		game, err := gameFromDetected(steam.DetectedGame{
+			Slug:    "icarus",
+			Name:    "Icarus",
+			Sources: map[string]string{"icarus": "icarus"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"icarus": "icarus"}, game.SourceIDs)
+	})
+}
+
 // TestGameFromDetected_Icarus_ProducesReadmeEquivalentValues proves the
 // #177 acceptance criterion directly: saving a detected Icarus produces a
 // games.yaml entry whose values match the README's hand-written example

--- a/cmd/lmm/list.go
+++ b/cmd/lmm/list.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -96,11 +97,20 @@ func doList(cmd *cobra.Command, service *core.Service, game *domain.Game) error 
 	// #97: lock state lives on the profile YAML ref, not the DB row
 	// GetInstalledMods above already returned - load it separately and key
 	// by domain.ModKey for O(1) lookup per mod below (a precomputed map,
-	// not per-row FindRef, since this loops over every mod). Tolerant of a
-	// missing/unreadable profile.yaml (mirrors coreProvider.Overview's own
-	// "_ =" shape, internal/tui/service_core.go): an unreadable profile just
-	// means nothing shows as locked, not a failed listing.
-	profileYAML, _ := config.LoadProfile(service.ConfigDir(), game.ID, profileName)
+	// not per-row FindRef, since this loops over every mod). Tolerant ONLY
+	// of a genuinely missing profile.yaml (domain.ErrProfileNotFound) - a
+	// fresh profile with no YAML on disk yet just means nothing shows as
+	// locked, not a failed listing. Any OTHER LoadProfile error, including
+	// #172's fail-loud link_method validation, must surface immediately
+	// instead of silently degrading: swallowing it here used to mean an
+	// invalid profile YAML made `lmm list` quietly show no lock info AND
+	// (per #201) treat every mod as absent from the load order, instead of
+	// reporting the same error every other command honors (#203 release
+	// review).
+	profileYAML, err := config.LoadProfile(service.ConfigDir(), game.ID, profileName)
+	if err != nil && !errors.Is(err, domain.ErrProfileNotFound) {
+		return fmt.Errorf("loading profile: %w", err)
+	}
 	lockedByKey := map[string]domain.ModReference{}
 	if profileYAML != nil {
 		for _, ref := range profileYAML.Mods {

--- a/cmd/lmm/list_profile_error_test.go
+++ b/cmd/lmm/list_profile_error_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDoList_InvalidProfileLinkMethod_FailsLoud guards a Copilot release-
+// review finding on #203: doList's own lock-state lookup used to ignore
+// EVERY config.LoadProfile error (`profileYAML, _ := config.LoadProfile(...)`),
+// including #172's fail-loud validation errors - an invalid link_method in
+// the profile YAML would silently degrade `lmm list` (no lock info shown,
+// and per #201 every mod would read as "absent from the load order")
+// instead of surfacing the same load-time error every other command
+// honors. Only a genuinely missing profile.yaml (domain.ErrProfileNotFound)
+// is tolerable; any other error, including validation, must surface.
+func TestDoList_InvalidProfileLinkMethod_FailsLoud(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	oldListProfile, oldListProfiles := listProfile, listProfiles
+	listProfile, listProfiles = "", false
+	t.Cleanup(func() { listProfile, listProfiles = oldListProfile, oldListProfiles })
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+
+	profilePath := filepath.Join(svc.ConfigDir(), "games", game.ID, "profiles", "default.yaml")
+	require.FileExists(t, profilePath, "precondition: setupDoDeployTest/seedDeployableMod must have created the profile")
+	data, err := os.ReadFile(profilePath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(profilePath, append(data, []byte("\nlink_method: bogus\n")...), 0o644))
+
+	err = doList(&cobra.Command{}, svc, game)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "link_method")
+	assert.Contains(t, err.Error(), "bogus")
+}
+
+// TestDoList_MissingProfileYAML_StillLists is the tolerant leg's guard: a
+// mod installed with NO profile.yaml ever written (e.g. a fresh DB row
+// with no matching ProfileManager.Create/AddMod call) must still list
+// successfully - only domain.ErrProfileNotFound is swallowed, unlike a
+// genuine validation error (the sibling test above).
+func TestDoList_MissingProfileYAML_StillLists(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	oldListProfile, oldListProfiles := listProfile, listProfiles
+	listProfile, listProfiles = "", false
+	t.Cleanup(func() { listProfile, listProfiles = oldListProfile, oldListProfiles })
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "a", SourceID: "src", Name: "Mod A", Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+	profilePath := filepath.Join(svc.ConfigDir(), "games", game.ID, "profiles", "default.yaml")
+	_, statErr := os.Stat(profilePath)
+	require.True(t, os.IsNotExist(statErr), "precondition: no profile.yaml should exist yet")
+
+	out := listNonVerbose(t, svc, game)
+	assert.Contains(t, out, "Mod A")
+}

--- a/internal/source/icarus/exmodz.go
+++ b/internal/source/icarus/exmodz.go
@@ -62,22 +62,38 @@ func ParseExmodz(zipData []byte) (*ExmodzBundle, error) {
 	if err != nil {
 		return nil, fmt.Errorf("icarus: %s: %w", manifestPath, err)
 	}
-	bundle := &ExmodzBundle{Diff: diff, Assets: make(map[string][]byte)}
-
+	// Collect the asset entries first and sum their DECLARED sizes before
+	// reading any of them: the per-entry cap alone lets an archive with many
+	// entries, each individually under it, still declare an unbounded total
+	// (e.g. five 60 MiB entries sum to 300 MiB despite none tripping the
+	// 64 MiB per-entry check on its own). Checking the declared-size total
+	// up front refuses a pathological archive before any asset content is
+	// read into memory at all.
+	var assetFiles []*zip.File
+	var totalDeclaredSize uint64
 	for _, f := range zr.File {
 		if f.Name == manifestPath || f.FileInfo().IsDir() {
 			continue
 		}
-		normalized := normalizeZipName(f.Name)
-		lower := strings.ToLower(normalized)
+		lower := strings.ToLower(normalizeZipName(f.Name))
 		if !strings.HasSuffix(lower, ".uasset") && !strings.HasSuffix(lower, ".uexp") {
 			continue // skip readme/image/other non-asset files — never placed into the output pak
 		}
+		assetFiles = append(assetFiles, f)
+		totalDeclaredSize += f.UncompressedSize64
+	}
+	if totalDeclaredSize > maxZipTotalAssetsSize {
+		return nil, fmt.Errorf("icarus: .EXMODZ bundled assets declare a combined %d-byte uncompressed size, "+
+			"exceeding the %d-byte total cap", totalDeclaredSize, uint64(maxZipTotalAssetsSize))
+	}
+
+	bundle := &ExmodzBundle{Diff: diff, Assets: make(map[string][]byte)}
+	for _, f := range assetFiles {
 		data, err := readZipFile(f)
 		if err != nil {
 			return nil, fmt.Errorf("icarus: reading asset %s: %w", f.Name, err)
 		}
-		bundle.Assets[normalized] = data
+		bundle.Assets[normalizeZipName(f.Name)] = data
 	}
 
 	return bundle, nil
@@ -98,6 +114,14 @@ func normalizeZipName(name string) string {
 // leaves generous headroom while refusing to trust an unbounded or lying
 // UncompressedSize64 in a third-party, user-downloaded zip archive.
 const maxZipEntrySize = 64 << 20
+
+// maxZipTotalAssetsSize caps the COMBINED declared uncompressed size of
+// every bundled asset in a single .EXMODZ - the per-entry cap alone doesn't
+// bound an archive with many entries each individually under it (#203
+// release review). A real bundle's assets are a handful of small UE files;
+// 256 MiB leaves generous headroom while still refusing to trust an
+// archive that declares an unbounded total.
+const maxZipTotalAssetsSize = 256 << 20
 
 func readZipFile(f *zip.File) ([]byte, error) {
 	if f.UncompressedSize64 > maxZipEntrySize {

--- a/internal/source/icarus/exmodz.go
+++ b/internal/source/icarus/exmodz.go
@@ -79,12 +79,19 @@ func ParseExmodz(zipData []byte) (*ExmodzBundle, error) {
 		if !strings.HasSuffix(lower, ".uasset") && !strings.HasSuffix(lower, ".uexp") {
 			continue // skip readme/image/other non-asset files — never placed into the output pak
 		}
+		// Checked against the remaining cap headroom BEFORE adding, not by
+		// summing first and comparing after: a declared size is
+		// attacker-controlled and `totalDeclaredSize += f.UncompressedSize64`
+		// can overflow a uint64, wrapping the running total to a value that
+		// falsely passes the cap check (#204 release review round 2).
+		// totalDeclaredSize <= maxZipTotalAssetsSize is an invariant of every
+		// prior iteration, so this subtraction never underflows.
+		if f.UncompressedSize64 > maxZipTotalAssetsSize-totalDeclaredSize {
+			return nil, fmt.Errorf("icarus: .EXMODZ bundled assets declare a combined uncompressed size "+
+				"exceeding the %d-byte total cap", uint64(maxZipTotalAssetsSize))
+		}
 		assetFiles = append(assetFiles, f)
 		totalDeclaredSize += f.UncompressedSize64
-	}
-	if totalDeclaredSize > maxZipTotalAssetsSize {
-		return nil, fmt.Errorf("icarus: .EXMODZ bundled assets declare a combined %d-byte uncompressed size, "+
-			"exceeding the %d-byte total cap", totalDeclaredSize, uint64(maxZipTotalAssetsSize))
 	}
 
 	bundle := &ExmodzBundle{Diff: diff, Assets: make(map[string][]byte)}

--- a/internal/source/icarus/exmodz_test.go
+++ b/internal/source/icarus/exmodz_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"hash/crc32"
+	"math"
 	"strings"
 	"testing"
 )
@@ -330,5 +331,62 @@ func TestParseExmodz_RejectsOversizedTotalAssetsSize(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "EXMODZ") {
 		t.Errorf("error %q should name the archive", err)
+	}
+}
+
+// TestParseExmodz_TotalAssetsSizeAccumulationIsOverflowSafe guards a
+// Copilot round-2 release-review finding on #204: totalDeclaredSize +=
+// f.UncompressedSize64 summed attacker-controlled declared sizes with no
+// per-entry gate, so two entries whose declared sizes overflow a uint64 sum
+// wrap the total to a value far below the 256 MiB cap - the total-cap check
+// meant to reject the whole bundle before any asset is read silently
+// passes, and the bundle only fails afterward (if at all) via the
+// UNRELATED per-entry cap inside readZipFile, once assets are actually
+// being opened. The fix must reject against the remaining cap headroom
+// BEFORE adding each declared size, so the total-cap error - not the
+// per-entry one - fires first, without ever calling readZipFile.
+func TestParseExmodz_TotalAssetsSizeAccumulationIsOverflowSafe(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	w, err := zw.Create("Extracted Mods/X.EXMOD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte(`{"name":"X","Rows":[]}`)) //nolint:errcheck
+
+	content := []byte("tiny")
+	crc := crc32.ChecksumIEEE(content)
+	// The sum of these two declared sizes overflows uint64 and wraps to 49
+	// (math.MaxUint64-50 + 100 == math.MaxUint64+50, mod 2^64), even though
+	// the first entry alone already dwarfs the 256 MiB total cap.
+	sizes := []uint64{math.MaxUint64 - 50, 100}
+	for i, size := range sizes {
+		rawW, err := zw.CreateRaw(&zip.FileHeader{
+			Name:               fmt.Sprintf("Bear_Mount/huge%d.uasset", i),
+			Method:             zip.Store,
+			UncompressedSize64: size,
+			CompressedSize64:   uint64(len(content)),
+			CRC32:              crc,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rawW.Write(content) //nolint:errcheck
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ParseExmodz(buf.Bytes())
+	if err == nil {
+		t.Fatal("expected an error for a declared-size sum that overflows uint64, got nil")
+	}
+	if !strings.Contains(err.Error(), "total cap") {
+		t.Errorf("error %q should name the total cap - an overflowed sum must not slip past it undetected", err)
+	}
+	if strings.Contains(err.Error(), "per-entry cap") {
+		t.Errorf("error %q fired from the per-entry check, meaning uint64 overflow bypassed the total-cap check", err)
 	}
 }

--- a/internal/source/icarus/exmodz_test.go
+++ b/internal/source/icarus/exmodz_test.go
@@ -3,6 +3,7 @@ package icarus
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
 	"hash/crc32"
 	"strings"
 	"testing"
@@ -278,5 +279,56 @@ func TestParseExmodz_RejectsLyingAssetDeclaredSize(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Bear_Mount/lying.uasset") {
 		t.Errorf("error %q should name the offending entry", err)
+	}
+}
+
+// TestParseExmodz_RejectsOversizedTotalAssetsSize guards a Copilot release-
+// review finding on #203: the per-entry cap (maxZipEntrySize, 64 MiB) alone
+// lets an archive with MANY entries, each individually under that cap,
+// still declare an unbounded total - e.g. five entries at 60 MiB apiece sum
+// to 300 MiB despite no single entry tripping the per-entry check. A total
+// cap across every bundled asset closes that gap. zw.CreateRaw declares the
+// size fields verbatim, so the fixture never needs real hundreds of MiB of
+// content, and the check must fire against the DECLARED sizes before any
+// asset is read - the fixture's real content is just a few bytes.
+func TestParseExmodz_RejectsOversizedTotalAssetsSize(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	w, err := zw.Create("Extracted Mods/X.EXMOD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte(`{"name":"X","Rows":[]}`)) //nolint:errcheck
+
+	// 5 entries * 60 MiB declared = 300 MiB, over the 256 MiB total cap,
+	// while each individual entry (60 MiB) stays under the 64 MiB per-entry
+	// cap.
+	const perEntryDeclared = 60 << 20
+	content := []byte("tiny")
+	for i := 0; i < 5; i++ {
+		rawW, err := zw.CreateRaw(&zip.FileHeader{
+			Name:               fmt.Sprintf("Bear_Mount/asset%d.uasset", i),
+			Method:             zip.Store,
+			UncompressedSize64: perEntryDeclared,
+			CompressedSize64:   uint64(len(content)),
+			CRC32:              crc32.ChecksumIEEE(content),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rawW.Write(content) //nolint:errcheck
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ParseExmodz(buf.Bytes())
+	if err == nil {
+		t.Fatal("expected an error for bundled assets whose combined declared size exceeds the total cap, got nil")
+	}
+	if !strings.Contains(err.Error(), "EXMODZ") {
+		t.Errorf("error %q should name the archive", err)
 	}
 }

--- a/internal/source/icarus/firestore_client.go
+++ b/internal/source/icarus/firestore_client.go
@@ -103,9 +103,13 @@ func (c *firestoreClient) getJSON(ctx context.Context, url string, out any) erro
 		// Firestore permission error, a quota message, and a malformed
 		// request all look identical without the URL and body.
 		const errBodySnippetCap = 512
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, errBodySnippetCap))
+		snippetBytes, _ := io.ReadAll(io.LimitReader(resp.Body, errBodySnippetCap))
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("icarus: GET %s: HTTP %d: %s", url, resp.StatusCode, strings.TrimSpace(string(snippet)))
+		snippet := strings.TrimSpace(string(snippetBytes))
+		if snippet == "" {
+			return fmt.Errorf("icarus: GET %s: HTTP %d", url, resp.StatusCode)
+		}
+		return fmt.Errorf("icarus: GET %s: HTTP %d: %s", url, resp.StatusCode, snippet)
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
 }

--- a/internal/source/icarus/firestore_client.go
+++ b/internal/source/icarus/firestore_client.go
@@ -93,13 +93,19 @@ func (c *firestoreClient) getJSON(ctx context.Context, url string, out any) erro
 	}
 	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode != http.StatusOK {
-		// Drain before Close so the underlying connection stays eligible for
-		// reuse — net/http only pools an HTTP/1.x connection once its body
-		// has been read to EOF; returning immediately here left whatever the
-		// server sent (however small) unread, forcing the transport to
-		// close the connection instead of reusing it for the next request.
+		// Read a capped snippet for the error message, then keep draining
+		// to EOF before Close so the underlying connection stays eligible
+		// for reuse — net/http only pools an HTTP/1.x connection once its
+		// body has been read to EOF; returning immediately here left
+		// whatever the server sent unread, forcing the transport to close
+		// the connection instead of reusing it for the next request. A bare
+		// "HTTP %d" left a 403 (or any other failure) undiagnosable: a
+		// Firestore permission error, a quota message, and a malformed
+		// request all look identical without the URL and body.
+		const errBodySnippetCap = 512
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, errBodySnippetCap))
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("HTTP %d", resp.StatusCode)
+		return fmt.Errorf("icarus: GET %s: HTTP %d: %s", url, resp.StatusCode, strings.TrimSpace(string(snippet)))
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
 }

--- a/internal/source/icarus/firestore_client_test.go
+++ b/internal/source/icarus/firestore_client_test.go
@@ -1,11 +1,13 @@
 package icarus
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -213,5 +215,53 @@ func TestFirestoreClient_GetJSON_DrainsBodyBeforeCloseOnErrorPath(t *testing.T) 
 	}
 	if !transport.tracked.closed {
 		t.Error("response body was not closed")
+	}
+}
+
+// TestFirestoreClient_GetJSON_ErrorNamesURLAndBodySnippet guards a Copilot
+// release-review finding on #203: getJSON's non-200 error was a bare "HTTP
+// %d", naming neither which request failed nor what the server actually
+// said - a 403 was otherwise undiagnosable (a Firestore permission error, a
+// quota message, and a malformed-request response all look identical). The
+// error must name the request URL and a snippet of the response body.
+func TestFirestoreClient_GetJSON_ErrorNamesURLAndBodySnippet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":{"message":"PERMISSION_DENIED: quota exceeded"}}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := newFirestoreClient("test-project", srv.Client())
+	err := c.getJSON(context.Background(), srv.URL+"/some/path", &struct{}{})
+	if err == nil {
+		t.Fatal("expected an error for a 403 response, got nil")
+	}
+	if !strings.Contains(err.Error(), srv.URL+"/some/path") {
+		t.Errorf("error %q does not name the request URL", err.Error())
+	}
+	if !strings.Contains(err.Error(), "PERMISSION_DENIED") {
+		t.Errorf("error %q does not include the response body snippet", err.Error())
+	}
+}
+
+// TestFirestoreClient_GetJSON_ErrorBodySnippetIsCapped guards the "cap it"
+// half of the same finding: a large/pathological error body (a stray HTML
+// error page, a runaway response, ...) must not be echoed in full into the
+// error message.
+func TestFirestoreClient_GetJSON_ErrorBodySnippetIsCapped(t *testing.T) {
+	const bodySize = 64 * 1024
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write(bytes.Repeat([]byte("x"), bodySize)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := newFirestoreClient("test-project", srv.Client())
+	err := c.getJSON(context.Background(), srv.URL, &struct{}{})
+	if err == nil {
+		t.Fatal("expected an error for a 403 response, got nil")
+	}
+	if len(err.Error()) >= bodySize {
+		t.Errorf("error message is %d bytes - the response body snippet must be capped, not echoed in full", len(err.Error()))
 	}
 }

--- a/internal/source/icarus/firestore_client_test.go
+++ b/internal/source/icarus/firestore_client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -263,5 +264,31 @@ func TestFirestoreClient_GetJSON_ErrorBodySnippetIsCapped(t *testing.T) {
 	}
 	if len(err.Error()) >= bodySize {
 		t.Errorf("error message is %d bytes - the response body snippet must be capped, not echoed in full", len(err.Error()))
+	}
+}
+
+// TestFirestoreClient_GetJSON_ErrorOmitsBodyClauseWhenSnippetIsEmpty guards
+// a Copilot round-2 release-review finding on #204: a non-200 response with
+// no body (or a whitespace-only one) left the ": %s" clause in the error
+// message with nothing after the trailing colon (e.g. "icarus: GET
+// http://...: HTTP 403: "). The body clause must be omitted entirely when
+// the trimmed snippet is empty, not rendered with a dangling colon.
+func TestFirestoreClient_GetJSON_ErrorOmitsBodyClauseWhenSnippetIsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := newFirestoreClient("test-project", srv.Client())
+	err := c.getJSON(context.Background(), srv.URL, &struct{}{})
+	if err == nil {
+		t.Fatal("expected an error for a 403 response, got nil")
+	}
+	if strings.HasSuffix(err.Error(), ":") || strings.HasSuffix(err.Error(), ": ") {
+		t.Errorf("error %q has a dangling colon with no body snippet after it", err.Error())
+	}
+	want := fmt.Sprintf("icarus: GET %s: HTTP 403", srv.URL)
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
 	}
 }

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -288,18 +288,34 @@ type UpdateItem struct {
 	// installed mod - and ApplyUpdate routes such a row to
 	// Service.ApplyMergedPakRegen instead of Service.ApplyUpdate.
 	RecompileNeeded bool
+	// RecompileReason is domain.Update's own distinct staleness reason
+	// ("base pak updated" - the fingerprint changed - or "not deployed" -
+	// the fingerprint still matches but the artifact is missing from the
+	// game directory), meaningful only when RecompileNeeded is true. #203
+	// release review: the TUI used to hardcode "(base pak updated)" for
+	// every staleness row regardless of the real cause, unlike `lmm verify`
+	// (cmd/lmm/verify.go), which already names the distinct reason.
+	RecompileReason string
 }
 
 // VersionLabel renders u's version change for display: the normal
-// "<from> → <to>" arrow for a real update, or "(base pak updated)" for a
-// #197 RecompileNeeded row, where FromVersion == ToVersion and an arrow
-// would misleadingly read as a no-op. Used everywhere an UpdateItem's
-// version change is shown - the apply-updates modal, its result lines, and
-// the changelog picker/overlay - so all of them read sanely for a
-// staleness row without duplicating this branch four times.
+// "<from> → <to>" arrow for a real update, or "(<reason>)" for a #197
+// RecompileNeeded row, where FromVersion == ToVersion and an arrow would
+// misleadingly read as a no-op - RecompileReason names the actual cause
+// ("base pak updated" or "not deployed"), matching what `lmm verify`
+// already shows; an empty RecompileReason (defensive - core always sets
+// one alongside RecompileNeeded) falls back to "base pak updated" rather
+// than rendering an empty "()". Used everywhere an UpdateItem's version
+// change is shown - the apply-updates modal, its result lines, and the
+// changelog picker/overlay - so all of them read sanely for a staleness
+// row without duplicating this branch four times.
 func (u UpdateItem) VersionLabel() string {
 	if u.RecompileNeeded {
-		return "(base pak updated)"
+		reason := u.RecompileReason
+		if reason == "" {
+			reason = "base pak updated"
+		}
+		return fmt.Sprintf("(%s)", reason)
 	}
 	return fmt.Sprintf("%s → %s", u.FromVersion, u.ToVersion)
 }

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -1454,6 +1454,7 @@ func (p *coreProvider) CheckUpdates(ctx context.Context) (UpdatesView, error) {
 			Changelog: core.CleanChangelog(u.Changelog),
 			Locked:    isLocked, LockedVersion: lockedVersion,
 			RecompileNeeded: u.RecompileNeeded,
+			RecompileReason: u.RecompileReason,
 		})
 	}
 	if skipped := updateSkipWarning(core.CountUpdateSkips(installed)); skipped != "" {

--- a/internal/tui/service_core_recompile_test.go
+++ b/internal/tui/service_core_recompile_test.go
@@ -145,7 +145,78 @@ func TestCoreProviderActions_CheckUpdates_ReportsRecompileNeeded(t *testing.T) {
 	require.Equal(t, "merged-pak", u.ID)
 	require.True(t, u.RecompileNeeded)
 	require.Equal(t, u.FromVersion, u.ToVersion, "a staleness row has no real version change")
+	require.Equal(t, "base pak updated", u.RecompileReason, "a never-before-synced profile's reason is the fingerprint-mismatch default")
 	require.Equal(t, "(base pak updated)", u.VersionLabel())
+}
+
+// TestCoreProviderActions_CheckUpdates_ReportsNotDeployedReason guards a
+// #203 release-review finding: the TUI used to hardcode "(base pak
+// updated)" for every staleness row, even when the real cause (the
+// fingerprint still matches; the artifact is just missing from the game
+// directory - core.CheckMergedPakStaleness's own "not deployed" case,
+// internal/core/merged_pak.go) is different. After a real sync/deploy, the
+// merged pak is removed WITHOUT anything else changing - the fingerprint
+// still matches, so the distinct "not deployed" reason must surface, not
+// the generic mismatch wording `lmm verify` would never use here either.
+func TestCoreProviderActions_CheckUpdates_ReportsNotDeployedReason(t *testing.T) {
+	actions, _, deployedPath := newRecompileActionsFixture(t)
+
+	view, err := actions.CheckUpdates(context.Background())
+	require.NoError(t, err)
+	require.Len(t, view.Updates, 1)
+	_, err = actions.ApplyUpdate(context.Background(), view.Updates[0], nil)
+	require.NoError(t, err)
+	require.FileExists(t, deployedPath, "precondition: the merged pak must be deployed")
+
+	require.NoError(t, os.Remove(deployedPath))
+
+	view, err = actions.CheckUpdates(context.Background())
+	require.NoError(t, err)
+	require.Len(t, view.Updates, 1)
+	u := view.Updates[0]
+	require.True(t, u.RecompileNeeded)
+	require.Equal(t, "not deployed", u.RecompileReason)
+	require.Equal(t, "(not deployed)", u.VersionLabel())
+}
+
+// TestUpdateItem_VersionLabel is a pure unit test over VersionLabel's own
+// branches, independent of any real staleness fixture: the normal arrow
+// case, both real RecompileReason values core.CheckMergedPakStaleness can
+// produce, and the defensive empty-reason fallback (core always sets one
+// alongside RecompileNeeded, but VersionLabel must not render a bare "()"
+// if some future caller ever leaves it unset).
+func TestUpdateItem_VersionLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		item tui.UpdateItem
+		want string
+	}{
+		{
+			name: "normal update shows the version arrow",
+			item: tui.UpdateItem{FromVersion: "1.0", ToVersion: "2.0"},
+			want: "1.0 → 2.0",
+		},
+		{
+			name: "recompile needed: base pak updated",
+			item: tui.UpdateItem{RecompileNeeded: true, RecompileReason: "base pak updated"},
+			want: "(base pak updated)",
+		},
+		{
+			name: "recompile needed: not deployed",
+			item: tui.UpdateItem{RecompileNeeded: true, RecompileReason: "not deployed"},
+			want: "(not deployed)",
+		},
+		{
+			name: "recompile needed: empty reason falls back to base pak updated",
+			item: tui.UpdateItem{RecompileNeeded: true},
+			want: "(base pak updated)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.item.VersionLabel())
+		})
+	}
 }
 
 // TestCoreProviderActions_ApplyUpdate_Recompile_AppliesAndRedeploys proves


### PR DESCRIPTION
## Summary

Five Copilot findings from PR #203's whole-batch release review (release/v1.28.0), fixed on `develop` since the release branch has already cut and none of this is shipped yet:

1. **`gameFromDetected` fails loud on missing source config** (`cmd/lmm/game.go`): a known-games entry with neither `Sources` nor a non-empty `NexusID` silently produced `{"nexusmods": ""}` — a garbage source mapping that would propagate into `games.yaml` unnoticed. Now errors, naming the game, unless at least one is set. The `deploy_mode` check still runs first (unchanged ordering).
2. **`getJSON` errors name the URL and a capped body snippet** (`internal/source/icarus/firestore_client.go`): a non-200 response was a bare `"HTTP %d"` — a 403 was undiagnosable (permission error, quota message, and malformed request all looked identical). Now includes the request URL and a 512-byte-capped snippet of the response body; connection-reuse draining is unchanged.
3. **`ParseExmodz` caps total bundled-asset size** (`internal/source/icarus/exmodz.go`): the existing per-entry cap (64 MiB) didn't bound an archive with many entries each individually under it — five 60 MiB entries sum to 300 MiB despite none tripping the per-entry check. Now sums every asset's declared size up front and refuses the archive, naming it, before reading any content, if the combined total exceeds a new 256 MiB cap.
4. **TUI threads the merged-pak staleness reason** (`internal/tui/actions_provider.go`, `service_core.go`): the TUI hardcoded `"(base pak updated)"` for every staleness row, even though `core.CheckMergedPakStaleness` already distinguishes two causes and `lmm verify` already shows the distinct reason. `UpdateItem` gains `RecompileReason`, and `VersionLabel()` renders it instead of the hardcoded string.
5. **`lmm list` surfaces `LoadProfile` errors beyond "not found"** (`cmd/lmm/list.go`): the lock-state lookup ignored every `LoadProfile` error, including #172's fail-loud `link_method` validation — an invalid profile YAML silently degraded the listing instead of erroring like every other command. Only `domain.ErrProfileNotFound` is still tolerated.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean
- [x] `go test ./...` (fresh, `go clean -testcache`) — full suite green, 17 packages
- [x] `trunk check` — clean (0 new issues)
- [x] TDD: RED test confirmed failing before each fix (compile error, wrong-error, or missing-field, as applicable), GREEN after — including a manual revert/reapply check for finding 4's field-threading change
- [x] Both legs tested for findings 1 and 5 (failure case + the success/tolerant cases that must stay unaffected)
- [x] Finding 3's fixture uses `zip.CreateRaw` to declare oversized sizes without needing real hundreds-of-MiB content

No CHANGELOG changes — all five are fixes to code that hasn't shipped (still `[Unreleased]` on `develop`), and none contradicts any existing CHANGELOG wording, so per the task's guidance nothing needed amending.

Full report: `.superpowers/sdd/2026-08-01-prerelease-batch/report-203-fixes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)