### PR TITLE
fix: thread the LMM game ID into install dependency resolution (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Install-plan dependency resolution now fetches dependencies using the
+  LMM game ID (translated through `source_ids` like every other fetch)
+  instead of feeding the source's own stamped game ID back into the
+  lookup (#230). The old path only worked while no configured LMM game
+  ID happened to equal another game's upstream domain (e.g. a game
+  literally named `skyrimspecialedition`); on such a collision,
+  dependencies were silently looked up in the wrong game and reported
+  missing.
 - `lmm verify --fix` now resolves a missing file's re-download URL against
   the source-mapped game, not the LMM game ID (#228). On a game whose
   `source_ids` maps to a different upstream domain (e.g. NexusMods

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -2934,7 +2934,7 @@ func (s *Service) PlanInstall(ctx context.Context, game *domain.Game, profileNam
 		for _, im := range installedMods {
 			installedIDs[domain.ModKey(im.SourceID, im.ID)] = true
 		}
-		plan.Dependencies, plan.MissingDependencies, plan.CycleDetected, plan.DependencyWarnings = s.resolveInstallDependencies(ctx, sourceID, mod, installedIDs)
+		plan.Dependencies, plan.MissingDependencies, plan.CycleDetected, plan.DependencyWarnings = s.resolveInstallDependencies(ctx, sourceID, game.ID, mod, installedIDs)
 	}
 
 	files, err := s.GetModFiles(ctx, sourceID, mod)
@@ -3010,7 +3010,16 @@ func (s *Service) PlanInstall(ctx context.Context, game *domain.Game, profileNam
 // OTHER error degrades the same way (the plan still succeeds) but is also
 // appended to warnings, since it represents an actual failure the caller
 // couldn't otherwise tell apart from "this mod genuinely has none".
-func (s *Service) resolveInstallDependencies(ctx context.Context, sourceID string, target *domain.Mod, installedIDs map[string]bool) (deps []domain.Mod, missing []domain.ModReference, cycleDetected bool, warnings []string) {
+//
+// gameID is the LMM game id (game.ID), NOT a mod's stamped GameID: sources
+// stamp their own SOURCE-DOMAIN id onto the mods they return (e.g. NexusMods
+// echoes "skyrimspecialedition"), and Service.GetMod translates an LMM id
+// into that domain id via game.SourceIDs. Feeding a stamped id back into
+// GetMod (#230) only worked while s.games[<source-domain-id>] happened to
+// miss - LMM ids are user-chosen in games.yaml, so a collision with another
+// game's LMM id would translate the already-translated id and silently fetch
+// dependencies from the wrong game.
+func (s *Service) resolveInstallDependencies(ctx context.Context, sourceID, gameID string, target *domain.Mod, installedIDs map[string]bool) (deps []domain.Mod, missing []domain.ModReference, cycleDetected bool, warnings []string) {
 	visited := make(map[string]bool)
 	stack := make(map[string]bool) // keys currently being visited (cycle detection)
 
@@ -3048,11 +3057,7 @@ func (s *Service) resolveInstallDependencies(ctx context.Context, sourceID strin
 				continue
 			}
 
-			gameIDForFetch := target.GameID
-			if gameIDForFetch == "" {
-				gameIDForFetch = mod.GameID
-			}
-			depMod, err := s.GetMod(ctx, sourceID, gameIDForFetch, ref.ModID)
+			depMod, err := s.GetMod(ctx, sourceID, gameID, ref.ModID)
 			if err != nil {
 				// Dependency not available on this source (e.g. an external
 				// requirement like SKSE).

--- a/internal/core/flows_install_test.go
+++ b/internal/core/flows_install_test.go
@@ -2644,3 +2644,101 @@ func TestService_ApplyInstall_BatchPath_TargetFileIDs_DuplicatesDeduped(t *testi
 	require.NoError(t, err)
 	assert.Equal(t, []string{"root-main-1"}, got.FileIDs, "duplicate pins collapse to one recorded file")
 }
+
+// --- resolveInstallDependencies game-ID threading (#230) ---
+
+// TestService_PlanInstall_DependencyFetchSurvivesGameIDNamespaceCollision is
+// the #230 regression test: dependency fetches must use the LMM game id (and
+// let Service.GetMod translate it) rather than feeding the SOURCE-DOMAIN id
+// the source stamped onto the target mod back into GetMod. The old code only
+// worked because s.games[<source-domain-id>] normally misses, letting the id
+// fall through untranslated - but LMM game ids are user-chosen in games.yaml,
+// so another game's LMM id can legally collide with this game's source-domain
+// id. Here "skyrimspecialedition" is BOTH skyrim's source-domain id on "src"
+// AND a second configured game's own LMM id: with the old code the dependency
+// fetch hit that second game's mapping ("other-domain") and silently looked
+// for the dependency in the wrong game.
+func TestService_PlanInstall_DependencyFetchSurvivesGameIDNamespaceCollision(t *testing.T) {
+	svc := newFlowsTestService(t)
+
+	game := &domain.Game{ID: "skyrim", Name: "Skyrim", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink,
+		SourceIDs: map[string]string{"src": "skyrimspecialedition"}}
+	require.NoError(t, svc.AddGame(game))
+	// The colliding game: its user-chosen LMM id equals skyrim's source-domain
+	// id, and it maps "src" to a different domain of its own.
+	require.NoError(t, svc.AddGame(&domain.Game{ID: "skyrimspecialedition", Name: "Collider",
+		ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink,
+		SourceIDs: map[string]string{"src": "other-domain"}}))
+
+	mock := newMockSource("src")
+	svc.RegisterSource(mock)
+	// Both mods live under skyrim's SOURCE-DOMAIN id, and the source stamps
+	// that id onto what it returns (mirroring the real sources - e.g.
+	// internal/source/nexusmods stamps the id it was queried with).
+	mock.AddMod("skyrimspecialedition", &domain.Mod{ID: "dep1", SourceID: "src", Name: "Dep One",
+		Version: "1.0", GameID: "skyrimspecialedition"})
+	mock.AddMod("skyrimspecialedition", &domain.Mod{ID: "root", SourceID: "src", Name: "Root",
+		Version: "1.0", GameID: "skyrimspecialedition",
+		Dependencies: []domain.ModReference{{SourceID: "src", ModID: "dep1"}}})
+
+	plan, err := svc.PlanInstall(context.Background(), game, "default", "src", "root", false)
+	require.NoError(t, err)
+	assert.Empty(t, plan.MissingDependencies,
+		"dependency must be fetched from skyrim's own source domain, not the colliding game's mapping")
+	require.Len(t, plan.Dependencies, 1)
+	assert.Equal(t, "dep1", plan.Dependencies[0].ID)
+}
+
+// TestService_PlanInstall_DependencyFetchTranslatesMappedGameID pins the
+// ordinary, non-colliding path around the #230 fix: with a real SourceIDs
+// mapping the source must keep receiving its own domain id for dependency
+// fetches - previously via the stamped id falling through GetMod untranslated,
+// now via GetMod translating the LMM id. The mods are registered ONLY under
+// the source-domain id, so the test fails if the dependency fetch ever sends
+// the raw LMM id ("skyrim") to the source.
+func TestService_PlanInstall_DependencyFetchTranslatesMappedGameID(t *testing.T) {
+	svc := newFlowsTestService(t)
+
+	game := &domain.Game{ID: "skyrim", Name: "Skyrim", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink,
+		SourceIDs: map[string]string{"src": "skyrimspecialedition"}}
+	require.NoError(t, svc.AddGame(game))
+
+	mock := newMockSource("src")
+	svc.RegisterSource(mock)
+	mock.AddMod("skyrimspecialedition", &domain.Mod{ID: "dep1", SourceID: "src", Name: "Dep One",
+		Version: "1.0", GameID: "skyrimspecialedition"})
+	mock.AddMod("skyrimspecialedition", &domain.Mod{ID: "root", SourceID: "src", Name: "Root",
+		Version: "1.0", GameID: "skyrimspecialedition",
+		Dependencies: []domain.ModReference{{SourceID: "src", ModID: "dep1"}}})
+
+	plan, err := svc.PlanInstall(context.Background(), game, "default", "src", "root", false)
+	require.NoError(t, err)
+	assert.Empty(t, plan.MissingDependencies)
+	require.Len(t, plan.Dependencies, 1)
+	assert.Equal(t, "dep1", plan.Dependencies[0].ID)
+}
+
+// TestService_PlanInstall_DependencyFetchEmptyMappingKeepsLMMGameID pins the
+// empty-mapping nuance of the #230 fix: a SourceIDs entry mapped to "" (e.g.
+// directory sources: `donovan-mods: ""`) means "this source applies to any
+// game" and must not blank the id GetMod sends - dependency fetches keep
+// using the LMM game id itself, exactly as the target-mod fetch does.
+func TestService_PlanInstall_DependencyFetchEmptyMappingKeepsLMMGameID(t *testing.T) {
+	svc := newFlowsTestService(t)
+
+	game := &domain.Game{ID: "g1", Name: "Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink,
+		SourceIDs: map[string]string{"src": ""}}
+	require.NoError(t, svc.AddGame(game))
+
+	mock := newMockSource("src")
+	svc.RegisterSource(mock)
+	mock.AddMod("g1", &domain.Mod{ID: "dep1", SourceID: "src", Name: "Dep One", Version: "1.0", GameID: "g1"})
+	mock.AddMod("g1", &domain.Mod{ID: "root", SourceID: "src", Name: "Root", Version: "1.0", GameID: "g1",
+		Dependencies: []domain.ModReference{{SourceID: "src", ModID: "dep1"}}})
+
+	plan, err := svc.PlanInstall(context.Background(), game, "default", "src", "root", false)
+	require.NoError(t, err)
+	assert.Empty(t, plan.MissingDependencies)
+	require.Len(t, plan.Dependencies, 1)
+	assert.Equal(t, "dep1", plan.Dependencies[0].ID)
+}

--- a/internal/core/flows_update_test.go
+++ b/internal/core/flows_update_test.go
@@ -569,7 +569,7 @@ func TestService_ApplyUpdate_ProgressEvents(t *testing.T) {
 // GAME's own ID (game.ID) throughout, never a possibly-different GameID a
 // source's GetMod stamps onto the freshly-fetched newMod (mirroring how a
 // source like NexusMods may map/rewrite GameID for querying purposes - see
-// resolveInstallDependencies' gameIDForFetch comment in flows.go). Traced:
+// resolveInstallDependencies' gameID doc comment in flows.go). Traced:
 // unlike ApplyInstall's SaveInstalledMod (an INSERT that writes a mod's
 // GameID column and therefore needs explicit normalization),
 // ApplyModUpdate/SetModLinkMethod/UpsertMod are all UPDATES keyed by the
@@ -612,7 +612,7 @@ func TestService_ApplyUpdate_GameIDNormalization(t *testing.T) {
 // gameIDStampingSource wraps multiFileDownloadSource but stamps a
 // caller-chosen (mismatched) GameID onto every Mod GetMod returns, simulating
 // a source that maps/rewrites GameID for its own querying purposes (see
-// resolveInstallDependencies' gameIDForFetch comment in flows.go).
+// resolveInstallDependencies' gameID doc comment in flows.go).
 type gameIDStampingSource struct {
 	*multiFileDownloadSource
 	stampGameID string


### PR DESCRIPTION
Fixes #230.

## Problem

`resolveInstallDependencies` fetched each dependency with `target.GameID` — the **source-domain** id the source stamps onto the mod it returns (e.g. NexusMods echoes `skyrimspecialedition`) — and fed it back into `Service.GetMod`, which expects an **LMM** game id and translates it through `game.SourceIDs`. That only worked because `s.games[<source-domain-id>]` normally misses, letting the id fall through untranslated. LMM game ids are user-chosen in `games.yaml`, so a user whose LMM game id collides with another game's source domain would have the lookup *hit*, translating the already-translated id and silently fetching dependencies from the wrong game (they'd surface as spuriously "missing", or worse, resolve to a same-numbered mod of a different game).

## Fix

Thread the LMM game id (`game.ID`, in scope at the single call site) into `resolveInstallDependencies` as a parameter and use it for the `GetMod` call, so the dependency fetch goes through the exact same translation as the target-mod fetch — correct by construction rather than by id-namespace non-collision.

## Behaviour equivalence for non-colliding setups

Every built-in source echoes the game id it was queried with onto the returned mod (`nexusmods.go` `modDataToDomain`, `curseforge.go` `GetMod`, `custom/{directory,manifest,api}.go`), so:

- **Real mapping** (`source_ids: {src: domain}`): old code fell through with the echoed `domain`; new code translates `game.ID` → `domain`. Identical.
- **Missing or empty mapping**: the target mod was fetched with `game.ID` untranslated and the source echoed it back, so old code already passed `game.ID` (and already *hit* the games map, harmlessly); new code does the same. `GetMod`'s `id != ""` guard keeps an empty "applies to any game" mapping from blanking the id — pinned by a dedicated test.
- The old `gameIDForFetch == ""` fallback was unreachable from `PlanInstall` (a configured game's id is never empty and sources echo the queried id), so removing it changes nothing.

## Tests (TDD)

- `TestService_PlanInstall_DependencyFetchSurvivesGameIDNamespaceCollision` — constructs the collision (an LMM game literally named `skyrimspecialedition` alongside skyrim's `source_ids` mapping to that domain). **Failed on unfixed code** with the dependency landing in `MissingDependencies`; passes now.
- `TestService_PlanInstall_DependencyFetchTranslatesMappedGameID` — pins the ordinary mapped path (mods registered only under the source domain, so a raw-LMM-id fetch would fail).
- `TestService_PlanInstall_DependencyFetchEmptyMappingKeepsLMMGameID` — pins the empty-mapping path.

`gofmt` clean, `go vet` clean, full `go test ./...` green (18 packages). No version bump (story PR into develop); CHANGELOG entry added under `[Unreleased]` → `### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)