### PR TITLE
hotfix: v1.29.1 — .EXMODZ bundled assets land where the game looks (#237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1231,7 +1231,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.29.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.29.1...HEAD
 [1.29.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.29.0...v1.29.1
 [1.29.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.28.0...v1.29.0
 [1.28.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.27.1...v1.28.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.29.1] - 2026-08-07
+
+### Fixed
+
+- Icarus mods that bundle prebuilt assets in their `.exmodz` now place those
+  assets where the game actually looks. Every real `.exmodz` nests its
+  `.uasset`/`.uexp` files in a directory named after the mod, and that wrapper
+  was being carried into the compiled pak — so each bundled asset landed one
+  directory below the base asset it was meant to override and the game
+  silently ignored it. A mod whose entire effect is assets (no data-table
+  rows) installed, deployed, and verified OK while doing nothing at all. The
+  wrapper is now stripped when it matches the manifest name, leaving bundles
+  that already store Content-relative paths untouched. Affects both
+  single-mod compiles and the merged pak; reinstall or redeploy affected
+  Icarus mods to pick up corrected artifacts. (#237)
+
 ## [1.29.0] - 2026-08-05
 
 ### Added
@@ -1216,6 +1232,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MIT License
 
 [Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.29.0...HEAD
+[1.29.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.29.0...v1.29.1
 [1.29.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.28.0...v1.29.0
 [1.28.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.27.1...v1.28.0
 [1.27.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.27.0...v1.27.1

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -39,7 +39,7 @@ var ErrCancelled = errors.New("cancelled")
 var ErrReported = errors.New("already reported")
 
 var (
-	version = "1.29.0"
+	version = "1.29.1"
 
 	// buildDescribe is injected at build time via -ldflags -X (see the
 	// Makefile's `build` target) with `git describe --tags --dirty`.

--- a/docs/man/man1/lmm-auth-login.1
+++ b/docs/man/man1/lmm-auth-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-auth-login - Authenticate with a mod source

--- a/docs/man/man1/lmm-auth-logout.1
+++ b/docs/man/man1/lmm-auth-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-auth-logout - Remove stored credentials for a mod source

--- a/docs/man/man1/lmm-auth-status.1
+++ b/docs/man/man1/lmm-auth-status.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-auth-status - Show authentication status for all sources

--- a/docs/man/man1/lmm-auth.1
+++ b/docs/man/man1/lmm-auth.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-auth - Manage authentication for mod sources

--- a/docs/man/man1/lmm-completion-bash.1
+++ b/docs/man/man1/lmm-completion-bash.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-completion-bash - Generate the autocompletion script for bash

--- a/docs/man/man1/lmm-completion-fish.1
+++ b/docs/man/man1/lmm-completion-fish.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-completion-fish - Generate the autocompletion script for fish

--- a/docs/man/man1/lmm-completion-powershell.1
+++ b/docs/man/man1/lmm-completion-powershell.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-completion-powershell - Generate the autocompletion script for powershell

--- a/docs/man/man1/lmm-completion-zsh.1
+++ b/docs/man/man1/lmm-completion-zsh.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-completion-zsh - Generate the autocompletion script for zsh

--- a/docs/man/man1/lmm-completion.1
+++ b/docs/man/man1/lmm-completion.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-completion - Generate the autocompletion script for the specified shell

--- a/docs/man/man1/lmm-conflicts.1
+++ b/docs/man/man1/lmm-conflicts.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-conflicts - Show all file conflicts in the current profile

--- a/docs/man/man1/lmm-deploy.1
+++ b/docs/man/man1/lmm-deploy.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-deploy - Deploy mods to game directory

--- a/docs/man/man1/lmm-game-add.1
+++ b/docs/man/man1/lmm-game-add.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-game-add - Add a game interactively

--- a/docs/man/man1/lmm-game-clear-default.1
+++ b/docs/man/man1/lmm-game-clear-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-game-clear-default - Clear the default game setting

--- a/docs/man/man1/lmm-game-detect.1
+++ b/docs/man/man1/lmm-game-detect.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-game-detect - Detect Steam games and add them to config

--- a/docs/man/man1/lmm-game-list.1
+++ b/docs/man/man1/lmm-game-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-game-list - List configured games

--- a/docs/man/man1/lmm-game-set-default.1
+++ b/docs/man/man1/lmm-game-set-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-game-set-default - Set the default game

--- a/docs/man/man1/lmm-game-show-default.1
+++ b/docs/man/man1/lmm-game-show-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-game-show-default - Show the current default game

--- a/docs/man/man1/lmm-game.1
+++ b/docs/man/man1/lmm-game.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-game - Game management commands

--- a/docs/man/man1/lmm-import.1
+++ b/docs/man/man1/lmm-import.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-import - Import mods from local files or scan mod_path

--- a/docs/man/man1/lmm-install.1
+++ b/docs/man/man1/lmm-install.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-install - Install a mod

--- a/docs/man/man1/lmm-list.1
+++ b/docs/man/man1/lmm-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-list - List installed mods

--- a/docs/man/man1/lmm-mod-disable.1
+++ b/docs/man/man1/lmm-mod-disable.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-mod-disable - Disable a mod without uninstalling

--- a/docs/man/man1/lmm-mod-edit.1
+++ b/docs/man/man1/lmm-mod-edit.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-mod-edit - Edit mod details (name, version, author, source, ID)

--- a/docs/man/man1/lmm-mod-enable.1
+++ b/docs/man/man1/lmm-mod-enable.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-mod-enable - Enable a disabled mod

--- a/docs/man/man1/lmm-mod-files.1
+++ b/docs/man/man1/lmm-mod-files.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-mod-files - List files deployed by a mod

--- a/docs/man/man1/lmm-mod-lock.1
+++ b/docs/man/man1/lmm-mod-lock.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-mod-lock - Lock a mod at its current or a specific version

--- a/docs/man/man1/lmm-mod-set-update.1
+++ b/docs/man/man1/lmm-mod-set-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-mod-set-update - Set update policy for a mod

--- a/docs/man/man1/lmm-mod-show.1
+++ b/docs/man/man1/lmm-mod-show.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-mod-show - Show mod details

--- a/docs/man/man1/lmm-mod-unlock.1
+++ b/docs/man/man1/lmm-mod-unlock.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-mod-unlock - Unlock a mod, restoring normal update behavior

--- a/docs/man/man1/lmm-mod.1
+++ b/docs/man/man1/lmm-mod.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-mod - Manage mod settings

--- a/docs/man/man1/lmm-profile-apply.1
+++ b/docs/man/man1/lmm-profile-apply.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-profile-apply - Apply profile to system

--- a/docs/man/man1/lmm-profile-create.1
+++ b/docs/man/man1/lmm-profile-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-profile-create - Create a new profile

--- a/docs/man/man1/lmm-profile-delete.1
+++ b/docs/man/man1/lmm-profile-delete.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-profile-delete - Delete a profile

--- a/docs/man/man1/lmm-profile-export.1
+++ b/docs/man/man1/lmm-profile-export.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-profile-export - Export a profile

--- a/docs/man/man1/lmm-profile-import.1
+++ b/docs/man/man1/lmm-profile-import.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-profile-import - Import a profile

--- a/docs/man/man1/lmm-profile-list.1
+++ b/docs/man/man1/lmm-profile-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-profile-list - List all profiles

--- a/docs/man/man1/lmm-profile-reorder.1
+++ b/docs/man/man1/lmm-profile-reorder.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-profile-reorder - View or change load order

--- a/docs/man/man1/lmm-profile-switch.1
+++ b/docs/man/man1/lmm-profile-switch.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-profile-switch - Switch to a different profile

--- a/docs/man/man1/lmm-profile-sync.1
+++ b/docs/man/man1/lmm-profile-sync.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-profile-sync - Sync profile to match installed mods

--- a/docs/man/man1/lmm-profile.1
+++ b/docs/man/man1/lmm-profile.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-profile - Manage mod profiles

--- a/docs/man/man1/lmm-purge.1
+++ b/docs/man/man1/lmm-purge.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-purge - Remove all deployed mods from game directory

--- a/docs/man/man1/lmm-search.1
+++ b/docs/man/man1/lmm-search.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-search - Search for mods

--- a/docs/man/man1/lmm-source-list.1
+++ b/docs/man/man1/lmm-source-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-source-list - List all mod sources

--- a/docs/man/man1/lmm-source-validate.1
+++ b/docs/man/man1/lmm-source-validate.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-source-validate - Validate a source definition file

--- a/docs/man/man1/lmm-source.1
+++ b/docs/man/man1/lmm-source.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-source - Manage mod sources

--- a/docs/man/man1/lmm-status.1
+++ b/docs/man/man1/lmm-status.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-status - Show current status

--- a/docs/man/man1/lmm-tui.1
+++ b/docs/man/man1/lmm-tui.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-tui - Launch the interactive terminal UI

--- a/docs/man/man1/lmm-uninstall.1
+++ b/docs/man/man1/lmm-uninstall.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-uninstall - Uninstall a mod

--- a/docs/man/man1/lmm-update-rollback.1
+++ b/docs/man/man1/lmm-update-rollback.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-update-rollback - Rollback a mod to its previous version

--- a/docs/man/man1/lmm-update.1
+++ b/docs/man/man1/lmm-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-update - Check for or apply mod updates

--- a/docs/man/man1/lmm-verify.1
+++ b/docs/man/man1/lmm-verify.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm-verify - Verify cached mod files

--- a/docs/man/man1/lmm.1
+++ b/docs/man/man1/lmm.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.29.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.29.1" "User Commands"
 
 .SH NAME
 lmm - Linux Mod Manager \- Terminal-based mod manager for Linux

--- a/internal/source/icarus/compile_test.go
+++ b/internal/source/icarus/compile_test.go
@@ -16,7 +16,10 @@ func writeTestExmodzFile(t *testing.T, manifestJSON string, assets map[string][]
 	path := filepath.Join(t.TempDir(), "mod.exmodz")
 	var buf bytes.Buffer
 	zw := zip.NewWriter(&buf)
-	w, _ := zw.Create("Extracted Mods/Test.EXMOD")
+	// Named to match the "Bear_Mount/" wrapper the asset fixtures below use:
+	// a real .EXMODZ nests its assets in a directory named after the manifest,
+	// and that pairing is what exercises the #237 wrapper strip.
+	w, _ := zw.Create("Extracted Mods/Bear_Mount.EXMOD")
 	w.Write([]byte(manifestJSON)) //nolint:errcheck
 	for name, data := range assets {
 		aw, _ := zw.Create(name)
@@ -64,7 +67,7 @@ func TestCompile_AppliesDiffAndBundlesAssets(t *testing.T) {
 		t.Errorf("patched data table = %s, want BaseMovementSpeed 235", patched)
 	}
 
-	asset, err := r.ReadFile("Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset")
+	asset, err := r.ReadFile("ASS/ITM/SK_ITM_Saddle_Bear.uasset")
 	if err != nil {
 		t.Fatalf("ReadFile bundled asset: %v", err)
 	}
@@ -111,8 +114,13 @@ func TestCompile_MountsAtTheGamesDataLoaderPath(t *testing.T) {
 	if _, err := r.ReadFile("AI/D_AIGrowth.json"); err == nil {
 		t.Error("patched table must NOT also exist at the unprefixed path")
 	}
-	if _, err := r.ReadFile("Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset"); err != nil {
-		t.Errorf("bundled asset must keep its own unprefixed path: %v", err)
+	// Assets get no "data/" prefix, and their own "<Mod>/" wrapper is stripped
+	// so they land exactly where the base asset they override lives (#237).
+	if _, err := r.ReadFile("ASS/ITM/SK_ITM_Saddle_Bear.uasset"); err != nil {
+		t.Errorf("bundled asset must land at its wrapper-stripped path: %v", err)
+	}
+	if _, err := r.ReadFile("Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset"); err == nil {
+		t.Error("bundled asset must NOT also exist under its .EXMODZ wrapper directory")
 	}
 }
 

--- a/internal/source/icarus/exmodz.go
+++ b/internal/source/icarus/exmodz.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"path"
 	"strings"
 )
 
@@ -94,16 +95,54 @@ func ParseExmodz(zipData []byte) (*ExmodzBundle, error) {
 		totalDeclaredSize += f.UncompressedSize64
 	}
 
+	wrapper := modWrapperDir(manifestPath)
 	bundle := &ExmodzBundle{Diff: diff, Assets: make(map[string][]byte)}
 	for _, f := range assetFiles {
 		data, err := readZipFile(f)
 		if err != nil {
 			return nil, fmt.Errorf("icarus: reading asset %s: %w", f.Name, err)
 		}
-		bundle.Assets[normalizeZipName(f.Name)] = data
+		bundle.Assets[stripModWrapper(normalizeZipName(f.Name), wrapper)] = data
 	}
 
 	return bundle, nil
+}
+
+// modWrapperDir names the directory an .EXMODZ nests its bundled assets
+// under: the manifest's own basename. Verified across every asset-bearing
+// bundle available (the #220 spike corpus plus DonovanMods/Icarus-Mods) —
+// each uses exactly one wrapper segment, and it equals the manifest basename
+// in all of them.
+func modWrapperDir(manifestPath string) string {
+	base := path.Base(normalizeZipName(manifestPath))
+	return strings.TrimSuffix(base, path.Ext(base))
+}
+
+// stripModWrapper removes the mod's own wrapper directory from a bundled
+// asset's path, yielding the Content-relative path the asset must occupy to
+// override the base game's copy.
+//
+// Without this the wrapper rides into the output pak and every bundled asset
+// lands one directory below its target, which the game silently ignores — so
+// an asset-only mod deploys, verifies OK, and does nothing (#237). Ground
+// truth is the dual-form mod Crys_Lvl120Cap_M25: its .EXMODZ stores
+// "Crys_Lvl120Cap_M25/data/Character/C_PlayerTalentGrowth.uasset" while its
+// own published _P.pak mounts that asset at
+// "Icarus/Content/data/Character/C_PlayerTalentGrowth.uasset".
+//
+// The strip is conditional on the leading segment matching the wrapper
+// (case-insensitively, since UE virtual paths are case-insensitive and
+// .EXMODZ producers vary casing). Stripping unconditionally would corrupt a
+// bundle that already stores its assets at their Content-relative path.
+func stripModWrapper(assetPath, wrapper string) string {
+	if wrapper == "" {
+		return assetPath
+	}
+	first, rest, found := strings.Cut(assetPath, "/")
+	if !found || rest == "" || !strings.EqualFold(first, wrapper) {
+		return assetPath
+	}
+	return rest
 }
 
 // normalizeZipName converts a zip entry's backslashes to forward slashes.

--- a/internal/source/icarus/exmodz_test.go
+++ b/internal/source/icarus/exmodz_test.go
@@ -45,7 +45,8 @@ func TestParseExmodz(t *testing.T) {
 	if bundle.Diff == nil || bundle.Diff.Name != "Bear Mount" {
 		t.Fatalf("Diff = %+v", bundle.Diff)
 	}
-	asset, ok := bundle.Assets["Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset"]
+	// Keyed by the wrapper-stripped, Content-relative path (#237).
+	asset, ok := bundle.Assets["ASS/ITM/SK_ITM_Saddle_Bear.uasset"]
 	if !ok {
 		t.Fatalf("Assets missing expected key; got keys: %v", mapKeys(bundle.Assets))
 	}
@@ -93,7 +94,7 @@ func TestParseExmodz_NormalizesBackslashNames(t *testing.T) {
 	if bundle.Diff == nil || bundle.Diff.Name != "Bear Mount" {
 		t.Fatalf("Diff = %+v", bundle.Diff)
 	}
-	asset, ok := bundle.Assets["Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset"]
+	asset, ok := bundle.Assets["ASS/ITM/SK_ITM_Saddle_Bear.uasset"]
 	if !ok {
 		t.Fatalf("Assets missing expected forward-slash key; got keys: %v", mapKeys(bundle.Assets))
 	}
@@ -133,7 +134,7 @@ func TestParseExmodz_MatchesCaseInsensitively(t *testing.T) {
 	if bundle.Diff == nil || bundle.Diff.Name != "Bear Mount" {
 		t.Fatalf("Diff = %+v", bundle.Diff)
 	}
-	if _, ok := bundle.Assets["Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.UASSET"]; !ok {
+	if _, ok := bundle.Assets["ASS/ITM/SK_ITM_Saddle_Bear.UASSET"]; !ok {
 		t.Fatalf("Assets missing case-varying key (original case preserved); got keys: %v", mapKeys(bundle.Assets))
 	}
 }
@@ -388,5 +389,61 @@ func TestParseExmodz_TotalAssetsSizeAccumulationIsOverflowSafe(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "per-entry cap") {
 		t.Errorf("error %q fired from the per-entry check, meaning uint64 overflow bypassed the total-cap check", err)
+	}
+}
+
+// Every real .EXMODZ wraps its bundled assets in a single directory named
+// after the mod, and that wrapper is stripped when the mod is compiled: the
+// dual-form mod Crys_Lvl120Cap_M25 ships
+// "Crys_Lvl120Cap_M25/data/Character/C_PlayerTalentGrowth.uasset" in its
+// .EXMODZ and mounts the same asset at "Icarus/Content/data/Character/
+// C_PlayerTalentGrowth.uasset" in its own published _P.pak. Carrying the
+// wrapper through into the output pak puts every bundled asset one directory
+// below the base asset it is meant to override, so the game silently ignores
+// it (#237).
+func TestParseExmodz_StripsModNameWrapper(t *testing.T) {
+	bundle, err := ParseExmodz(buildTestExmodz(t))
+	if err != nil {
+		t.Fatalf("ParseExmodz: %v", err)
+	}
+	if _, ok := bundle.Assets["Bear_Mount/ASS/ITM/SK_ITM_Saddle_Bear.uasset"]; ok {
+		t.Errorf("asset key kept the %q wrapper; it must be stripped so the asset "+
+			"overrides the base game's own path", "Bear_Mount/")
+	}
+	asset, ok := bundle.Assets["ASS/ITM/SK_ITM_Saddle_Bear.uasset"]
+	if !ok {
+		t.Fatalf("Assets missing wrapper-stripped key; got keys: %v", mapKeys(bundle.Assets))
+	}
+	if string(asset) != "fake-uasset-bytes" {
+		t.Errorf("asset content = %q", asset)
+	}
+}
+
+// Only the mod's own wrapper is stripped. An .EXMODZ whose assets already sit
+// at their Content-relative path must be left exactly as authored - stripping
+// a leading segment unconditionally would corrupt those instead.
+func TestParseExmodz_LeavesUnwrappedAssetPathUnchanged(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("Extracted Mods/Bear_Mount.EXMOD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte(`{"name":"Bear Mount","Rows":[]}`)) //nolint:errcheck
+	assetW, err := zw.Create("ASS/ITM/SK_ITM_Saddle_Bear.uasset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assetW.Write([]byte("fake-uasset-bytes")) //nolint:errcheck
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	bundle, err := ParseExmodz(buf.Bytes())
+	if err != nil {
+		t.Fatalf("ParseExmodz: %v", err)
+	}
+	if _, ok := bundle.Assets["ASS/ITM/SK_ITM_Saddle_Bear.uasset"]; !ok {
+		t.Fatalf("unwrapped asset path was modified; got keys: %v", mapKeys(bundle.Assets))
 	}
 }


### PR DESCRIPTION
Hotfix from `main` per the branch model. Fixes #237.

## The bug

`ParseExmodz` keyed `ExmodzBundle.Assets` by the raw zip entry path. Every real `.EXMODZ` nests its `.uasset`/`.uexp` files in a directory named after the mod, so `Compile` and `applyBundle` wrote that wrapper into the output pak:

```
emitted:  Icarus/Content/MegaPoints/data/Character/C_PlayerTalentGrowth.uasset
expected: Icarus/Content/Data/Character/C_PlayerTalentGrowth.uasset
```

UE pak overrides bind by exact virtual path, so **every bundled asset from an asset-bearing `.EXMODZ` landed at a path the game ignores**. A mod whose entire effect is assets — `Rows` consisting only of `EndOfMod` — installed, deployed, verified OK, and did nothing.

Confirmed on a live deployed `zzz_LMM_Merged_P.pak`, not just by reading code.

## Ground truth

The dual-form mod `Crys_Lvl120Cap_M25` ships both artifacts:

| | path |
|---|---|
| its `.EXMODZ` | `Crys_Lvl120Cap_M25/data/Character/C_PlayerTalentGrowth.uasset` |
| its published `_P.pak` | mount `../../../Icarus/Content/data/Character/` + `C_PlayerTalentGrowth.uasset` |
| base game (`pakchunk0_s20`) | mount `../../../Icarus/Content/` + `Data/Character/C_PlayerTalentGrowth.uasset` |

The wrapper is stripped at compile time. It equals the manifest basename in all six asset-bearing bundles available (the #220 spike corpus plus DonovanMods/Icarus-Mods), each using exactly one wrapper segment.

## The fix

Stripped in `ParseExmodz` — the one place that knows the manifest name — so both compile paths inherit it. Conditional on the leading segment matching the wrapper case-insensitively, so a bundle already storing Content-relative paths is untouched. Pak→exmod conversion is unaffected: `convertPakToBundle` builds asset paths from pak entries, which are already Content-relative.

## Why it shipped

The tests asserted the broken path. `compile_test.go` built bundles with a `Bear_Mount/` asset wrapper but named the manifest `Test.EXMOD`, so the wrapper never matched and the compile-level path was never exercised; `exmodz_test.go` read the unstripped key back and passed. The `Icarus/Content/` convention was validated from the *pak* side (TurretVariants, an already-built pak) and never cross-checked against what an `.EXMODZ` compiles to. In-game validation used table-patching mods, where this is invisible.

Both are corrected here: the helper now names its manifest to match the fixture wrapper, and `TestCompile_MountsAtTheGamesDataLoaderPath` asserts the asset is present at the stripped path **and absent** under the wrapper.

## Verification

- Full suite green (19 packages), `gofmt`/`go vet` clean
- Real-data check: `MegaPoints.EXMODZ` compiled against the installed `data.pak` now emits `data/Character/C_PlayerTalentGrowth.uasset` under `../../../Icarus/Content/` — case-insensitively identical to the base game's path and matching a known-good published mod's shape
- Man pages regenerated (`make man`); version bumped to 1.29.1

**In-game confirmation is still the final gate** — affected Icarus mods need a redeploy to pick up corrected artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)