### PR TITLE
fix: verify --fix re-download queries the source-mapped game (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `lmm verify --fix` now resolves a missing file's re-download URL against
+  the source-mapped game, not the LMM game ID (#228). On a game whose
+  `source_ids` maps to a different upstream domain (e.g. NexusMods
+  `skyrim-se` → `skyrimspecialedition`), the repair previously queried the
+  wrong game and failed. Sources with empty or identity mappings
+  (directory, local) were unaffected.
 - `lmm verify` no longer skips the deployment-convergence sweep when the
   profile has no installed mods, so stray lmm-deployed files (e.g.
   dangling cache symlinks left after uninstalling everything) are

--- a/cmd/lmm/install_test.go
+++ b/cmd/lmm/install_test.go
@@ -516,6 +516,13 @@ type fakeInstallSource struct {
 	// (or didn't apply) the game's per-source ID mapping before calling in.
 	receivedGameFileIDs []string
 
+	// receivedGameDownloadIDs records the mod.GameID GetDownloadURL was
+	// actually called with, in call order - the download-side twin of
+	// receivedGameFileIDs. Service.DownloadMod forwards its mod straight to
+	// the source with no game-ID translation of its own (#228), so callers
+	// driving a download off an installed row must map it themselves.
+	receivedGameDownloadIDs []string
+
 	// getModFilesErr, when set, makes GetModFiles return this error
 	// instead of a normal lookup - for tests exercising a "source
 	// unreachable" path (nil by default, so every other test is unaffected).
@@ -580,6 +587,7 @@ func (s *fakeInstallSource) GetModFiles(ctx context.Context, mod *domain.Mod) ([
 	return s.files[mod.ID], nil
 }
 func (s *fakeInstallSource) GetDownloadURL(ctx context.Context, mod *domain.Mod, fileID string) (string, error) {
+	s.receivedGameDownloadIDs = append(s.receivedGameDownloadIDs, mod.GameID)
 	return s.srv.URL + "/" + fileID, nil
 }
 func (s *fakeInstallSource) CheckUpdates(ctx context.Context, installed []domain.InstalledMod) ([]domain.Update, error) {

--- a/cmd/lmm/verify_test.go
+++ b/cmd/lmm/verify_test.go
@@ -1728,6 +1728,53 @@ func TestDoVerify_Fix_Redownload_MapsGameIDPerSourceMapping(t *testing.T) {
 	assert.Equal(t, "mapped-domain", src.receivedGameFileIDs[1], "redownloadModFile must translate GameID through game.SourceIDs, same rule as Service.GetMod and the version-record pre-pass")
 }
 
+// TestDoVerify_Fix_Redownload_MapsGameIDForDownloadURL is the download-side
+// half of the sibling test above, and guards #228: redownloadModFile mapped
+// its GetModFiles lookup but then handed the RAW installed mod (&mod.Mod,
+// GameID = the LMM game ID) to Service.DownloadMod, which forwards it
+// straight to src.GetDownloadURL with no translation of its own. On any game
+// whose per-source mapping differs from its LMM ID, the repair therefore
+// resolved the download URL against the wrong upstream game. The fixture
+// stages no content for file "2", so the HTTP fetch still 404s - but
+// GetDownloadURL is reached (and recorded) before that, which is all this
+// pins.
+func TestDoVerify_Fix_Redownload_MapsGameIDForDownloadURL(t *testing.T) {
+	cmd, svc, game, src := setupDoVerifyRedownloadTest(t)
+	game.SourceIDs["test-src"] = "mapped-domain"
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	_ = captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	require.Len(t, src.receivedGameDownloadIDs, 1, "expected GetDownloadURL exactly once, for the MISSING file's repair")
+	assert.Equal(t, "mapped-domain", src.receivedGameDownloadIDs[0], "the --fix re-download must resolve its URL against the source-mapped game, same rule as its own GetModFiles lookup")
+}
+
+// TestDoVerify_Fix_Redownload_EmptyMappingKeepsLMMGameIDForDownloadURL is the
+// #228 fix's companion guard, mirroring the GetModFiles-side test above: an
+// empty per-source mapping value means "this source applies to any game"
+// (directory sources declare `donovan-mods: ""`), so it must NOT blank out
+// the LMM game ID on the way to GetDownloadURL either.
+func TestDoVerify_Fix_Redownload_EmptyMappingKeepsLMMGameIDForDownloadURL(t *testing.T) {
+	cmd, svc, game, src := setupDoVerifyRedownloadTest(t)
+	game.SourceIDs["test-src"] = ""
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	_ = captureStdout(t, func() error {
+		return doVerify(cmd, svc, game, nil)
+	})
+
+	require.Len(t, src.receivedGameDownloadIDs, 1)
+	assert.Equal(t, game.ID, src.receivedGameDownloadIDs[0], "an empty per-source mapping must keep the LMM game ID, not blank it out")
+}
+
 // TestDoVerify_Fix_NoChecksum_JSONNotesRedownloadFailure is the NO
 // CHECKSUM half of audit Finding 7: same missing-download fixture, but
 // with the cache entry actually present (so the file reads as NO

--- a/internal/core/verify_repair.go
+++ b/internal/core/verify_repair.go
@@ -37,7 +37,14 @@ func (r *verifyRun) redownloadModFile(ctx context.Context, mod *domain.Installed
 	if downloadFile == nil {
 		return false, fmt.Errorf("file %s not found in mod", fileID)
 	}
-	result, err := r.svc.DownloadMod(ctx, mod.SourceID, r.game, &mod.Mod, downloadFile, nil)
+	// SourceMappedMod on the download too (#228): Service.DownloadMod
+	// forwards its mod straight to src.GetDownloadURL with no translation of
+	// its own, so passing the raw installed row here - whose GameID is the
+	// LMM game ID - resolved the URL against the wrong upstream game on any
+	// source with a non-identity SourceIDs mapping, while the GetModFiles
+	// lookup directly above was already mapped. The cache side is unaffected
+	// either way: every cache path is keyed off game.ID, not mod.GameID.
+	result, err := r.svc.DownloadMod(ctx, mod.SourceID, r.game, SourceMappedMod(r.game, &mod.Mod), downloadFile, nil)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Fixes #228.

## Problem

`redownloadModFile` (`internal/core/verify_repair.go`) mapped its `GetModFiles`
lookup through `game.SourceIDs`, but then handed the **raw** installed row
(`&mod.Mod`, whose `GameID` is the LMM game ID) to `Service.DownloadMod` —
which forwards straight to `src.GetDownloadURL` with no translation of its own.

On a game whose per-source mapping differs from its LMM ID (NexusMods
`skyrim-se` → `skyrimspecialedition`), a `verify --fix` re-download of a missing
file therefore resolved its URL against the wrong upstream game.

The defect pre-dates #227 — the byte-identical verify-engine extraction
deliberately preserved it, so it was filed separately.

## Fix

Pass `SourceMappedMod(r.game, &mod.Mod)` to `DownloadMod` too, matching the
sibling `GetModFiles` call three lines above.

Nothing else shifts: every cache path inside `DownloadModToCache` keys off
`game.ID`, not `mod.GameID` (`prepareStaging`, `prepareUnseededStaging`,
`gameCache.ListFiles`), so the mapped copy only changes the upstream URL lookup.

## Tests (written first, confirmed failing)

`fakeInstallSource` gains `receivedGameDownloadIDs`, the download-side twin of
the existing `receivedGameFileIDs` capture. Two tests sit next to their
`GetModFiles` siblings in `cmd/lmm/verify_test.go`:

- `TestDoVerify_Fix_Redownload_MapsGameIDForDownloadURL` — pins the mapped ID
  reaching `GetDownloadURL`. Failed pre-fix with `g1` (the LMM ID) vs the
  expected `mapped-domain`.
- `TestDoVerify_Fix_Redownload_EmptyMappingKeepsLMMGameIDForDownloadURL` — an
  empty mapping (`donovan-mods: ""`, "applies to any game") must not blank out
  the LMM ID. Regression guard; passes either way.

The 24 frozen verify goldens are unaffected, as #228 predicted — this changes an
upstream request, not CLI output shape.

## Blast radius

Affected in practice: NexusMods (`nexusmods.go:219`, `GetDownloadLinks(ctx,
mod.GameID, ...)`) and custom `api` sources (`api.go:343`, the `game_id`
template var) with a non-identity `SourceIDs` mapping. CurseForge, Icarus,
Steam, directory, and manifest sources don't read `mod.GameID` in
`GetDownloadURL`.

I audited all 9 non-test `DownloadMod`/`DownloadModToCache` call sites for the
same untranslated-`mod` pattern: **this was the only affected one.** The other
eight all pass source-fetched mod objects (via `Service.GetMod` or
`SearchMods`, both of which translate internally), which carry the source-domain
`GameID` already.

## Verification

`go build ./...`, `go vet ./...`, and the full `go test ./...` are green.

No version bump (bump-at-release); CHANGELOG entry added under `[Unreleased]` → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)