### PR TITLE
test(icarus): golden dual-form test compiling a real .EXMODZ against its published pak (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Closed the test gap that let #237 ship: a new env-gated golden test
+  (`ICARUS_GOLDEN_MOD_DIR`) compiles a real dual-form mod's `.EXMODZ`
+  with the full pipeline and asserts the resulting pak's virtual paths
+  match the author's own published `_P.pak` — the first check of
+  compiled output against an artifact not produced by lmm itself
+  (#242). Test-only; skips unless pointed at a local dual-form mod.
 - Install-plan dependency resolution now fetches dependencies using the
   LMM game ID (translated through `source_ids` like every other fetch)
   instead of feeding the source's own stamped game ID back into the

--- a/internal/source/icarus/golden_test.go
+++ b/internal/source/icarus/golden_test.go
@@ -144,7 +144,14 @@ func readVirtualPathSet(t *testing.T, pakPath string) map[string]string {
 	set := make(map[string]string)
 	for _, f := range r.Files() {
 		full := path.Join(r.MountPoint(), f.Path)
-		set[strings.ToLower(full)] = full
+		folded := strings.ToLower(full)
+		// Two entries differing only by case would collapse into one key and
+		// could hide a divergence; UE couldn't distinguish them either, so a
+		// pak like that is malformed — refuse it rather than compare loosely.
+		if prev, ok := set[folded]; ok {
+			t.Fatalf("%s: case-insensitive path collision between %q and %q", pakPath, prev, full)
+		}
+		set[folded] = full
 	}
 	if len(set) == 0 {
 		t.Fatalf("%s holds no entries", pakPath)

--- a/internal/source/icarus/golden_test.go
+++ b/internal/source/icarus/golden_test.go
@@ -1,0 +1,160 @@
+package icarus
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/go-unrealpak"
+)
+
+// defaultIcarusBasePak is where a stock Steam library keeps the installed
+// game's own data.pak; ICARUS_GOLDEN_BASE_PAK overrides it for other layouts.
+const defaultIcarusBasePak = "/data/SteamLibrary/steamapps/common/Icarus/Icarus/Content/Data/data.pak"
+
+// TestGoldenDualForm_CompiledExmodzMatchesPublishedPak compiles a real
+// .EXMODZ with the full pipeline and checks the resulting pak's virtual
+// paths against the SAME mod's author-published _P.pak — an out-of-loop
+// oracle no other test in this package has. Every other fixture base pak
+// here is built by lmm's own writer and read back by lmm's own reader, a
+// closed loop that proves the two agree with each other, not that either
+// agrees with the game; bundled assets deployed one directory too deep for
+// months inside that blind spot (#237) while the suite stayed green. Any
+// future divergence in mount point, data/ prefix, or asset placement fails
+// this test immediately (#242).
+//
+// Gated like go-unrealpak's UNREALPAK_TEST_PAK real-file test: set
+// ICARUS_GOLDEN_MOD_DIR to a directory holding ONE dual-form mod — its
+// .EXMODZ plus the author's own published .pak — e.g.
+//
+//	ICARUS_GOLDEN_MOD_DIR=/path/to/dual-form-mod go test ./internal/source/icarus/ -run Golden -v
+//
+// The mod must carry bundled assets: a table-only mod would pass without
+// exercising asset placement at all — exactly the passes-for-the-wrong-reason
+// gap this test exists to close — so the test refuses it loudly instead.
+// (Of the #220 spike corpus's eleven dual-form pairs, only the two
+// Crys_Lvl120Cap mods qualify.) ICARUS_GOLDEN_BASE_PAK overrides the
+// default Steam location of the installed game's data.pak.
+func TestGoldenDualForm_CompiledExmodzMatchesPublishedPak(t *testing.T) {
+	modDir := os.Getenv("ICARUS_GOLDEN_MOD_DIR")
+	if modDir == "" {
+		t.Skip("set ICARUS_GOLDEN_MOD_DIR to a directory holding one dual-form mod (.EXMODZ + published .pak) to run this test")
+	}
+	basePak := os.Getenv("ICARUS_GOLDEN_BASE_PAK")
+	if basePak == "" {
+		basePak = defaultIcarusBasePak
+	}
+	if _, err := os.Stat(basePak); err != nil {
+		t.Fatalf("installed base data.pak not found: %v (set ICARUS_GOLDEN_BASE_PAK to the game's Content/Data/data.pak)", err)
+	}
+
+	exmodzPath, publishedPakPath := findDualFormPair(t, modDir)
+
+	exmodzData, err := os.ReadFile(exmodzPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", exmodzPath, err)
+	}
+	bundle, err := ParseExmodz(exmodzData)
+	if err != nil {
+		t.Fatalf("ParseExmodz(%s): %v", exmodzPath, err)
+	}
+	if len(bundle.Assets) == 0 {
+		t.Fatalf("%s bundles no assets, so this test would pass without exercising asset placement — the exact #237 blind spot it exists to close; point ICARUS_GOLDEN_MOD_DIR at an asset-bearing dual-form mod (e.g. Crys_Lvl120Cap_M25)",
+			filepath.Base(exmodzPath))
+	}
+
+	compiledPath := filepath.Join(t.TempDir(), "compiled_P.pak")
+	if err := Compile(basePak, exmodzPath, compiledPath); err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	compiled := readVirtualPathSet(t, compiledPath)
+	published := readVirtualPathSet(t, publishedPakPath)
+
+	// UE resolves a pak entry at MountPoint + entry path, case-insensitively;
+	// the two paks legitimately split that differently (the author's pak
+	// mounts deeper), so only the joined, case-folded form is comparable.
+	var missing, extra []string
+	for folded, orig := range published {
+		if _, ok := compiled[folded]; !ok {
+			missing = append(missing, orig)
+		}
+	}
+	for folded, orig := range compiled {
+		if _, ok := published[folded]; !ok {
+			extra = append(extra, orig)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	if len(missing) > 0 || len(extra) > 0 {
+		t.Fatalf("compiled pak's virtual paths diverge from the author's published pak:\n"+
+			"  in published pak but not compiled output:\n%s\n"+
+			"  in compiled output but not published pak:\n%s",
+			formatPathList(missing), formatPathList(extra))
+	}
+	t.Logf("%s: %d virtual paths agree with %s (%d bundled assets)",
+		filepath.Base(exmodzPath), len(published), filepath.Base(publishedPakPath), len(bundle.Assets))
+}
+
+// findDualFormPair locates the single .EXMODZ and single published .pak in
+// dir, failing loudly on anything other than exactly one of each — a
+// directory with several candidates would make the test's subject ambiguous.
+func findDualFormPair(t *testing.T, dir string) (exmodzPath, pakPath string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading ICARUS_GOLDEN_MOD_DIR: %v", err)
+	}
+	var exmodzs, paks []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		lower := strings.ToLower(e.Name())
+		switch {
+		case strings.HasSuffix(lower, ".exmodz"):
+			exmodzs = append(exmodzs, filepath.Join(dir, e.Name()))
+		case strings.HasSuffix(lower, ".pak"):
+			paks = append(paks, filepath.Join(dir, e.Name()))
+		}
+	}
+	if len(exmodzs) != 1 || len(paks) != 1 {
+		t.Fatalf("ICARUS_GOLDEN_MOD_DIR must hold exactly one .EXMODZ and one published .pak; found %d .EXMODZ %v and %d .pak %v in %s",
+			len(exmodzs), exmodzs, len(paks), paks, dir)
+	}
+	return exmodzs[0], paks[0]
+}
+
+// readVirtualPathSet opens a pak and returns every entry's full virtual path
+// (mount point + entry path), keyed by its case-folded form for the
+// case-insensitive comparison, with the original spelling as the value for
+// readable failure output.
+func readVirtualPathSet(t *testing.T, pakPath string) map[string]string {
+	t.Helper()
+	r, err := unrealpak.Open(pakPath)
+	if err != nil {
+		t.Fatalf("opening %s: %v", pakPath, err)
+	}
+	defer r.Close() //nolint:errcheck
+
+	set := make(map[string]string)
+	for _, f := range r.Files() {
+		full := path.Join(r.MountPoint(), f.Path)
+		set[strings.ToLower(full)] = full
+	}
+	if len(set) == 0 {
+		t.Fatalf("%s holds no entries", pakPath)
+	}
+	return set
+}
+
+func formatPathList(paths []string) string {
+	if len(paths) == 0 {
+		return "    (none)"
+	}
+	return "    " + strings.Join(paths, "\n    ")
+}


### PR DESCRIPTION
## Summary

Adds the out-of-loop check whose absence let #237 ship: an env-gated golden test in `internal/source/icarus` that compiles a real dual-form mod's `.EXMODZ` with the full `Compile` pipeline (against the installed game's `data.pak`) and asserts the resulting pak's **full virtual paths** (mount point + entry path, case-folded as UE resolves them) exactly match the author's own published `_P.pak` of the same mod.

Every other test in the package builds its fixture base pak with lmm's own writer and reads it back with lmm's own reader — a closed loop that can never catch writer and reader agreeing on the wrong answer. Any future divergence in mount point, `data/` prefix, or asset placement now fails immediately.

## Design

- **Gated like `go-unrealpak`'s `UNREALPAK_TEST_PAK` test**: `t.Skip` when `ICARUS_GOLDEN_MOD_DIR` is unset, so CI and contributors without a game install are unaffected. `ICARUS_GOLDEN_BASE_PAK` overrides the default Steam location of the installed `data.pak`.
- **Refuses to pass for the wrong reason**: a mod that bundles no assets `t.Fatal`s (9 of the 11 known dual-form pairs are table-only and would exercise nothing about asset placement — the exact #237 blind spot).
- The dual-form corpus is copyrighted mod content and is **not** committed; the test points at a local directory, mirroring the realfile-test precedent one layer down.

## Proof it catches #237

With `stripModWrapper` temporarily reverted to the pre-#237 behavior, the test fails:

```
--- FAIL: TestGoldenDualForm_CompiledExmodzMatchesPublishedPak (0.00s)
    golden_test.go:94: compiled pak's virtual paths diverge from the author's published pak:
          in published pak but not compiled output:
            ../../../Icarus/Content/data/Character/C_PlayerTalentGrowth.uasset
            ../../../Icarus/Content/data/Character/C_PlayerTalentGrowth.uexp
            ../../../Icarus/Content/data/Character/C_SoloTalentGrowth.uasset
            ../../../Icarus/Content/data/Character/C_SoloTalentGrowth.uexp
          in compiled output but not published pak:
            ../../../Icarus/Content/Crys_Lvl120Cap_M25/data/Character/C_PlayerTalentGrowth.uasset
            ../../../Icarus/Content/Crys_Lvl120Cap_M25/data/Character/C_PlayerTalentGrowth.uexp
            ../../../Icarus/Content/Crys_Lvl120Cap_M25/data/Character/C_SoloTalentGrowth.uasset
            ../../../Icarus/Content/Crys_Lvl120Cap_M25/data/Character/C_SoloTalentGrowth.uexp
```

With the strip restored it passes against both asset-bearing pairs in the #220 corpus (`Crys_Lvl120Cap_M25`, `Crys_Lvl120Cap_M50`), and the asset-free guard fires correctly against a table-only pair.

## Verification

- `go test ./internal/source/icarus/ -run Golden` → SKIP with no env var
- `gofmt -l ./cmd ./internal` → clean; `go vet ./...` → clean
- `go test ./...` → no failures

Fixes #242 (manual close on merge — develop-merge policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)