### PR TITLE
fix(core): propagate real DB errors from ModDetail instead of masking as not-installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `lmm mod show` and the TUI mod details view no longer report a mod as
+  not installed when the installed-state lookup fails outright (e.g. a
+  locked or corrupted database) — only a genuine "no such row" omits the
+  Installed section; any other database error now surfaces as an error
+  (#236).
 - `lmm verify --fix` now resolves a missing file's re-download URL against
   the source-mapped game, not the LMM game ID (#228). On a game whose
   `source_ids` maps to a different upstream domain (e.g. NexusMods

--- a/internal/core/moddetail.go
+++ b/internal/core/moddetail.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -45,12 +46,16 @@ func (s *Service) ModDetail(ctx context.Context, game *domain.Game, profile, sou
 	}
 	detail := &ModDetail{Mod: mod}
 
-	// A GetInstalledMod failure means "not installed" - the ordinary case for
-	// a mod browsed from search - so it omits the block rather than failing
-	// the whole call (verbatim from doModShow's own convention).
+	// Only a genuine "not installed" - the ordinary case for a mod browsed
+	// from search - omits the Installed block. Any other failure is a real
+	// DB error and must surface rather than masquerade as an uninstalled
+	// mod, which the user cannot tell apart from an absence (#236).
 	installed, err := s.GetInstalledMod(sourceID, modID, game.ID, profile)
-	if err != nil {
+	switch {
+	case errors.Is(err, domain.ErrModNotFound):
 		return detail, nil
+	case err != nil:
+		return nil, fmt.Errorf("loading installed mod: %w", err)
 	}
 
 	info := &InstalledDetail{

--- a/internal/core/moddetail_test.go
+++ b/internal/core/moddetail_test.go
@@ -2,10 +2,12 @@ package core_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/core"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/db"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -205,4 +207,59 @@ func TestModDetail_UnknownModErrors(t *testing.T) {
 	_, err := svc.ModDetail(context.Background(), game, "default", "src", "nope")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mod not found")
+}
+
+// TestModDetail_DBErrorPropagates (#236): only a genuine "not installed"
+// (domain.ErrModNotFound) may omit the Installed block; any other
+// GetInstalledMod failure must propagate as an error, never be rendered as
+// "not installed" - a locked/corrupted DB silently reading as an uninstalled
+// mod is indistinguishable from a real absence on both surfaces. The
+// corruption vector: a NULL installed_at fails GetInstalledMod's Scan into a
+// non-pointer time.Time, written through a second raw handle on the same DB
+// file (converge_test.go's seam), since the typed API can't produce a bad row.
+func TestModDetail_DBErrorPropagates(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   dataDir,
+		CacheDir:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+	src := newMockSource("src")
+	svc.RegisterSource(src)
+	src.AddMod(game.ID, &domain.Mod{ID: "a", SourceID: "src", GameID: game.ID, Name: "Mod A", Version: "1.5"})
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod: domain.Mod{
+			ID:       "a",
+			SourceID: "src",
+			Name:     "Mod A",
+			Version:  "1.5",
+			GameID:   game.ID,
+		},
+		ProfileName:  "default",
+		UpdatePolicy: domain.UpdateNotify,
+		Enabled:      true,
+	}))
+
+	rawDB, err := db.New(filepath.Join(dataDir, "lmm.db"))
+	require.NoError(t, err)
+	_, err = rawDB.Exec(`UPDATE installed_mods SET installed_at = NULL WHERE source_id = 'src' AND mod_id = 'a'`)
+	require.NoError(t, err)
+	require.NoError(t, rawDB.Close())
+
+	// Guard: the corruption must actually yield a real (non-not-found) error
+	// from the underlying lookup - otherwise a schema change could silently
+	// turn this into a passing-for-the-wrong-reason test.
+	_, gerr := svc.GetInstalledMod("src", "a", game.ID, "default")
+	require.Error(t, gerr)
+	require.NotErrorIs(t, gerr, domain.ErrModNotFound)
+
+	detail, err := svc.ModDetail(context.Background(), game, "default", "src", "a")
+	require.Error(t, err, "a real DB failure must surface, not read as \"not installed\"")
+	assert.NotErrorIs(t, err, domain.ErrModNotFound)
+	assert.Nil(t, detail)
 }


### PR DESCRIPTION
Fixes #236.

## Problem

`core.Service.ModDetail` treated **any** `GetInstalledMod` error as "this mod is not installed":

```go
installed, err := s.GetInstalledMod(sourceID, modID, game.ID, profile)
if err != nil {
    return detail, nil // every error becomes "not installed"
}
```

A real DB failure (locked database, corrupted row, I/O error) was therefore reported as an uninstalled mod — no error, no log. Both surfaces rendered the lie: `lmm mod show` silently omitted its `Installed:` section, and the TUI mod details view omitted its Installed block. The user could not distinguish a real absence from a database problem.

## Fix

The DB layer already distinguishes the two cases (`sql.ErrNoRows` → `domain.ErrModNotFound`, anything else wrapped as a real error), so the swallow is narrowed to the sentinel:

```go
installed, err := s.GetInstalledMod(sourceID, modID, game.ID, profile)
switch {
case errors.Is(err, domain.ErrModNotFound):
    return detail, nil // ordinary: genuinely not installed
case err != nil:
    return nil, fmt.Errorf("loading installed mod: %w", err)
}
```

## Tests (written first, TDD)

- **New** `TestModDetail_DBErrorPropagates`: corrupts the installed row through a second raw DB handle (`installed_at = NULL` fails the `Scan` into a non-pointer `time.Time` — the typed API can't produce a bad row), guards that the underlying lookup really errors with a non-not-found error, then asserts `ModDetail` propagates it. Failed before the fix (`Error: An error is expected but got nil`), passes after.
- **Unchanged** `TestModDetail_NotInstalled` still pins the ordinary path: a genuinely uninstalled mod returns a detail with `nil` Installed and no error.

## Verification

- `gofmt -l ./cmd ./internal` — clean
- `go vet ./...` — clean
- `go test ./...` — no failures
- `cmd/lmm/testdata/mod_show_golden/` — **no golden changed** (git status confirms only `moddetail.go`, `moddetail_test.go`, `CHANGELOG.md` touched)

No version bump (story PR into develop). CHANGELOG entry added under `[Unreleased]` → `### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)