### PR TITLE
fix: manifest-aware deploy — stop shipping unclaimed cache files (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `lmm game detect` now marks a game already present in `games.yaml` as `[configured]` (mirroring `search`'s `[installed]` convention) and excludes it from the default "all" selection, since it needs no re-offering. It stays listed, and naming its number explicitly still selects it — the same re-add/repair path `lmm game add` has always used unconditionally (games.yaml entry + a fresh empty default profile, replacing any existing one) (#205)
 
+### Fixed
+
+- Deploy no longer links cache files that no download manifest claims: stale
+  per-mod paks left behind by pre-v1.28 exmodz installs were being deployed
+  alongside the merged pak, double-applying their table edits. One
+  `lmm deploy` cycle now removes such links, download commits prune the
+  stale files, and the conflict scanner ignores them. Legacy cache entries
+  without recorded manifests keep their exact previous behavior. (#210)
+
 ## [1.28.0] - 2026-08-02
 
 ### Added

--- a/internal/core/conflicts.go
+++ b/internal/core/conflicts.go
@@ -96,7 +96,7 @@ func (s *Service) GetProfileConflicts(ctx context.Context, game *domain.Game, pr
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		files, err := gameCache.ListFiles(game.ID, m.SourceID, m.ID, m.Version)
+		files, err := deployableFiles(gameCache, game.ID, m.SourceID, m.ID, m.Version)
 		if err != nil {
 			// A missing cache entry (e.g. manually deleted) just means the mod
 			// provides nothing; any OTHER read failure (permissions, corruption)

--- a/internal/core/conflicts_test.go
+++ b/internal/core/conflicts_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -255,4 +256,40 @@ func TestGetProfileConflictsOwnerLookupErrorPropagates(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "file owner")
 	assert.Nil(t, conflicts)
+}
+
+// TestProfileConflicts_IgnoresUnclaimedCacheFiles: a stale unclaimed file in
+// mod A's cache entry that collides with a path mod B legitimately provides
+// must NOT be reported - deploy will never link it (#210).
+//
+// Fixture: mod A's cache entry has a recorded, zero-member "exmodz" marker
+// plus a retained compile source (the full manifest-aware narrowing gate),
+// but "shared.pak" on disk is claimed by no manifest member. Mod B's entry
+// claims "shared.pak" via its own recorded "exmodz" marker plus retained
+// source. Expect: no conflict on "shared.pak" (A provides nothing).
+func TestProfileConflicts_IgnoresUnclaimedCacheFiles(t *testing.T) {
+	svc := newFlowsTestService(t)
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+
+	seedNamedInstalledMod(t, svc, game, "src", "modA", "Mod A", "1.0", true, map[string][]byte{"shared.pak": []byte("A-content")})
+	seedNamedInstalledMod(t, svc, game, "src", "modB", "Mod B", "1.0", true, map[string][]byte{"shared.pak": []byte("B-content")})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "modA", "1.0")
+	seedProfileWithMod(t, svc, "g1", "default", "src", "modB", "1.0")
+
+	gameCache := svc.GetGameCache(game)
+
+	dirA := gameCache.ModPath("g1", "src", "modA", "1.0")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dirA, "exmodz", nil))
+	require.NoError(t, os.WriteFile(filepath.Join(dirA, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
+
+	dirB := gameCache.ModPath("g1", "src", "modB", "1.0")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dirB, "exmodz", []string{"shared.pak"}))
+	require.NoError(t, os.WriteFile(filepath.Join(dirB, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
+
+	_, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, nil)
+	require.NoError(t, err)
+
+	conflicts, err := svc.GetProfileConflicts(context.Background(), game, "default")
+	require.NoError(t, err)
+	assert.Empty(t, conflicts, "mod A's unclaimed shared.pak must not be reported as a conflict provider")
 }

--- a/internal/core/deployable.go
+++ b/internal/core/deployable.go
@@ -1,0 +1,58 @@
+// Package core provides business logic orchestration for lmm.
+// deployable.go holds the deploy-direction file resolver (#210). Removal-direction
+// operations (Uninstall, the old side of a replace) deliberately do NOT use it -
+// cleanup must remove anything that might ever have been linked, so they keep the
+// full ListFiles union. That asymmetry is what lets one deploy cycle self-heal an
+// entry polluted by a stale, unclaimed file: the union side unlinks it, this
+// resolver never re-links it.
+package core
+
+import (
+	"fmt"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+)
+
+// deployableFiles returns the version-dir-relative files that deploy-direction
+// operations may link for this cache entry, in ListFiles order.
+//
+// When EVERY completion marker in the entry carries a recorded member
+// manifest, the result is the union of recorded members intersected with the
+// files actually on disk - content claimed by no manifest (e.g. a stale
+// pre-#197 compiled per-mod pak carried forward by staging seeding, #210) is
+// excluded. A claimed-but-missing member is silently dropped here; verify
+// owns missing-file detection and repair.
+//
+// When ANY marker is bare (Recorded=false - "provenance unknown, never
+// none"), or the entry has no markers at all, the full ListFiles union is
+// returned unchanged: pre-manifest entries, import-populated entries, and
+// pure pre-#197 entries keep their historical deploy behavior exactly.
+func deployableFiles(gameCache *cache.Cache, gameID, sourceID, modID, version string) ([]string, error) {
+	files, err := gameCache.ListFiles(gameID, sourceID, modID, version)
+	if err != nil {
+		return nil, fmt.Errorf("listing cached files: %w", err)
+	}
+	manifests, err := gameCache.FileManifests(gameID, sourceID, modID, version)
+	if err != nil {
+		return nil, fmt.Errorf("reading cache manifests: %w", err)
+	}
+	if len(manifests) == 0 {
+		return files, nil
+	}
+	claimed := make(map[string]bool)
+	for _, m := range manifests {
+		if !m.Recorded {
+			return files, nil
+		}
+		for _, member := range m.Members {
+			claimed[member] = true
+		}
+	}
+	deployable := make([]string, 0, len(files))
+	for _, f := range files {
+		if claimed[f] {
+			deployable = append(deployable, f)
+		}
+	}
+	return deployable, nil
+}

--- a/internal/core/deployable.go
+++ b/internal/core/deployable.go
@@ -8,8 +8,6 @@
 package core
 
 import (
-	"fmt"
-
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
 )
 
@@ -27,14 +25,17 @@ import (
 // none"), or the entry has no markers at all, the full ListFiles union is
 // returned unchanged: pre-manifest entries, import-populated entries, and
 // pure pre-#197 entries keep their historical deploy behavior exactly.
+//
+// Errors from ListFiles and FileManifests are returned unwrapped; the caller
+// adds context with a single "resolving deployable files" wrapper.
 func deployableFiles(gameCache *cache.Cache, gameID, sourceID, modID, version string) ([]string, error) {
 	files, err := gameCache.ListFiles(gameID, sourceID, modID, version)
 	if err != nil {
-		return nil, fmt.Errorf("listing cached files: %w", err)
+		return nil, err
 	}
 	manifests, err := gameCache.FileManifests(gameID, sourceID, modID, version)
 	if err != nil {
-		return nil, fmt.Errorf("reading cache manifests: %w", err)
+		return nil, err
 	}
 	if len(manifests) == 0 {
 		return files, nil

--- a/internal/core/deployable.go
+++ b/internal/core/deployable.go
@@ -42,8 +42,10 @@ import (
 // contested "recorded manifests plus unattributed content" shape.
 //
 // Errors from ListFiles, FileManifests, and HasRetainedSource are returned
-// unwrapped; the caller adds context with a single "resolving deployable
-// files" wrapper.
+// unwrapped; each caller adds a single contextual wrapper of its own choosing
+// (e.g. Installer.Install's "resolving deployable files", conflicts.go's
+// pre-existing "listing cache files for %s") - this resolver does not
+// prescribe the wording.
 func deployableFiles(gameCache *cache.Cache, gameID, sourceID, modID, version string) ([]string, error) {
 	files, err := gameCache.ListFiles(gameID, sourceID, modID, version)
 	if err != nil {

--- a/internal/core/deployable.go
+++ b/internal/core/deployable.go
@@ -14,20 +14,36 @@ import (
 // deployableFiles returns the version-dir-relative files that deploy-direction
 // operations may link for this cache entry, in ListFiles order.
 //
-// When EVERY completion marker in the entry carries a recorded member
-// manifest, the result is the union of recorded members intersected with the
-// files actually on disk - content claimed by no manifest (e.g. a stale
-// pre-#197 compiled per-mod pak carried forward by staging seeding, #210) is
-// excluded. A claimed-but-missing member is silently dropped here; verify
-// owns missing-file detection and repair.
+// The narrowing gate is a three-way rule (#210, amended after Task 3's #144
+// regression):
 //
-// When ANY marker is bare (Recorded=false - "provenance unknown, never
-// none"), or the entry has no markers at all, the full ListFiles union is
-// returned unchanged: pre-manifest entries, import-populated entries, and
-// pure pre-#197 entries keep their historical deploy behavior exactly.
+//  1. EVERY completion marker in the entry must carry a recorded member
+//     manifest (Recorded=true). ANY bare marker (Recorded=false -
+//     "provenance unknown, never none"), or no markers at all, falls back to
+//     the full ListFiles union unchanged: pre-manifest entries and
+//     pure pre-#197 entries keep their historical deploy behavior exactly.
+//  2. Even with full attribution, the entry must hold at least one retained
+//     compile source (cache.HasRetainedSource) - the validate+retain compile
+//     model's signature, present in every real #210 entry (a merged-pak
+//     deploy that keeps its .exmodz for offline recompile), and the same
+//     signal verify's retained-source carve-out trusts. Without it,
+//     unattributed content on disk cannot be told apart from an
+//     unmanifested contributor (#144, e.g. an entry `lmm import` populated
+//     directly) rather than a stale pre-#197 leftover, so the full union is
+//     the only safe answer.
 //
-// Errors from ListFiles and FileManifests are returned unwrapped; the caller
-// adds context with a single "resolving deployable files" wrapper.
+// Only when BOTH hold does the result narrow to the union of recorded
+// members intersected with the files actually on disk - content claimed by
+// no manifest (e.g. a stale pre-#197 compiled per-mod pak carried forward by
+// staging seeding) is excluded. A claimed-but-missing member is silently
+// dropped here; verify owns missing-file detection and repair. When
+// attribution is complete and every listed file is claimed, the narrowed
+// result equals the union anyway, so this gate only changes behavior for the
+// contested "recorded manifests plus unattributed content" shape.
+//
+// Errors from ListFiles, FileManifests, and HasRetainedSource are returned
+// unwrapped; the caller adds context with a single "resolving deployable
+// files" wrapper.
 func deployableFiles(gameCache *cache.Cache, gameID, sourceID, modID, version string) ([]string, error) {
 	files, err := gameCache.ListFiles(gameID, sourceID, modID, version)
 	if err != nil {
@@ -48,6 +64,13 @@ func deployableFiles(gameCache *cache.Cache, gameID, sourceID, modID, version st
 		for _, member := range m.Members {
 			claimed[member] = true
 		}
+	}
+	hasRetainedSource, err := cache.HasRetainedSource(gameCache.ModPath(gameID, sourceID, modID, version))
+	if err != nil {
+		return nil, err
+	}
+	if !hasRetainedSource {
+		return files, nil
 	}
 	deployable := make([]string, 0, len(files))
 	for _, f := range files {

--- a/internal/core/deployable_internal_test.go
+++ b/internal/core/deployable_internal_test.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
@@ -23,6 +25,7 @@ func TestDeployableFiles_AllRecorded_ExcludesUnclaimed(t *testing.T) {
 		"stale.pak":   []byte("b"), // claimed by no manifest
 	})
 	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", []string{"claimed.pak"}))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
 
 	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
 	require.NoError(t, err)
@@ -34,10 +37,30 @@ func TestDeployableFiles_RecordedZeroMembers_DeploysNothing(t *testing.T) {
 	// plus a stale pre-#197 compiled pak.
 	c, dir := seedEntry(t, map[string][]byte{"LargerResourceStacks_P.pak": []byte("pak")})
 	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
 
 	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
 	require.NoError(t, err)
 	require.Empty(t, files)
+}
+
+// TestDeployableFiles_AllRecordedNoRetainedSource_FallsBackToUnion pins the
+// #210 amendment: a fully-recorded manifest set is not narrowing evidence by
+// itself. Without a retained compile source present (the validate+retain
+// model's signature), unattributed content on disk cannot be distinguished
+// from an unmanifested contributor (#144, e.g. an entry `lmm import`
+// populated directly), so the full union must still deploy.
+func TestDeployableFiles_AllRecordedNoRetainedSource_FallsBackToUnion(t *testing.T) {
+	c, dir := seedEntry(t, map[string][]byte{
+		"claimed.pak": []byte("a"),
+		"stale.pak":   []byte("b"), // claimed by no manifest
+	})
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", []string{"claimed.pak"}))
+	// Deliberately no retained source written.
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"claimed.pak", "stale.pak"}, files)
 }
 
 func TestDeployableFiles_BareMarker_FallsBackToUnion(t *testing.T) {
@@ -79,6 +102,7 @@ func TestDeployableFiles_ClaimedButMissingOnDisk_Dropped(t *testing.T) {
 	// returns what is actually deployable (verify owns missing-file repair).
 	c, dir := seedEntry(t, map[string][]byte{"present.pak": []byte("a")})
 	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "f1", []string{"present.pak", "gone.pak"}))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("f1")), []byte("zip"), 0o644))
 
 	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
 	require.NoError(t, err)

--- a/internal/core/deployable_internal_test.go
+++ b/internal/core/deployable_internal_test.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/require"
+)
+
+// seedEntry stores the given files and returns the cache and version dir.
+func seedEntry(t *testing.T, files map[string][]byte) (*cache.Cache, string) {
+	t.Helper()
+	c := cache.New(t.TempDir())
+	for name, content := range files {
+		require.NoError(t, c.Store("g", "src", "mod", "1.0", name, content))
+	}
+	return c, c.ModPath("g", "src", "mod", "1.0")
+}
+
+func TestDeployableFiles_AllRecorded_ExcludesUnclaimed(t *testing.T) {
+	c, dir := seedEntry(t, map[string][]byte{
+		"claimed.pak": []byte("a"),
+		"stale.pak":   []byte("b"), // claimed by no manifest
+	})
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", []string{"claimed.pak"}))
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"claimed.pak"}, files)
+}
+
+func TestDeployableFiles_RecordedZeroMembers_DeploysNothing(t *testing.T) {
+	// The live #210 shape: retain-only exmodz marker (recorded, zero members)
+	// plus a stale pre-#197 compiled pak.
+	c, dir := seedEntry(t, map[string][]byte{"LargerResourceStacks_P.pak": []byte("pak")})
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.Empty(t, files)
+}
+
+func TestDeployableFiles_BareMarker_FallsBackToUnion(t *testing.T) {
+	c, dir := seedEntry(t, map[string][]byte{
+		"a.pak": []byte("a"),
+		"b.pak": []byte("b"),
+	})
+	// Legacy bare marker: completion vouched, provenance unknown.
+	require.NoError(t, cache.MarkFileComplete(dir, "pak"))
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"a.pak", "b.pak"}, files)
+}
+
+func TestDeployableFiles_MixedRecordedAndBare_FallsBackToUnion(t *testing.T) {
+	c, dir := seedEntry(t, map[string][]byte{
+		"a.pak": []byte("a"),
+		"b.pak": []byte("b"),
+	})
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "f1", []string{"a.pak"}))
+	require.NoError(t, cache.MarkFileComplete(dir, "f2")) // bare
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"a.pak", "b.pak"}, files)
+}
+
+func TestDeployableFiles_NoMarkers_FallsBackToUnion(t *testing.T) {
+	c, _ := seedEntry(t, map[string][]byte{"a.pak": []byte("a")})
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.pak"}, files)
+}
+
+func TestDeployableFiles_ClaimedButMissingOnDisk_Dropped(t *testing.T) {
+	// A manifest may claim a member that was manually deleted; the resolver
+	// returns what is actually deployable (verify owns missing-file repair).
+	c, dir := seedEntry(t, map[string][]byte{"present.pak": []byte("a")})
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "f1", []string{"present.pak", "gone.pak"}))
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"present.pak"}, files)
+}

--- a/internal/core/flows_deploy_selfheal_test.go
+++ b/internal/core/flows_deploy_selfheal_test.go
@@ -1,0 +1,65 @@
+package core_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeployProfile_SelfHealsStaleUnclaimedPak is #210's acceptance test:
+// a pre-fix deploy linked a stale unclaimed pak into the game dir; one
+// deploy cycle must remove that link (Uninstall's union direction) and not
+// re-create it (Install's manifest-aware direction).
+//
+// Fixture: installed mod m1@1.4, cache entry = stale "Stale_P.pak" on disk
+// plus a recorded "exmodz" marker with zero members AND a retained source
+// file (the amended resolver semantics: deployableFiles only narrows when
+// every marker is recorded AND the entry holds a retained source). Game dir
+// already contains a symlink Stale_P.pak -> the cached stale pak (simulating
+// the pre-fix deployment).
+//
+// After DeployProfile: game dir does NOT contain Stale_P.pak; result has
+// Deployed == 1 (the mod "deploys" successfully with zero files of its
+// own); no Skipped entries.
+//
+// This would fail against pre-#210 code: Install re-linked the full cache
+// union (deployableFiles narrowing didn't exist), so Stale_P.pak would be
+// re-created immediately after Uninstall removed it, and the Lstat below
+// would find the stale symlink still present.
+func TestDeployProfile_SelfHealsStaleUnclaimedPak(t *testing.T) {
+	svc := newFlowsTestService(t)
+	gameDir := t.TempDir()
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+
+	seedInstalledMod(t, svc, game, "src", "m1", "1.4", true, map[string][]byte{
+		"Stale_P.pak": []byte("stale-pak-content"),
+	})
+	seedProfileWithMod(t, svc, "g1", "default", "src", "m1", "1.4")
+
+	gameCache := svc.GetGameCache(game)
+	versionDir := gameCache.ModPath(game.ID, "src", "m1", "1.4")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(versionDir, "exmodz", nil))
+	require.NoError(t, os.WriteFile(filepath.Join(versionDir, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
+
+	// Simulate the pre-fix deployment: a symlink in the game dir pointing at
+	// the now-stale cached pak.
+	stalePath := filepath.Join(gameDir, "Stale_P.pak")
+	require.NoError(t, os.Symlink(filepath.Join(versionDir, "Stale_P.pak"), stalePath))
+
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	_, err = os.Lstat(stalePath)
+	assert.True(t, os.IsNotExist(err), "stale pak symlink must be removed, not re-linked")
+	assert.Equal(t, 1, result.Deployed)
+	assert.Empty(t, result.Skipped)
+}

--- a/internal/core/installer.go
+++ b/internal/core/installer.go
@@ -42,7 +42,7 @@ func (i *Installer) Install(ctx context.Context, game *domain.Game, mod *domain.
 	// Get list of files in the cached mod
 	files, err := deployableFiles(i.cache, game.ID, mod.SourceID, mod.ID, mod.Version)
 	if err != nil {
-		return fmt.Errorf("listing cached files: %w", err)
+		return fmt.Errorf("resolving deployable files: %w", err)
 	}
 
 	var deployed []string
@@ -454,7 +454,7 @@ func (i *Installer) IsInstalled(game *domain.Game, mod *domain.Mod) (bool, error
 	// Get list of files in the cached mod
 	files, err := deployableFiles(i.cache, game.ID, mod.SourceID, mod.ID, mod.Version)
 	if err != nil {
-		return false, fmt.Errorf("listing cached files: %w", err)
+		return false, fmt.Errorf("resolving deployable files: %w", err)
 	}
 
 	if len(files) == 0 {
@@ -497,7 +497,7 @@ func (i *Installer) GetConflicts(ctx context.Context, game *domain.Game, mod *do
 	// Get list of files in the cached mod
 	files, err := deployableFiles(i.cache, game.ID, mod.SourceID, mod.ID, mod.Version)
 	if err != nil {
-		return nil, fmt.Errorf("listing cached files: %w", err)
+		return nil, fmt.Errorf("resolving deployable files: %w", err)
 	}
 
 	// Check for conflicts
@@ -529,7 +529,7 @@ func (i *Installer) GetDeployedFiles(game *domain.Game, mod *domain.Mod) ([]stri
 
 	files, err := deployableFiles(i.cache, game.ID, mod.SourceID, mod.ID, mod.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolving deployable files: %w", err)
 	}
 
 	var deployed []string

--- a/internal/core/installer.go
+++ b/internal/core/installer.go
@@ -40,7 +40,7 @@ func (i *Installer) Install(ctx context.Context, game *domain.Game, mod *domain.
 	}
 
 	// Get list of files in the cached mod
-	files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	files, err := deployableFiles(i.cache, game.ID, mod.SourceID, mod.ID, mod.Version)
 	if err != nil {
 		return fmt.Errorf("listing cached files: %w", err)
 	}
@@ -406,7 +406,10 @@ func rollbackDeploy(lnk linker.Linker, modPath string, relativePaths []string) e
 
 // Uninstall removes a mod from the game directory
 func (i *Installer) Uninstall(ctx context.Context, game *domain.Game, mod *domain.Mod, profileName string) error {
-	// Get list of files in the cached mod
+	// Deliberately the full ListFiles union, not deployableFiles (#210):
+	// removal must cover anything that might ever have been linked, including
+	// stale unclaimed files a pre-fix deploy linked. Narrowing this would
+	// strand those links forever.
 	files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
 	if err != nil {
 		return fmt.Errorf("listing cached files: %w", err)
@@ -449,7 +452,7 @@ func (i *Installer) IsInstalled(game *domain.Game, mod *domain.Mod) (bool, error
 	}
 
 	// Get list of files in the cached mod
-	files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	files, err := deployableFiles(i.cache, game.ID, mod.SourceID, mod.ID, mod.Version)
 	if err != nil {
 		return false, fmt.Errorf("listing cached files: %w", err)
 	}
@@ -492,7 +495,7 @@ func (i *Installer) GetConflicts(ctx context.Context, game *domain.Game, mod *do
 	}
 
 	// Get list of files in the cached mod
-	files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	files, err := deployableFiles(i.cache, game.ID, mod.SourceID, mod.ID, mod.Version)
 	if err != nil {
 		return nil, fmt.Errorf("listing cached files: %w", err)
 	}
@@ -524,7 +527,7 @@ func (i *Installer) GetDeployedFiles(game *domain.Game, mod *domain.Mod) ([]stri
 		return nil, nil
 	}
 
-	files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	files, err := deployableFiles(i.cache, game.ID, mod.SourceID, mod.ID, mod.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/installer.go
+++ b/internal/core/installer.go
@@ -130,9 +130,9 @@ func (i *Installer) replaceWithCaches(ctx context.Context, game *domain.Game, ol
 	if err != nil {
 		return fmt.Errorf("listing old cached files: %w", err)
 	}
-	newFiles, err := newCache.ListFiles(game.ID, newMod.SourceID, newMod.ID, newMod.Version)
+	newFiles, err := deployableFiles(newCache, game.ID, newMod.SourceID, newMod.ID, newMod.Version)
 	if err != nil {
-		return fmt.Errorf("listing new cached files: %w", err)
+		return fmt.Errorf("resolving deployable new-side files: %w", err)
 	}
 
 	// #144 item 4: in the degenerate same-version shape (old and new resolve
@@ -260,6 +260,13 @@ func (i *Installer) replaceWithCaches(ctx context.Context, game *domain.Game, ol
 //     one recorded manifest, stale markers included (unattributed content
 //     proves an unmanifested contributor exists, e.g. an entry populated
 //     directly by `lmm import`).
+//
+// unionFiles is the caller's deploy-direction set (deployableFiles' output,
+// #210), not always the raw ListFiles union: when that resolver narrowed to
+// recorded members, every entry here is attributed by construction, since
+// resolveSharedDirUpdate independently requires all-recorded provenance too;
+// when it fell back to the full union, the attribution check below behaves
+// exactly as before.
 //
 // The ownership rule: the DEPLOY set is exactly the members attributed to the
 // mod's current (new-side) file IDs - newCurrent. Every other listed member

--- a/internal/core/installer.go
+++ b/internal/core/installer.go
@@ -145,7 +145,20 @@ func (i *Installer) replaceWithCaches(ctx context.Context, game *domain.Game, ol
 	// (distinct dirs, no departing ID, or incomplete provenance) leaves the
 	// historical union behavior byte-for-byte intact.
 	newCurrent, oldDeployed, provenanceOK := resolveSharedDirUpdate(game.ID, oldCache, newCache, oldMod, newMod, oldFileIDs, newFileIDs, newFiles)
-	oldRestorable := oldFiles
+
+	// oldRestorable starts as the old side's deployable set (deploy-direction,
+	// #210), not the raw oldFiles union: a rollback restores the pre-replace
+	// DEPLOYMENT, which is whatever deployableFiles resolved for the old
+	// entry, never the union. An old-side mixed entry (recorded markers plus
+	// a retained source plus an unclaimed stale file) never deploys the stale
+	// file in the first place, so a mid-replace failure must not link it
+	// fresh either - using oldFiles here would resurrect it through this
+	// error path even though the #210 narrowing kept it off disk on every
+	// success path.
+	oldRestorable, err := deployableFiles(oldCache, game.ID, oldMod.SourceID, oldMod.ID, oldMod.Version)
+	if err != nil {
+		return fmt.Errorf("resolving deployable old-side files: %w", err)
+	}
 	if provenanceOK {
 		kept := make([]string, 0, len(newFiles))
 		for _, file := range newFiles {

--- a/internal/core/installer_test.go
+++ b/internal/core/installer_test.go
@@ -452,6 +452,39 @@ func TestInstaller_Replace_DeployFailureRestoresOldFiles(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "new-only file should not remain after rollback")
 }
 
+// TestInstaller_Replace_NewSideSkipsUnclaimed: replacing onto a version whose
+// cache entry mixes a recorded retain-only marker with a stale unclaimed pak
+// must (a) undeploy the old version's files, (b) NOT deploy the stale pak.
+func TestInstaller_Replace_NewSideSkipsUnclaimed(t *testing.T) {
+	cacheDir := t.TempDir()
+	gameDir := t.TempDir()
+	modCache := cache.New(cacheDir)
+
+	// Old version: ordinary claimed pak, deployed.
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.0", "Old_P.pak", []byte("old")))
+	oldDir := modCache.ModPath("icarus", "icarus", "m1", "1.0")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(oldDir, "pak", []string{"Old_P.pak"}))
+
+	// New version: the #210 mixed shape.
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.4", "Stale_P.pak", []byte("stale")))
+	newDir := modCache.ModPath("icarus", "icarus", "m1", "1.4")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(newDir, "exmodz", nil))
+	require.NoError(t, os.WriteFile(filepath.Join(newDir, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
+
+	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	oldMod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.0", GameID: "icarus"}
+	newMod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.4", GameID: "icarus"}
+	inst := core.NewInstaller(modCache, linker.New(domain.LinkSymlink), nil)
+
+	require.NoError(t, inst.Install(context.Background(), game, oldMod, "default"))
+	require.NoError(t, inst.Replace(context.Background(), game, oldMod, newMod, "default"))
+
+	_, err := os.Lstat(filepath.Join(gameDir, "Old_P.pak"))
+	assert.True(t, os.IsNotExist(err), "old file must be undeployed")
+	_, err = os.Lstat(filepath.Join(gameDir, "Stale_P.pak"))
+	assert.True(t, os.IsNotExist(err), "stale unclaimed pak must not deploy")
+}
+
 func TestInstaller_ReplaceWithOldCache_SameVersionRemovesStaleFiles(t *testing.T) {
 	oldCacheDir := t.TempDir()
 	newCacheDir := t.TempDir()

--- a/internal/core/installer_test.go
+++ b/internal/core/installer_test.go
@@ -1012,9 +1012,9 @@ func TestInstaller_Install_LegacyBareMarker_DeploysUnion(t *testing.T) {
 }
 
 // TestInstaller_IsInstalled_RetainOnlyEntry guards the deploy-loop
-// interaction: a retain-only entry (deployable set empty) must not report
-// "not installed" in a way that spins redeploy loops - with nothing
-// deployable and nothing deployed there is nothing missing.
+// interaction: a retain-only entry (empty deployable set) consistently reports
+// "not installed" via IsInstalled's len==0 answer. This is stable and expected
+// because the mod's content deploys via the shared merged pak.
 func TestInstaller_IsInstalled_RetainOnlyEntry(t *testing.T) {
 	cacheDir := t.TempDir()
 	gameDir := t.TempDir()

--- a/internal/core/installer_test.go
+++ b/internal/core/installer_test.go
@@ -873,3 +873,74 @@ func TestInstaller_ReplaceForUpdate_DistinctCacheDirs_MatchesReplace(t *testing.
 	assert.Equal(t, modCache.GetFilePath("g", "src", "mod", "2.0", "shared.esp"), target,
 		"shared members must point at the NEW version's cache entry")
 }
+
+// TestInstaller_Install_SkipsUnclaimedFiles reproduces the #210 live shape:
+// a retain-only marker (recorded, zero members) plus a stale unclaimed pak.
+// Install must deploy nothing; a legacy bare-marker entry must keep the
+// historical deploy-everything behavior.
+func TestInstaller_Install_SkipsUnclaimedFiles(t *testing.T) {
+	cacheDir := t.TempDir()
+	gameDir := t.TempDir()
+	modCache := cache.New(cacheDir)
+
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.4", "Stale_P.pak", []byte("stale")))
+	dir := modCache.ModPath("icarus", "icarus", "m1", "1.4")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+
+	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	mod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.4", GameID: "icarus"}
+	inst := core.NewInstaller(modCache, linker.New(domain.LinkSymlink), nil)
+
+	require.NoError(t, inst.Install(context.Background(), game, mod, "default"))
+	_, err := os.Lstat(filepath.Join(gameDir, "Stale_P.pak"))
+	assert.True(t, os.IsNotExist(err), "unclaimed stale pak must not deploy")
+
+	// Deployed-file views agree with the deploy decision.
+	deployed, err := inst.GetDeployedFiles(game, mod)
+	require.NoError(t, err)
+	assert.Empty(t, deployed)
+}
+
+func TestInstaller_Install_LegacyBareMarker_DeploysUnion(t *testing.T) {
+	cacheDir := t.TempDir()
+	gameDir := t.TempDir()
+	modCache := cache.New(cacheDir)
+
+	require.NoError(t, modCache.Store("icarus", "icarus", "m2", "2.2", "MorePoints_P.pak", []byte("pak")))
+	dir := modCache.ModPath("icarus", "icarus", "m2", "2.2")
+	require.NoError(t, cache.MarkFileComplete(dir, "exmodz")) // pre-manifest bare marker
+
+	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	mod := &domain.Mod{ID: "m2", SourceID: "icarus", Version: "2.2", GameID: "icarus"}
+	inst := core.NewInstaller(modCache, linker.New(domain.LinkSymlink), nil)
+
+	require.NoError(t, inst.Install(context.Background(), game, mod, "default"))
+	_, err := os.Lstat(filepath.Join(gameDir, "MorePoints_P.pak"))
+	assert.NoError(t, err, "legacy entry must keep deploying its pak")
+
+	installed, err := inst.IsInstalled(game, mod)
+	require.NoError(t, err)
+	assert.True(t, installed)
+}
+
+// TestInstaller_IsInstalled_RetainOnlyEntry guards the deploy-loop
+// interaction: a retain-only entry (deployable set empty) must not report
+// "not installed" in a way that spins redeploy loops - with nothing
+// deployable and nothing deployed there is nothing missing.
+func TestInstaller_IsInstalled_RetainOnlyEntry(t *testing.T) {
+	cacheDir := t.TempDir()
+	gameDir := t.TempDir()
+	modCache := cache.New(cacheDir)
+
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.4", "Stale_P.pak", []byte("stale")))
+	dir := modCache.ModPath("icarus", "icarus", "m1", "1.4")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+
+	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	mod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.4", GameID: "icarus"}
+	inst := core.NewInstaller(modCache, linker.New(domain.LinkSymlink), nil)
+
+	installed, err := inst.IsInstalled(game, mod)
+	require.NoError(t, err)
+	assert.False(t, installed, "empty deployable set keeps IsInstalled's len==0 false answer")
+}

--- a/internal/core/installer_test.go
+++ b/internal/core/installer_test.go
@@ -886,6 +886,7 @@ func TestInstaller_Install_SkipsUnclaimedFiles(t *testing.T) {
 	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.4", "Stale_P.pak", []byte("stale")))
 	dir := modCache.ModPath("icarus", "icarus", "m1", "1.4")
 	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
 
 	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
 	mod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.4", GameID: "icarus"}
@@ -935,6 +936,7 @@ func TestInstaller_IsInstalled_RetainOnlyEntry(t *testing.T) {
 	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.4", "Stale_P.pak", []byte("stale")))
 	dir := modCache.ModPath("icarus", "icarus", "m1", "1.4")
 	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
 
 	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
 	mod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.4", GameID: "icarus"}

--- a/internal/core/installer_test.go
+++ b/internal/core/installer_test.go
@@ -452,6 +452,60 @@ func TestInstaller_Replace_DeployFailureRestoresOldFiles(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "new-only file should not remain after rollback")
 }
 
+// TestInstaller_Replace_FailedReplaceDoesNotResurrectStaleOldPak: the
+// old-side entry mixes a recorded claimed pak with an unclaimed stale pak
+// plus a retained source (the #210 mixed shape), so only Old_P.pak was ever
+// deployed - deployableFiles narrows the initial Install to it alone. A
+// mid-replace deploy failure must restore exactly what was deployed
+// (deploy-direction, #210): the rollback must not resurrect the never-linked
+// stale pak through the old-side ListFiles union.
+func TestInstaller_Replace_FailedReplaceDoesNotResurrectStaleOldPak(t *testing.T) {
+	cacheDir := t.TempDir()
+	gameDir := t.TempDir()
+	modCache := cache.New(cacheDir)
+
+	// Old version: claimed pak (recorded marker) + unclaimed stale pak on
+	// disk + retained source - deployableFiles narrows to Old_P.pak only.
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.0", "Old_P.pak", []byte("old")))
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.0", "Stale_P.pak", []byte("stale")))
+	oldDir := modCache.ModPath("icarus", "icarus", "m1", "1.0")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(oldDir, "pak", []string{"Old_P.pak"}))
+	require.NoError(t, os.WriteFile(filepath.Join(oldDir, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
+
+	// New version: a claimed file whose deploy will fail.
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.4", "New_P.pak", []byte("new")))
+	newDir := modCache.ModPath("icarus", "icarus", "m1", "1.4")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(newDir, "pak", []string{"New_P.pak"}))
+
+	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	oldMod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.0", GameID: "icarus"}
+	newMod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.4", GameID: "icarus"}
+
+	baseLinker := linker.New(domain.LinkSymlink)
+	initialInstaller := core.NewInstaller(modCache, baseLinker, nil)
+	require.NoError(t, initialInstaller.Install(context.Background(), game, oldMod, "default"))
+
+	// Sanity: only the claimed old pak deployed, not the stale one.
+	_, err := os.Lstat(filepath.Join(gameDir, "Stale_P.pak"))
+	require.True(t, os.IsNotExist(err), "stale pak must not have been deployed initially")
+
+	lnk := &conditionalFailingLinker{
+		Linker:           linker.New(domain.LinkSymlink),
+		failSrcSubstring: string(filepath.Separator) + "1.4" + string(filepath.Separator),
+		failAfter:        0,
+	}
+	installer := core.NewInstaller(modCache, lnk, nil)
+	err = installer.Replace(context.Background(), game, oldMod, newMod, "default")
+	require.Error(t, err)
+
+	_, err = os.Lstat(filepath.Join(gameDir, "Stale_P.pak"))
+	assert.True(t, os.IsNotExist(err), "stale pak must not be resurrected by rollback")
+
+	oldTarget, err := os.Readlink(filepath.Join(gameDir, "Old_P.pak"))
+	require.NoError(t, err)
+	assert.Equal(t, modCache.GetFilePath("icarus", "icarus", "m1", "1.0", "Old_P.pak"), oldTarget)
+}
+
 // TestInstaller_Replace_NewSideSkipsUnclaimed: replacing onto a version whose
 // cache entry mixes a recorded retain-only marker with a stale unclaimed pak
 // must (a) undeploy the old version's files, (b) NOT deploy the stale pak.

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -844,6 +844,14 @@ func commitStagedCacheWithMarker(cachePath, stagePath, fileID string, members []
 	if err := cache.MarkFileCompleteWithMembers(stagePath, fileID, members); err != nil {
 		return err
 	}
+	// #210: with full provenance recorded AND a retained source present, drop
+	// anything no manifest claims (pre-#197 compiled paks carried forward by
+	// prepareStaging's seeding). A legacy bare marker anywhere, or an entry
+	// with no retained source, makes this a silent no-op - see
+	// cache.PruneUnclaimed's doc comment for the full gate.
+	if err := cache.PruneUnclaimed(stagePath); err != nil {
+		return err
+	}
 	return commitStagedCache(cachePath, stagePath)
 }
 

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -844,13 +844,19 @@ func commitStagedCacheWithMarker(cachePath, stagePath, fileID string, members []
 	if err := cache.MarkFileCompleteWithMembers(stagePath, fileID, members); err != nil {
 		return err
 	}
-	// #210: with full provenance recorded AND a retained source present, drop
-	// anything no manifest claims (pre-#197 compiled paks carried forward by
-	// prepareStaging's seeding). A legacy bare marker anywhere, or an entry
-	// with no retained source, makes this a silent no-op - see
-	// cache.PruneUnclaimed's doc comment for the full gate.
-	if err := cache.PruneUnclaimed(stagePath); err != nil {
-		return err
+	// A fileID the marker layer cannot verify writes no marker (see
+	// writeFileMarker), so the members this very commit contributes would
+	// be unattributable - pruning now could delete them. Judge the prune
+	// gate only when every contributor is marker-visible (#210).
+	if cache.VerifiableFileID(fileID) {
+		// #210: with full provenance recorded AND a retained source present, drop
+		// anything no manifest claims (pre-#197 compiled paks carried forward by
+		// prepareStaging's seeding). A legacy bare marker anywhere, or an entry
+		// with no retained source, makes this a silent no-op - see
+		// cache.PruneUnclaimed's doc comment for the full gate.
+		if err := cache.PruneUnclaimed(stagePath); err != nil {
+			return err
+		}
 	}
 	return commitStagedCache(cachePath, stagePath)
 }

--- a/internal/core/service_internal_prune_test.go
+++ b/internal/core/service_internal_prune_test.go
@@ -1,0 +1,31 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommitStagedCacheWithMarker_UnverifiableFileIDSkipsPrune: an
+// unverifiable fileID writes no marker, so its just-committed members are
+// unattributable - the prune must not run and delete them (#210 PR review).
+func TestCommitStagedCacheWithMarker_UnverifiableFileIDSkipsPrune(t *testing.T) {
+	base := t.TempDir()
+	cachePath := filepath.Join(base, "entry")
+	stagePath := cachePath + ".staging"
+	require.NoError(t, os.MkdirAll(stagePath, 0o755))
+	// Seeded state: recorded marker claiming a.pak, retained source, and the
+	// new unverifiable-ID download's member new.dat (no marker possible).
+	require.NoError(t, os.WriteFile(filepath.Join(stagePath, "a.pak"), []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(stagePath, "new.dat"), []byte("n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(stagePath, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(stagePath, "f1", []string{"a.pak"}))
+
+	require.NoError(t, commitStagedCacheWithMarker(cachePath, stagePath, "unverifiable/id", []string{"new.dat"}))
+
+	_, err := os.Stat(filepath.Join(cachePath, "new.dat"))
+	require.NoError(t, err, "the unverifiable fileID's own member must survive the commit")
+}

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -660,6 +661,56 @@ func TestService_DownloadMod_RecordsMemberManifests(t *testing.T) {
 	content, err := os.ReadFile(svc.GetGameCache(game).GetFilePath("testgame", "test", "123", "1.0.0", "shared.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "from file2", string(content))
+}
+
+// TestService_DownloadMod_PrunesUnclaimedStaleFiles is the #210 wiring test:
+// commitStagedCacheWithMarker's single choke point calls cache.PruneUnclaimed
+// right after stamping its own marker, so a cache entry carrying stale
+// unclaimed debris (e.g. a pre-#197 compiled pak carried forward by
+// prepareStaging's reseed, sitting beside a #197 retained-source marker) gets
+// cleaned up the moment every marker in the entry becomes recorded - while
+// the retained source itself, being reserved bookkeeping, survives.
+func TestService_DownloadMod_PrunesUnclaimedStaleFiles(t *testing.T) {
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	mock := newMockSourceWithDownloads("test")
+	defer mock.Close()
+	svc.RegisterSource(mock)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir()}
+	require.NoError(t, svc.AddGame(game))
+	mod := &domain.Mod{ID: "123", SourceID: "test", Name: "Mod", Version: "1.0.0", GameID: "testgame"}
+
+	gameCache := svc.GetGameCache(game)
+	dir := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
+
+	// Pre-seed the entry with debris a manifest-unaware world would have left
+	// behind: a stale pak no current marker claims, and a #197 retained
+	// source whose own marker IS recorded (claiming nothing).
+	require.NoError(t, gameCache.Store(game.ID, mod.SourceID, mod.ID, mod.Version, "stale.pak", []byte("debris")))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("legacy")), []byte("zip"), 0o644))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "legacy", nil))
+
+	zip1, err := os.ReadFile(createTestZip(t, t.TempDir(), map[string]string{"new.txt": "fresh content"}))
+	require.NoError(t, err)
+	mock.AddDownload("file1", zip1)
+
+	ctx := context.Background()
+	_, err = svc.DownloadMod(ctx, "test", game, mod, &domain.DownloadableFile{ID: "file1", FileName: "file1.zip"}, nil)
+	require.NoError(t, err)
+
+	files, err := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"new.txt"}, files, "the unclaimed stale pak must be pruned once every marker is recorded")
+
+	_, err = os.Stat(filepath.Join(dir, cache.RetainedSourceName("legacy")))
+	require.NoError(t, err, "the retained source is reserved bookkeeping and must survive the prune")
 }
 
 // TestService_DownloadMod_ForgedCacheMarkerInArchiveIsRejected is the

--- a/internal/storage/cache/cache.go
+++ b/internal/storage/cache/cache.go
@@ -317,11 +317,12 @@ func HasRetainedSource(versionDir string) (bool, error) {
 // (#210). It is a no-op unless EVERY marker carries a recorded manifest AND
 // the entry holds a retained source (.lmm-source-*) - the validate+retain
 // model's signature (#210); pruning on anything less could delete legacy
-// content no manifest attributes. A bare marker means unknown provenance -
-// pruning on guesswork could delete a legacy file's live content, so any
-// bare marker anywhere in versionDir makes the whole call a no-op. Reserved
-// (ReservedPrefix) entries are never candidates. Callers invoke it on a
-// STAGING directory at commit time, so a prune can never race a deploy.
+// content no manifest attributes (#144, e.g. an entry `lmm import` populated
+// directly). A bare marker means unknown provenance - pruning on guesswork
+// could delete a legacy file's live content, so any bare marker anywhere in
+// versionDir makes the whole call a no-op. Reserved (ReservedPrefix) entries
+// are never candidates. Callers invoke it on a STAGING directory at commit
+// time, so a prune can never race a deploy.
 func PruneUnclaimed(versionDir string) error {
 	manifests, err := fileManifestsAt(versionDir)
 	if err != nil {
@@ -335,8 +336,14 @@ func PruneUnclaimed(versionDir string) error {
 		if !m.Recorded {
 			return nil
 		}
+		// m.Members already arrives OS-native: parseManifest applies
+		// filepath.FromSlash per line when it decodes the marker body, so
+		// re-converting here would be a redundant double-conversion.
+		// deployableFiles (internal/core/deployable.go) uses the same
+		// convention directly off FileManifests for its claimed set - both
+		// builders agree members are OS-separator paths.
 		for _, member := range m.Members {
-			claimed[filepath.FromSlash(member)] = true
+			claimed[member] = true
 		}
 	}
 	hasRetained, err := HasRetainedSource(versionDir)

--- a/internal/storage/cache/cache.go
+++ b/internal/storage/cache/cache.go
@@ -165,7 +165,14 @@ type FileManifest struct {
 // union-fallback direction - so pre-manifest entries and any future format
 // revision both degrade silently rather than misreport provenance.
 func (c *Cache) FileManifests(gameID, sourceID, modID, version string) (map[string]FileManifest, error) {
-	versionDir := c.ModPath(gameID, sourceID, modID, version)
+	return fileManifestsAt(c.ModPath(gameID, sourceID, modID, version))
+}
+
+// fileManifestsAt is FileManifests' shared implementation, taking a raw
+// directory path instead of a cache key so PruneUnclaimed (which operates on
+// a STAGING directory, not a committed cache entry) can read the same
+// markers.
+func fileManifestsAt(versionDir string) (map[string]FileManifest, error) {
 	entries, err := os.ReadDir(versionDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -303,6 +310,82 @@ func HasRetainedSource(versionDir string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// PruneUnclaimed deletes non-reserved regular files in versionDir that no
+// recorded manifest claims, then removes directories the deletions emptied
+// (#210). It is a no-op unless EVERY marker carries a recorded manifest AND
+// the entry holds a retained source (.lmm-source-*) - the validate+retain
+// model's signature (#210); pruning on anything less could delete legacy
+// content no manifest attributes. A bare marker means unknown provenance -
+// pruning on guesswork could delete a legacy file's live content, so any
+// bare marker anywhere in versionDir makes the whole call a no-op. Reserved
+// (ReservedPrefix) entries are never candidates. Callers invoke it on a
+// STAGING directory at commit time, so a prune can never race a deploy.
+func PruneUnclaimed(versionDir string) error {
+	manifests, err := fileManifestsAt(versionDir)
+	if err != nil {
+		return fmt.Errorf("reading manifests for prune: %w", err)
+	}
+	if len(manifests) == 0 {
+		return nil
+	}
+	claimed := make(map[string]bool)
+	for _, m := range manifests {
+		if !m.Recorded {
+			return nil
+		}
+		for _, member := range m.Members {
+			claimed[filepath.FromSlash(member)] = true
+		}
+	}
+	hasRetained, err := HasRetainedSource(versionDir)
+	if err != nil {
+		return fmt.Errorf("checking retained source for prune: %w", err)
+	}
+	if !hasRetained {
+		return nil
+	}
+	files, err := walkEntries(versionDir, false) // same walker ListFiles uses
+	if err != nil {
+		return fmt.Errorf("walking entry for prune: %w", err)
+	}
+	for _, f := range files {
+		if claimed[f] {
+			continue
+		}
+		if err := os.Remove(filepath.Join(versionDir, f)); err != nil {
+			return fmt.Errorf("pruning unclaimed %s: %w", f, err)
+		}
+	}
+	removeEmptyDirs(versionDir)
+	return nil
+}
+
+// removeEmptyDirs removes every empty subdirectory under versionDir
+// (post-order, so a directory left empty by an inner removal is itself
+// removed), never versionDir itself. Best-effort: a directory a concurrent
+// writer has since populated (ENOTEMPTY) is simply left in place rather than
+// treated as an error, matching removeIfEmpty's tolerant style elsewhere in
+// this package.
+func removeEmptyDirs(versionDir string) {
+	var dirs []string
+	_ = filepath.WalkDir(versionDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || !d.IsDir() || path == versionDir {
+			return nil
+		}
+		dirs = append(dirs, path)
+		return nil
+	})
+	// Remove deepest-first so a parent emptied by removing its last child
+	// subdirectory is itself a candidate on this same pass.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		entries, err := os.ReadDir(dirs[i])
+		if err != nil || len(entries) > 0 {
+			continue
+		}
+		_ = os.Remove(dirs[i])
+	}
 }
 
 // mergeFingerprintMarkerName names the single JSON fingerprint marker a

--- a/internal/storage/cache/cache.go
+++ b/internal/storage/cache/cache.go
@@ -274,6 +274,37 @@ func RetainedSourceName(fileID string) string {
 	return retainedSourcePrefix + filepath.Base(fileID)
 }
 
+// HasRetainedSource reports whether versionDir contains at least one
+// retained compile source (any entry named by RetainedSourceName, for any
+// fileID). It is deployableFiles' narrowing gate (#210): a retained source
+// is the validate+retain compile model's signature, present in every real
+// #210 entry (a merged-pak deploy that keeps its .exmodz for offline
+// recompile) and the same signal verify's retained-source carve-out trusts.
+// Its absence means unattributed content on disk cannot be distinguished
+// from an unmanifested contributor (#144, e.g. `lmm import`), so callers
+// must fall back to the full union rather than narrow.
+//
+// A missing versionDir is not an error - it reports (false, nil), same as
+// an empty directory.
+func HasRetainedSource(versionDir string) (bool, error) {
+	entries, err := os.ReadDir(versionDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), retainedSourcePrefix) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // mergeFingerprintMarkerName names the single JSON fingerprint marker a
 // merged-pak cache entry carries (#197): what base pak and which
 // (source, mod, version, exmodz-checksum) tuples, in order, the pak was

--- a/internal/storage/cache/cache_test.go
+++ b/internal/storage/cache/cache_test.go
@@ -548,3 +548,88 @@ func TestCache_MergeFingerprintPath_ExcludedFromContent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"zzz_LMM_Merged_P.pak"}, files, "the fingerprint marker must never be listed as deployable content")
 }
+
+// TestPruneUnclaimed_RemovesUnclaimedWhenAllRecorded proves the#210 core
+// case: once every marker in the entry carries a recorded manifest AND the
+// entry holds a retained source, anything no manifest claims is stale
+// debris and gets removed - including the now-empty subdirectory it lived
+// in - while the retained source itself, which is reserved bookkeeping
+// claimed by nothing, survives.
+func TestPruneUnclaimed_RemovesUnclaimedWhenAllRecorded(t *testing.T) {
+	c := cache.New(t.TempDir())
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "claimed.pak", []byte("a")))
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "stale.pak", []byte("b")))
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "sub/stale2.pak", []byte("c")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("f1")), []byte("zip"), 0o644))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "f1", []string{"claimed.pak"}))
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	files, err := c.ListFiles("g", "s", "m", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"claimed.pak"}, files)
+	// Emptied subdirectory is removed too.
+	_, err = os.Stat(filepath.Join(dir, "sub"))
+	require.True(t, os.IsNotExist(err))
+}
+
+// TestPruneUnclaimed_NoOpWithoutRetainedSource proves the retained-source
+// gate: even with every marker recorded, an entry holding no retained
+// source is left untouched - unattributed content on disk could be
+// legacy/import-populated (#144's protected shapes) rather than debris, and
+// only a retained source's presence is the validate+retain model's actual
+// signature.
+func TestPruneUnclaimed_NoOpWithoutRetainedSource(t *testing.T) {
+	c := cache.New(t.TempDir())
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "claimed.pak", []byte("a")))
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "stale.pak", []byte("b")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "f1", []string{"claimed.pak"}))
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	files, err := c.ListFiles("g", "s", "m", "1.0")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"claimed.pak", "stale.pak"}, files, "no retained source means no-op, even with all markers recorded")
+}
+
+func TestPruneUnclaimed_NoOpWithBareMarker(t *testing.T) {
+	c := cache.New(t.TempDir())
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "a.pak", []byte("a")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+	require.NoError(t, cache.MarkFileComplete(dir, "f1")) // bare: provenance unknown
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	files, err := c.ListFiles("g", "s", "m", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.pak"}, files)
+}
+
+func TestPruneUnclaimed_NoOpWithoutMarkers(t *testing.T) {
+	c := cache.New(t.TempDir())
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "a.pak", []byte("a")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	files, err := c.ListFiles("g", "s", "m", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.pak"}, files)
+}
+
+func TestPruneUnclaimed_NeverTouchesReservedEntries(t *testing.T) {
+	c := cache.New(t.TempDir())
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "claimed.pak", []byte("a")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+	// A retained source is reserved bookkeeping, claimed by nothing.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "f1", []string{"claimed.pak"}))
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	_, err := os.Stat(filepath.Join(dir, cache.RetainedSourceName("exmodz")))
+	require.NoError(t, err, "reserved entries are never pruned")
+}

--- a/internal/storage/cache/cache_test.go
+++ b/internal/storage/cache/cache_test.go
@@ -549,7 +549,7 @@ func TestCache_MergeFingerprintPath_ExcludedFromContent(t *testing.T) {
 	assert.Equal(t, []string{"zzz_LMM_Merged_P.pak"}, files, "the fingerprint marker must never be listed as deployable content")
 }
 
-// TestPruneUnclaimed_RemovesUnclaimedWhenAllRecorded proves the#210 core
+// TestPruneUnclaimed_RemovesUnclaimedWhenAllRecorded proves the #210 core
 // case: once every marker in the entry carries a recorded manifest AND the
 // entry holds a retained source, anything no manifest claims is stale
 // debris and gets removed - including the now-empty subdirectory it lived

--- a/internal/storage/cache/cache_test.go
+++ b/internal/storage/cache/cache_test.go
@@ -505,6 +505,26 @@ func TestCache_RetainedSourceName_UniquePerFileID(t *testing.T) {
 	assert.NotEqual(t, cache.RetainedSourceName("file-a"), cache.RetainedSourceName("file-b"))
 }
 
+// TestCache_HasRetainedSource pins deployableFiles' narrowing gate (#210):
+// present when the version dir holds a retained compile source, absent
+// otherwise, and a missing directory is not an error.
+func TestCache_HasRetainedSource(t *testing.T) {
+	dir := t.TempDir()
+	has, err := cache.HasRetainedSource(dir)
+	require.NoError(t, err)
+	assert.False(t, has, "an empty dir has no retained source")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
+	has, err = cache.HasRetainedSource(dir)
+	require.NoError(t, err)
+	assert.True(t, has, "a retained source entry must be detected")
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	has, err = cache.HasRetainedSource(missing)
+	require.NoError(t, err)
+	assert.False(t, has, "a missing version dir is not an error")
+}
+
 // TestCache_MergeFingerprintPath_IsReserved pins that the merged pak's
 // fingerprint marker (#197) lives under the reserved namespace, like every
 // other lmm bookkeeping file.


### PR DESCRIPTION
Fixes #210 (issues don't auto-close on develop merges — close manually after merge).

## Problem

Deploy linked every regular file in a mod's cache version dir (`cache.ListFiles` union) and never consulted the completion-marker member manifests (#144). Stale pre-#197 compiled per-mod paks — carried forward unclaimed by staging seeding — deployed alongside the profile merged pak, double-applying their Icarus table edits (observed live: `LargerResourceStacks_P.pak` + `MegaPoints_P.pak` beside `zzz_LMM_Merged_P.pak`). The conflict scanner had the same blind spot.

## Fix

- **`deployableFiles` resolver** (`internal/core/deployable.go`): returns the full `ListFiles` union UNLESS every marker manifest is Recorded AND the entry holds a retained source (`.lmm-source-*`, via new `cache.HasRetainedSource`); only then narrows to claimed∩on-disk. The retained-source gate protects #144's legacy shapes (unattributed content = unmanifested contributor → union); it is the validate+retain model's signature and the same signal `verify`'s carve-out already trusts.
- **Deploy-direction sites use the resolver**: `Install`, `IsInstalled`, `GetConflicts`, `GetDeployedFiles`, the **new** side of `replaceWithCaches`, the rollback **restore set** (`restoreOldFiles` input), and the profile conflict scanner.
- **Removal-direction sites keep the union** (`Uninstall`, replace old-side undeploy loop) — so one `lmm deploy` cycle self-heals an affected game dir: the union pass unlinks the stale pak, the resolver never re-links it.
- **`cache.PruneUnclaimed`** at the download-commit choke point (`commitStagedCacheWithMarker`: marker → prune → commit), same two-part gate, so re-downloads clean the stale bytes out of the cache.
- `verify` is deliberately unchanged — its `hasRetainedSource` carve-out already handles these entries (see design doc's Verify amendment).

## Testing

TDD throughout; acceptance test `TestDeployProfile_SelfHealsStaleUnclaimedPak` drives the real `Service.DeployProfile` seam with the exact live cache shape (recorded zero-member marker + retained source + stale pak + pre-existing stale symlink) and proves removal without re-creation. Legacy matrix pinned: bare marker, no markers, mixed recorded+bare, recorded-without-retained-source all keep the byte-for-byte union. New rollback test proves a failed replace can no longer resurrect a stale pak. Full suite + `go vet` + `trunk check` green.

## Notes

- Two mid-flight design amendments (human-approved, documented in the local plan/spec): the retained-source narrowing gate (after the original all-recorded rule broke two #144 regression tests) and single-layer error wrapping.
- Follow-up filed: #212 (narrow dangling-symlink edge when prune precedes a deploy cycle — harmless litter, out of scope here).
- No version bump per develop workflow; CHANGELOG entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)