### PR TITLE
docs: archive completed plan docs — #170 plus the v1.29.0 backlog

### DIFF
--- a/docs/plans/archive/2026-08-03-manifest-aware-deploy-and-exmodz-default-design.md
+++ b/docs/plans/archive/2026-08-03-manifest-aware-deploy-and-exmodz-default-design.md
@@ -1,0 +1,174 @@
+# Manifest-Aware Deploy & Exmodz-Default Selection — Design
+
+**Date:** 2026-08-03
+**Status:** Approved design, pre-implementation
+**Issues:** [#210](https://github.com/DonovanMods/linux-mod-manager/issues/210) (bug: manifest-aware deploy) and [#211](https://github.com/DonovanMods/linux-mod-manager/issues/211) (feature: exmodz default) — two story branches, #210 first.
+
+## Background / Evidence
+
+Investigated from a live report (Icarus, 4 mods, `lmm -g icarus deploy`):
+
+- The merged pak itself was verified correct at the byte level (mount point,
+  entry paths byte-matching author-built pak conventions, diff values applied,
+  fingerprint BaseIndexHash matching the installed `data.pak`).
+- The real defects are upstream of the merge:
+
+**Defect 1 (bug):** `installer.Install` deploys `cache.ListFiles(...)` — the
+union of every regular file in a cache version dir — and never consults the
+completion-marker member manifests (`cache.MarkFileCompleteWithMembers` /
+`cache.FileManifests`, #144). Pre-#197 exmodz downloads compiled a per-mod
+`<stem>_P.pak` into the cache; the post-#197 retain-only path seeds staging
+from the existing entry (`prepareStaging`, `internal/core/service.go:778-796`)
+and never removes it. Result: a mixed entry like
+`icarus-dLs3nvmWj5uOPnXxezGe/1.4/` holds `LargerResourceStacks_P.pak`
+(claimed by **no** manifest) next to `.lmm-source-exmodz` (marker records
+zero members), yet deploy still symlinks the stale pak into the game dir —
+double-applying tables alongside `zzz_LMM_Merged_P.pak`. The conflict scanner
+(`internal/core/conflicts.go:99`) has the same blind spot (phantom conflicts).
+
+**Defect 2 (feature gap):** the Icarus source emits two `DownloadableFile`s
+(IDs `"pak"` / `"exmodz"`) but sets `IsPrimary` only when exactly one exists
+(`internal/source/icarus/icarus.go:172-174`). With both present, every
+non-interactive selection path — TUI install (no file chooser exists), `--yes`,
+batch/dependency install, profile apply — falls through `selectDeployFiles`
+to `files[0]` = **pak**. The mergeable variant silently loses everywhere, and
+the CLI chooser rows (`(PAK, 0 B)` / `(EXMODZ, 0 B)`, no default mark) give
+the user no basis to choose. The CLI multi-select also permits installing
+_both_ variants, recreating the double-apply by explicit choice.
+
+## Part 1 — Manifest-aware deploy (bug; ship first)
+
+### Resolver
+
+New helper in `internal/core` (beside the installer):
+
+```
+deployableFiles(cache, gameID, sourceID, modID, version) ([]string, error)
+```
+
+1. Read `FileManifests` for the version dir.
+2. **All markers `Recorded=true` AND the entry holds at least one retained
+   source (`.lmm-source-*`)** → deployable set = union of recorded members,
+   intersected with files actually on disk (`ListFiles`). Unclaimed files
+   are excluded.
+3. **Otherwise** (any marker `Recorded=false`, no markers, or no retained
+   source) → fall back to the full `ListFiles` union (legacy behavior,
+   unchanged).
+
+**Amended during implementation (user ruling 2026-08-03, Task 3 breaker):**
+the original rule narrowed on "all markers recorded" alone, which is
+indistinguishable from #144's protected legacy shapes — an entry holding
+content no recorded manifest attributes (unverifiable file IDs, `lmm
+import`-populated entries) must keep the union
+(`TestInstaller_ReplaceForUpdate_SameCacheDir_FallsBackToUnionWithoutProvenance`).
+The retained source is the discriminator: it is the validate+retain model's
+signature, present in every real #210 entry, and the same signal `verify`'s
+`hasRetainedSource` carve-out already trusts. When attribution is complete
+the narrowed set equals the union anyway, so the gate only changes behavior
+for entries with unattributed content and no retained source — exactly the
+#144 shapes. `PruneUnclaimed` (Part 1's prune-on-commit) carries the same
+retained-source gate so a commit can never delete legacy content.
+
+Rationale for the any-legacy-marker fallback: a bare marker means "unknown
+provenance — never none" (`cache.FileManifest.Recorded` contract); dropping
+its members would break legitimately deployed legacy files.
+
+### Call-site rule: deploy-direction vs removal-direction
+
+- **Deploy-direction sites use the resolver:** `Installer.Install`, the _new_
+  side of `Replace`/`ReplaceForUpdate`, `IsDeployed`/deploy-state checks, and
+  the conflict scanner.
+- **Removal-direction sites keep the `ListFiles` union:** `Uninstall`,
+  undeploy, the _old_ side of Replace. Cleanup must remove anything that
+  might ever have been linked.
+
+This asymmetry makes a redeploy cycle self-heal an affected game dir: the
+union side unlinks the stale pak; the resolver side never re-creates it.
+
+### Prune-on-commit (cache hygiene)
+
+When a download commit completes and _all_ markers in the entry are
+`Recorded`, delete non-reserved files claimed by no manifest (the
+seeded-staging leftovers). Skip pruning entirely if any legacy bare marker is
+present.
+
+### Verify
+
+**Amended during planning (2026-08-03):** verify needs no change. Its
+`hasRetainedSource` carve-out (`cmd/lmm/verify.go:269`) already skips the
+count-mismatch check for compile-mode retained-only entries — including the
+mixed stale-pak shape — before `ListFiles` is consulted, and its per-file
+checksum loop keys off DB rows, not directory listings. Replacing the
+carve-out with the resolver would have _introduced_ a false FILE COUNT
+MISMATCH for healed retained-only entries (deployable set empty vs
+expected downloads > 0). The implementation plan adds no verify task.
+
+### Acceptance criteria
+
+- A cache entry shaped like the live report (recorded zero-member manifest +
+  unclaimed stale pak) deploys **nothing** of its own; a deploy cycle removes
+  previously-linked stale symlinks from the game dir.
+- Legacy bare-marker entries deploy exactly as today.
+- Conflict scan no longer reports unclaimed files.
+- Prune-on-commit removes unclaimed files only when provenance is fully
+  recorded.
+
+## Part 2 — Exmodz default + variant exclusivity (feature)
+
+### Source-level primary
+
+`icarus.GetModFiles`:
+
+- Both variants present → set `IsPrimary` on **exmodz** (single-file behavior
+  unchanged: sole file is primary).
+- Fill `Description`: `"mergeable EXMOD — recommended"` / `"prebuilt PAK"` so
+  the CLI chooser rows are distinguishable.
+
+Every selection path already honors `IsPrimary` (CLI default mark + `--yes`,
+TUI plan, batch/dependency, profile apply, `selectDeployFiles`), so no core
+plumbing is needed — CLI/TUI parity for free. Escape hatch preserved:
+`--file pak` or explicit chooser selection still installs the pak.
+
+### Mixed-variant rejection (core seam)
+
+For a source implementing `MergeCompiler`, a file selection that mixes an
+exmodz file (`isExmodzFile`) with any other file is rejected:
+
+> pak and exmodz are alternate forms of the same mod — select one
+
+Enforced at the core resolution seam (`resolveTargetFiles`, covering
+`--file pak,exmodz` and batch paths) and surfaced in the CLI chooser as a
+re-prompt rather than a hard exit. Per the #197 lesson, both entry points get
+CLI-layer integration tests, not just core unit tests.
+
+### Acceptance criteria
+
+- With both variants, TUI/`--yes`/batch/profile-apply install exmodz; CLI
+  chooser shows exmodz as `<- default` with descriptive labels.
+- `--file pak` still installs the pak alone.
+- `--file pak,exmodz` and chooser `1,2` are rejected with the message above.
+
+## Testing (TDD)
+
+- **Bug:** failing test first reproducing the live cache shape; legacy
+  bare-marker union preservation; replace-cycle stale-symlink removal;
+  prune-on-commit unit tests; conflict-scan test.
+- **Feature:** icarus source table tests (both→exmodz primary,
+  single→unchanged); CLI chooser default + rejection integration tests; TUI
+  plan test asserting `plan.Files == [exmodz]`.
+
+## Rollout
+
+Two GitHub issues; two story branches off `develop` (`fix/…` then `feat/…`);
+separate PRs `--base develop`; CHANGELOG entries under `[Unreleased]`; no
+per-story version bump (bug = PATCH-class, feature = MINOR-class for the
+release batch). Issues do not auto-close on develop merges — close manually.
+
+## Decisions log
+
+- Exmodz default, pak selectable (user-approved; "exmodz-only/hide pak" and
+  "label-only" rejected).
+- Two issues, bug first (user-approved; combined story rejected).
+- Preference implemented source-level via `IsPrimary`, not core game-aware
+  plumbing (YAGNI: icarus source is only used with compile-mode games).
+- Deploy-direction/removal-direction asymmetry is deliberate (self-healing).

--- a/docs/plans/archive/2026-08-03-manifest-aware-deploy-plan.md
+++ b/docs/plans/archive/2026-08-03-manifest-aware-deploy-plan.md
@@ -1,0 +1,748 @@
+# Manifest-Aware Deploy (#210) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy-direction operations link only cache files vouched for by a recorded completion-marker manifest; removal-direction operations keep the full union, so a deploy cycle self-heals entries polluted by stale pre-#197 per-mod paks.
+
+**Architecture:** One new unexported resolver `deployableFiles` in `internal/core` encapsulates the recorded-manifests-else-union rule. Deploy-direction call sites (`Install`, new side of `replaceWithCaches`, `IsInstalled`, `GetDeployedFiles`, `GetConflicts`, profile conflict scanner) switch to it; removal-direction sites (`Uninstall`, old side of replace) stay on `ListFiles`. A `cache.PruneUnclaimed` helper removes unclaimed files at download-commit time when provenance is fully recorded.
+
+**Tech Stack:** Go, testify, `t.TempDir()` filesystem tests (repo testing conventions: `internal/core` tests in `core_test` package; internal tests in `*_internal_test.go` package `core`).
+
+**Spec:** `docs/plans/2026-08-03-manifest-aware-deploy-and-exmodz-default-design.md` (Part 1). Issue: #210.
+
+## Amendment (user ruling 2026-08-03, Task 3 breaker)
+
+`deployableFiles` narrows ONLY when all markers are recorded AND the entry
+holds at least one retained source (`.lmm-source-*` — detected via a new
+`cache.HasRetainedSource(versionDir)` helper); otherwise it returns the full
+`ListFiles` union. This protects #144's unattributed-content shapes
+(`TestInstaller_ReplaceForUpdate_SameCacheDir_FallsBackToUnionWithoutProvenance`,
+`TestApplyUpdate_SameVersionFileOnlyUpdate_LegacyCacheFallsBackToUnion`),
+which the original all-recorded rule broke. Consequences for the tasks below:
+Task 1's narrowing-case test fixtures gain a retained-source file and a new
+union test covers all-recorded-without-retained-source; Task 2/3/6 fixtures
+that model the #210 mixed shape gain a retained-source file (matching the
+real entries, which always have one); Task 5's `PruneUnclaimed` carries the
+same retained-source gate. Error-wrap amendment (Task 2 review): the
+resolver returns cache errors unwrapped; call sites wrap once with
+"resolving deployable files: %w" (replace path: "resolving deployable
+new-side files: %w").
+
+## Global Constraints
+
+- Branch `fix/210-manifest-aware-deploy` off `develop`; PR `--base develop` (main is the default branch — a forgotten flag targets protected main).
+- No version bump; CHANGELOG entry under `[Unreleased]`.
+- TDD: every behavior change lands with its failing test written and run first.
+- `gofmt` (tabs), error wrapping with `%w`, table-driven tests where repetition warrants.
+- Never pipe `go test` into another command in a `&&` chain (repo lesson — the pipe eats the exit code).
+- Legacy behavior is sacred: any cache entry with a bare (`Recorded=false`) marker, or no markers, must deploy the full `ListFiles` union byte-for-byte as today.
+
+---
+
+### Task 1: `deployableFiles` resolver
+
+**Files:**
+
+- Create: `internal/core/deployable.go`
+- Test: `internal/core/deployable_internal_test.go` (package `core`, precedent: `merged_pak_internal_test.go`)
+
+**Interfaces:**
+
+- Consumes: `cache.Cache.ListFiles/FileManifests/ModPath` (existing).
+- Produces: `func deployableFiles(gameCache *cache.Cache, gameID, sourceID, modID, version string) ([]string, error)` — used by Tasks 2–4. Returns files in `ListFiles` order. Errors are `ListFiles`/`FileManifests` errors wrapped with `%w`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package core
+
+import (
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/require"
+)
+
+// seedEntry stores the given files and returns the cache and version dir.
+func seedEntry(t *testing.T, files map[string][]byte) (*cache.Cache, string) {
+	t.Helper()
+	c := cache.New(t.TempDir())
+	for name, content := range files {
+		require.NoError(t, c.Store("g", "src", "mod", "1.0", name, content))
+	}
+	return c, c.ModPath("g", "src", "mod", "1.0")
+}
+
+func TestDeployableFiles_AllRecorded_ExcludesUnclaimed(t *testing.T) {
+	c, dir := seedEntry(t, map[string][]byte{
+		"claimed.pak": []byte("a"),
+		"stale.pak":   []byte("b"), // claimed by no manifest
+	})
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", []string{"claimed.pak"}))
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"claimed.pak"}, files)
+}
+
+func TestDeployableFiles_RecordedZeroMembers_DeploysNothing(t *testing.T) {
+	// The live #210 shape: retain-only exmodz marker (recorded, zero members)
+	// plus a stale pre-#197 compiled pak.
+	c, dir := seedEntry(t, map[string][]byte{"LargerResourceStacks_P.pak": []byte("pak")})
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.Empty(t, files)
+}
+
+func TestDeployableFiles_BareMarker_FallsBackToUnion(t *testing.T) {
+	c, dir := seedEntry(t, map[string][]byte{
+		"a.pak": []byte("a"),
+		"b.pak": []byte("b"),
+	})
+	// Legacy bare marker: completion vouched, provenance unknown.
+	require.NoError(t, cache.MarkFileComplete(dir, "pak"))
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"a.pak", "b.pak"}, files)
+}
+
+func TestDeployableFiles_MixedRecordedAndBare_FallsBackToUnion(t *testing.T) {
+	c, dir := seedEntry(t, map[string][]byte{
+		"a.pak": []byte("a"),
+		"b.pak": []byte("b"),
+	})
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "f1", []string{"a.pak"}))
+	require.NoError(t, cache.MarkFileComplete(dir, "f2")) // bare
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"a.pak", "b.pak"}, files)
+}
+
+func TestDeployableFiles_NoMarkers_FallsBackToUnion(t *testing.T) {
+	c, _ := seedEntry(t, map[string][]byte{"a.pak": []byte("a")})
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.pak"}, files)
+}
+
+func TestDeployableFiles_ClaimedButMissingOnDisk_Dropped(t *testing.T) {
+	// A manifest may claim a member that was manually deleted; the resolver
+	// returns what is actually deployable (verify owns missing-file repair).
+	c, dir := seedEntry(t, map[string][]byte{"present.pak": []byte("a")})
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "f1", []string{"present.pak", "gone.pak"}))
+
+	files, err := deployableFiles(c, "g", "src", "mod", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"present.pak"}, files)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/ -run TestDeployableFiles -v`
+Expected: FAIL — `undefined: deployableFiles` (compile error). If `cache.MarkFileComplete` has a different exported name for the bare-marker writer, check `internal/storage/cache/cache.go` (~line 80) and use the actual name in both test and doc comment.
+
+- [ ] **Step 3: Implement the resolver**
+
+```go
+// Package-level doc: deployable.go holds the deploy-direction file resolver
+// (#210). Removal-direction operations (Uninstall, the old side of a
+// replace) deliberately do NOT use it - cleanup must remove anything that
+// might ever have been linked, so they keep the full ListFiles union. That
+// asymmetry is what lets one deploy cycle self-heal an entry polluted by a
+// stale, unclaimed file: the union side unlinks it, this resolver never
+// re-links it.
+package core
+
+import (
+	"fmt"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+)
+
+// deployableFiles returns the version-dir-relative files that deploy-direction
+// operations may link for this cache entry, in ListFiles order.
+//
+// When EVERY completion marker in the entry carries a recorded member
+// manifest, the result is the union of recorded members intersected with the
+// files actually on disk - content claimed by no manifest (e.g. a stale
+// pre-#197 compiled per-mod pak carried forward by staging seeding, #210) is
+// excluded. A claimed-but-missing member is silently dropped here; verify
+// owns missing-file detection and repair.
+//
+// When ANY marker is bare (Recorded=false - "provenance unknown, never
+// none"), or the entry has no markers at all, the full ListFiles union is
+// returned unchanged: pre-manifest entries, import-populated entries, and
+// pure pre-#197 entries keep their historical deploy behavior exactly.
+func deployableFiles(gameCache *cache.Cache, gameID, sourceID, modID, version string) ([]string, error) {
+	files, err := gameCache.ListFiles(gameID, sourceID, modID, version)
+	if err != nil {
+		return nil, fmt.Errorf("listing cached files: %w", err)
+	}
+	manifests, err := gameCache.FileManifests(gameID, sourceID, modID, version)
+	if err != nil {
+		return nil, fmt.Errorf("reading cache manifests: %w", err)
+	}
+	if len(manifests) == 0 {
+		return files, nil
+	}
+	claimed := make(map[string]bool)
+	for _, m := range manifests {
+		if !m.Recorded {
+			return files, nil
+		}
+		for _, member := range m.Members {
+			claimed[member] = true
+		}
+	}
+	deployable := make([]string, 0, len(files))
+	for _, f := range files {
+		if claimed[f] {
+			deployable = append(deployable, f)
+		}
+	}
+	return deployable, nil
+}
+```
+
+Note: `FileManifests` members are stored slash-separated and `ListFiles` returns OS-separator paths — on Linux they agree; mirror how `resolveSharedDirUpdate` (installer.go:314-326) compares them (it uses the manifest strings directly against listing entries). If tests on the nested-path case disagree, normalize with `filepath.FromSlash` on the claimed side.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -run TestDeployableFiles -v`
+Expected: PASS (all six).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/core/deployable.go internal/core/deployable_internal_test.go
+git commit -m "feat: add manifest-aware deployableFiles resolver (#210)"
+```
+
+---
+
+### Task 2: Install, IsInstalled, GetDeployedFiles, GetConflicts use the resolver
+
+**Files:**
+
+- Modify: `internal/core/installer.go:43` (Install), `:452` (IsInstalled), `:495` (GetConflicts), `:527` (GetDeployedFiles)
+- Test: `internal/core/installer_test.go` (package `core_test`)
+
+**Interfaces:**
+
+- Consumes: `deployableFiles` (Task 1).
+- Produces: no signature changes — behavior only. `Uninstall` (installer.go:410) is intentionally untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// In internal/core/installer_test.go (package core_test).
+
+// TestInstaller_Install_SkipsUnclaimedFiles reproduces the #210 live shape:
+// a retain-only marker (recorded, zero members) plus a stale unclaimed pak.
+// Install must deploy nothing; a legacy bare-marker entry must keep the
+// historical deploy-everything behavior.
+func TestInstaller_Install_SkipsUnclaimedFiles(t *testing.T) {
+	cacheDir := t.TempDir()
+	gameDir := t.TempDir()
+	modCache := cache.New(cacheDir)
+
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.4", "Stale_P.pak", []byte("stale")))
+	dir := modCache.ModPath("icarus", "icarus", "m1", "1.4")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+
+	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	mod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.4", GameID: "icarus"}
+	inst := core.NewInstaller(modCache, linker.New(domain.LinkSymlink), nil)
+
+	require.NoError(t, inst.Install(context.Background(), game, mod, "default"))
+	_, err := os.Lstat(filepath.Join(gameDir, "Stale_P.pak"))
+	assert.True(t, os.IsNotExist(err), "unclaimed stale pak must not deploy")
+
+	// Deployed-file views agree with the deploy decision.
+	deployed, err := inst.GetDeployedFiles(game, mod)
+	require.NoError(t, err)
+	assert.Empty(t, deployed)
+}
+
+func TestInstaller_Install_LegacyBareMarker_DeploysUnion(t *testing.T) {
+	cacheDir := t.TempDir()
+	gameDir := t.TempDir()
+	modCache := cache.New(cacheDir)
+
+	require.NoError(t, modCache.Store("icarus", "icarus", "m2", "2.2", "MorePoints_P.pak", []byte("pak")))
+	dir := modCache.ModPath("icarus", "icarus", "m2", "2.2")
+	require.NoError(t, cache.MarkFileComplete(dir, "exmodz")) // pre-manifest bare marker
+
+	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	mod := &domain.Mod{ID: "m2", SourceID: "icarus", Version: "2.2", GameID: "icarus"}
+	inst := core.NewInstaller(modCache, linker.New(domain.LinkSymlink), nil)
+
+	require.NoError(t, inst.Install(context.Background(), game, mod, "default"))
+	_, err := os.Lstat(filepath.Join(gameDir, "MorePoints_P.pak"))
+	assert.NoError(t, err, "legacy entry must keep deploying its pak")
+
+	installed, err := inst.IsInstalled(game, mod)
+	require.NoError(t, err)
+	assert.True(t, installed)
+}
+
+// TestInstaller_IsInstalled_RetainOnlyEntry guards the deploy-loop
+// interaction: a retain-only entry (deployable set empty) must not report
+// "not installed" in a way that spins redeploy loops - with nothing
+// deployable and nothing deployed there is nothing missing.
+func TestInstaller_IsInstalled_RetainOnlyEntry(t *testing.T) {
+	cacheDir := t.TempDir()
+	gameDir := t.TempDir()
+	modCache := cache.New(cacheDir)
+
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.4", "Stale_P.pak", []byte("stale")))
+	dir := modCache.ModPath("icarus", "icarus", "m1", "1.4")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+
+	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	mod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.4", GameID: "icarus"}
+	inst := core.NewInstaller(modCache, linker.New(domain.LinkSymlink), nil)
+
+	installed, err := inst.IsInstalled(game, mod)
+	require.NoError(t, err)
+	assert.False(t, installed, "empty deployable set keeps IsInstalled's len==0 false answer")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/ -run 'TestInstaller_Install_SkipsUnclaimedFiles|TestInstaller_Install_LegacyBareMarker|TestInstaller_IsInstalled_RetainOnlyEntry' -v`
+Expected: `TestInstaller_Install_SkipsUnclaimedFiles` FAILS (stale pak IS deployed today); the legacy test PASSES already (it pins existing behavior — keep it as the regression guard).
+
+- [ ] **Step 3: Switch the four call sites**
+
+In `Install` (installer.go:43), `IsInstalled` (:452), `GetConflicts` (:495), `GetDeployedFiles` (:527), replace
+
+```go
+files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+```
+
+with
+
+```go
+files, err := deployableFiles(i.cache, game.ID, mod.SourceID, mod.ID, mod.Version)
+```
+
+**Amended after Task 2 review (user ruling 2026-08-03):** `deployableFiles`
+returns cache-layer errors UNWRAPPED (the cache layer already contextualizes
+them), and each switched call site wraps with
+`fmt.Errorf("resolving deployable files: %w", err)` — including
+`GetDeployedFiles`, which previously returned the error bare. This replaces
+the original "keep each site's existing error-wrapping line unchanged"
+instruction, which produced doubled/misleading prefixes. Do NOT touch `Uninstall` (:410) — add a comment there:
+
+```go
+// Deliberately the full ListFiles union, not deployableFiles (#210):
+// removal must cover anything that might ever have been linked, including
+// stale unclaimed files a pre-fix deploy linked. Narrowing this would
+// strand those links forever.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -v`
+Expected: the three new tests PASS; the full package stays green (existing installer tests exercise no-marker entries → union fallback keeps them passing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/core/installer.go internal/core/installer_test.go
+git commit -m "fix: deploy-direction installer paths use manifest-aware file set (#210)"
+```
+
+---
+
+### Task 3: replaceWithCaches deploys the manifest-aware new side
+
+**Files:**
+
+- Modify: `internal/core/installer.go:129-136` (old/new listing block), `:242-280` (resolveSharedDirUpdate doc comment)
+- Test: `internal/core/installer_test.go`
+
+**Interfaces:**
+
+- Consumes: `deployableFiles` (Task 1).
+- Produces: no signature changes. `oldFiles` stays the `ListFiles` union (removal direction); `newFiles` becomes the resolver output and is also what `resolveSharedDirUpdate` receives as `unionFiles`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// TestInstaller_Replace_NewSideSkipsUnclaimed: replacing onto a version whose
+// cache entry mixes a recorded retain-only marker with a stale unclaimed pak
+// must (a) undeploy the old version's files, (b) NOT deploy the stale pak.
+func TestInstaller_Replace_NewSideSkipsUnclaimed(t *testing.T) {
+	cacheDir := t.TempDir()
+	gameDir := t.TempDir()
+	modCache := cache.New(cacheDir)
+
+	// Old version: ordinary claimed pak, deployed.
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.0", "Old_P.pak", []byte("old")))
+	oldDir := modCache.ModPath("icarus", "icarus", "m1", "1.0")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(oldDir, "pak", []string{"Old_P.pak"}))
+
+	// New version: the #210 mixed shape.
+	require.NoError(t, modCache.Store("icarus", "icarus", "m1", "1.4", "Stale_P.pak", []byte("stale")))
+	newDir := modCache.ModPath("icarus", "icarus", "m1", "1.4")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(newDir, "exmodz", nil))
+
+	game := &domain.Game{ID: "icarus", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	oldMod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.0", GameID: "icarus"}
+	newMod := &domain.Mod{ID: "m1", SourceID: "icarus", Version: "1.4", GameID: "icarus"}
+	inst := core.NewInstaller(modCache, linker.New(domain.LinkSymlink), nil)
+
+	require.NoError(t, inst.Install(context.Background(), game, oldMod, "default"))
+	require.NoError(t, inst.Replace(context.Background(), game, oldMod, newMod, "default"))
+
+	_, err := os.Lstat(filepath.Join(gameDir, "Old_P.pak"))
+	assert.True(t, os.IsNotExist(err), "old file must be undeployed")
+	_, err = os.Lstat(filepath.Join(gameDir, "Stale_P.pak"))
+	assert.True(t, os.IsNotExist(err), "stale unclaimed pak must not deploy")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/core/ -run TestInstaller_Replace_NewSideSkipsUnclaimed -v`
+Expected: FAIL — `Stale_P.pak` is deployed today.
+
+- [ ] **Step 3: Implement**
+
+In `replaceWithCaches` (installer.go:133), replace the new-side listing:
+
+```go
+newFiles, err := deployableFiles(newCache, game.ID, newMod.SourceID, newMod.ID, newMod.Version)
+if err != nil {
+	return fmt.Errorf("listing new cached files: %w", err)
+}
+```
+
+Leave `oldFiles` on `ListFiles` (removal direction). Update `resolveSharedDirUpdate`'s doc comment where it describes `unionFiles` ("every file in the shared directory's listing is attributed"): it now receives the deploy-direction set — when the resolver narrowed, every entry is attributed by construction (resolver requires all-recorded); when the resolver fell back to the union, the attribution check behaves exactly as before. Add one sentence there stating this, citing #210.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -v`
+Expected: new test PASSES; all existing replace/update tests (including the #144 same-version suite and #150 rollback suite) stay green — they build fully-recorded or fully-legacy entries, both of which the resolver passes through faithfully. If any #144 test fails, STOP and re-read its fixture: it means the fixture mixes recorded and unrecorded markers and the interaction needs a design conversation, not a patch.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/core/installer.go internal/core/installer_test.go
+git commit -m "fix: replace deploys manifest-aware new side, union removal (#210)"
+```
+
+---
+
+### Task 4: Profile conflict scanner ignores unclaimed files
+
+**Files:**
+
+- Modify: `internal/core/conflicts.go:99` (the `gameCache.ListFiles` call in the enabled-mods provider loop)
+- Test: `internal/core/conflicts_test.go` (add to the existing scanner suite; follow its established fixture pattern)
+
+**Interfaces:**
+
+- Consumes: `deployableFiles` (Task 1).
+- Produces: no signature changes.
+
+- [ ] **Step 1: Write the failing test**
+
+Follow the existing test fixtures in `internal/core/conflicts_test.go` for constructing the service/DB/profile (reuse its helper if one exists — read the file first). The new case, shaped on the existing two-mods-one-path tests:
+
+```go
+// TestProfileConflicts_IgnoresUnclaimedCacheFiles: a stale unclaimed file in
+// mod A's cache entry that collides with a path mod B legitimately provides
+// must NOT be reported - deploy will never link it (#210).
+//
+// Fixture: mod A's entry = claimed "shared.pak" is NOT present; instead A has
+// marker "exmodz" with zero members plus unclaimed file "shared.pak" on disk.
+// Mod B's entry = "shared.pak" claimed by its marker. Expect: no conflict on
+// "shared.pak" (A provides nothing).
+```
+
+Write it as real code against the suite's actual helpers (they exist in the file — mirror the neighboring test's setup verbatim, changing only the cache-entry construction to use `cache.MarkFileCompleteWithMembers`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/core/ -run TestProfileConflicts_IgnoresUnclaimedCacheFiles -v`
+Expected: FAIL — conflict on `shared.pak` is reported today.
+
+- [ ] **Step 3: Implement**
+
+In `internal/core/conflicts.go:99`, replace `gameCache.ListFiles(game.ID, m.SourceID, m.ID, m.Version)` with `deployableFiles(gameCache, game.ID, m.SourceID, m.ID, m.Version)`. Keep the surrounding `fs.ErrNotExist` tolerance exactly as is (`deployableFiles` wraps `ListFiles`' error with `%w`, so `errors.Is(err, fs.ErrNotExist)` still matches).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -run TestProfileConflicts -v`
+Expected: PASS, including all pre-existing scanner tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/core/conflicts.go internal/core/conflicts_test.go
+git commit -m "fix: conflict scanner uses manifest-aware provider set (#210)"
+```
+
+---
+
+### Task 5: Prune unclaimed files at download commit
+
+**Files:**
+
+- Modify: `internal/storage/cache/cache.go` (extract dir-based manifest reader; add `PruneUnclaimed`)
+- Modify: `internal/core/service.go` (`commitStagedCacheWithMarker`, ~line 855)
+- Test: `internal/storage/cache/cache_test.go`, `internal/core/service_test.go`
+
+**Interfaces:**
+
+- Consumes: the existing marker/manifest parsing inside `Cache.FileManifests`.
+- Produces: `func PruneUnclaimed(versionDir string) error` (package-level in `cache`, like `MarkFileCompleteWithMembers`). Refactor `Cache.FileManifests` to delegate to a new unexported `fileManifestsAt(versionDir string) (map[string]FileManifest, error)` so both share one parser.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// In internal/storage/cache/cache_test.go:
+
+func TestPruneUnclaimed_RemovesUnclaimedWhenAllRecorded(t *testing.T) {
+	c := cache.New(t.TempDir())
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "claimed.pak", []byte("a")))
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "stale.pak", []byte("b")))
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "sub/stale2.pak", []byte("c")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "f1", []string{"claimed.pak"}))
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	files, err := c.ListFiles("g", "s", "m", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"claimed.pak"}, files)
+	// Emptied subdirectory is removed too.
+	_, err = os.Stat(filepath.Join(dir, "sub"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestPruneUnclaimed_NoOpWithBareMarker(t *testing.T) {
+	c := cache.New(t.TempDir())
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "a.pak", []byte("a")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+	require.NoError(t, cache.MarkFileComplete(dir, "f1")) // bare: provenance unknown
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	files, err := c.ListFiles("g", "s", "m", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.pak"}, files)
+}
+
+func TestPruneUnclaimed_NoOpWithoutMarkers(t *testing.T) {
+	c := cache.New(t.TempDir())
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "a.pak", []byte("a")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	files, err := c.ListFiles("g", "s", "m", "1.0")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.pak"}, files)
+}
+
+func TestPruneUnclaimed_NeverTouchesReservedEntries(t *testing.T) {
+	c := cache.New(t.TempDir())
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "claimed.pak", []byte("a")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+	// A retained source is reserved bookkeeping, claimed by nothing.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("exmodz")), []byte("zip"), 0o644))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "f1", []string{"claimed.pak"}))
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	_, err := os.Stat(filepath.Join(dir, cache.RetainedSourceName("exmodz")))
+	require.NoError(t, err, "reserved entries are never pruned")
+}
+```
+
+(Adjust `cache.RetainedSourceName`'s exact call shape to its real signature in `cache.go:273` — it takes the fileID.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/storage/cache/ -run TestPruneUnclaimed -v`
+Expected: FAIL — `undefined: cache.PruneUnclaimed`.
+
+- [ ] **Step 3: Implement**
+
+In `cache.go`: extract the body of `FileManifests` into `fileManifestsAt(versionDir string)`; `FileManifests` becomes `return fileManifestsAt(c.ModPath(gameID, sourceID, modID, version))`. Then:
+
+```go
+// PruneUnclaimed deletes non-reserved regular files in versionDir that no
+// recorded manifest claims, then removes directories the deletions emptied
+// (#210). It is a no-op unless EVERY marker in the directory carries a
+// recorded manifest - a bare marker means unknown provenance, and pruning
+// on guesswork could delete a legacy file's live content. Reserved
+// (ReservedPrefix) entries are never candidates. Callers invoke it on a
+// STAGING directory at commit time, so a prune can never race a deploy.
+func PruneUnclaimed(versionDir string) error {
+	manifests, err := fileManifestsAt(versionDir)
+	if err != nil {
+		return fmt.Errorf("reading manifests for prune: %w", err)
+	}
+	if len(manifests) == 0 {
+		return nil
+	}
+	claimed := make(map[string]bool)
+	for _, m := range manifests {
+		if !m.Recorded {
+			return nil
+		}
+		for _, member := range m.Members {
+			claimed[filepath.FromSlash(member)] = true
+		}
+	}
+	files, err := walkEntries(versionDir, false) // same walker ListFiles uses
+	if err != nil {
+		return fmt.Errorf("walking entry for prune: %w", err)
+	}
+	for _, f := range files {
+		if claimed[f] {
+			continue
+		}
+		if err := os.Remove(filepath.Join(versionDir, f)); err != nil {
+			return fmt.Errorf("pruning unclaimed %s: %w", f, err)
+		}
+	}
+	removeEmptyDirs(versionDir)
+	return nil
+}
+```
+
+`removeEmptyDirs`: if the cache package has no such helper, add a small unexported one (post-order walk, `os.Remove` on empty dirs, never removing versionDir itself; ignore ENOTEMPTY). Check `internal/linker.CleanupEmptyDirs` first — if its semantics fit (it exists per installer.go:438), prefer reusing it over writing a twin; importing linker from cache is NOT acceptable (dependency direction), so a local helper is right if reuse would invert layers.
+
+In `internal/core/service.go`, wire into the single commit point:
+
+```go
+func commitStagedCacheWithMarker(cachePath, stagePath, fileID string, members []string) error {
+	if err := cache.MarkFileCompleteWithMembers(stagePath, fileID, members); err != nil {
+		return err
+	}
+	// #210: with full provenance recorded, drop anything no manifest claims
+	// (pre-#197 compiled paks carried forward by prepareStaging's seeding).
+	// A legacy bare marker anywhere makes this a silent no-op.
+	if err := cache.PruneUnclaimed(stagePath); err != nil {
+		return err
+	}
+	return commitStagedCache(cachePath, stagePath)
+}
+```
+
+Add a service-level test in `internal/core/service_test.go` following the file's existing download/ingest test fixtures (read neighbors first): stage a seeded entry containing a stale unclaimed pak plus a recorded marker, run the commit path (whichever existing test helper drives `DownloadModToCache`'s commit — mirror it), assert the stale pak is gone from the committed entry and the retained source survives.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/storage/cache/ ./internal/core/ -v`
+Expected: PASS. Watch specifically for `service_test.go`/`extractor_test.go` fixtures that committed entries with deliberately-unclaimed extra files — if one fails, the fixture was depending on pre-#210 debris surviving; update the fixture, not the prune rule.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/cache/cache.go internal/storage/cache/cache_test.go internal/core/service.go internal/core/service_test.go
+git commit -m "fix: prune unclaimed cache files at download commit (#210)"
+```
+
+---
+
+### Task 6: DeployProfile self-heal integration test + CHANGELOG
+
+**Files:**
+
+- Test: `internal/core/flows_deploy_selfheal_test.go` (new; package `core_test`)
+- Modify: `CHANGELOG.md` (`[Unreleased]` section)
+
+**Interfaces:**
+
+- Consumes: everything above through `Service.DeployProfile` — the seam both `lmm deploy` (cmd/lmm/deploy.go:65 → doDeploy → DeployProfile) and the TUI call, satisfying the #197 entry-point-test lesson for this mutation.
+- Produces: nothing new — acceptance proof.
+
+- [ ] **Step 1: Write the failing-before/green-after integration test**
+
+Build the fixture with the same service-construction helpers the existing `flows.go` deploy tests use (find a `DeployProfile` test in `internal/core/` and mirror its setup — service with temp config/db, one installed+enabled mod row). The scenario:
+
+```go
+// TestDeployProfile_SelfHealsStaleUnclaimedPak is #210's acceptance test:
+// a pre-fix deploy linked a stale unclaimed pak into the game dir; one
+// deploy cycle must remove that link (Uninstall's union direction) and not
+// re-create it (Install's manifest-aware direction).
+//
+// Fixture: installed mod m1@1.4, cache entry = stale "Stale_P.pak" on disk
+// + marker "exmodz" recorded with zero members. Game dir already contains
+// a symlink Stale_P.pak -> the cached stale pak (simulating the pre-fix
+// deployment).
+//
+// After DeployProfile: game dir does NOT contain Stale_P.pak; result has
+// Deployed == 1 (the mod "deploys" successfully with zero files of its
+// own); no Skipped entries.
+```
+
+Write it as real code against the discovered helpers; the assertions are the three lines in the comment (Lstat IsNotExist, `result.Deployed == 1`, `len(result.Skipped) == 0`).
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `go test ./... -v` (capture to a file, no pipes in `&&` chains) and `go vet ./...`
+Expected: everything PASSES.
+
+- [ ] **Step 3: CHANGELOG**
+
+Under `## [Unreleased]` add (create a `### Fixed` heading if absent):
+
+```markdown
+### Fixed
+
+- Deploy no longer links cache files that no download manifest claims: stale
+  per-mod paks left behind by pre-v1.28 exmodz installs were being deployed
+  alongside the merged pak, double-applying their table edits. One
+  `lmm deploy` cycle now removes such links, download commits prune the
+  stale files, and the conflict scanner ignores them. Legacy cache entries
+  without recorded manifests keep their exact previous behavior. (#210)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/core/flows_deploy_selfheal_test.go CHANGELOG.md
+git commit -m "test: DeployProfile self-heal acceptance for #210 + changelog"
+```
+
+---
+
+### Task 7: PR
+
+- [ ] **Step 1: Final verification**
+
+Run: `go build -o lmm ./cmd/lmm && go vet ./...` then `go test ./...` (separately, never piped).
+Run: `trunk check` if available in the environment.
+
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push -u origin fix/210-manifest-aware-deploy
+gh pr create --base develop \
+  --title "fix: manifest-aware deploy — stop shipping unclaimed cache files (#210)" \
+  --body "Closes #210 (close manually after merge — develop merges don't auto-close). <summary per repo template>. 🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 3: Copilot triage** — wait for the automatic review (`gh-await-review` via background Bash), triage every comment (fix or reply with rationale), and re-check for NEW comments after any fix push before merging.
+
+---
+
+## Verification checklist (post-merge, live machine)
+
+The user's real Icarus install is the origin of this bug. After merge, build `./lmm` and have the user (or a sandboxed HOME per repo sandboxing rules) run `lmm -g icarus deploy`: `LargerResourceStacks_P.pak` and `MegaPoints_P.pak` symlinks must disappear from `.../Icarus/Content/Paks/mods/`, while `laanp-Combined_QOL_v1_w243_P.pak` (pak-only mod, claimed) and `zzz_LMM_Merged_P.pak` remain.

--- a/docs/plans/archive/2026-08-04-batch-preresolve-order-plan.md
+++ b/docs/plans/archive/2026-08-04-batch-preresolve-order-plan.md
@@ -1,0 +1,132 @@
+# Batch Pre-Resolution Before install.before_all (#214) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A batch-path install whose primary file pre-resolution fails (bad `--file` ID, mixed pak+exmodz) aborts before `install.before_all` fires.
+
+**Architecture:** Hoist the BATCH path's primary pre-resolution block (pool fetch → `selectInstallTargetFiles` → `ValidateInstallFileSelection`) from inside the `len(plan.Dependencies) > 0` branch (currently after the hook) to a new guarded block placed after the STRICT block and BEFORE `lockedInstallRefusal` — making both paths follow the same order: resolve pins → lock gate → hooks. The block is read-only (source fetch + pure selection), so success-path behavior is unchanged.
+
+**Tech Stack:** Go, testify; existing fixtures in `internal/core/flows_variant_exclusivity_test.go` (stub MergeCompiler source, batch-path seam test) and the flows tests' hook-recording patterns.
+
+**Spec:** `docs/plans/2026-08-04-deploy-convergence-and-batch-hook-order-design.md` Part 1. Issue: #214.
+
+## Global Constraints
+
+- Branch `fix/214-batch-preresolve-order` off `develop`; PR `--base develop`.
+- No version bump; CHANGELOG entry under `[Unreleased]` / `### Fixed`.
+- TDD; gofmt (tabs); never pipe `go test` into another command in a `&&` chain.
+- Success-path behavior byte-identical: `install.before_all` still runs exactly once, after the lock gate, before any mod installs; `primaryOverrideFiles` semantics unchanged (nil when no pins; #96/#140 "pins the primary's selection only" preserved).
+- The #96/#140/#140-item-2 doc comments describing the batch path's ordering must be updated wherever they claim the pre-resolution happens after the hook (grep `pre-resolution` and the ApplyInstall doc block).
+
+---
+
+### Task 1: Hoist + tests
+
+**Files:**
+
+- Modify: `internal/core/flows.go` (ApplyInstall: current pre-resolution block at ~3731-3751 moves above `lockedInstallRefusal` at ~3686; ApplyInstall's doc comment ~3591-3625; any batch-ordering doc comments the grep finds)
+- Test: `internal/core/flows_variant_exclusivity_test.go` (extend — the batch fixture from #211 already exists there)
+
+**Interfaces:**
+
+- Consumes: existing `resolveInstallCandidatePool`, `selectInstallTargetFiles`, `ValidateInstallFileSelection`, the batch stub fixture, and whatever hook-recording mechanism existing flows tests use (grep `before_all` in `internal/core/*_test.go`; if none records invocations, use `InstallOptions.Hooks`/`HookRunner` with a `ResolvedHooks` whose `install.before_all` script writes a sentinel file in `t.TempDir()` — mirror how hook tests elsewhere in the repo drive real hooks; report NEEDS_CONTEXT if no drivable pattern exists).
+- Produces: no signature changes. `primaryOverrideFiles` is declared before the hoisted block and consumed by the batch loop exactly as today.
+
+- [ ] **Step 1: Write the failing tests**
+
+Two additions to `flows_variant_exclusivity_test.go`, built on the existing batch-path fixture (mod with one dependency):
+
+```go
+// TestApplyInstall_BatchPath_PreResolutionFailure_SkipsBeforeAllHook is
+// #214: a failing primary pre-resolution (here: the #211 mixed-variant
+// rejection) must abort BEFORE install.before_all fires. The hook writes a
+// sentinel file; the sentinel must not exist after the failed install.
+func TestApplyInstall_BatchPath_PreResolutionFailure_SkipsBeforeAllHook(t *testing.T) {
+	// fixture: batch plan (non-empty Dependencies), opts.TargetFileIDs =
+	// []string{"pak", "exmodz"}, hooks wired so install.before_all runs
+	//   touch <tmpdir>/before_all_ran
+	// Assert: ApplyInstall errors with "alternate forms of the same mod";
+	// the sentinel file does NOT exist; no downloads occurred.
+}
+
+// Same shape for the pre-existing failure class: opts.TargetFileIDs =
+// []string{"no-such-id"} -> "file ID no-such-id not found", sentinel absent.
+func TestApplyInstall_BatchPath_BadFileID_SkipsBeforeAllHook(t *testing.T) { /* as above */ }
+
+// Success-path ordering guard: batch install with valid pins succeeds AND
+// the sentinel exists (hook still runs on the happy path).
+func TestApplyInstall_BatchPath_Success_StillRunsBeforeAll(t *testing.T) { /* ... */ }
+```
+
+Write all three fully against the discovered hook-driving pattern.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/ -run TestApplyInstall_BatchPath -v`
+Expected: the two Skips tests FAIL (sentinel exists today — hook fires first); the success test PASSES already (pin, keep as regression guard; note that in the report).
+
+- [ ] **Step 3: Implement the hoist**
+
+Move the `primaryOverrideFiles` pre-resolution block (the `if opts.TargetVersion != "" || len(opts.TargetFileIDs) > 0 { ... }` inside the batch branch) to a new block between the STRICT block's close and `lockedInstallRefusal`:
+
+```go
+	// #214: the BATCH path's primary pre-resolution (#96/#140 - pins the
+	// primary's file selection only) runs HERE, before the lock gate and
+	// install.before_all, for the same reason the STRICT path resolves
+	// pins up front: a selection the user asked for that cannot be honored
+	// must fail before any hook or side effect. The block is read-only
+	// (candidate-pool fetch + pure selection), so a successful install is
+	// byte-identical to the previous ordering.
+	var primaryOverrideFiles []domain.DownloadableFile
+	if len(plan.Dependencies) > 0 && (opts.TargetVersion != "" || len(opts.TargetFileIDs) > 0) {
+		primary := plan.Mod
+		pool, err := s.resolveInstallCandidatePool(ctx, primary.SourceID, &primary, plan.ShowArchived, opts.TargetVersion)
+		if err != nil {
+			return result, err
+		}
+		primaryOverrideFiles, err = selectInstallTargetFiles(pool, opts.TargetFileIDs)
+		if err != nil {
+			return result, err
+		}
+		if err := s.ValidateInstallFileSelection(primary.SourceID, primaryOverrideFiles); err != nil {
+			return result, err
+		}
+	}
+```
+
+Adapt to the block's exact current contents (copy it verbatim including its comments; do not re-derive) — the batch branch then keeps only the use of `primaryOverrideFiles`. Match existing local-variable declarations (the batch branch previously declared `primary`; keep a local copy in the hoisted block as shown so `&primary` stays addressable). Update ApplyInstall's doc comment and any other stale ordering description.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -run TestApplyInstall_BatchPath -v` then the full package `go test ./internal/core/` and `gofmt -l internal/core/` (expect empty). All pre-existing batch tests (including #211's seam test) must stay green — they now fail before the hook, which none of them asserts against.
+
+- [ ] **Step 5: CHANGELOG + commit**
+
+Under `## [Unreleased]` / `### Fixed`:
+
+```markdown
+- Batch installs (dependencies present) now resolve and validate the primary
+  mod's `--version`/`--file` pins before the `install.before_all` hook runs,
+  so an unhonorable selection can no longer fire user hooks first. (#214)
+```
+
+```bash
+git add internal/core/flows.go internal/core/flows_variant_exclusivity_test.go CHANGELOG.md
+git commit -m "fix: resolve batch primary pins before install.before_all (#214)"
+```
+
+---
+
+### Task 2: PR
+
+- [ ] **Step 1: Final verification** — `go build -o lmm ./cmd/lmm`, `go vet ./...`, `go test ./...` (separately, unpiped); `trunk check` if available.
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push -u origin fix/214-batch-preresolve-order
+gh pr create --base develop \
+  --title "fix: resolve batch primary pins before install.before_all (#214)" \
+  --body "Fixes #214 (close manually after merge). <summary>. 🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 3: Copilot triage** — `gh-await-review` in background; triage every comment; re-check after pushes.

--- a/docs/plans/archive/2026-08-04-deploy-convergence-and-batch-hook-order-design.md
+++ b/docs/plans/archive/2026-08-04-deploy-convergence-and-batch-hook-order-design.md
@@ -1,0 +1,122 @@
+# Deploy Convergence (#168+#212) & Batch Hook Ordering (#214) — Design
+
+**Date:** 2026-08-04
+**Status:** Draft, awaiting user review
+**Issues:** [#214](https://github.com/DonovanMods/linux-mod-manager/issues/214) (ship first),
+[#168](https://github.com/DonovanMods/linux-mod-manager/issues/168) + [#212](https://github.com/DonovanMods/linux-mod-manager/issues/212)
+(one story), plus branch-deferred polish. All target the v1.29.0 batch
+(#210 + #211 already merged).
+
+## Part 1 — #214: batch primary pre-resolution before `install.before_all`
+
+**Problem:** In `ApplyInstall`'s BATCH path (`internal/core/flows.go`), the
+`install.before_all` hook fires before the primary's
+`TargetVersion`/`TargetFileIDs` pre-resolution block. Any failure there — an
+unresolvable `--file` ID (pre-existing) or #211's mixed-variant rejection —
+aborts after a user hook with arbitrary side effects already ran. The STRICT
+path resolves and validates before all hooks.
+
+**Fix: hoist, don't dry-run.** Move the primary pre-resolution block (pool
+fetch → `selectInstallTargetFiles` → `ValidateInstallFileSelection`) above
+the BATCH path's `install.before_all` call. The block is read-only (source
+fetch + pure selection), so hoisting cannot change what any hook observes on
+success; on failure the install now aborts before the hook, matching the
+STRICT path's documented "resolve pins up front, before any side effect"
+philosophy (#140). The #96/#140 doc comments describing the batch path's
+"ONE divergence" ordering are updated to match.
+
+**Tests (TDD):** a batch-path install whose primary pre-resolution fails
+(bad `--file` ID, and the #211 mixed rejection) must NOT run
+`install.before_all` (hook-recording fixture); success path ordering
+unchanged (hook still runs exactly once, before any mod installs).
+
+**Class:** PATCH. Branch `fix/214-batch-preresolve-order`.
+
+## Part 2 — #168 + #212: `verify --fix` converges the deployment
+
+**Problem family:** nothing reconciles the game directory with current
+reality after the cache moves on. Two known shapes:
+
+- #168: a directory-source member deleted upstream stays linked until the
+  next reinstall (`verify --fix` repairs the cache but never the deployment).
+- #212: a pre-#210 stale-pak symlink dangles forever once `PruneUnclaimed`
+  removes its cache target before any deploy cycle (post-prune, no
+  `ListFiles` union ever names it again).
+
+**Fix: one core convergence pass, provenance-gated.** New core method
+(shared seam per [[lmm-cli-tui-parity]]; the TUI has no verify surface
+today, but the capability lands in core):
+
+```
+func (s *Service) ConvergeDeployedFiles(ctx context.Context, game *domain.Game, profileName string) (*ConvergeResult, error)
+```
+
+Two sub-passes, both remove-only, never deploy:
+
+1. **Row-driven (the #168 shape):** for every installed mod in the profile,
+   compute the current deployable set (`deployableFiles`, #210) and compare
+   against the mod's `deployed_files` DB rows. A row whose relative path is
+   NOT in the deployable set is stale: `Undeploy` the game-dir path (the
+   linker tolerates already-absent paths) and delete the row. Provenance is
+   the DB row itself — lmm recorded that it deployed this path for this
+   mod — plus the resolver saying the mod no longer provides it.
+2. **Dangling-link sweep (the #212 shape):** walk the game's ModPath for
+   symlinks whose target resolves under the lmm cache root(s) for this game
+   (global cache dir and any per-game `cache_path`) and whose target does
+   not exist. Attribution is the link target itself — only lmm creates
+   links into its cache — so these are removed even when no DB row survives
+   (the #212 sequence rewrites rows). Regular files and symlinks pointing
+   anywhere else are never touched.
+
+Safety rules (hard):
+
+- Remove-only; a convergence never deploys or modifies file content.
+- Non-symlink game-dir files are removed ONLY via sub-pass 1 (row-attributed
+  — covers copy/hardlink deploys); the sweep in sub-pass 2 is symlink-only.
+- Every removal is reported (path + reason + owning mod when known); a
+  `--fix` run prints them under the existing verify output conventions and
+  counts them in the summary. Errors on individual removals are warnings,
+  not aborts (verify's existing per-item tolerance).
+
+**Wiring:** `cmd/lmm/verify.go` calls the method during `--fix` after the
+existing cache repairs (so re-ingested caches are judged in their repaired
+state). Plain `verify` (no `--fix`) reports what WOULD be removed as
+warnings, using the same core pass in dry-run form: the method signature is
+`ConvergeDeployedFiles(ctx, game, profileName string, dryRun bool)
+(*ConvergeResult, error)` with `ConvergeResult{Removed []ConvergedFile}`
+(`ConvergedFile{Path, Reason, SourceID, ModID string}`); with `dryRun=true`
+nothing is touched and `Removed` lists the candidates.
+
+**Merged-pak note:** the profile-level `zzz_LMM_Merged_P.pak` link is owned
+by the merged-pak subsystem, not per-mod rows; the sweep must treat a
+HEALTHY merged-pak link (target exists) as untouchable, and a dangling one
+as removable like any other cache-pointing link (the next deploy/recompile
+recreates it).
+
+**Class:** MINOR (widens `--fix`'s contract — matches #168's own framing).
+Branch `feat/168-212-deploy-convergence`. Closes #168 and #212.
+
+**Polish folded into this branch (final task):**
+
+- Organic compile+redownload prune integration test (deferred from #210 T5).
+- CLI chooser test hardening: EOF-after-rejected-selection; validate-runs-on
+  single-file/`--yes` paths (deferred from #211 T3).
+- `internal/core/deployable.go`: reuse the computed `ModPath` for the
+  `HasRetainedSource` call (deferred from #210 T3).
+- `docs/configuration.md` compile bullet: replace the stale "compiled into a
+  new artifact … produce a deployable `_P.pak`" wording (pre-#197 model)
+  with the validate+retain + profile-level merged-pak description.
+
+## Out of scope
+
+- TUI verify surface (tracked by #168's note; capability lands in core).
+- Automatic convergence during `deploy` (deploy's Uninstall-union pass
+  already self-heals everything with a live cache member; only the
+  cache-member-gone shapes need `--fix`).
+- #170, #206, and the feature epics.
+
+## Rollout
+
+Two branches off develop, `--base develop`, in order: #214 (PATCH-class)
+then #168+#212 (MINOR-class). CHANGELOG under `[Unreleased]`. Close #168,
+#212, #214 manually after merges. Then cut `release/v1.29.0`.

--- a/docs/plans/archive/2026-08-04-deploy-convergence-plan.md
+++ b/docs/plans/archive/2026-08-04-deploy-convergence-plan.md
@@ -1,0 +1,199 @@
+# Deploy Convergence (#168 + #212) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `verify --fix` converges the game directory with current reality — removing lmm-attributed stale deployed files (#168) and dangling cache-pointing symlinks (#212) — with plain `verify` reporting the same findings as warnings.
+
+**Architecture:** One remove-only core method `Service.ConvergeDeployedFiles` with two provenance-gated passes: (1) row-driven — `deployed_files` rows whose paths no current mod provides (judged against the union of ALL installed mods' `deployableFiles` sets, so ownership churn can't remove a path another mod legitimately deploys) are undeployed and their rows deleted; (2) a symlink-only sweep of the game dir removing links that point at nonexistent targets under an lmm cache root. CLI `verify` wires dry-run (warnings) and `--fix` (removal) modes.
+
+**Tech Stack:** Go, testify, `t.TempDir()` symlink fixtures; in-memory SQLite for rows; existing verify CLI test patterns.
+
+**Spec:** `docs/plans/2026-08-04-deploy-convergence-and-batch-hook-order-design.md` Part 2. Issues: #168, #212 (both closed by this).
+
+## Global Constraints
+
+- Branch `feat/168-212-deploy-convergence` off `develop` (after #214 merges); PR `--base develop`.
+- No version bump; CHANGELOG under `[Unreleased]` (`### Added` — widens `--fix`'s contract, MINOR-class per #168's framing).
+- TDD; gofmt (tabs); `%w` wrapping; never pipe `go test` into another command in a `&&` chain.
+- **Remove-only invariant:** a convergence never deploys, never modifies content, never touches a non-symlink file except via a DB row, never touches a symlink pointing outside the lmm cache roots, never removes a path any installed mod's current deployable set still contains.
+- Cache roots for the sweep's prefix check: the service's global `CacheDir` and the game's `CachePath` (when set) — resolved via `filepath.Clean` + separator-suffix prefix comparison (no naive `strings.HasPrefix` that would match `/cache-evil`).
+- Healthy (target-exists) symlinks are never sweep candidates — this structurally protects the merged pak's link; a dangling merged-pak link IS removable (next deploy/recompile recreates it).
+
+---
+
+### Task 1: DB — per-path deployed-file delete
+
+**Files:**
+
+- Modify: `internal/storage/db/files.go`
+- Test: `internal/storage/db/files_test.go` (or wherever `SaveDeployedFile`'s tests live — grep and colocate)
+
+**Interfaces:**
+
+- Consumes: existing `deployed_files` schema (`game_id, profile_name, relative_path, source_id, mod_id`).
+- Produces: `func (d *DB) DeleteDeployedFile(gameID, profileName, relativePath string) error` — deletes one row; deleting a nonexistent row is a silent no-op (idempotent). Task 2 consumes it.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestDeleteDeployedFile(t *testing.T) {
+	d, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer func() { _ = d.Close() }()
+
+	require.NoError(t, d.SaveDeployedFile("g", "default", "mods/a.pak", "src", "m1"))
+	require.NoError(t, d.SaveDeployedFile("g", "default", "mods/b.pak", "src", "m1"))
+
+	require.NoError(t, d.DeleteDeployedFile("g", "default", "mods/a.pak"))
+	files, err := d.GetDeployedFilesForMod("g", "default", "src", "m1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"mods/b.pak"}, files)
+
+	// Idempotent: deleting again is a no-op, not an error.
+	require.NoError(t, d.DeleteDeployedFile("g", "default", "mods/a.pak"))
+}
+```
+
+- [ ] **Step 2: RED** — `go test ./internal/storage/db/ -run TestDeleteDeployedFile -v` (undefined method).
+
+- [ ] **Step 3: Implement**
+
+```go
+// DeleteDeployedFile removes one deployed-file ownership row. Deleting a
+// row that does not exist is a silent no-op - convergence (#168/#212) calls
+// this for paths it just undeployed, and a row may already be gone when the
+// path was attributed only by a dangling link.
+func (d *DB) DeleteDeployedFile(gameID, profileName, relativePath string) error {
+	_, err := d.Exec(`
+		DELETE FROM deployed_files
+		WHERE game_id = ? AND profile_name = ? AND relative_path = ?`,
+		gameID, profileName, relativePath)
+	if err != nil {
+		return fmt.Errorf("deleting deployed file record: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: GREEN** — focused run, then `go test ./internal/storage/db/`.
+- [ ] **Step 5: Commit** — `git add internal/storage/db/files.go <test file>` ; `git commit -m "feat: per-path deployed-file delete for convergence (#168)"`
+
+---
+
+### Task 2: Core — ConvergeDeployedFiles
+
+**Files:**
+
+- Create: `internal/core/converge.go`
+- Test: `internal/core/converge_test.go` (package `core_test`, mirroring the flows-test service builders; internal test file only if the helpers demand it)
+
+**Interfaces:**
+
+- Consumes: `deployableFiles` (internal/core/deployable.go, #210), `s.GetGameCache`/`GetGameCachePath`, `s.GetInstalledMods`, `s.db.GetDeployedFilesForMod` (via existing service wrapper `GetDeployedFilesForMod`), Task 1's `DeleteDeployedFile` (add a thin service wrapper if the service pattern requires one — mirror `SetModDeployed`'s shape), the profile-effective linker (`s.GetInstallerForProfile` or the raw `linker` — use whatever undeploys elsewhere in core; `linker.Linker.Undeploy` tolerates absent paths).
+- Produces:
+
+```go
+type ConvergedFile struct {
+	Path     string // game-dir-relative
+	Reason   string // "no longer provided by <source>/<mod>" | "dangling link into lmm cache"
+	SourceID string // owning mod when known ("" for sweep finds with no row)
+	ModID    string
+}
+
+type ConvergeResult struct {
+	Removed []ConvergedFile // dryRun=true: candidates; dryRun=false: actually removed
+}
+
+func (s *Service) ConvergeDeployedFiles(ctx context.Context, game *domain.Game, profileName string, dryRun bool) (*ConvergeResult, error)
+```
+
+Behavior:
+
+1. Build `provided` = union over ALL installed mods (this game+profile, enabled AND disabled — a disabled mod's files are undeployed by disable, but its rows may linger; treat rows below) of `deployableFiles(...)`, tolerating per-mod `fs.ErrNotExist` cache misses (mod provides nothing).
+2. Row pass: for each installed mod, each row path from `GetDeployedFilesForMod`; if path ∉ `provided` → candidate `{Path, "no longer provided by ...", SourceID, ModID}`; unless dryRun: `Undeploy(gameDir/path)` (error → collect as warning-style error in Reason? NO — keep result simple: an Undeploy failure aborts nothing; record the error by returning it wrapped in a joined error at the end while continuing; mirror verify's per-item tolerance) then `DeleteDeployedFile`.
+3. Sweep pass: `filepath.WalkDir(game.ModPath)`; for each symlink (`d.Type()&fs.ModeSymlink != 0`): `os.Readlink`; if target (made absolute relative to the link's dir when relative) is under a cache root AND `os.Stat(linkPath)` fails with `fs.ErrNotExist` (dangling) → candidate `{Path: rel, Reason: "dangling link into lmm cache"}`; unless dryRun: `os.Remove(linkPath)` + best-effort `DeleteDeployedFile`. Deduplicate against paths already handled by the row pass.
+4. ctx checked between mods and periodically in the walk (mirror the conflict scanner's ctx pattern).
+
+- [ ] **Step 1: Write the failing tests** — table/scenario tests, real filesystem:
+
+```go
+// Scenarios (each its own test, shared builder):
+// 1. RowDrivenStaleRemoved: mod m1 rows {a.esp, gone.esp}; cache provides
+//    only a.esp (recorded manifest). Converge(dryRun=false): gone.esp's
+//    game-dir symlink removed, row deleted, a.esp untouched; Result lists
+//    exactly gone.esp with m1 attribution.
+// 2. SharedPathProtectedByUnion: m1 row for shared.esp but m2's deployable
+//    set still contains shared.esp -> NOT removed, not in Result.
+// 3. DanglingCacheLinkSwept: symlink stray.pak -> <cacheRoot>/...missing
+//    target, no DB row. Swept with reason "dangling link into lmm cache".
+// 4. ForeignSymlinkUntouched: symlink user.pak -> /somewhere/else (dangling
+//    or not) stays; not in Result.
+// 5. HealthySymlinkUntouched: link with existing cache target (the merged-
+//    pak shape) stays even though no row exists for it.
+// 6. DryRunTouchesNothing: scenario 1+3 with dryRun=true -> Result lists
+//    both, filesystem and DB unchanged.
+// 7. RegularFileNeedsRow: a REGULAR file (copy-mode deploy) with a stale
+//    row IS removed via the row pass; a regular file with NO row is never
+//    touched by the sweep.
+```
+
+Write them fully against the existing service/DB builders (the flows tests construct Service with temp config + `:memory:` DB — mirror; NEEDS_CONTEXT if no reusable builder exists).
+
+- [ ] **Step 2: RED** — `go test ./internal/core/ -run TestConverge -v` (undefined types/method).
+- [ ] **Step 3: Implement** `internal/core/converge.go` per the Produces contract, doc comments carrying the remove-only invariant and the union guard rationale (#168/#212, the #210 resolver as the provenance source).
+- [ ] **Step 4: GREEN** — focused, then full `go test ./internal/core/` and `gofmt -l internal/core/`.
+- [ ] **Step 5: Commit** — `git commit -m "feat: ConvergeDeployedFiles core pass (#168, #212)"` (add converge.go, converge_test.go, service wrapper file if touched).
+
+---
+
+### Task 3: CLI — verify wiring
+
+**Files:**
+
+- Modify: `cmd/lmm/verify.go`
+- Test: colocate with existing verify CLI tests (grep `verify` tests in cmd/lmm; mirror their service/fixture pattern)
+
+**Interfaces:**
+
+- Consumes: `Service.ConvergeDeployedFiles` (Task 2).
+- Produces: user-visible behavior only. Plain `verify`: after existing checks, run dryRun and print each candidate as a warning row (match the file's existing warning format, e.g. `! <path> - STALE DEPLOYMENT (<reason>)`) and count them in the existing warnings tally. `--fix`: run with dryRun=false AFTER the existing cache repairs, print each removal (`Fixed: removed <path> (<reason>)` matching the file's existing --fix output style — read the file and copy its conventions exactly), count into the fixed tally. JSON mode (`--json`): emit candidates/removals as entries in the existing `verifyFileJSON` array with `Status: "stale_deployment"` / `"fixed_stale_deployment"` — follow the file's existing status-string style; JSON additions are MINOR-class (established repo precedent), consistent with this branch's class.
+
+- [ ] **Step 1: Write the failing CLI-seam test** — per the #197 lesson, at least one test drives the real verify command path (however the existing verify tests invoke it) against a fixture with one stale row + one dangling link: plain verify reports 2 warnings, `--fix` removes both and reports them fixed, second `--fix` run reports clean. Write against discovered patterns; NEEDS_CONTEXT if verify has no test harness at all (then the test lives at the core seam already covered in Task 2 and this task documents manual verification output in its report — but grep first, verify.go behaviors have tests from #164/#166 era).
+- [ ] **Step 2: RED** — new test fails (no such output today).
+- [ ] **Step 3: Implement** the wiring per Produces.
+- [ ] **Step 4: GREEN** — focused, then `go test ./cmd/lmm/`; `gofmt -l cmd/lmm/`.
+- [ ] **Step 5: Commit** — `git commit -m "feat: verify reports and --fix removes stale deployments (#168, #212)"`
+
+---
+
+### Task 4: Polish bundle + CHANGELOG
+
+**Files:**
+
+- Modify: `internal/core/deployable.go` (ModPath reuse), `cmd/lmm/install_test.go` (EOF + uniform-validate tests), `internal/core/service_test.go` or the prune tests' home (organic prune integration test), `docs/configuration.md` (compile bullet rewrite), `CHANGELOG.md`.
+
+**Contracts:**
+
+1. `deployable.go`: compute `versionDir := gameCache.ModPath(gameID, sourceID, modID, version)` once and pass it to `HasRetainedSource` (behavior unchanged; existing tests stay green).
+2. `cmd/lmm/install_test.go`: (a) `TestSelectInstallFiles_EOFAfterRejectedSelection` — input `"1,2\n"` (no second line) with the mixed-reject validate → returns an error (not a hang); (b) `TestSelectInstallFiles_ValidateRunsOnFastPaths` — single-file list with an always-error validate → error returned (fast path); two-file list + `installYes=true` (save/restore global) with always-error validate → error returned.
+3. Organic prune test: drive a real DeployCompile download twice (mock source serving an exmodz; first ingest under pre-#197-shaped entry seeded with a compiled pak + recorded marker claiming it, then re-download) asserting the stale pak is pruned at the second commit — mirror `TestService_DownloadMod_PrunesUnclaimedStaleFiles`'s fixtures, replacing the hand-seeded debris with a first-generation commit whose marker claims the pak (the honest pre-#197 shape). If the mock-source plumbing can't express two generations, report the limitation and keep the existing test as-is (say so in the report; do not force it).
+4. `docs/configuration.md` compile bullet: replace the stale sentence "The downloaded file is compiled into a new artifact before caching (currently Icarus only: an `.exmodz` diff is applied to the game's base data tables to produce a deployable `_P.pak`)" with: "The downloaded `.exmodz` is validated and retained (currently Icarus only); at deploy time, every enabled compile-mode mod's changes are merged — in profile load order — into one profile-level `zzz_LMM_Merged_P.pak` built against the installed game's own base tables. Only sources that implement compiling support this mode." (Keep the rest of the bullet and the Merge precedence paragraph unchanged.)
+5. CHANGELOG under `### Added`:
+
+```markdown
+- `lmm verify` now detects stale deployments — game-directory files lmm
+  deployed that no installed mod still provides, and dangling symlinks
+  left pointing into the mod cache — and `verify --fix` removes them
+  (provenance-gated: only lmm-attributed files are ever touched). (#168, #212)
+```
+
+- [ ] **Steps:** TDD where behavior changes (the two new CLI tests + organic prune test are the RED/GREEN items; ModPath reuse and docs are mechanical), full `go test ./...` + `go vet ./...` + `gofmt -l` at the end, then:
+      `git commit -m "test/docs: polish bundle — prune provenance test, chooser edge tests, docs refresh (#168)"`
+
+---
+
+### Task 5: PR
+
+- [ ] `go build -o lmm ./cmd/lmm`; `go vet ./...`; `go test ./...`; `trunk check` if available.
+- [ ] Push `feat/168-212-deploy-convergence`; `gh pr create --base develop --title "feat: verify --fix converges stale deployments (#168, #212)"` with body ending `🤖 Generated with [Claude Code](https://claude.com/claude-code)`; note "Fixes #168, #212 — close manually after merge".
+- [ ] Copilot triage via `gh-await-review` (background), including post-push rounds.

--- a/docs/plans/archive/2026-08-04-exmodz-default-plan.md
+++ b/docs/plans/archive/2026-08-04-exmodz-default-plan.md
@@ -1,0 +1,422 @@
+# Exmodz Default + Variant Exclusivity (#211) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When an Icarus mod publishes both a `pak` and an `exmodz` variant, every selection path defaults to the mergeable `exmodz`, and a selection mixing the two variants is rejected everywhere with a clear message.
+
+**Architecture:** Source-level `IsPrimary` on the exmodz variant flips every existing default (CLI default mark + `--yes`, TUI plan, batch, profile apply, `selectDeployFiles`) with no core plumbing. A new `Service.ValidateInstallFileSelection` enforces variant exclusivity for `MergeCompiler` sources at the core install seams (backstop, per the #197 CLI-seam lesson), and the CLI chooser applies the same rule interactively with a re-prompt.
+
+**Tech Stack:** Go, testify; existing fixtures: icarus source httptest Firestore stubs, core flows-test service builders, `promptMultiSelectionFrom`-style reader injection in cmd/lmm.
+
+**Spec:** `docs/plans/2026-08-03-manifest-aware-deploy-and-exmodz-default-design.md` Part 2. Issue: #211. Predecessor #210 is merged (`c6dac33`).
+
+## Global Constraints
+
+- Branch `feat/211-exmodz-default` off `develop`; PR `--base develop`.
+- No version bump; CHANGELOG entry under `[Unreleased]` (feature = MINOR-class for the release batch).
+- TDD: every behavior change lands with its failing test written and run first.
+- gofmt (tabs); error wrapping with `%w`; never pipe `go test` into another command in a `&&` chain.
+- Rejection message, exact string everywhere: `pak and exmodz are alternate forms of the same mod - select one`.
+- Escape hatch preserved: `--file pak` (alone) and explicit chooser selection of the pak keep working.
+- Out of scope (documented, not implemented): already-installed mods keep their stored FileIDs on update/redeploy (`selectVersionedDeployFiles` untouched); mods installed pre-#211 with both variants are not migrated.
+
+---
+
+### Task 1: Icarus source — exmodz primary + descriptions
+
+**Files:**
+
+- Modify: `internal/source/icarus/icarus.go` (`GetModFiles`, ~lines 150-176)
+- Test: `internal/source/icarus/icarus_test.go` (extend the existing `TestIcarus_GetModFiles_ReturnsExmodzAndPak` suite at ~line 135; mirror its httptest Firestore stub setup)
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces: `GetModFiles` behavior later tasks rely on — with both variants present, the `exmodz` entry has `IsPrimary: true`; `Description` is `"mergeable EXMOD - recommended"` for exmodz and `"prebuilt PAK"` for pak (set on every returned file, single-variant included).
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend the icarus test file, mirroring the existing stub-server pattern (the suite already builds a Firestore doc with a `files` map — reuse its helper/shape verbatim):
+
+```go
+func TestIcarus_GetModFiles_BothVariants_ExmodzIsPrimary(t *testing.T) {
+	// Stub doc with files: {"pak": "<url>/Mod_P.pak", "exmodz": "<url>/Mod.exmodz"}
+	// (construct exactly like TestIcarus_GetModFiles_ReturnsExmodzAndPak).
+	files := getModFilesFromStub(t /* ... same fixture plumbing ... */)
+	require.Len(t, files, 2)
+	byID := map[string]domain.DownloadableFile{}
+	for _, f := range files {
+		byID[f.ID] = f
+	}
+	assert.True(t, byID["exmodz"].IsPrimary, "exmodz must be the default when both variants exist")
+	assert.False(t, byID["pak"].IsPrimary)
+	assert.Equal(t, "mergeable EXMOD - recommended", byID["exmodz"].Description)
+	assert.Equal(t, "prebuilt PAK", byID["pak"].Description)
+}
+
+func TestIcarus_GetModFiles_SingleVariant_StaysPrimary(t *testing.T) {
+	// pak-only doc: pak entry IsPrimary (existing single-file rule unchanged)
+	// and Description "prebuilt PAK". Then exmodz-only doc: exmodz IsPrimary,
+	// Description "mergeable EXMOD - recommended".
+}
+```
+
+Write the second test fully (two sub-cases or two stub docs) following the file's conventions — the assertions above are the contract. If the existing suite has no reusable stub helper, inline the httptest server exactly as the neighboring test does.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/source/icarus/ -run TestIcarus_GetModFiles -v`
+Expected: the new both-variants test FAILS (no primary today with two files, empty descriptions); existing tests still pass.
+
+- [ ] **Step 3: Implement**
+
+In `GetModFiles`, set `Description` inside the loop and mark exmodz primary when both exist:
+
+```go
+	for _, kind := range []string{"pak", "exmodz"} {
+		rawURL, ok := filesField[kind].(string)
+		if !ok || rawURL == "" {
+			continue
+		}
+		description := "prebuilt PAK"
+		if kind == "exmodz" {
+			description = "mergeable EXMOD - recommended"
+		}
+		out = append(out, domain.DownloadableFile{
+			ID:          kind,
+			Name:        kind,
+			FileName:    fileNameFromURL(rawURL, kind),
+			Category:    strings.ToUpper(kind),
+			Description: description,
+		})
+	}
+	if len(out) == 1 {
+		out[0].IsPrimary = true
+	} else {
+		// #211: with both variants published, the mergeable exmodz is the
+		// default everywhere IsPrimary is honored (CLI default mark, --yes,
+		// TUI plan, batch, profile apply, selectDeployFiles) - the prebuilt
+		// pak stays explicitly selectable.
+		for i := range out {
+			if out[i].ID == "exmodz" {
+				out[i].IsPrimary = true
+			}
+		}
+	}
+```
+
+Update the function's doc comment ("A single file is marked primary...") to describe the new rule.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/source/icarus/ -v`
+Expected: PASS (whole package).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/source/icarus/icarus.go internal/source/icarus/icarus_test.go
+git commit -m "feat: icarus prefers exmodz variant as primary, labels chooser rows (#211)"
+```
+
+---
+
+### Task 2: Core variant-exclusivity validation
+
+**Files:**
+
+- Modify: `internal/core/service.go` (new method near `GetSource`, ~line 107)
+- Modify: `internal/core/flows.go` (`resolveStrictInstallFiles` ~line 3576; ApplyInstall strict path's final plan.Files; the batch path's TargetFileIDs pre-resolution site)
+- Test: `internal/core/flows_variant_exclusivity_test.go` (new)
+
+**Interfaces:**
+
+- Consumes: `source.MergeCompiler` (internal/source/source.go:146), `isExmodzFile(fileName string) bool` (internal/core/service.go, unexported), `s.registry.Get`.
+- Produces: `func (s *Service) ValidateInstallFileSelection(sourceID string, files []domain.DownloadableFile) error` — nil for <2 files, unknown source, or non-MergeCompiler source; the exact rejection error otherwise when the selection mixes an exmodz file with any other file. Task 3's CLI closure wraps this method.
+
+- [ ] **Step 1: Write the failing tests**
+
+New file `internal/core/flows_variant_exclusivity_test.go`. For the unit tests, package `core_test` with an in-registry stub source implementing `MergeCompiler`: FIRST look for an existing test stub in `internal/core` that already implements `source.MergeCompiler` (the #197 merged-pak suites have one — grep `MergeCompiler` in `internal/core/*_test.go`) and reuse it via the same registration pattern those tests use. If none is reusable from `core_test`, define a minimal local stub satisfying `source.ModSource` + `source.MergeCompiler` the way the flows tests define theirs. Tests:
+
+```go
+// Unit: the rule itself.
+func TestValidateInstallFileSelection(t *testing.T) {
+	// service with two registered sources: one MergeCompiler ("mc"),
+	// one plain ("plain") - mirror the flows-test service builder.
+	pakFile := domain.DownloadableFile{ID: "pak", FileName: "Mod_P.pak"}
+	exmodzFile := domain.DownloadableFile{ID: "exmodz", FileName: "Mod.exmodz"}
+
+	cases := []struct {
+		name     string
+		sourceID string
+		files    []domain.DownloadableFile
+		wantErr  bool
+	}{
+		{"mixed on merge-compiler source rejected", "mc", []domain.DownloadableFile{pakFile, exmodzFile}, true},
+		{"exmodz alone allowed", "mc", []domain.DownloadableFile{exmodzFile}, false},
+		{"pak alone allowed (escape hatch)", "mc", []domain.DownloadableFile{pakFile}, false},
+		{"two non-exmodz files allowed", "mc", []domain.DownloadableFile{pakFile, {ID: "extra", FileName: "readme.pak"}}, false},
+		{"mixed on plain source allowed", "plain", []domain.DownloadableFile{pakFile, exmodzFile}, false},
+		{"unknown source is not this check's problem", "ghost", []domain.DownloadableFile{pakFile, exmodzFile}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := svc.ValidateInstallFileSelection(tc.sourceID, tc.files)
+			if tc.wantErr {
+				require.ErrorContains(t, err, "alternate forms of the same mod")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Seam: explicit --file pins through ApplyInstall's strict resolution.
+// Mirror an existing ApplyInstall strict-path test's fixture (plan built by
+// PlanInstall against the stub MergeCompiler source whose GetModFiles
+// returns both variants), then:
+//   opts.TargetFileIDs = []string{"pak", "exmodz"}
+// ApplyInstall must fail with the rejection message BEFORE any download
+// side effect (assert no cache entry was created).
+
+// Seam: caller-supplied mixed plan.Files (the CLI interactive override
+// shape): build the plan, overwrite plan.Files with both variants, no
+// TargetFileIDs. ApplyInstall must fail with the same message.
+```
+
+Write the two seam tests as real code against the discovered fixtures (the file's other ApplyInstall tests show the service/plan construction — mirror the closest one; report NEEDS_CONTEXT if no ApplyInstall test drives a stubbed source end-to-end).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/ -run 'TestValidateInstallFileSelection|TestApplyInstall.*Variant' -v`
+Expected: unit test FAILS (method undefined — compile error first); after stubbing the method to `return nil`, seam tests FAIL (mixed selections currently install).
+
+- [ ] **Step 3: Implement**
+
+Method in service.go (near GetSource):
+
+```go
+// ValidateInstallFileSelection rejects an install selection that mixes a
+// merge-compile source's exmodz variant with any other file (#211): the two
+// are alternate forms of the same mod, and installing both double-applies
+// its table edits (the pak deploys standalone while the exmodz joins the
+// merged pak). Sources that don't implement source.MergeCompiler are never
+// restricted, single-file selections are always fine, and an unknown
+// sourceID is not this check's problem - pool resolution errors on it
+// first.
+func (s *Service) ValidateInstallFileSelection(sourceID string, files []domain.DownloadableFile) error {
+	if len(files) < 2 {
+		return nil
+	}
+	src, err := s.registry.Get(sourceID)
+	if err != nil {
+		return nil
+	}
+	if _, ok := src.(source.MergeCompiler); !ok {
+		return nil
+	}
+	var exmodz, other bool
+	for _, f := range files {
+		if isExmodzFile(f.FileName) {
+			exmodz = true
+		} else {
+			other = true
+		}
+	}
+	if exmodz && other {
+		return fmt.Errorf("pak and exmodz are alternate forms of the same mod - select one")
+	}
+	return nil
+}
+```
+
+Wire three seams (grep `selectInstallTargetFiles(` for the exact call sites):
+
+1. `resolveStrictInstallFiles`: after `selectInstallTargetFiles` returns a selection, `if err := s.ValidateInstallFileSelection(plan.SourceID, selection); err != nil { return nil, err }`.
+2. ApplyInstall strict path: after the strict resolution folds pins into plan.Files (i.e. the final selection, covering caller-supplied interactive overrides where resolveStrictInstallFiles returned (nil, nil)), validate `plan.Files` the same way before the lock gate / any side effect.
+3. The batch path's up-front TargetFileIDs pre-resolution for the primary (ApplyInstall doc comment: "#96/#140, which pins the primary's file selection only") — validate its resolved selection identically.
+
+If sites 1 and 2 turn out to be the same code point (strict path always passes through one place), one call there is correct — say so in the report rather than adding a redundant second call.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -v`
+Expected: new tests PASS; full package green (default selections are single-file, so nothing else trips the rule).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/core/service.go internal/core/flows.go internal/core/flows_variant_exclusivity_test.go
+git commit -m "feat: reject mixed pak+exmodz install selections at core seams (#211)"
+```
+
+---
+
+### Task 3: CLI chooser — re-prompt on mixed selection, hard error on --file
+
+**Files:**
+
+- Modify: `cmd/lmm/install.go` (`selectInstallFiles` ~line 104, its caller where `plan.Files` is overridden ~line 520-533)
+- Test: `cmd/lmm/install_test.go` (or the file where cmd/lmm's selection tests live — find `parseRangeSelection`/`promptMultiSelectionFrom` tests and colocate)
+
+**Interfaces:**
+
+- Consumes: `Service.ValidateInstallFileSelection` (Task 2).
+- Produces: `selectInstallFiles(files []domain.DownloadableFile, validate func([]domain.DownloadableFile) error) ([]*domain.DownloadableFile, error)` — signature gains the validate parameter (nil = no validation, preserving other callers if any; grep for callers and update them all). Interactive path re-prompts on a validation error; `--file` path returns it.
+
+- [ ] **Step 1: Write the failing tests**
+
+`selectInstallFiles` reads the prompt via `promptMultiSelection` (os.Stdin). Refactor for testability the way the file already does it: extract `selectInstallFilesFrom(r io.Reader, files []domain.DownloadableFile, validate func([]domain.DownloadableFile) error)` with `selectInstallFiles` delegating with `os.Stdin` (mirror `promptMultiSelection`/`promptMultiSelectionFrom`). Tests:
+
+```go
+func TestSelectInstallFiles_MixedSelectionReprompts(t *testing.T) {
+	files := []domain.DownloadableFile{
+		{ID: "pak", FileName: "Mod_P.pak", Category: "PAK"},
+		{ID: "exmodz", FileName: "Mod.exmodz", Category: "EXMODZ", IsPrimary: true},
+	}
+	validate := func(sel []domain.DownloadableFile) error {
+		// same shape the real closure has - reject mixed
+		var ex, other bool
+		for _, f := range sel {
+			if strings.HasSuffix(strings.ToLower(f.FileName), ".exmodz") { ex = true } else { other = true }
+		}
+		if ex && other { return fmt.Errorf("pak and exmodz are alternate forms of the same mod - select one") }
+		return nil
+	}
+	// First input line picks both (rejected, re-prompted); second picks 2.
+	in := strings.NewReader("1,2\n2\n")
+	selected, err := selectInstallFilesFrom(in, files, validate)
+	require.NoError(t, err)
+	require.Len(t, selected, 1)
+	assert.Equal(t, "exmodz", selected[0].ID)
+}
+
+func TestSelectInstallFiles_FileFlagMixedRejected(t *testing.T) {
+	// installFileID global set to "pak,exmodz" (save/restore the global the
+	// way neighboring tests handle flag globals); validate as above.
+	// Expect the error returned (no re-prompt on explicit flags).
+}
+```
+
+Write the second test fully, handling the `installFileID` package global with save/defer-restore.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/lmm/ -run TestSelectInstallFiles -v`
+Expected: FAIL — `selectInstallFilesFrom` undefined.
+
+- [ ] **Step 3: Implement**
+
+- Extract `selectInstallFilesFrom(r io.Reader, files, validate)`; keep all existing logic. Apply `validate` (when non-nil):
+  - `--file` path: validate the resolved selection; return the error as-is.
+  - single-file fast path and `--yes` default: single file — validation is a no-op but call it anyway (uniform).
+  - interactive loop: after `promptMultiSelectionFrom` returns and the selection is materialized, validate; on error `fmt.Printf("Invalid selection: %v\n", err)` and loop back to the prompt (restructure so the prompt+materialize+validate sequence loops — mirror `promptMultiSelectionFrom`'s own retry style).
+- At the caller (where `plan.Files` is overridden, ~install.go:520-533): build the closure
+
+  ```go
+  validate := func(sel []domain.DownloadableFile) error {
+      return service.ValidateInstallFileSelection(plan.SourceID, sel)
+  }
+  ```
+
+  (adjust to the caller's actual variable names for the service and plan) and pass it. Grep for any other `selectInstallFiles(` callers and pass `nil` or the equivalent closure as appropriate — every caller must compile and be listed in your report.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/lmm/ -v`
+Expected: PASS (whole package).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/lmm/install.go cmd/lmm/install_test.go
+git commit -m "feat: CLI chooser enforces variant exclusivity with re-prompt (#211)"
+```
+
+---
+
+### Task 4: Default-selection acceptance test + CHANGELOG + docs
+
+**Files:**
+
+- Test: `internal/core/flows_variant_exclusivity_test.go` (extend from Task 2)
+- Modify: `CHANGELOG.md` (`[Unreleased]`), `docs/configuration.md` (~line 62, the `compile` bullet)
+
+**Interfaces:**
+
+- Consumes: Task 1's IsPrimary behavior through `PlanInstall`'s `selectDeployFiles` default (`internal/core/flows.go:2940-2962` region).
+- Produces: acceptance evidence for the CLI/TUI parity claim (TUI installs `plan.Files` verbatim — `internal/tui/service_core.go:1291`'s documented contract — so a core `PlanInstall` assertion covers both interfaces).
+
+- [ ] **Step 1: Write the acceptance test**
+
+Using the same stub MergeCompiler source as Task 2 (GetModFiles returns both variants with exmodz `IsPrimary` — i.e. the stub mirrors Task 1's real behavior):
+
+```go
+// TestPlanInstall_BothVariants_DefaultsToExmodz is #211's parity acceptance:
+// PlanInstall's non-interactive default (what the TUI, --yes, and every
+// batch path install) must pick the exmodz variant when both exist. The TUI
+// has no file chooser and installs plan.Files exactly as planned
+// (internal/tui/service_core.go), so this single core assertion covers both
+// interfaces.
+func TestPlanInstall_BothVariants_DefaultsToExmodz(t *testing.T) {
+	// fixture per Task 2's seam tests
+	plan, err := svc.PlanInstall(ctx /* ... */)
+	require.NoError(t, err)
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, "exmodz", plan.Files[0].ID)
+}
+```
+
+Fill in the fixture from the file's existing tests. Expected: PASSES immediately if the stub marks exmodz primary (that is the point — IsPrimary flows through with zero core changes); to prove the assertion bites, temporarily flip the stub's primary to "pak" and confirm the test fails, then restore (note this RED check in your report).
+
+- [ ] **Step 2: CHANGELOG**
+
+Under `## [Unreleased]`, `### Added` (create the heading if absent, Added→Changed→Fixed order):
+
+```markdown
+### Added
+
+- Icarus mods that publish both a prebuilt pak and a mergeable `.exmodz`
+  now install the `.exmodz` by default everywhere (TUI, `--yes`, batch and
+  profile installs, and the CLI chooser's default), with descriptive
+  chooser labels. Selecting both variants together is rejected — they are
+  alternate forms of the same mod; `--file pak` remains the escape hatch
+  for installing the prebuilt pak alone. (#211)
+```
+
+- [ ] **Step 3: docs/configuration.md**
+
+In the `compile` deploy-mode bullet (~line 62), append one sentence:
+
+```markdown
+When a mod publishes both a prebuilt pak and an `.exmodz`, lmm installs the `.exmodz` by default; the pak remains selectable explicitly (CLI chooser or `--file pak`), and installing both together is rejected as they are alternate forms of the same mod.
+```
+
+- [ ] **Step 4: Full verification + commit**
+
+Run: `go test ./...` (once, unpiped), `go vet ./...`, `gofmt -l cmd/ internal/` (expect empty).
+
+```bash
+git add internal/core/flows_variant_exclusivity_test.go CHANGELOG.md docs/configuration.md
+git commit -m "test: exmodz-default parity acceptance + changelog/docs (#211)"
+```
+
+---
+
+### Task 5: PR
+
+- [ ] **Step 1: Final verification** — `go build -o lmm ./cmd/lmm`, `go vet ./...`, then `go test ./...` (separately); `trunk check` if available.
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push -u origin feat/211-exmodz-default
+gh pr create --base develop \
+  --title "feat: default to exmodz variant, reject mixed pak+exmodz installs (#211)" \
+  --body "Fixes #211 (close manually after merge). <summary>. 🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 3: Copilot triage** — `gh-await-review` in background; triage every comment; re-check after any fix push.
+
+## Post-merge verification (user's machine)
+
+Reinstall or newly install a both-variants Icarus mod (e.g. Increase Stacks publishes exmodz-only, laanp pak-only — a both-variants mod like the user's own Larger Resource Stacks is the target): `lmm -g icarus install <mod>` with no flags must pick the exmodz (cache gains `.lmm-source-exmodz`, no standalone pak deploy), and `lmm -g icarus install <mod> --file pak,exmodz` must be rejected with the exact message.

--- a/docs/plans/archive/2026-08-07-go-unrealpak-module-and-cli-plan.md
+++ b/docs/plans/archive/2026-08-07-go-unrealpak-module-and-cli-plan.md
@@ -1,0 +1,1421 @@
+# go-unrealpak Module + CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract lmm's `internal/unrealpak` into a standalone public Go module with a general-purpose CLI, and have lmm consume it as a dependency (#170).
+
+**Architecture:** The package moves verbatim to the root of a new repo via `git subtree split`, preserving its history. A `cmd/unrealpak` CLI wraps the existing public API with five subcommands — `info`, `list`, `cat`, `extract`, `build` — using only the standard library. The package stays game-agnostic: no Icarus knowledge, no game-specific constants. lmm then swaps its import path and deletes the internal copy.
+
+**Tech Stack:** Go (stdlib only — no external dependencies anywhere in the module), GitHub Actions, `git subtree split`.
+
+## Global Constraints
+
+- Module path: `github.com/DonovanMods/go-unrealpak`. Package name: `unrealpak`, at the repo root.
+- CLI binary name: `unrealpak`, at `cmd/unrealpak`.
+- **Zero external dependencies.** Library and CLI both. Use `flag` from the stdlib, not Cobra. This is a deliberate selling point for a format library — do not add a dependency for convenience.
+- **Game-agnostic.** No Icarus mount points, `data/` prefixes, `.EXMOD` knowledge, or any other game-specific value may enter this module. Those live in the consumer.
+- Go directive: `go 1.25` (matches the toolchain the code is tested against in lmm).
+- License: MIT, `Copyright (c) 2026 Donovan C. Young` — copied from lmm's `LICENSE`.
+- **Writes are stored (uncompressed) only. Reads handle stored and Zlib. Oodle is out of scope** — index reads never need it; an Oodle _payload_ read must fail with an error naming the entry.
+- **No silent fallbacks.** Zero or ambiguous matches, unsupported shapes, and failed hash gates are loud errors with a non-zero exit.
+- Every CLI subcommand writes results to an injected `io.Writer`, never directly to `os.Stdout`, so it is testable.
+
+---
+
+## File Structure
+
+**New repo `go-unrealpak`:**
+
+| File                                                                    | Responsibility                                                      |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `go.mod`                                                                | Module declaration. No `require` block — there are no dependencies. |
+| `LICENSE`                                                               | MIT, copied verbatim from lmm.                                      |
+| `README.md`                                                             | What it is, install, CLI usage, library usage, scope limits.        |
+| `docs/format.md`                                                        | The byte-level UE v11 pak format spec.                              |
+| `pak.go`, `reader.go`, `writer.go`                                      | The package, moved verbatim. Unchanged.                             |
+| `reader_test.go`, `writer_test.go`, `roundtrip_test.go`, `zlib_test.go` | Moved verbatim. Unchanged.                                          |
+| `cmd/unrealpak/main.go`                                                 | `main` + `run(args, out)` dispatch.                                 |
+| `cmd/unrealpak/commands.go`                                             | The five subcommand implementations.                                |
+| `cmd/unrealpak/sidecar.go`                                              | `.unrealpak.json` read/write.                                       |
+| `cmd/unrealpak/main_test.go`                                            | CLI tests, driven through `run`.                                    |
+| `.github/workflows/test.yml`                                            | gofmt + vet + race tests.                                           |
+
+**Modified in `linux-mod-manager`:** `go.mod`, `internal/core/service.go`, `internal/source/icarus/{compile,merge,pakconvert}.go`, and six test files — import path only. `internal/unrealpak/` is deleted.
+
+---
+
+### Task 1: Extract the package into a new module
+
+**Files:**
+
+- Create: new repo `go-unrealpak` containing `go.mod`, `LICENSE`, `.github/workflows/test.yml`, and the moved `pak.go`/`reader.go`/`writer.go` + their tests
+
+> **Steps 1-3 are already done (2026-08-07).** The repo exists at
+> <https://github.com/DonovanMods/go-unrealpak> (public), carries the package's
+> 14-commit history with the files at the repo root, and is cloned locally at
+> `~/Projects/apps/go-unrealpak` on `main`. **Start at Step 4.** It has no
+> `go.mod` yet, so it will not build until Step 4 lands — that is expected, not
+> a broken checkout.
+
+**Interfaces:**
+
+- Consumes: nothing
+- Produces: the module `github.com/DonovanMods/go-unrealpak` exposing `Open(path string) (*Reader, error)`, `(*Reader).Close() error`, `(*Reader).MountPoint() string`, `(*Reader).IndexHash() string`, `(*Reader).Files() []FileEntry`, `(*Reader).ReadFile(path string) ([]byte, error)`, `FileEntry{Path string; Size int64}`, `Create(path string, opts ...Option) (*Writer, error)`, `Option`, `WithMountPoint(mountPoint string) Option`, `(*Writer).AddFile(mountPath string, data []byte) error`, `(*Writer).Close() error`, and `ErrUnsupportedFormat`
+
+- [x] **Step 1: Split the package history out of lmm** — DONE 2026-08-07
+
+From the lmm checkout, on `develop`:
+
+```bash
+git subtree split --prefix=internal/unrealpak -b unrealpak-split
+git log --oneline unrealpak-split | head -5   # expect the package's own history, files at root
+```
+
+- [x] **Step 2: Create the empty GitHub repo** — DONE 2026-08-07
+
+```bash
+gh repo create DonovanMods/go-unrealpak --public \
+  --description "Pure-Go reader and writer for Unreal Engine v11 .pak archives, with a CLI."
+```
+
+- [x] **Step 3: Push the split history as `main`** — DONE 2026-08-07
+
+```bash
+cd ~/Projects/apps
+git clone https://github.com/DonovanMods/go-unrealpak.git
+cd go-unrealpak
+git pull ../linux-mod-manager unrealpak-split
+git push -u origin main
+ls   # expect: pak.go reader.go reader_test.go roundtrip_test.go writer.go writer_test.go zlib_test.go
+```
+
+- [ ] **Step 4: Add go.mod, LICENSE, and CI**
+
+`go.mod`:
+
+```
+module github.com/DonovanMods/go-unrealpak
+
+go 1.25
+```
+
+Copy `LICENSE` from the lmm checkout verbatim.
+
+`.github/workflows/test.yml`:
+
+```yaml
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "gofmt needed on:" >&2
+            echo "$unformatted" >&2
+            exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test (race)
+        run: go test -race ./...
+```
+
+- [ ] **Step 5: Verify the moved package builds and its tests pass unchanged**
+
+Run: `go build ./... && go test -race ./...`
+Expected: PASS. These are the tests that already covered this code in lmm; they are the regression gate for the move. If any fails, the move is wrong — do not edit the tests to accommodate it.
+
+- [ ] **Step 6: Verify there are no dependencies**
+
+Run: `go mod tidy && git diff --exit-code go.mod`
+Expected: no change, and `go.mod` still has no `require` block.
+
+- [ ] **Step 7: Add a real-file regression test**
+
+Every existing reader test reads a pak this package's own writer just
+produced — a closed loop that never sees real cooker output (Zlib block
+lists, 1 MiB alignment padding between entries, a populated pruned
+directory index). This test breaks that loop. It is skipped unless
+`UNREALPAK_TEST_PAK` names a real pak, so CI and contributors without a game
+installed are unaffected.
+
+Create `realfile_test.go`:
+
+```go
+package unrealpak
+
+import (
+	"os"
+	"testing"
+)
+
+// TestRealPak_DecodesShippedArchive reads a pak produced by a real Unreal
+// cooker rather than by this package's writer. Set UNREALPAK_TEST_PAK to a
+// shipped .pak to run it, e.g.
+//
+//	UNREALPAK_TEST_PAK=/path/to/Icarus/Content/Data/data.pak go test -run RealPak -v
+func TestRealPak_DecodesShippedArchive(t *testing.T) {
+	path := os.Getenv("UNREALPAK_TEST_PAK")
+	if path == "" {
+		t.Skip("set UNREALPAK_TEST_PAK to a real .pak to run this test")
+	}
+
+	r, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open(%s): %v", path, err)
+	}
+	defer r.Close() //nolint:errcheck
+
+	files := r.Files()
+	if len(files) == 0 {
+		t.Fatal("real pak decoded to zero entries")
+	}
+	if r.MountPoint() == "" {
+		t.Error("real pak decoded to an empty mount point")
+	}
+	if r.IndexHash() == "" {
+		t.Error("index hash is empty")
+	}
+	t.Logf("%s: mount %q, %d entries", path, r.MountPoint(), len(files))
+
+	// Read every entry the reader claims to support. Unsupported ones
+	// (Oodle) must fail with ErrUnsupportedFormat rather than garbage or a
+	// panic; anything else read must match its recorded size, which is the
+	// per-entry SHA1 gate doing its job.
+	var read, unsupported int
+	for _, f := range files {
+		data, err := r.ReadFile(f.Path)
+		if err != nil {
+			if errors.Is(err, ErrUnsupportedFormat) {
+				unsupported++
+				continue
+			}
+			t.Errorf("ReadFile(%s): %v", f.Path, err)
+			continue
+		}
+		if int64(len(data)) != f.Size {
+			t.Errorf("%s: read %d bytes, index says %d", f.Path, len(data), f.Size)
+		}
+		read++
+	}
+	t.Logf("read %d entries, %d unsupported (Oodle)", read, unsupported)
+	if read == 0 {
+		t.Error("no entry was readable; the reader is not exercising real data")
+	}
+}
+```
+
+Add `"errors"` to the test file's imports.
+
+- [ ] **Step 8: Run the real-file test against a shipped pak**
+
+```bash
+UNREALPAK_TEST_PAK=/data/SteamLibrary/steamapps/common/Icarus/Icarus/Content/Data/data.pak \
+  go test -run RealPak -v
+```
+
+Expected: PASS, logging 298 entries with 0 unsupported (that pak is stored +
+Zlib only). Then repeat against a pak that _does_ contain Oodle, to prove the
+unsupported path is clean rather than merely untaken:
+
+```bash
+UNREALPAK_TEST_PAK=/data/SteamLibrary/steamapps/common/Icarus/Icarus/Content/Paks/pakchunk0-WindowsNoEditor.pak \
+  go test -run RealPak -v
+```
+
+Expected: PASS with a non-zero unsupported count and no errors.
+
+- [ ] **Step 9: Confirm the test skips cleanly without the env var**
+
+Run: `go test -run RealPak -v`
+Expected: SKIP, not FAIL. CI must stay green on a machine with no game installed.
+
+- [ ] **Step 10: Commit**
+
+```bash
+gofmt -w .
+git add go.mod LICENSE .github/workflows/test.yml realfile_test.go
+git commit -m "chore: add module declaration, license, CI, and a real-file test
+
+Extracted from DonovanMods/linux-mod-manager internal/unrealpak via
+git subtree split, preserving the package's history (#170).
+
+The real-file test is env-gated (UNREALPAK_TEST_PAK): every other reader
+test reads a pak this package's own writer produced, which never exercises
+real cooker output."
+git push
+```
+
+---
+
+### Task 2: CLI scaffold with `info` and `list`
+
+**Files:**
+
+- Create: `cmd/unrealpak/main.go`, `cmd/unrealpak/commands.go`, `cmd/unrealpak/main_test.go`
+
+**Interfaces:**
+
+- Consumes: `unrealpak.Open`, `(*Reader).Close/MountPoint/IndexHash/Files`, `FileEntry{Path, Size}` from Task 1
+- Produces: `run(args []string, out io.Writer) error` — the testable entry point every later CLI task extends with a new `case` in its switch; `openPak(path string) (*unrealpak.Reader, error)`; `sortedFiles(r *unrealpak.Reader) []unrealpak.FileEntry`
+
+- [ ] **Step 1: Write the failing test**
+
+`cmd/unrealpak/main_test.go`:
+
+```go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/go-unrealpak"
+)
+
+// writeFixturePak builds a small real pak with the library itself, so CLI
+// tests exercise the same reader path production callers use.
+func writeFixturePak(t *testing.T, mount string, files map[string][]byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.pak")
+	w, err := unrealpak.Create(path, unrealpak.WithMountPoint(mount))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range files {
+		if err := w.AddFile(name, data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRun_List_PrintsSortedMountRelativePaths(t *testing.T) {
+	pak := writeFixturePak(t, "../../../Game/Content/", map[string][]byte{
+		"b/second.json": []byte("22"),
+		"a/first.json":  []byte("1"),
+	})
+
+	var out bytes.Buffer
+	if err := run([]string{"list", pak}, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got := out.String()
+	first := strings.Index(got, "a/first.json")
+	second := strings.Index(got, "b/second.json")
+	if first < 0 || second < 0 {
+		t.Fatalf("both entries must be listed; got:\n%s", got)
+	}
+	if first > second {
+		t.Errorf("entries must be sorted by path; got:\n%s", got)
+	}
+}
+
+func TestRun_List_JSONIsMachineReadable(t *testing.T) {
+	pak := writeFixturePak(t, "../../../Game/Content/", map[string][]byte{
+		"a/first.json": []byte("1"),
+	})
+
+	var out bytes.Buffer
+	if err := run([]string{"list", "--json", pak}, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	var doc struct {
+		MountPoint string `json:"mountPoint"`
+		Files      []struct {
+			Path string `json:"path"`
+			Size int64  `json:"size"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if doc.MountPoint != "../../../Game/Content/" {
+		t.Errorf("mountPoint = %q", doc.MountPoint)
+	}
+	if len(doc.Files) != 1 || doc.Files[0].Path != "a/first.json" || doc.Files[0].Size != 1 {
+		t.Errorf("files = %+v", doc.Files)
+	}
+}
+
+func TestRun_Info_ReportsMountAndEntryCount(t *testing.T) {
+	pak := writeFixturePak(t, "../../../Game/Content/", map[string][]byte{
+		"a/first.json": []byte("1"),
+	})
+
+	var out bytes.Buffer
+	if err := run([]string{"info", pak}, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{"../../../Game/Content/", "entries", "1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("info output missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestRun_UnknownSubcommand_Errors(t *testing.T) {
+	var out bytes.Buffer
+	err := run([]string{"frobnicate"}, &out)
+	if err == nil {
+		t.Fatal("unknown subcommand must be an error, not a silent no-op")
+	}
+	if !strings.Contains(err.Error(), "frobnicate") {
+		t.Errorf("error should name the unknown subcommand; got %v", err)
+	}
+}
+
+func TestRun_NoArgs_Errors(t *testing.T) {
+	var out bytes.Buffer
+	if err := run(nil, &out); err == nil {
+		t.Fatal("no arguments must be an error")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/unrealpak/ -run TestRun -v`
+Expected: FAIL — `undefined: run`
+
+- [ ] **Step 3: Write the implementation**
+
+`cmd/unrealpak/main.go`:
+
+```go
+// Command unrealpak inspects and builds Unreal Engine v11 .pak archives.
+//
+// It is deliberately game-agnostic: mount points and entry paths are
+// whatever the caller supplies, and no game's conventions are baked in.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "unrealpak:", err)
+		os.Exit(1)
+	}
+}
+
+const usage = `unrealpak - inspect and build Unreal Engine v11 .pak archives
+
+usage:
+  unrealpak info    <pak>
+  unrealpak list    <pak> [--json]
+  unrealpak cat     <pak> <path>
+  unrealpak extract <pak> <dir> [--filter <glob>]
+  unrealpak build   <dir> <pak> [--mount <mountpoint>]
+`
+
+// run is the testable entry point: every subcommand writes its results to
+// out rather than os.Stdout so tests can drive the real dispatch path.
+func run(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("no subcommand given\n\n%s", usage)
+	}
+	switch args[0] {
+	case "info":
+		return cmdInfo(args[1:], out)
+	case "list":
+		return cmdList(args[1:], out)
+	case "help", "-h", "--help":
+		fmt.Fprint(out, usage)
+		return nil
+	default:
+		return fmt.Errorf("unknown subcommand %q\n\n%s", args[0], usage)
+	}
+}
+```
+
+`cmd/unrealpak/commands.go`:
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/DonovanMods/go-unrealpak"
+)
+
+// openPak opens path, wrapping the error with the path so a failure names
+// the file the user actually passed.
+func openPak(path string) (*unrealpak.Reader, error) {
+	r, err := unrealpak.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", path, err)
+	}
+	return r, nil
+}
+
+// sortedFiles returns the pak's entries ordered by mount-relative path. The
+// index's own order reflects how the pak was written, which is not stable
+// across writers; sorting makes CLI output diffable.
+func sortedFiles(r *unrealpak.Reader) []unrealpak.FileEntry {
+	files := r.Files()
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files
+}
+
+func cmdInfo(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("info", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("info takes exactly one pak path")
+	}
+	r, err := openPak(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	defer r.Close() //nolint:errcheck
+
+	files := r.Files()
+	var total int64
+	for _, f := range files {
+		total += f.Size
+	}
+	fmt.Fprintf(out, "mount point: %s\n", r.MountPoint())
+	fmt.Fprintf(out, "entries:     %d\n", len(files))
+	fmt.Fprintf(out, "total size:  %d bytes\n", total)
+	fmt.Fprintf(out, "index hash:  %s\n", r.IndexHash())
+	return nil
+}
+
+type listJSON struct {
+	MountPoint string         `json:"mountPoint"`
+	IndexHash  string         `json:"indexHash"`
+	Files      []listFileJSON `json:"files"`
+}
+
+type listFileJSON struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+func cmdList(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	asJSON := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("list takes exactly one pak path")
+	}
+	r, err := openPak(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	defer r.Close() //nolint:errcheck
+
+	files := sortedFiles(r)
+	if *asJSON {
+		doc := listJSON{MountPoint: r.MountPoint(), IndexHash: r.IndexHash(), Files: make([]listFileJSON, 0, len(files))}
+		for _, f := range files {
+			doc.Files = append(doc.Files, listFileJSON{Path: f.Path, Size: f.Size})
+		}
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(doc)
+	}
+	for _, f := range files {
+		fmt.Fprintf(out, "%10d  %s\n", f.Size, f.Path)
+	}
+	return nil
+}
+```
+
+Note `flag.ContinueOnError` with `SetOutput(io.Discard)`: the default `ExitOnError` would call `os.Exit` inside a test.
+
+Note the `--json` flag must precede the pak path, since Go's `flag` stops parsing at the first non-flag argument.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/unrealpak/ -run TestRun -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w ./cmd
+git add cmd/unrealpak/
+git commit -m "feat(cli): add unrealpak info and list"
+git push
+```
+
+---
+
+### Task 3: `cat` and `extract`
+
+**Files:**
+
+- Create: `cmd/unrealpak/sidecar.go`
+- Modify: `cmd/unrealpak/main.go` (add two `case`s), `cmd/unrealpak/commands.go`, `cmd/unrealpak/main_test.go`
+
+**Interfaces:**
+
+- Consumes: `run`, `openPak`, `sortedFiles` from Task 2; `(*Reader).ReadFile` from Task 1
+- Produces: `sidecarName` (const `".unrealpak.json"`), `writeSidecar(dir, mountPoint string) error`, `readSidecar(dir string) (string, error)` — Task 4's `build` reads the mount point back through `readSidecar`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/unrealpak/main_test.go`:
+
+```go
+func TestRun_Cat_WritesEntryBytesVerbatim(t *testing.T) {
+	pak := writeFixturePak(t, "../../../Game/Content/", map[string][]byte{
+		"a/first.json": []byte(`{"hello":"world"}`),
+	})
+
+	var out bytes.Buffer
+	if err := run([]string{"cat", pak, "a/first.json"}, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() != `{"hello":"world"}` {
+		t.Errorf("cat output = %q", out.String())
+	}
+}
+
+func TestRun_Cat_MissingEntry_Errors(t *testing.T) {
+	pak := writeFixturePak(t, "../../../Game/Content/", map[string][]byte{
+		"a/first.json": []byte("1"),
+	})
+
+	var out bytes.Buffer
+	err := run([]string{"cat", pak, "nope.json"}, &out)
+	if err == nil {
+		t.Fatal("missing entry must be a loud error, never empty output")
+	}
+	if !strings.Contains(err.Error(), "nope.json") {
+		t.Errorf("error should name the missing entry; got %v", err)
+	}
+}
+
+func TestRun_Extract_WritesFilesAtMountRelativePathsPlusSidecar(t *testing.T) {
+	pak := writeFixturePak(t, "../../../Game/Content/", map[string][]byte{
+		"a/first.json":  []byte("1"),
+		"b/second.json": []byte("22"),
+	})
+	dir := t.TempDir()
+
+	var out bytes.Buffer
+	if err := run([]string{"extract", pak, dir}, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	for name, want := range map[string]string{
+		"a/first.json":  "1",
+		"b/second.json": "22",
+	} {
+		got, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(name)))
+		if err != nil {
+			t.Fatalf("reading extracted %s: %v", name, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+
+	mount, err := readSidecar(dir)
+	if err != nil {
+		t.Fatalf("readSidecar: %v", err)
+	}
+	if mount != "../../../Game/Content/" {
+		t.Errorf("sidecar mountPoint = %q", mount)
+	}
+}
+
+func TestRun_Extract_FilterSelectsASubset(t *testing.T) {
+	pak := writeFixturePak(t, "../../../Game/Content/", map[string][]byte{
+		"a/first.json": []byte("1"),
+		"b/second.txt": []byte("22"),
+	})
+	dir := t.TempDir()
+
+	var out bytes.Buffer
+	if err := run([]string{"extract", pak, dir, "--filter", "a/*"}, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "a", "first.json")); err != nil {
+		t.Errorf("filtered-in file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "b", "second.txt")); !os.IsNotExist(err) {
+		t.Errorf("filtered-out file should not exist; stat err = %v", err)
+	}
+}
+
+// A crafted pak could carry an entry path that climbs out of the target
+// directory. Extraction must refuse it rather than write outside dir.
+func TestRun_Extract_RefusesPathEscape(t *testing.T) {
+	dir := t.TempDir()
+	if err := checkExtractPath(dir, "../escape.json"); err == nil {
+		t.Error("a parent-traversal entry path must be refused")
+	}
+	if err := checkExtractPath(dir, "/absolute.json"); err == nil {
+		t.Error("an absolute entry path must be refused")
+	}
+	if err := checkExtractPath(dir, "safe/nested.json"); err != nil {
+		t.Errorf("an ordinary nested path must be allowed; got %v", err)
+	}
+}
+```
+
+Add `"os"` to the test file's imports.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/unrealpak/ -run 'TestRun_(Cat|Extract)' -v`
+Expected: FAIL — `undefined: readSidecar`, `undefined: writeSidecar`, `undefined: checkExtractPath`
+
+- [ ] **Step 3: Write the sidecar helper**
+
+`cmd/unrealpak/sidecar.go`:
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// sidecarName is the file extract drops into its output directory to record
+// the source pak's mount point, so build can reproduce it without the user
+// having to remember and retype it.
+const sidecarName = ".unrealpak.json"
+
+type sidecar struct {
+	MountPoint string `json:"mountPoint"`
+}
+
+func writeSidecar(dir, mountPoint string) error {
+	data, err := json.MarshalIndent(sidecar{MountPoint: mountPoint}, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, sidecarName), append(data, '\n'), 0o644)
+}
+
+// readSidecar returns the mount point recorded in dir. A missing sidecar is
+// reported as such so build can tell "no recorded mount" apart from "the
+// sidecar is corrupt" and ask the user for --mount in the first case only.
+func readSidecar(dir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(dir, sidecarName))
+	if err != nil {
+		return "", err
+	}
+	var s sidecar
+	if err := json.Unmarshal(data, &s); err != nil {
+		return "", fmt.Errorf("parsing %s: %w", sidecarName, err)
+	}
+	if s.MountPoint == "" {
+		return "", fmt.Errorf("%s records no mountPoint", sidecarName)
+	}
+	return s.MountPoint, nil
+}
+```
+
+- [ ] **Step 4: Write the two subcommands**
+
+Append to `cmd/unrealpak/commands.go`:
+
+```go
+func cmdCat(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("cat", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return fmt.Errorf("cat takes a pak path and an entry path")
+	}
+	r, err := openPak(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	defer r.Close() //nolint:errcheck
+
+	data, err := r.ReadFile(fs.Arg(1))
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", fs.Arg(1), err)
+	}
+	_, err = out.Write(data)
+	return err
+}
+
+// checkExtractPath refuses an entry path that would write outside dir. Pak
+// entry paths are attacker-controlled in any archive the user did not build
+// themselves, so this is the extract-side equivalent of a zip-slip guard.
+func checkExtractPath(dir, entryPath string) error {
+	if filepath.IsAbs(entryPath) || strings.HasPrefix(entryPath, "/") {
+		return fmt.Errorf("entry %q: absolute paths are not allowed", entryPath)
+	}
+	target := filepath.Join(dir, filepath.FromSlash(entryPath))
+	rel, err := filepath.Rel(dir, target)
+	if err != nil {
+		return fmt.Errorf("entry %q: %w", entryPath, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("entry %q: escapes the output directory", entryPath)
+	}
+	return nil
+}
+
+func cmdExtract(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("extract", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	filter := fs.String("filter", "", "only extract entries whose path matches this glob")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return fmt.Errorf("extract takes a pak path and an output directory")
+	}
+	pakPath, dir := fs.Arg(0), fs.Arg(1)
+
+	r, err := openPak(pakPath)
+	if err != nil {
+		return err
+	}
+	defer r.Close() //nolint:errcheck
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	count := 0
+	for _, f := range sortedFiles(r) {
+		if *filter != "" {
+			ok, err := path.Match(*filter, f.Path)
+			if err != nil {
+				return fmt.Errorf("bad --filter pattern %q: %w", *filter, err)
+			}
+			if !ok {
+				continue
+			}
+		}
+		if err := checkExtractPath(dir, f.Path); err != nil {
+			return err
+		}
+		data, err := r.ReadFile(f.Path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", f.Path, err)
+		}
+		target := filepath.Join(dir, filepath.FromSlash(f.Path))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(target, data, 0o644); err != nil {
+			return err
+		}
+		count++
+	}
+
+	if err := writeSidecar(dir, r.MountPoint()); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "extracted %d entries to %s (mount point recorded in %s)\n", count, dir, sidecarName)
+	return nil
+}
+```
+
+Add `"os"`, `"path"`, `"path/filepath"`, and `"strings"` to `commands.go`'s imports.
+
+- [ ] **Step 5: Wire the subcommands into dispatch**
+
+In `cmd/unrealpak/main.go`, add to the switch in `run`, after the `list` case:
+
+```go
+	case "cat":
+		return cmdCat(args[1:], out)
+	case "extract":
+		return cmdExtract(args[1:], out)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./cmd/unrealpak/ -v`
+Expected: PASS (all tests, including Task 2's)
+
+- [ ] **Step 7: Commit**
+
+```bash
+gofmt -w ./cmd
+git add cmd/unrealpak/
+git commit -m "feat(cli): add unrealpak cat and extract
+
+extract records the source mount point in a .unrealpak.json sidecar so
+build can reproduce it, and refuses entry paths that escape the output
+directory."
+git push
+```
+
+---
+
+### Task 4: `build`, and the extract→build round trip
+
+**Files:**
+
+- Modify: `cmd/unrealpak/main.go` (one `case`), `cmd/unrealpak/commands.go`, `cmd/unrealpak/main_test.go`
+
+**Interfaces:**
+
+- Consumes: `run`, `openPak`, `sortedFiles` from Task 2; `readSidecar`, `sidecarName` from Task 3; `unrealpak.Create`, `WithMountPoint`, `(*Writer).AddFile`, `(*Writer).Close` from Task 1
+- Produces: `cmdBuild(args []string, out io.Writer) error` — the last subcommand; no later task consumes it
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/unrealpak/main_test.go`:
+
+```go
+func TestRun_Build_ProducesAReadablePakWithTheGivenMount(t *testing.T) {
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "a", "first.json"), []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outPak := filepath.Join(t.TempDir(), "built.pak")
+
+	var out bytes.Buffer
+	if err := run([]string{"build", src, outPak, "--mount", "../../../Game/Content/"}, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	r, err := unrealpak.Open(outPak)
+	if err != nil {
+		t.Fatalf("built pak is not readable: %v", err)
+	}
+	defer r.Close()
+	if r.MountPoint() != "../../../Game/Content/" {
+		t.Errorf("MountPoint = %q", r.MountPoint())
+	}
+	data, err := r.ReadFile("a/first.json")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "1" {
+		t.Errorf("entry = %q", data)
+	}
+}
+
+// The sidecar exists so a plain extract->build cycle needs no flags at all.
+func TestRun_Build_DefaultsMountFromSidecar(t *testing.T) {
+	pak := writeFixturePak(t, "../../../Game/Content/", map[string][]byte{
+		"a/first.json":  []byte("1"),
+		"b/second.json": []byte("22"),
+	})
+	dir := t.TempDir()
+	rebuilt := filepath.Join(t.TempDir(), "rebuilt.pak")
+
+	var out bytes.Buffer
+	if err := run([]string{"extract", pak, dir}, &out); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if err := run([]string{"build", dir, rebuilt}, &out); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	orig, err := unrealpak.Open(pak)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer orig.Close()
+	round, err := unrealpak.Open(rebuilt)
+	if err != nil {
+		t.Fatalf("round-tripped pak is not readable: %v", err)
+	}
+	defer round.Close()
+
+	if orig.MountPoint() != round.MountPoint() {
+		t.Errorf("mount point drifted: %q -> %q", orig.MountPoint(), round.MountPoint())
+	}
+	if len(orig.Files()) != len(round.Files()) {
+		t.Fatalf("entry count drifted: %d -> %d", len(orig.Files()), len(round.Files()))
+	}
+	for _, f := range orig.Files() {
+		want, err := orig.ReadFile(f.Path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := round.ReadFile(f.Path)
+		if err != nil {
+			t.Errorf("round-tripped pak missing %s: %v", f.Path, err)
+			continue
+		}
+		if !bytes.Equal(want, got) {
+			t.Errorf("%s: content drifted", f.Path)
+		}
+	}
+}
+
+// The sidecar must never end up inside the pak it describes.
+func TestRun_Build_ExcludesTheSidecar(t *testing.T) {
+	pak := writeFixturePak(t, "../../../Game/Content/", map[string][]byte{
+		"a/first.json": []byte("1"),
+	})
+	dir := t.TempDir()
+	rebuilt := filepath.Join(t.TempDir(), "rebuilt.pak")
+
+	var out bytes.Buffer
+	if err := run([]string{"extract", pak, dir}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if err := run([]string{"build", dir, rebuilt}, &out); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := unrealpak.Open(rebuilt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	for _, f := range r.Files() {
+		if f.Path == sidecarName {
+			t.Error("the sidecar must not be packed into the pak")
+		}
+	}
+}
+
+func TestRun_Build_NoMountAndNoSidecar_Errors(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "only.json"), []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := run([]string{"build", src, filepath.Join(t.TempDir(), "x.pak")}, &out)
+	if err == nil {
+		t.Fatal("build with no --mount and no sidecar must fail loudly, not guess a default")
+	}
+	if !strings.Contains(err.Error(), "--mount") {
+		t.Errorf("error should tell the user how to fix it; got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/unrealpak/ -run TestRun_Build -v`
+Expected: FAIL — `unknown subcommand "build"`
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `cmd/unrealpak/commands.go`:
+
+```go
+func cmdBuild(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("build", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	mount := fs.String("mount", "", "mount point to record in the built pak")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return fmt.Errorf("build takes an input directory and an output pak path")
+	}
+	dir, pakPath := fs.Arg(0), fs.Arg(1)
+
+	// An explicit --mount always wins; the sidecar is only a convenience for
+	// the extract->build cycle. Neither present is a hard error: guessing a
+	// mount point produces a pak that loads and silently does nothing.
+	mountPoint := *mount
+	if mountPoint == "" {
+		recorded, err := readSidecar(dir)
+		if err != nil {
+			return fmt.Errorf("no --mount given and no usable %s in %s: %w "+
+				"(pass --mount <mountpoint>)", sidecarName, dir, err)
+		}
+		mountPoint = recorded
+	}
+
+	// os.DirEntry, not fs.DirEntry: the flag.FlagSet above is bound to `fs`,
+	// so naming the io/fs package here would be shadowed. os.DirEntry is an
+	// alias for the same type, so this needs no extra import at all.
+	var entries []string
+	err := filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == sidecarName {
+			return nil // metadata about the pak, never content of it
+		}
+		entries = append(entries, rel)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking %s: %w", dir, err)
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("%s contains no files to pack", dir)
+	}
+	sort.Strings(entries)
+
+	w, err := unrealpak.Create(pakPath, unrealpak.WithMountPoint(mountPoint))
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", pakPath, err)
+	}
+	for _, rel := range entries {
+		data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+		if err != nil {
+			w.Close() //nolint:errcheck
+			os.Remove(pakPath)
+			return err
+		}
+		if err := w.AddFile(rel, data); err != nil {
+			w.Close() //nolint:errcheck
+			os.Remove(pakPath)
+			return fmt.Errorf("adding %s: %w", rel, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		os.Remove(pakPath)
+		return fmt.Errorf("finalizing %s: %w", pakPath, err)
+	}
+
+	fmt.Fprintf(out, "built %s: %d entries, mount point %s\n", pakPath, len(entries), mountPoint)
+	return nil
+}
+```
+
+No new imports are needed for this step — `os`, `sort`, `filepath`, `flag`,
+`fmt`, and `io` are already present from Tasks 2 and 3.
+
+The `os.Remove` on every failure path mirrors the fail-clean contract lmm's own compile path uses: a half-written pak left on disk could be picked up and deployed.
+
+- [ ] **Step 4: Wire it into dispatch**
+
+In `cmd/unrealpak/main.go`, add to the switch in `run`:
+
+```go
+	case "build":
+		return cmdBuild(args[1:], out)
+```
+
+- [ ] **Step 5: Run the full CLI suite**
+
+Run: `go test -race ./... -v`
+Expected: PASS — all library tests and all CLI tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+gofmt -w ./cmd
+git add cmd/unrealpak/
+git commit -m "feat(cli): add unrealpak build
+
+Mount point comes from --mount or the extract sidecar; with neither, build
+fails rather than guessing, since a wrong mount produces a pak that loads
+and silently does nothing."
+git push
+```
+
+---
+
+### Task 5: README and format documentation
+
+**Files:**
+
+- Create: `README.md`, `docs/format.md`
+
+**Interfaces:**
+
+- Consumes: the CLI surface from Tasks 2-4
+- Produces: nothing consumed by later tasks
+
+- [ ] **Step 1: Write `docs/format.md`**
+
+Copy the byte-level spec from the lmm checkout at
+`docs/plans/archive/icarus-pak-format-findings.md`, keeping Part 1 (footer
+layout), Part 2 (primary index, encoded entry bit-packing, full directory
+index, path-hash index and its FNV-1a recipe, local headers, data-region
+packing), and dropping Part 3 (hosted base-table dumps — an Icarus product
+decision with no bearing on the format).
+
+Edit as you copy:
+
+- Remove Icarus-specific framing: this documents UE v11 paks, not Icarus's.
+- Keep the empirical numbers and worked examples. They are what makes the
+  document trustworthy, and they were verified against 173,078 real entries
+  across 34 paks.
+- Keep the two corrections already noted in that document (`bEncryptedIndex`
+  sits _before_ `Magic`; `data.pak` is Zlib not Oodle). The falsified-twice
+  history is a feature of the record, not noise.
+- Add a header noting the source: empirical decode against a real UE 4.25+
+  title, not Epic documentation.
+
+- [ ] **Step 2: Write `README.md`**
+
+````markdown
+# go-unrealpak
+
+Pure-Go reader and writer for Unreal Engine v11 (`PakFile_Version_Fnv64BugFix`)
+`.pak` archives, plus a CLI. No cgo, no external dependencies.
+
+Existing tooling is Rust (repak) or Python (u4pak); this exists because a Go
+mod manager needed to read and write these archives in-process.
+
+## Scope
+
+|            |                                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------- |
+| Read       | stored (uncompressed) and Zlib entries                                                                  |
+| Write      | stored entries only                                                                                     |
+| Oodle      | **not supported** — indexes read fine, but reading an Oodle _payload_ returns an error naming the entry |
+| Encryption | not supported; an encrypted index is rejected                                                           |
+| Versions   | v10+ (the path-hash index format); v11 is what it writes                                                |
+
+The format documentation is in [docs/format.md](docs/format.md), decoded
+empirically and verified against 173,078 entries across 34 real paks.
+
+## CLI
+
+```
+go install github.com/DonovanMods/go-unrealpak/cmd/unrealpak@latest
+```
+
+```
+unrealpak info    <pak>                          # version, mount point, entry count, index hash
+unrealpak list    <pak> [--json]                 # entries with sizes, sorted by path
+unrealpak cat     <pak> <path>                   # one entry's bytes to stdout
+unrealpak extract <pak> <dir> [--filter <glob>]  # entries to dir, + a .unrealpak.json sidecar
+unrealpak build   <dir> <pak> [--mount <mount>]  # pack dir; mount defaults to the sidecar's
+```
+
+`extract` records the source mount point in `.unrealpak.json` so a plain
+`extract` → `build` cycle round-trips without flags. `build` refuses to guess a
+mount point: a wrong one produces a pak that loads and silently does nothing.
+
+## Library
+
+```go
+r, err := unrealpak.Open("pakchunk0-WindowsNoEditor.pak")
+if err != nil {
+    return err
+}
+defer r.Close()
+
+fmt.Println(r.MountPoint(), len(r.Files()))
+
+data, err := r.ReadFile("Engine/Config/Base.ini")
+```
+
+```go
+w, err := unrealpak.Create("out_P.pak", unrealpak.WithMountPoint("../../../Game/Content/"))
+if err != nil {
+    return err
+}
+if err := w.AddFile("data/Thing.json", payload); err != nil {
+    return err
+}
+return w.Close()
+```
+
+## License
+
+MIT
+````
+
+- [ ] **Step 3: Verify every documented command actually works**
+
+Run each command from the README against a pak you build with the CLI itself:
+
+```bash
+go build -o /tmp/unrealpak ./cmd/unrealpak
+mkdir -p /tmp/paksrc/data && echo '{}' > /tmp/paksrc/data/Thing.json
+/tmp/unrealpak build /tmp/paksrc /tmp/out_P.pak --mount ../../../Game/Content/
+/tmp/unrealpak info /tmp/out_P.pak
+/tmp/unrealpak list /tmp/out_P.pak --json
+/tmp/unrealpak cat /tmp/out_P.pak data/Thing.json
+/tmp/unrealpak extract /tmp/out_P.pak /tmp/pakout
+```
+
+Expected: every command succeeds; `cat` prints `{}`; `extract` writes
+`/tmp/pakout/data/Thing.json` and `/tmp/pakout/.unrealpak.json`. Fix the README
+if any documented flag or output differs — the docs must describe what shipped.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/format.md
+git commit -m "docs: add README and the empirical v11 pak format spec"
+git push
+```
+
+---
+
+### Task 6: Tag v0.1.0 and swap lmm's dependency
+
+**Files:**
+
+- Modify (go-unrealpak): none — tag only
+- Modify (lmm): `go.mod`, `go.sum`, `internal/core/service.go`, `internal/source/icarus/compile.go`, `internal/source/icarus/merge.go`, `internal/source/icarus/pakconvert.go`, `cmd/lmm/install_compile_test.go`, `internal/core/service_icarus_compile_test.go`, `internal/source/icarus/compile_test.go`, `internal/source/icarus/helpers_test.go`, `internal/source/icarus/merge_test.go`, `internal/source/icarus/pakconvert_test.go`, `internal/tui/health_e2e_test.go`, `internal/tui/service_core_recompile_test.go`
+- Delete (lmm): `internal/unrealpak/`
+
+**Interfaces:**
+
+- Consumes: the tagged module from Tasks 1-5
+- Produces: lmm building against `github.com/DonovanMods/go-unrealpak`
+
+- [ ] **Step 1: Tag the module**
+
+`v0.1.0` rather than `v1.0.0`: the API is small and settled in practice, but
+this is its first release outside lmm and pre-1.0 leaves room to correct the
+surface without a major bump.
+
+```bash
+cd ~/Projects/apps/go-unrealpak
+git tag v0.1.0 && git push origin v0.1.0
+```
+
+- [ ] **Step 2: Create the lmm branch**
+
+```bash
+cd ~/Projects/apps/linux-mod-manager
+git checkout develop && git pull
+git checkout -b feat/170-unrealpak-module
+```
+
+- [ ] **Step 3: Add the dependency and rewrite every import**
+
+```bash
+go get github.com/DonovanMods/go-unrealpak@v0.1.0
+grep -rl '"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"' --include='*.go' . \
+  | xargs sed -i 's|"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"|"github.com/DonovanMods/go-unrealpak"|'
+```
+
+The package name is `unrealpak` in both, so every `unrealpak.Open` /
+`unrealpak.Create` / `unrealpak.Reader` reference at the call sites is
+unchanged — only the import line moves.
+
+- [ ] **Step 4: Delete the internal copy**
+
+```bash
+git rm -r internal/unrealpak
+```
+
+- [ ] **Step 5: Verify the swap**
+
+Run: `go mod tidy && gofmt -l ./cmd ./internal && go vet ./... && go test -race ./...`
+Expected: PASS, no gofmt output. The icarus and core suites exercise the
+library heavily through `Compile`, `MergeCompile`, and `convertPakToBundle`;
+they passing against the module is the integration gate for the extraction.
+
+Also confirm nothing still references the old path:
+
+Run: `grep -rn 'internal/unrealpak' --include='*.go' . ; echo "exit=$?"`
+Expected: no matches.
+
+- [ ] **Step 6: Add the CHANGELOG entry**
+
+Under `## [Unreleased]`, in the `### Changed` section (create it if absent):
+
+```markdown
+- `internal/unrealpak` is now the standalone module
+  [`github.com/DonovanMods/go-unrealpak`](https://github.com/DonovanMods/go-unrealpak),
+  consumed as a dependency. No behavior change — the package moved verbatim,
+  with its history, and gained a `unrealpak` CLI (`info`/`list`/`cat`/
+  `extract`/`build`) that lmm does not use. (#170)
+```
+
+- [ ] **Step 7: Commit and open the PR**
+
+```bash
+git add -A
+git commit -m "refactor: consume go-unrealpak as a module instead of internal/unrealpak
+
+The package moved verbatim to github.com/DonovanMods/go-unrealpak via
+git subtree split, preserving its history, and lmm now depends on v0.1.0.
+Call sites are unchanged: the package name is still unrealpak, so only the
+import line moves.
+
+Fixes #170"
+git push -u origin feat/170-unrealpak-module
+gh pr create --base develop \
+  --title "refactor: extract internal/unrealpak into the go-unrealpak module (#170)" \
+  --body "Fixes #170.
+
+\`internal/unrealpak\` is now [\`github.com/DonovanMods/go-unrealpak\`](https://github.com/DonovanMods/go-unrealpak) v0.1.0.
+
+## What moved
+
+The package went out verbatim via \`git subtree split\`, keeping its own commit history. No source change: the package name is still \`unrealpak\`, so every call site is untouched and only the import line moves. \`internal/unrealpak/\` is deleted here.
+
+## What the module adds
+
+A \`unrealpak\` CLI (\`info\`/\`list\`/\`cat\`/\`extract\`/\`build\`) that lmm does not use, the empirical v11 format spec as \`docs/format.md\`, and an env-gated real-file test that reads shipped game paks rather than ones the writer produced. The module has zero external dependencies and stays game-agnostic — no Icarus constants crossed over.
+
+## Verification
+
+- \`go mod tidy\`, \`gofmt\`, \`go vet\`, \`go test -race ./...\` all clean
+- No remaining references to the old import path
+- The icarus and core suites exercise the library through \`Compile\`, \`MergeCompile\`, and \`convertPakToBundle\`; those passing against the module is the integration gate
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Note the explicit `--base develop`: `main` is the default branch, so a
+forgotten flag targets protected `main`.
+
+---
+
+## Follow-ups (not in this plan)
+
+- The Icarus mod-authoring skill in `Icarus-Mods`, which drives this CLI — see
+  §3 of the design doc.
+- Lowering the `go` directive below 1.25 once tested against an older
+  toolchain. The package uses nothing newer than `strings.Cut`, so the real
+  floor is likely much lower, but it is unverified.
+- Oodle support, if a caller ever needs to read base-game asset payloads.
+  `docs/format.md` records where the method table lives.

--- a/docs/plans/archive/2026-08-07-unrealpak-module-and-icarus-mod-skill-design.md
+++ b/docs/plans/archive/2026-08-07-unrealpak-module-and-icarus-mod-skill-design.md
@@ -1,0 +1,319 @@
+# go-unrealpak Module + Icarus Mod-Authoring Skill — Design
+
+**Date:** 2026-08-07
+**Issues:** #170 (module extraction), plus one new issue for the lmm asset-path defect found while designing this
+**Repos touched:** `linux-mod-manager` (module extraction, dependency swap, bug fix), new `go-unrealpak`, `Icarus-Mods` (skill + rebuilt artifacts)
+
+---
+
+## STATUS 2026-08-07 — delivered, with the skill deliberately descoped
+
+**Read this before implementing anything below.** Two of the three layers shipped
+as designed; the third was cut on evidence. Do not build §3 as written.
+
+| Layer                                 | Outcome                                                                                                           |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| §2 `go-unrealpak` module + CLI (#170) | **Shipped.** v0.1.0 public and tagged; lmm swapped via PR #239, merged to `develop` as `9c7d108`; #170 closed.    |
+| §4.2 lmm asset-path defect            | **Shipped early**, out of order, as hotfix v1.29.1 (#237, PR #238, `f495794`). In-game validated.                 |
+| §3 the authoring skill                | **Descoped to the analysis procedure only** (§3.2). §3.3, §3.4, §3.5 and §3.6 were _not_ built and should not be. |
+
+**Why the skill was cut.** Running §3.2's analysis against the real mods
+answered the question the whole design existed to serve — and the answer was
+that nothing needed rebuilding. All three mods resolve clean against build
+`3.0.22.155681` while still declaring `week: "171"`.
+
+The premise in §1 and the Goal above is wrong in one important way: **an `.EXMOD`
+is a diff, rebased onto the live `data.pak` at every compile, so table patches do
+not go stale.** The Friday problem afflicts prebuilt `.pak` files, not `.exmodz`.
+`week` is metadata, and `modinfo.json` declares `"compatibility": "all"` anyway.
+So §3.3 (rebuild `.EXMODZ`) and §3.4 (rebuild `.pak`) address a problem the
+author does not have — the second only mattering at all if pak variants were ever
+published, which `modinfo.json` does not do.
+
+**What genuinely can rot, and what shipped to catch it:** bundled `.uasset`/
+`.uexp` files are whole-file overrides frozen at build time and do **not** rebase
+— if the game moves or renames the asset they override, the mod keeps installing
+and deploying while doing nothing. Plus a patched row renamed upstream, or the
+base value catching up (a silent no-op). All three are checked by
+`Icarus-Mods/tools/check-mods.py`, with the domain rules recorded in
+`Icarus-Mods/CLAUDE.md` (commit `b78efb7`). It exits non-zero only on a genuine
+break, and was verified against deliberately broken fixtures so it can actually
+fail rather than only ever printing `ok`.
+
+**Not a skill.** `superpowers:writing-skills` is explicit that project-specific
+conventions belong in the instructions file, not `.claude/skills/`. One repo, one
+script — `CLAUDE.md` is the right home.
+
+**Still true and worth keeping** from below: §3.1's rules table (all empirical,
+and the wrapper rule is now lmm's shipped behavior), §3.2's analysis design, and
+§2's entire CLI rationale.
+
+---
+
+## Goal
+
+Let a future session maintain the author's own Icarus mods in the `Icarus-Mods`
+repo: analyze each mod against the game's _current_ data, then re-create its
+`.EXMODZ` and `.pak` artifacts from source.
+
+Icarus ships a data update most weeks. A mod's built artifacts are a snapshot
+against whichever `data.pak` existed when they were built — the "Friday
+problem" from the author's side rather than the mod manager's. Nothing today
+tells the author whether a mod still does what its README claims, and rebuilding
+by hand means re-deriving a binary format that was falsified twice during #136
+planning.
+
+## Non-goals
+
+- Authoring or recompiling UE assets (`.uasset`/`.uexp`). They are carried
+  through verbatim; producing them is an Unreal Editor task.
+- Replacing IMM (Icarus Mod Tools/Manager) or its `.EXMODZ` conventions. This
+  matches the existing ecosystem format, it does not redefine it.
+- Oodle decompression (see §2.3).
+- Any change to lmm's merged-pak consumer pipeline beyond the §4.2 defect fix.
+
+## Architecture
+
+Three layers, each with one job.
+
+```text
+Icarus-Mods/.claude/skills/icarus-mod-build/   Icarus semantics: EXMOD schema,
+  ├── SKILL.md                                 path rules, drift analysis,
+  ├── scripts/                                 rebuild + verify procedures
+  └── reference/
+                    │ drives (binary work only)
+                    ▼
+github.com/DonovanMods/go-unrealpak            game-agnostic UE v11 pak
+  ├── unrealpak/    (extracted package)         read/write + CLI
+  └── cmd/unrealpak (CLI)
+                    ▲
+                    │ consumed as a dependency
+linux-mod-manager   internal/unrealpak → module dep
+```
+
+The split is forced by #170's own constraint: the package is deliberately
+game-agnostic with zero Icarus imports. Every Icarus-specific rule the author
+workflow needs — the `.EXMOD` schema, `CurrentFile` flattening, the `data/`
+table prefix, the `Icarus/Content/` mount, the asset-wrapper strip, patching
+against `data.pak` — therefore cannot live in the module. It lives in the skill.
+
+## 1. Source of truth in `Icarus-Mods`
+
+Unchanged from today; the design only adds a second built artifact.
+
+```text
+<Mod>/<Mod>.EXMOD        # source: the hand-maintained diff manifest
+<Mod>/**/*.uasset|.uexp  # source: prebuilt assets, under a <Mod>/ wrapper dir
+<Mod>.EXMODZ             # built artifact
+<Mod>_P.pak              # built artifact (new)
+modinfo.json             # catalog entry; gains files.pak, week bumped
+```
+
+## 2. Layer 1 — `go-unrealpak` (#170)
+
+### 2.1 Package
+
+`internal/unrealpak` extracted as-is, history riding along via `git subtree
+split`. Public API is what lmm already uses: `Open`, `Create`, `Reader`,
+`Writer`, `WithMountPoint`. The byte-level format spec in
+`docs/plans/archive/icarus-pak-format-findings.md` seeds the module's format
+documentation — that document is the empirical record and should not be
+paraphrased from memory.
+
+### 2.2 CLI surface
+
+```text
+unrealpak info    <pak>                     version, footer size, mount point, entry
+                                            count, compression methods, hash gates
+unrealpak list    <pak> [--json]            mount-relative paths, size, compression
+unrealpak cat     <pak> <path>              one entry's bytes to stdout
+unrealpak extract <pak> <dir> [--filter G]  entries to dir at their mount-relative
+                                            paths, plus a sidecar recording the mount
+unrealpak build   <dir> <pak> --mount=M     pack dir; --mount defaults from sidecar
+```
+
+`extract` writes a sidecar (`.unrealpak.json`) holding the source mount point so
+`build` can round-trip a pak without the caller having to remember it. `--mount`
+given explicitly always wins.
+
+### 2.3 Deliberate limits
+
+- **Writes are stored (uncompressed) only.** Every mod pak in the #220 corpus is
+  stored-uncompressed, and lmm's shipped writer already emits only this shape.
+- **Reads handle stored and Zlib.** That covers all of `data.pak` (40 stored,
+  258 Zlib — #175).
+- **Oodle is out of scope, and says so.** Index reads never need it, so `info`,
+  `list`, and `extract --filter` over non-Oodle entries all work against
+  `pakchunk0*`. Reading an Oodle _payload_ fails with a named error identifying
+  the entry. This answers #170's open "does Oodle belong in the module"
+  checkbox: it is a caller concern. The author workflow never needs it, because
+  mods carry prebuilt assets rather than extracting base ones.
+- **No silent fallbacks.** Zero or ambiguous matches, unsupported shapes, and
+  failed hash gates are loud errors with a non-zero exit (repo precedent #95).
+
+### 2.4 Testing
+
+- Port the existing `internal/unrealpak` tests unchanged; they are the
+  regression gate for extraction.
+- CLI: `extract` → `build` round-trip on a fixture pak, asserting the rebuilt
+  index structures and entry set match; `list --json` golden output.
+- Real-file tests gated behind an env var naming the Icarus install, following
+  the repo's existing convention for install-dependent tests.
+- lmm's own suite passing after the dependency swap is the integration gate.
+
+## 3. Layer 2 — the skill (DESCOPED — only §3.2 shipped; see STATUS above)
+
+Lives at `Icarus-Mods/.claude/skills/icarus-mod-build/`, so it is discovered
+whenever a session works in the mods repo and is versioned with the mods it
+builds.
+
+### 3.1 The rules it encodes
+
+Each is empirical. None is inferred from convention.
+
+| Rule                                                                                                             | Evidence                                                                                                                                                                                                                                                                                 |
+| ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mount point is `../../../Icarus/Content/`; output is named `<Name>_P.pak`                                        | two real prebuilt mods (#178, pak-divergence-report)                                                                                                                                                                                                                                     |
+| Patched tables land at `data/` + the table's mount-relative path                                                 | byte-matched against FloofLevelCap and Intreeg's 4XP                                                                                                                                                                                                                                     |
+| `CurrentFile` ⇄ mount path by replacing `-` ⇄ `/`                                                                | no base table path contains a hyphen (verified across all 298)                                                                                                                                                                                                                           |
+| Bundled assets land at their zip path **minus the leading `<Mod>/` wrapper**, which equals the manifest basename | dual-form ground truth: `Crys_Lvl120Cap_M25/data/Character/C_PlayerTalentGrowth.uasset` in the EXMODZ ⇒ `Icarus/Content/data/Character/C_PlayerTalentGrowth.uasset` in the shipped pak; holds for all 6 asset-bearing bundles available; now also lmm's shipped behavior (#237, v1.29.1) |
+| `{"CurrentFile":"EndOfMod"}` is a terminator row: no `File_Items`, no table                                      | author manifests + #220 corpus                                                                                                                                                                                                                                                           |
+| Rows upsert: matching `Name` shallow-merges fields, otherwise appends                                            | `ApplyRowPatch`; matches real mod behavior                                                                                                                                                                                                                                               |
+| `.EXMOD` carries pass-through fields lmm's parser drops — `week`, `fileName`, `readmeURL`, `imageURL`, `Level2`  | the author's own three manifests                                                                                                                                                                                                                                                         |
+| Base tables come from the installed `Icarus/Content/Data/data.pak`                                               | #175; offline and week-correct by construction                                                                                                                                                                                                                                           |
+| UE virtual paths are case-insensitive; match case-insensitively, preserve original case                          | #220 constraint 4 (capital `Data/` mounts are real)                                                                                                                                                                                                                                      |
+
+### 3.2 Procedure: analyze
+
+Against the installed `data.pak`, per mod, report:
+
+- **Install identity** — `Major.Minor.Patch.Changelist` from
+  `Icarus/Config/version.json`, and the data changelist.
+- **Per overridden field**, one of:
+  - `applies` — base differs from your value; the patch does something
+  - `no-op` — base already equals your value; the game caught up, drop it
+  - `missing-row` — the row name is gone from the base table
+  - `missing-table` — `CurrentFile` no longer resolves
+  - `field-absent-in-base` — a field the base row does not have: intentional
+    addition, or a typo that silently does nothing
+- **Assets** — each bundled asset's stripped path checked against the real base
+  asset paths (index reads across the pakchunks; no Oodle needed).
+
+Asset checking can go further than path matching, because the base assets an
+Icarus mod overrides turn out to be **readable, not Oodle** — `pakchunk0_s20`'s
+`Data/Character/C_*Growth.uexp` decode with the stdlib. So the analysis can
+compare a mod's curve against the stock one it replaces, not merely assert the
+path exists. Worked example from #237's validation: `.uexp` curve keypairs sit at
+byte offsets 165/169 and 192/196 as `(level, cumulative total)`, giving stock
+1.5 talent / 0.5 solo / 3.5 blueprint per level against MegaPoints' 6 / 2 / 10.
+Reading the _reference_ rather than the curve is what makes this discoverable:
+`Character/D_CharacterGrowth.json`'s `Player` row names the three curve assets.
+Treat the offsets as an example, not a spec — they were not verified beyond
+these three assets, and a general curve reader is out of scope.
+
+A mod may have no overridden fields at all: MegaPoints and MorePoints are
+asset-only, with `Rows` consisting solely of `EndOfMod`. That is a valid shape,
+not an empty report — for those mods the asset check _is_ the analysis, and the
+report must say so rather than rendering an empty field table.
+
+`no-op` and `field-absent-in-base` are the two the author cannot currently see
+and the reason existence checks alone were rejected.
+
+### 3.3 Procedure: rebuild `.EXMODZ`
+
+Set `week` to the week the rebuild targets — it records which base the artifact
+was built against, so it changes on every rebuild. `version` is the author's own
+semantic version and changes only when the mod's _content_ changes, never for a
+rebuild alone. Preserve every pass-through field, then zip
+`Extracted Mods/<Name>.EXMOD` plus the `<Name>/` asset tree verbatim.
+Entry order sorted and timestamps fixed, so an unchanged mod rebuilds to
+identical bytes and `git status` stays honest.
+
+### 3.4 Procedure: rebuild `.pak`
+
+1. Stage a directory.
+2. For each row: `unrealpak cat data.pak <resolved path>` → apply the row's
+   upserts → write to `stage/data/<mount-relative path>`.
+3. For each asset: copy `<Name>/<rest>` → `stage/<rest>` (the wrapper strip).
+4. `unrealpak build stage <Name>_P.pak --mount=../../../Icarus/Content/`.
+
+### 3.5 Procedure: verify
+
+`unrealpak list` the output and assert: mount point exact, table entries under
+`data/`, asset entries matching real base asset paths case-insensitively, and a
+spot-read of one patched table showing the intended value. In-game confirmation
+remains the final gate — every Icarus finding in #136 was settled that way, and
+Icarus's shipping build writes no logs.
+
+### 3.6 Bundled helper
+
+The JSON and zip work — applying upserts to tables up to 7 MB, preserving
+pass-through fields, deterministic zipping — is a bundled Python script with
+unit tests, not something re-derived per run. Python because it needs no
+toolchain beyond what the machine has, and because the JSON layer has no
+overlap with the module's binary concerns.
+
+**Accepted duplication:** upsert semantics then exist both here and in lmm's
+`ApplyRowPatch`. It is roughly 30 lines of fully specified JSON logic, and the
+two sides genuinely differ — lmm consumes published mods and merges N of them
+against a shared evolving base, while this produces one mod's artifacts and must
+preserve author-facing fields lmm discards. Unifying them would mean either
+importing Go from a Python helper or making the mods repo depend on the mod
+manager. Recorded as a conscious choice so a future reader does not "fix" it.
+
+## 4. Layer 3 — `linux-mod-manager` changes
+
+### 4.1 Dependency swap
+
+Replace `internal/unrealpak` with the module. Mechanical; the existing suite is
+the gate.
+
+### 4.2 Asset-path defect (new issue)
+
+`Compile` and `applyBundle` pass each `.EXMODZ` entry's zip path through
+`sanitizeAssetPath` and write it into the pak unchanged. Because every real
+`.EXMODZ` wraps its assets in a `<Mod>/` directory (verified against the
+author's three mods, Cry's two, and All_Ammo_Turret), lmm emits
+`Icarus/Content/<Mod>/data/Character/X.uasset` where the game expects
+`Icarus/Content/data/Character/X.uasset`.
+
+Consequence: **bundled assets from every asset-bearing `.EXMODZ` land at a path
+the game ignores.** For a mod whose entire effect is assets — MegaPoints and
+MorePoints both have `Rows` consisting only of `EndOfMod` — the mod installs,
+deploys, and does nothing.
+
+Fix: strip the leading wrapper segment before writing. Per repo directive this
+starts with a failing test reproducing the wrong output path. Sequenced after
+extraction so it is written against the module API, and it needs its own smoke
+validation since it changes what lands in a deployed pak.
+
+## 5. Build order
+
+1. **#170** — extract the module, add the CLI, port the format docs, CI, semver
+   tag; lmm swaps the dependency.
+2. ~~**Asset-strip fix**~~ — **DONE, shipped as v1.29.1** (#237, PR #238, merged
+   `f495794`, tagged, back-merged to develop `9715f05`). Pulled forward out of
+   order because it was a shipped-behavior defect: bundled assets landed one
+   directory too deep, so asset-bearing `.EXMODZ` mods deployed and did nothing.
+   In-game validated — MegaPoints alone yields 4× stock talent points.
+3. ~~**The skill** — rules, four procedures, helper script and its tests.~~
+   **DESCOPED** — shipped as the analysis procedure only:
+   `Icarus-Mods/tools/check-mods.py` + `Icarus-Mods/CLAUDE.md` (`b78efb7`).
+   See the STATUS section at the top.
+4. ~~**Validate** — rebuild all three mods against the current week...~~
+   **NOT NEEDED.** The analysis showed all three mods already resolve clean
+   against the current build, so there was nothing to rebuild and no
+   `modinfo.json` change to make. Adding `files.pak` remains optional and
+   unmotivated: nothing consumes a pak variant of these mods.
+
+Step 1 shipped and closed #170. Steps 3 and 4 collapsed into "run the check,
+confirm nothing is broken" — which is the outcome, not a shortcut.
+
+## 6. Open items
+
+- Module path: `github.com/DonovanMods/go-unrealpak` (#170's suggestion) — to
+  confirm at extraction.
+- Whether `modinfo.json` should ship a `pak` URL for all three mods or only
+  those whose users need the non-lmm path.
+- Whether the skill's analyze step should cache the pakchunk asset-path index
+  between runs (33 index reads per invocation is fast but not free).


### PR DESCRIPTION
Moves eight completed plan docs into `docs/plans/archive/`, where they become tracked (the `docs/plans/*` ignore carves out `archive`). Docs only; no code change.

## #170 — go-unrealpak

- `2026-08-07-unrealpak-module-and-icarus-mod-skill-design.md`
- `2026-08-07-go-unrealpak-module-and-cli-plan.md`

Both complete: `go-unrealpak` v0.1.0 shipped and lmm swapped to it in #239, closing #170.

The design carries a STATUS block recording that its third layer — the Icarus mod-authoring skill — was **deliberately descoped**. Running its own analysis procedure against the real mods showed nothing needed rebuilding, because an `.EXMOD` is a diff rebased onto the live `data.pak` at every compile: table patches don't go stale, so two of the four planned procedures addressed a problem that doesn't exist. What survives shipped to `DonovanMods/Icarus-Mods` as a drift check.

That correction is the reason to archive these rather than drop them — it's the kind of premise that would otherwise be re-derived into the same over-built design later.

## v1.29.0 backlog

These shipped in v1.29.0 (released 2026-08-05) and should have been archived at that release:

- `2026-08-03-manifest-aware-deploy-and-exmodz-default-design.md` (#210, #211)
- `2026-08-03-manifest-aware-deploy-plan.md`
- `2026-08-04-exmodz-default-plan.md`
- `2026-08-04-batch-preresolve-order-plan.md` (#214)
- `2026-08-04-deploy-convergence-and-batch-hook-order-design.md` (#168, #212)
- `2026-08-04-deploy-convergence-plan.md`

Caught up here rather than compounded at the next release.

## Still in flight, deliberately

The #220/#221, #224, and #86 plan docs stay local — that work is merged to `develop` but unreleased, and the convention archives at release. `docs/pak-to-exmod-feature` stays retained until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)