### PR TITLE
fix: run verify's convergence sweep even with no installed mods (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON additions: `convert_paks` in `lmm list --json`, `lmm mod show
 --json`, and `lmm game list --json`.
 
+### Fixed
+
+- `lmm verify` no longer skips the deployment-convergence sweep when the
+  profile has no installed mods, so stray lmm-deployed files (e.g.
+  dangling cache symlinks left after uninstalling everything) are
+  reported — and removed with `--fix` (#217).
+
 ## [1.29.0] - 2026-08-05
 
 ### Added

--- a/cmd/lmm/verify.go
+++ b/cmd/lmm/verify.go
@@ -132,7 +132,9 @@ symlink with no record. This is provenance-gated - only content lmm
 itself deployed or is tracking is ever touched, never a foreign file
 just sitting in the game directory. Like the merged-pak staleness check
 above, this is profile-wide and still runs even when you pass a specific
-mod-id filter.
+mod-id filter - and it runs even when the profile has no installed mods
+at all, since a game dir can still hold stray lmm-deployed files after
+everything is uninstalled (#217).
 
 Mods installed from a local source, mods requiring manual download, and
 mods with no recorded file IDs are skipped silently - there is nothing
@@ -274,15 +276,32 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 	}
 
 	if len(files) == 0 {
+		// #217: don't return before the deploy-convergence sweep - it needs
+		// no installed mods at all, and a game dir can still hold stray
+		// lmm-deployed files (e.g. dangling cache-rooted symlinks left after
+		// uninstalling everything). The checksum/version/count passes all
+		// have nothing to do here, so only convergence runs.
+		var warnings int
+		jsonFiles := []verifyFileJSON{}
+		if !jsonOutput {
+			fmt.Println("No installed mods to verify.")
+		}
+		reportConvergencePass(cmd.Context(), svc, game, profile, &jsonFiles, &warnings)
 		if jsonOutput {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
-			if err := enc.Encode(verifyJSONOutput{GameID: game.ID, Profile: profile, Files: []verifyFileJSON{}, Issues: 0, Warnings: 0}); err != nil {
+			if err := enc.Encode(verifyJSONOutput{GameID: game.ID, Profile: profile, Files: jsonFiles, Issues: 0, Warnings: warnings}); err != nil {
 				return fmt.Errorf("encoding json: %w", err)
 			}
 			return nil
 		}
-		fmt.Println("No installed mods to verify.")
+		if warnings > 0 {
+			fmt.Println()
+			fmt.Printf("0 issue(s), %d warning(s) found.\n", warnings)
+			if !verifyFix {
+				fmt.Println("Run with --fix to remove stale lmm-deployed files.")
+			}
+		}
 		return nil
 	}
 
@@ -856,53 +875,9 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 	// (ConvergeDeployedFiles, internal/core/converge.go). Runs AFTER the
 	// cache repairs above so --fix converges against the POST-repair state
 	// (a version-mismatch repair or a merged-pak resync can change what's
-	// currently "provided"). Plain verify passes dryRun=true (report
-	// candidates only, nothing mutates, cf below is never actually removed);
-	// --fix passes dryRun=false (act). Like the merged-pak staleness check
-	// above, this is profile-scoped, not per-mod - modFilter has no effect.
-	convResult, convErr := svc.ConvergeDeployedFiles(ctx, game, profile, !verifyFix)
-	if convResult != nil {
-		for _, cf := range convResult.Removed {
-			// ConvergeResult's own contract: with dryRun=true (plain verify)
-			// every candidate here is unactioned and reported as a warning;
-			// with dryRun=false (--fix) every candidate here already
-			// succeeded (a failed item never lands in Removed - see the
-			// joined-error handling below), so it's reported as fixed and
-			// deliberately does NOT add to warnings - same convention as a
-			// successful NO CHECKSUM re-download or VERSION MISMATCH repair
-			// elsewhere in this function, which don't count a resolved
-			// problem as an outstanding one.
-			if verifyFix {
-				if jsonOutput {
-					jsonFiles = append(jsonFiles, verifyFileJSON{ModID: cf.ModID, FileID: cf.Path, Status: "fixed_stale_deployment", Note: cf.Reason})
-				} else {
-					fmt.Println(colorGreen(fmt.Sprintf("Fixed: removed %s (%s)", cf.Path, cf.Reason)))
-				}
-			} else {
-				if jsonOutput {
-					jsonFiles = append(jsonFiles, verifyFileJSON{ModID: cf.ModID, FileID: cf.Path, Status: "stale_deployment", Note: cf.Reason})
-				} else {
-					fmt.Printf("%s %s - STALE DEPLOYMENT (%s)\n", colorYellow("?"), cf.Path, cf.Reason)
-				}
-				warnings++
-			}
-		}
-	}
-	// Per-item convergence failures (an Undeploy or sweep os.Remove that
-	// failed) are joined into one error by ConvergeDeployedFiles rather than
-	// aborting the whole pass (ConvergeResult's doc comment) - surfaced the
-	// same way every other per-item problem in this command is: a warning,
-	// not a fatal verify failure.
-	if convErr != nil {
-		for _, e := range unwrapJoinedErrors(convErr) {
-			if jsonOutput {
-				jsonFiles = append(jsonFiles, verifyFileJSON{Status: "skipped", Note: fmt.Sprintf("convergence: %v", e)})
-			} else {
-				fmt.Printf("%s convergence: %v\n", colorYellow("?"), e)
-			}
-			warnings++
-		}
-	}
+	// currently "provided"). Like the merged-pak staleness check above, this
+	// is profile-scoped, not per-mod - modFilter has no effect.
+	reportConvergencePass(ctx, svc, game, profile, &jsonFiles, &warnings)
 
 	if jsonOutput {
 		enc := json.NewEncoder(os.Stdout)
@@ -930,6 +905,59 @@ func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []s
 	}
 
 	return nil
+}
+
+// reportConvergencePass runs ConvergeDeployedFiles and reports its results
+// through the command's global output flags - appending --json rows or
+// printing lines, and counting unactioned candidates into warnings. Plain
+// verify passes dryRun=true (report candidates only, nothing mutates);
+// --fix passes dryRun=false (act). Split out of doVerify's main flow so the
+// "no checksummed files" path can run it too (#217): the sweep needs no
+// installed mods at all.
+func reportConvergencePass(ctx context.Context, svc *core.Service, game *domain.Game, profile string, jsonFiles *[]verifyFileJSON, warnings *int) {
+	convResult, convErr := svc.ConvergeDeployedFiles(ctx, game, profile, !verifyFix)
+	if convResult != nil {
+		for _, cf := range convResult.Removed {
+			// ConvergeResult's own contract: with dryRun=true (plain verify)
+			// every candidate here is unactioned and reported as a warning;
+			// with dryRun=false (--fix) every candidate here already
+			// succeeded (a failed item never lands in Removed - see the
+			// joined-error handling below), so it's reported as fixed and
+			// deliberately does NOT add to warnings - same convention as a
+			// successful NO CHECKSUM re-download or VERSION MISMATCH repair
+			// elsewhere in doVerify, which don't count a resolved problem
+			// as an outstanding one.
+			if verifyFix {
+				if jsonOutput {
+					*jsonFiles = append(*jsonFiles, verifyFileJSON{ModID: cf.ModID, FileID: cf.Path, Status: "fixed_stale_deployment", Note: cf.Reason})
+				} else {
+					fmt.Println(colorGreen(fmt.Sprintf("Fixed: removed %s (%s)", cf.Path, cf.Reason)))
+				}
+			} else {
+				if jsonOutput {
+					*jsonFiles = append(*jsonFiles, verifyFileJSON{ModID: cf.ModID, FileID: cf.Path, Status: "stale_deployment", Note: cf.Reason})
+				} else {
+					fmt.Printf("%s %s - STALE DEPLOYMENT (%s)\n", colorYellow("?"), cf.Path, cf.Reason)
+				}
+				*warnings++
+			}
+		}
+	}
+	// Per-item convergence failures (an Undeploy or sweep os.Remove that
+	// failed) are joined into one error by ConvergeDeployedFiles rather than
+	// aborting the whole pass (ConvergeResult's doc comment) - surfaced the
+	// same way every other per-item problem in this command is: a warning,
+	// not a fatal verify failure.
+	if convErr != nil {
+		for _, e := range unwrapJoinedErrors(convErr) {
+			if jsonOutput {
+				*jsonFiles = append(*jsonFiles, verifyFileJSON{Status: "skipped", Note: fmt.Sprintf("convergence: %v", e)})
+			} else {
+				fmt.Printf("%s convergence: %v\n", colorYellow("?"), e)
+			}
+			*warnings++
+		}
+	}
 }
 
 // sourceMappedMod returns a copy of mod with GameID translated through the

--- a/cmd/lmm/verify_converge_test.go
+++ b/cmd/lmm/verify_converge_test.go
@@ -214,3 +214,97 @@ func TestDoVerify_Fix_StaleDeployment_SecondRunClean(t *testing.T) {
 	assert.NotContains(t, out2, "STALE DEPLOYMENT", "a second --fix run must not re-report anything")
 	assert.Contains(t, out2, "All files verified OK.", "a second --fix run must be genuinely clean")
 }
+
+// --- #217: convergence must run even with no checksummed files ---
+//
+// setupDoVerifyEmptyProfileConvergeTest builds the #217 shape: a profile
+// with NO installed mods at all, but a game dir still holding a dangling
+// symlink into the game's cache root (e.g. left behind after uninstalling
+// everything, or manual cache surgery). The sweep needs no installed mods,
+// so verify must not early-return before it.
+func setupDoVerifyEmptyProfileConvergeTest(t *testing.T) (*cobra.Command, *core.Service, *domain.Game, string) {
+	t.Helper()
+
+	svc, game, _ := setupDoInstallTest(t)
+
+	pm := getProfileManager(svc)
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+
+	cacheRoot := svc.GetGameCachePath(game)
+	strayTarget := filepath.Join(cacheRoot, game.ID, "stray-src", "1.0", "stray.pak")
+	strayLink := filepath.Join(game.ModPath, "stray.pak")
+	require.NoError(t, os.Symlink(strayTarget, strayLink))
+
+	verifyProfile = "default"
+	t.Cleanup(func() { verifyProfile = "" })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	return cmd, svc, game, strayLink
+}
+
+// TestDoVerify_EmptyProfile_ConvergenceStillRuns guards #217's plain-verify
+// half: with zero checksummed files the command still runs the convergence
+// sweep, reports the dangling link as a STALE DEPLOYMENT warning (with the
+// --fix hint), and mutates nothing.
+func TestDoVerify_EmptyProfile_ConvergenceStillRuns(t *testing.T) {
+	cmd, svc, game, strayLink := setupDoVerifyEmptyProfileConvergeTest(t)
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "No installed mods to verify.")
+	assert.Contains(t, out, "stray.pak - STALE DEPLOYMENT")
+	assert.Contains(t, out, "1 warning(s)")
+	assert.Contains(t, out, "--fix")
+
+	_, err := os.Lstat(strayLink)
+	assert.NoError(t, err, "plain verify must not sweep the dangling link")
+
+	jsonOutput = true
+	outJSON := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	var result verifyJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &result))
+	assert.Equal(t, 0, result.Issues)
+	assert.Equal(t, 1, result.Warnings)
+	require.Len(t, result.Files, 1)
+	assert.Equal(t, "stale_deployment", result.Files[0].Status)
+	assert.Equal(t, "stray.pak", result.Files[0].FileID)
+
+}
+
+// TestDoVerify_Fix_EmptyProfile_SweepsDanglingLink guards #217's --fix half:
+// the dangling link is actually removed and reported as fixed, and a second
+// run comes back with nothing to report.
+func TestDoVerify_Fix_EmptyProfile_SweepsDanglingLink(t *testing.T) {
+	cmd, svc, game, strayLink := setupDoVerifyEmptyProfileConvergeTest(t)
+
+	oldJSON, oldFix := jsonOutput, verifyFix
+	jsonOutput, verifyFix = false, true
+	t.Cleanup(func() { jsonOutput, verifyFix = oldJSON, oldFix })
+
+	out := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out, "Fixed: removed stray.pak")
+
+	_, err := os.Lstat(strayLink)
+	assert.True(t, os.IsNotExist(err), "verify --fix must sweep the dangling link")
+
+	// Second run: converged, nothing to report beyond the no-mods line.
+	out2 := captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+	assert.Contains(t, out2, "No installed mods to verify.")
+	assert.NotContains(t, out2, "STALE DEPLOYMENT")
+	assert.NotContains(t, out2, "Fixed:")
+
+}

--- a/docs/man/man1/lmm-verify.1
+++ b/docs/man/man1/lmm-verify.1
@@ -118,7 +118,9 @@ symlink with no record. This is provenance-gated - only content lmm
 itself deployed or is tracking is ever touched, never a foreign file
 just sitting in the game directory. Like the merged-pak staleness check
 above, this is profile-wide and still runs even when you pass a specific
-mod-id filter.
+mod-id filter - and it runs even when the profile has no installed mods
+at all, since a game dir can still hold stray lmm-deployed files after
+everything is uninstalled (#217).
 
 .PP
 Mods installed from a local source, mods requiring manual download, and


### PR DESCRIPTION
Fixes #217 (manual close needed — non-default base branch).

## Problem

`doVerify` returned early with "No installed mods to verify" before the deployment-convergence pass (#168/#212) ever ran. The sweep needs no installed mods at all, so a game directory left with stray lmm-deployed files — e.g. dangling cache-rooted symlinks after uninstalling everything, or manual cache surgery — was exactly the state `verify`/`verify --fix` could not detect or clean.

## Fix (design decision: always run the sweep)

- The convergence reporting block is extracted verbatim into `reportConvergencePass` (same dry-run/--fix contract, same warning accounting).
- The zero-checksummed-files path now runs it:
  - **Human output:** `No installed mods to verify.` followed by any `STALE DEPLOYMENT` / `Fixed: removed …` lines, then the `0 issue(s), N warning(s)` summary + `--fix` hint when something turned up. A clean empty profile prints exactly what it did before.
  - **--json:** unchanged shape; `files` carries the sweep's `stale_deployment`/`fixed_stale_deployment` rows and `warnings` counts them.
- Long help + regenerated man page document that the sweep runs even with an empty profile.

The issue's second, related gap (verify's row pass can't reach rows of fully-uninstalled mods) is deliberately **not** in scope here.

## Testing

TDD: both new tests (`TestDoVerify_EmptyProfile_ConvergenceStillRuns`, `TestDoVerify_Fix_EmptyProfile_SweepsDanglingLink`) reproduced the bug before the fix — plain verify reports-without-mutating, `--fix` sweeps the link and a second run comes back clean. Full suite, gofmt, vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)