### PR TITLE
fix(sources): stop aliasing Description to Summary (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Source adapters no longer alias `Description` to a copy of `Summary`
+  (#235). CurseForge, custom `directory`, and custom `manifest` mods —
+  none of which carry a full description — now leave the field empty, so
+  `lmm mod show` and the TUI details view stop rendering the identical
+  paragraph under both headings; custom `api` sources keep a mapped
+  `description` but no longer fall back to the summary when it is
+  unmapped. JSON contract change: `lmm mod show --json`'s `description`
+  field is now empty for those sources instead of duplicating `summary`.
 - Install-plan dependency resolution now fetches dependencies using the
   LMM game ID (translated through `source_ids` like every other fetch)
   instead of feeding the source's own stamped game ID back into the

--- a/internal/source/curseforge/curseforge.go
+++ b/internal/source/curseforge/curseforge.go
@@ -363,13 +363,15 @@ func modToDomain(data Mod, gameID string) domain.Mod {
 	}
 
 	return domain.Mod{
-		ID:           strconv.Itoa(data.ID),
-		SourceID:     "curseforge",
-		Name:         data.Name,
-		Version:      version,
-		Author:       author,
-		Summary:      data.Summary,
-		Description:  data.Summary, // CurseForge API doesn't include full description in mod response
+		ID:       strconv.Itoa(data.ID),
+		SourceID: "curseforge",
+		Name:     data.Name,
+		Version:  version,
+		Author:   author,
+		Summary:  data.Summary,
+		// Description deliberately left empty: the mod response has no full
+		// description, and copying Summary made every surface showing both
+		// render the same text twice (#235).
 		GameID:       gameID,
 		Category:     category,
 		Downloads:    data.DownloadCount,

--- a/internal/source/curseforge/curseforge_test.go
+++ b/internal/source/curseforge/curseforge_test.go
@@ -541,3 +541,15 @@ func TestCurseForge_ListGames_PropagatesAuthRequired(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, domain.ErrAuthRequired)
 }
+
+// TestModToDomain_DescriptionNotAliasedToSummary (#235): the CurseForge mod
+// response carries no full-description field, and the adapter used to paper
+// over that by copying Summary into Description — so every surface showing
+// both rendered the same paragraph twice. When the source has no description,
+// the field must stay empty.
+func TestModToDomain_DescriptionNotAliasedToSummary(t *testing.T) {
+	mod := modToDomain(Mod{ID: 1, Name: "JEI", Summary: "View Items and Recipes"}, "432")
+
+	assert.Equal(t, "View Items and Recipes", mod.Summary)
+	assert.Empty(t, mod.Description, "Description must not be a copy of Summary (#235)")
+}

--- a/internal/source/custom/directory.go
+++ b/internal/source/custom/directory.go
@@ -155,7 +155,6 @@ func applyMetadata(mod *domain.Mod, info *metadata.Info) {
 	}
 	mod.Version = info.Version
 	mod.Summary = info.Summary
-	mod.Description = info.Summary
 	mod.Author = info.Author
 }
 

--- a/internal/source/custom/directory_test.go
+++ b/internal/source/custom/directory_test.go
@@ -117,6 +117,15 @@ func TestDirectorySearch(t *testing.T) {
 		assert.Equal(t, "my-mods", m.SourceID)
 	})
 
+	t.Run("description is not aliased to summary (#235)", func(t *testing.T) {
+		res, err := d.Search(ctx, source.SearchQuery{Query: "backpack"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		assert.Equal(t, "Carry more stuff", res.Mods[0].Summary)
+		assert.Empty(t, res.Mods[0].Description,
+			"ModInfo metadata has no full-description field; Description must stay empty, not copy Summary")
+	})
+
 	t.Run("fallback parses version from name", func(t *testing.T) {
 		res, err := d.Search(ctx, source.SearchQuery{Query: "plainmod"})
 		require.NoError(t, err)

--- a/internal/source/custom/manifest.go
+++ b/internal/source/custom/manifest.go
@@ -260,14 +260,13 @@ func (m *Manifest) TypeLabel() string { return "manifest" }
 // searchMods / the callers, not here.
 func (m *Manifest) toMod(mm manifestMod) domain.Mod {
 	mod := domain.Mod{
-		ID:          mm.ID,
-		SourceID:    m.id,
-		Name:        mm.Name,
-		Version:     mm.Version,
-		Author:      mm.Author,
-		Summary:     mm.Summary,
-		Description: mm.Summary,
-		SourceURL:   mm.URL,
+		ID:        mm.ID,
+		SourceID:  m.id,
+		Name:      mm.Name,
+		Version:   mm.Version,
+		Author:    mm.Author,
+		Summary:   mm.Summary,
+		SourceURL: mm.URL,
 	}
 	if mm.UpdatedAt != "" {
 		if ts, err := time.Parse(time.RFC3339, mm.UpdatedAt); err == nil {

--- a/internal/source/custom/manifest_test.go
+++ b/internal/source/custom/manifest_test.go
@@ -302,6 +302,15 @@ func TestManifestSearch(t *testing.T) {
 		assert.Equal(t, "Makes things cooler", mod.Summary)
 		assert.Equal(t, "skyrim", mod.GameID)
 	})
+
+	t.Run("description is not aliased to summary (#235)", func(t *testing.T) {
+		res, err := m.Search(ctx, source.SearchQuery{Query: "cool", GameID: "skyrim"})
+		require.NoError(t, err)
+		require.Len(t, res.Mods, 1)
+		assert.Equal(t, "Makes things cooler", res.Mods[0].Summary)
+		assert.Empty(t, res.Mods[0].Description,
+			"the manifest schema has no description field; Description must stay empty, not copy Summary")
+	})
 }
 
 func TestManifestGetMod(t *testing.T) {

--- a/internal/source/custom/mapping.go
+++ b/internal/source/custom/mapping.go
@@ -90,9 +90,6 @@ func mapMod(doc any, mapping map[string]string, sourceID string) (domain.Mod, er
 	mod.Author = pathString(doc, mapping, "author")
 	mod.Summary = pathString(doc, mapping, "summary")
 	mod.Description = pathString(doc, mapping, "description")
-	if mod.Description == "" {
-		mod.Description = mod.Summary
-	}
 	mod.SourceURL = pathString(doc, mapping, "url")
 	mod.PictureURL = pathString(doc, mapping, "picture_url")
 

--- a/internal/source/custom/mapping_test.go
+++ b/internal/source/custom/mapping_test.go
@@ -77,6 +77,29 @@ func TestMapMod(t *testing.T) {
 	assert.Equal(t, "https://x.test/mods/77", mod.SourceURL)
 }
 
+// TestMapModDescription (#235): a mapped description flows through; an
+// unmapped or missing one stays empty instead of falling back to Summary,
+// which made every surface showing both render the same paragraph twice.
+func TestMapModDescription(t *testing.T) {
+	doc := jsonDoc(t, `{"id": 1, "name": "X", "blurb": "short text", "body": "the real full description"}`)
+
+	t.Run("mapped description flows through", func(t *testing.T) {
+		mapping := map[string]string{"id": "id", "name": "name", "summary": "blurb", "description": "body"}
+		mod, err := mapMod(doc, mapping, "s")
+		require.NoError(t, err)
+		assert.Equal(t, "short text", mod.Summary)
+		assert.Equal(t, "the real full description", mod.Description)
+	})
+
+	t.Run("unmapped description stays empty, not aliased to summary", func(t *testing.T) {
+		mapping := map[string]string{"id": "id", "name": "name", "summary": "blurb"}
+		mod, err := mapMod(doc, mapping, "s")
+		require.NoError(t, err)
+		assert.Equal(t, "short text", mod.Summary)
+		assert.Empty(t, mod.Description, "Description must not be a copy of Summary (#235)")
+	})
+}
+
 func TestMapModRequiredFields(t *testing.T) {
 	mapping := map[string]string{"id": "id", "name": "name"}
 

--- a/internal/source/nexusmods/nexusmods_test.go
+++ b/internal/source/nexusmods/nexusmods_test.go
@@ -623,3 +623,17 @@ func TestNexusMods_ValidateKey_WrongKeyAgainstAuthenticatedReceiver(t *testing.T
 	err = nm.ValidateKey(context.Background(), "good-key")
 	assert.NoError(t, err)
 }
+
+// TestModDataToDomain_RealDescriptionFlowsThrough pins the other side of #235:
+// NexusMods is the one source whose API returns a genuine full description,
+// and it must keep flowing into domain.Mod untouched.
+func TestModDataToDomain_RealDescriptionFlowsThrough(t *testing.T) {
+	mod := modDataToDomain(ModData{
+		ModID:       1,
+		Summary:     "short summary",
+		Description: "the real full description",
+	}, "starrupture")
+
+	assert.Equal(t, "short summary", mod.Summary)
+	assert.Equal(t, "the real full description", mod.Description)
+}


### PR DESCRIPTION
Fixes #235.

## Problem

Four of the five source adapters set `Description` to a copy of `Summary` (`curseforge.go:372`, `custom/directory.go:158`, `custom/manifest.go:269`, and `custom/api`'s `mapping.go:93-94` as an unmapped fallback). Only NexusMods carries a real full description, so on every other source both `lmm mod show` and the TUI details view rendered the identical paragraph under both the **Summary:** and **Description:** headings.

## Fix — option (a) from the issue, bounded

Stop aliasing at the adapters and leave `Description` empty when the source genuinely has none. Both surfaces already omit an empty Description block (`cmd/lmm/mod.go:699`, `internal/tui/moddetails.go:64`), so the duplication disappears with no presentation change:

- **CurseForge** (`modToDomain`): field left empty, with a comment pinning why.
- **custom `directory`** (`applyMetadata`): `metadata.Info` has no full-description field (ModInfo.xml's `<Description>` element is a one-liner that maps to `Summary`); the copy is removed.
- **custom `manifest`** (`toMod`): the manifest schema has no `description` field; the copy is removed.
- **custom `api`** (`mapMod`): a mapped `description` still flows through untouched — only the fall-back-to-summary is removed.
- **NexusMods**: unchanged; a new test pins that its real description keeps flowing through.

Description is never persisted in the DB (it is fetched live on the detail path), so there is no stale-data migration concern.

## JSON contract change

`lmm mod show --json` emits `description` raw as a machine contract. For the sources above it is now **empty** instead of duplicating `summary` — it stops asserting a description exists when none does. Called out in the CHANGELOG under `[Unreleased] → Fixed`.

## Goldens: verified untouched, deliberately

The task expected `cmd/lmm/testdata/mod_show_golden/` to need re-recording. It does not, and that is structural, not luck: the golden fixtures are **hand-built `domain.Mod` values** (`richMod` has a genuinely distinct Description; the sparse case has none), never routed through a source adapter. Verified empirically by running `go test ./cmd/lmm -run TestModShowGolden -update-modshow` and confirming `git diff` shows zero byte drift.

## Tests (test-first)

New failing-first tests, each confirmed red on the pre-fix code with "Should be empty, but was `<summary text>`":

- `curseforge`: `TestModToDomain_DescriptionNotAliasedToSummary`
- `custom`: `TestDirectorySearch/description is not aliased to summary (#235)`
- `custom`: `TestManifestSearch/description is not aliased to summary (#235)`
- `custom`: `TestMapModDescription` (mapped description flows through; unmapped stays empty)
- `nexusmods`: `TestModDataToDomain_RealDescriptionFlowsThrough` (pin; passes before and after)

`gofmt -l`, `go vet ./...`, and `go test ./...` are all clean.

## Follow-up filed

The issue's speculation is confirmed: CurseForge exposes `GET /v1/mods/{modId}/description` returning the full description as HTML. Wiring it up is a feature (new API round-trip), excluded from this cleanup per the scope boundary — filed as #246.

No version bump (story PR into develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)