### PR TITLE
fix(tui): collapse help rows by priority so headline actions survive (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TUI: the help panel's `+N more` collapse now drops rows by priority
+  instead of purely by position, so a screen's headline action (e.g. the
+  Search screen's `enter: open mod details` row, formerly last in its
+  group and swallowed entirely at a normal 100x30 terminal) stays
+  visible however large its group grows (#234). Only the current
+  screen's (or pushed content's) group gets this treatment — other
+  screens' rows still collapse positionally.
 - Install-plan dependency resolution now fetches dependencies using the
   LMM game ID (translated through `source_ids` like every other fetch)
   instead of feeding the source's own stamped game ID back into the

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2756,20 +2756,38 @@ func healthScanLabel(now time.Time, at *time.Time, full bool, checked int, hasFi
 // lowercase per Task 9's copy convention (see helpGroups).
 type helpGroup struct {
 	name    string
-	entries []string
+	entries []helpItem
+}
+
+// helpItem is one row of a helpGroup plus its collapse priority: keep marks
+// a screen's headline action so helpView's "+N more" cap drops unmarked
+// rows first (#234) instead of tail-dropping purely by position - which
+// used to swallow the search group's LAST entry (enter: open mod details)
+// at a normal 100x30 size. The marker only takes effect while the row's
+// group is promoted (see helpView); an unpromoted group's headline can't
+// force itself into another screen's help window.
+type helpItem struct {
+	text string
+	keep bool
+}
+
+// kept returns a copy of the item marked as its group's headline action.
+func (i helpItem) kept() helpItem {
+	i.keep = true
+	return i
 }
 
 // helpRow formats a single help-panel row: left-aligned key (16 chars),
 // space, description.
-func helpRow(key, desc string) string {
-	return fmt.Sprintf("%-16s %s", key, desc)
+func helpRow(key, desc string) helpItem {
+	return helpItem{text: fmt.Sprintf("%-16s %s", key, desc)}
 }
 
 // helpEntry formats one keybinding as a help-panel row, reusing the
 // binding's own key.WithHelp key/description from keys.go rather than
 // restating it - the single source of truth for "what does this key do"
 // stays in DefaultKeyMap.
-func helpEntry(kb key.Binding) string {
+func helpEntry(kb key.Binding) helpItem {
 	h := kb.Help()
 	return helpRow(h.Key, h.Desc)
 }
@@ -2784,7 +2802,7 @@ func helpEntry(kb key.Binding) string {
 func (m Model) helpGroups() []helpGroup {
 	global := helpGroup{
 		name: "global",
-		entries: []string{
+		entries: []helpItem{
 			helpEntry(m.keys.Quit),
 			helpEntry(m.keys.Help),
 			helpEntry(m.keys.NextScreen),
@@ -2796,13 +2814,13 @@ func (m Model) helpGroups() []helpGroup {
 
 	dashboard := helpGroup{
 		name: "dashboard",
-		entries: []string{
+		entries: []helpItem{
 			// Select ("enter") is context-dependent (see updateKey): on
 			// the Dashboard it opens the selected menu entry
 			// (openSelectedMenuEntry), so the description is written out
 			// here rather than reusing keys.go's generic "open" - the same
 			// ad-hoc shape as the profiles group's "switch profile" below.
-			helpRow(m.keys.Select.Help().Key, "open menu entry"),
+			helpRow(m.keys.Select.Help().Key, "open menu entry").kept(),
 			helpEntry(m.keys.Deploy),
 			helpEntry(m.keys.CheckUpdates),
 			helpEntry(m.keys.Purge),
@@ -2811,13 +2829,13 @@ func (m Model) helpGroups() []helpGroup {
 
 	installedMods := helpGroup{
 		name: "installed mods",
-		entries: []string{
+		entries: []helpItem{
 			// Select is #86's enter-opens-details binding. Hand-written
 			// (not helpEntry) for the same reason the dashboard's and
 			// profiles' own rows above are: keys.go's Select.Help() is the
 			// generic "enter"/"open" shared across every screen it applies
 			// to, and never says WHAT it opens - smoke round 2's finding 2.
-			helpRow(m.keys.Select.Help().Key, "open mod details"),
+			helpRow(m.keys.Select.Help().Key, "open mod details").kept(),
 			helpEntry(m.keys.ToggleEnable),
 			helpEntry(m.keys.Uninstall),
 			helpEntry(m.keys.Deploy),
@@ -2853,7 +2871,7 @@ func (m Model) helpGroups() []helpGroup {
 
 	search := helpGroup{
 		name: "search",
-		entries: []string{
+		entries: []helpItem{
 			helpEntry(m.keys.Search),
 			// Submit and Select share the same physical key ("enter") but
 			// fire in mutually exclusive states (updateKey's focused-input
@@ -2864,8 +2882,13 @@ func (m Model) helpGroups() []helpGroup {
 			// round 2's finding 2: listing both via helpEntry rendered
 			// "enter / search" next to "enter / open" with nothing saying
 			// which state either applies to, so both are hand-written here
-			// instead, each naming its own state explicitly.
-			helpRow(m.keys.Submit.Help().Key, "search (query input focused)"),
+			// instead, each naming its own state explicitly. Both are the
+			// screen's headline actions - the two mutually exclusive things
+			// enter does here - so both are kept() ahead of the collapse
+			// (#234): Submit's row happens to sit early enough to survive
+			// positionally at 100x30 today, but that's an accident of entry
+			// count, not a guarantee.
+			helpRow(m.keys.Submit.Help().Key, "search (query input focused)").kept(),
 			helpEntry(m.keys.Blur),
 			helpEntry(m.keys.NextPage),
 			helpEntry(m.keys.PrevPage),
@@ -2873,20 +2896,22 @@ func (m Model) helpGroups() []helpGroup {
 			helpEntry(m.keys.Install),
 			// Select is #86's enter-opens-details binding - fires with the
 			// input blurred and a result selected, mirroring Install's own
-			// scoping (see openSelectedModDetails).
-			helpRow(m.keys.Select.Help().Key, "open mod details (input blurred, result selected)"),
+			// scoping (see openSelectedModDetails). kept() is #234's actual
+			// fix: this row is the group's LAST entry, and the positional
+			// tail-collapse used to swallow it at a normal 100x30 size.
+			helpRow(m.keys.Select.Help().Key, "open mod details (input blurred, result selected)").kept(),
 		},
 	}
 
 	profiles := helpGroup{
 		name: "profiles",
-		entries: []string{
+		entries: []helpItem{
 			// Select ("enter") is context-dependent (see updateKey): on
 			// Profiles it switches, not "open" like keys.go's generic
 			// Select.Help() says elsewhere - so this one entry is written
 			// out rather than reusing helpEntry, matching the actual
 			// behavior on this screen.
-			helpRow(m.keys.Select.Help().Key, "switch profile"),
+			helpRow(m.keys.Select.Help().Key, "switch profile").kept(),
 			helpEntry(m.keys.CreateProfile),
 			helpEntry(m.keys.DeleteProfile),
 			// ImportProfile is Task 9's import binding (see mutations.go's
@@ -2903,7 +2928,7 @@ func (m Model) helpGroups() []helpGroup {
 	// other than health below.
 	sources := helpGroup{
 		name: "sources",
-		entries: []string{
+		entries: []helpItem{
 			helpEntry(m.keys.ToggleAllSources),
 		},
 	}
@@ -2926,7 +2951,7 @@ func (m Model) helpGroups() []helpGroup {
 	// guard, mutations.go) for that remedy to be actionable in place.
 	health := helpGroup{
 		name: "health",
-		entries: []string{
+		entries: []helpItem{
 			helpEntry(m.keys.HealthScreen),
 			helpEntry(m.keys.Up),
 			helpEntry(m.keys.Down),
@@ -3007,14 +3032,20 @@ func (m Model) helpView() string {
 	width := m.availableWidth()
 	panelContentWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
 
-	var body []string
+	// The keep marker is honored only for the promoted group - index 1,
+	// immediately after "global", per helpGroups' ordering contract (the
+	// current screen's group, or pushed content's HelpGroup()). Any other
+	// group's headline describes a screen the user is NOT on, and letting
+	// it survive would force header-less rows from distant groups into the
+	// few visible lines at the current screen's expense (#234).
+	var body []helpItem
 	for i, g := range m.helpGroups() {
 		if i > 0 {
-			body = append(body, "")
+			body = append(body, helpItem{})
 		}
-		body = append(body, truncate(m.theme.PanelTitle.Render(g.name), panelContentWidth))
+		body = append(body, helpItem{text: truncate(m.theme.PanelTitle.Render(g.name), panelContentWidth)})
 		for _, e := range g.entries {
-			body = append(body, truncate(e, panelContentWidth))
+			body = append(body, helpItem{text: truncate(e.text, panelContentWidth), keep: e.keep && i == 1})
 		}
 	}
 
@@ -3022,11 +3053,36 @@ func (m Model) helpView() string {
 	budget := m.helpBodyBudget()
 	if len(body) > budget {
 		shown := max(budget-1, 0)
-		more := len(body) - shown
-		lines = append(lines, body[:shown]...)
-		lines = append(lines, truncate(m.theme.MutedText.Render(fmt.Sprintf("+%d more", more)), panelContentWidth))
+		// Drop by priority, not position (#234): walk from the tail
+		// dropping unkept rows first, so a kept headline row survives
+		// wherever it sits in its group; only when fewer than `shown` rows
+		// are unkept does a second pass reach the kept ones. Survivors
+		// render in their original order, so the "+N more" tail can stand
+		// in for rows dropped from the middle, not just below it.
+		drop := len(body) - shown
+		dropped := make([]bool, len(body))
+		for i := len(body) - 1; i >= 0 && drop > 0; i-- {
+			if !body[i].keep {
+				dropped[i] = true
+				drop--
+			}
+		}
+		for i := len(body) - 1; i >= 0 && drop > 0; i-- {
+			if !dropped[i] {
+				dropped[i] = true
+				drop--
+			}
+		}
+		for i, item := range body {
+			if !dropped[i] {
+				lines = append(lines, item.text)
+			}
+		}
+		lines = append(lines, truncate(m.theme.MutedText.Render(fmt.Sprintf("+%d more", len(body)-shown)), panelContentWidth))
 	} else {
-		lines = append(lines, body...)
+		for _, item := range body {
+			lines = append(lines, item.text)
+		}
 	}
 
 	return m.panel(width).Render(strings.Join(lines, "\n"))

--- a/internal/tui/health_screen_test.go
+++ b/internal/tui/health_screen_test.go
@@ -548,7 +548,7 @@ func (f *fakeContextContent) HandleKey(msg tea.KeyMsg) (contextContent, tea.Cmd,
 }
 
 func (f *fakeContextContent) HelpGroup() helpGroup {
-	return helpGroup{name: "fake", entries: []string{"x", "press"}}
+	return helpGroup{name: "fake", entries: []helpItem{{text: "x"}, {text: "press"}}}
 }
 
 // TestHealthContextHostPushRenderKeyAndEscPop is the SPEC-CRITERION-4 proof:

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -163,7 +163,9 @@ func TestHelpViewEnterRowsDisambiguated(t *testing.T) {
 // a normal terminal size (100x30), not just in helpGroups' unrendered data -
 // it's the group's first entry, so helpBodyBudget's "+N more" tail-collapse
 // (which starts biting well before the full grouped list at this size, per
-// TestHelpViewSearchEnterRowCollapsedAtNormalSize below) never reaches it.
+// TestHelpViewSearchEnterRowSurvivesCollapseAtNormalSize below) never
+// reaches it - and since #234 it is also marked kept(), so it would survive
+// even if later entries were reordered above it.
 func TestHelpViewInstalledModsEnterRowSurvivesAtNormalSize(t *testing.T) {
 	t.Parallel()
 
@@ -176,19 +178,22 @@ func TestHelpViewInstalledModsEnterRowSurvivesAtNormalSize(t *testing.T) {
 		"installed mods help group must say what enter opens, at a normal terminal size")
 }
 
-// TestHelpViewSearchEnterRowCollapsedAtNormalSize documents a finding from
-// verifying the smoke-fix brief's request ("check the enter row actually
-// survives... at 100x30"): on the Search screen, Select's disambiguated row
-// ("open mod details...") is the group's LAST entry, and at 100x30 it does
-// NOT survive - helpBodyBudget's "+N more" tail-collapse swallows it before
-// rendering reaches it (Submit's row, earlier in the group, does survive).
-// This is a PRE-EXISTING helpBodyBudget limitation, not a regression from
-// this fix: the search group's entry COUNT is unchanged (8 before and
-// after - see helpGroups), only two of its existing entries' wording
-// changed. Left as-is per the brief's explicit instruction not to
-// restructure the help system to fix this without checking first; flagged
-// in this fix's own report instead.
-func TestHelpViewSearchEnterRowCollapsedAtNormalSize(t *testing.T) {
+// TestHelpViewSearchEnterRowSurvivesCollapseAtNormalSize is #234's
+// regression test, deliberately inverted from the characterization test
+// (TestHelpViewSearchEnterRowCollapsedAtNormalSize) that used to pin the
+// bug it fixes: on the Search screen, Select's disambiguated row ("open mod
+// details...") is the group's LAST entry, and at 100x30 helpBodyBudget's
+// "+N more" tail-collapse used to swallow it before rendering reached it -
+// the screen's headline action was undiscoverable from its own help panel.
+// The collapse now drops by priority, not position: rows marked kept() in
+// the promoted (current-screen) group survive wherever they sit, so BOTH of
+// the search group's hand-written headline rows - Submit's ("query input
+// focused") and Select's ("open mod details...") - must render. The
+// "+N more" tail must ALSO still be present: the rows survive because the
+// collapse prefers them, not because the budget grew - a raised budget
+// would regress the terminal-bounds invariant
+// (TestHelpViewCapsWithMoreTailAtSmallHeight) instead.
+func TestHelpViewSearchEnterRowSurvivesCollapseAtNormalSize(t *testing.T) {
 	t.Parallel()
 
 	model := sizedPrototypeModel(t, "wizardry", 100, 30)
@@ -197,9 +202,9 @@ func TestHelpViewSearchEnterRowCollapsedAtNormalSize(t *testing.T) {
 
 	view := model.View()
 	require.Contains(t, view, "query input focused",
-		"submit's disambiguated row survives at 100x30 (earlier in the group)")
-	require.NotContains(t, view, "open mod details",
-		"select's disambiguated row is collapsed away by helpBodyBudget at 100x30 - a pre-existing limitation")
+		"submit's disambiguated row must survive the collapse at 100x30")
+	require.Contains(t, view, "open mod details",
+		"select's disambiguated row (the screen's headline action) must survive the collapse at 100x30 (#234)")
 	require.Regexp(t, `\+\d+ more`, view,
-		"the search group's tail is in fact collapsed at this size")
+		"the search group's tail must still collapse at this size - survival comes from priority, not a raised budget")
 }

--- a/internal/tui/moddetails.go
+++ b/internal/tui/moddetails.go
@@ -174,7 +174,7 @@ func (c *modDetailsContent) HandleKey(msg tea.KeyMsg) (contextContent, tea.Cmd, 
 func (c *modDetailsContent) HelpGroup() helpGroup {
 	return helpGroup{
 		name: "mod details",
-		entries: []string{
+		entries: []helpItem{
 			helpRow("↑/↓", "scroll"),
 			helpRow("esc", "back"),
 		},


### PR DESCRIPTION
Fixes #234

## Problem

`helpBodyBudget`'s `+N more` cap tail-collapsed the flat help body purely by position. The Search group has 8 entries and its headline action — `enter    open mod details (input blurred, result selected)`, added by #86 — sits **last**, so at a normal 100x30 terminal it was collapsed away entirely: a user opening the help panel on Search could not discover that `enter` opens mod details.

## Fix (issue's option 3 — drop by priority, not position)

- Help entries are now `helpItem`s (`text` + `keep`) with an explicit `kept()` marker; `helpRow`/`helpEntry` return them, so group definitions keep their existing shape.
- The collapse walks from the tail dropping **unmarked** rows first, so a marked row survives wherever it sits in its group; survivors render in original order with the `+N more` tail standing in for rows dropped from the middle. Only if fewer than `budget-1` rows are unmarked does a second pass reach the kept ones.
- The marker is honored **only for the promoted group** (index 1 — the current screen's group, or pushed content's `HelpGroup()`): another screen's headline describing a screen the user is not on can't force header-less rows into the few visible lines.
- Marked rows: the hand-written per-screen `enter` rows — dashboard's "open menu entry", installed mods' "open mod details", Search's Submit **and** Select pair (the two mutually exclusive things `enter` does there), profiles' "switch profile".
- `helpBodyBudget` itself is untouched (options 1/2 rejected per the issue), so the panel occupies exactly the same rows and the terminal-bounds invariants are unaffected. This also stays fixed the next time a group grows — the ~20-entry installed-mods group already has its headline first *and* marked.

At 100x30 on Search the panel now renders both headline rows under the `search` header, with the `/ focus` row moving into the tail (it remains hinted inline in the search box itself):

```
│ search                                                       │
│ enter            search (query input focused)                │
│ enter            open mod details (input blurred, result se… │
│ +46 more                                                     │
```

## Characterization test — deliberately inverted

`TestHelpViewSearchEnterRowCollapsedAtNormalSize` pinned the broken behavior by design. It is **not deleted**: it's inverted into `TestHelpViewSearchEnterRowSurvivesCollapseAtNormalSize`, which requires at 100x30 on Search that (1) Submit's "query input focused" row renders, (2) Select's "open mod details" row renders, and (3) the `+N more` tail is **still present** — proving the rows survive because the collapse prefers them, not because the budget grew (a raised budget would regress the bounds invariant instead). Confirmed failing before the fix (`does not contain "open mod details"`), passing after.

## Verification

- `gofmt -l ./cmd ./internal` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass, including the small-terminal suites (`TestHelpViewCapsWithMoreTailAtSmallHeight` at 80x24, `TestViewFitsTerminalBoundsWithHelpVisible`, `TestScreenViewsFitHeightBudgetAtAllSizes`, …) — the panel still fits 80x24 exactly.

No version bump (story PR); CHANGELOG entry added at the top of `### Fixed` under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)