### PR TITLE
fix(core): claim only the fileID's own cache member in pak reconcile (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pak-manifest reconciliation now claims only the cache member(s) actually
+  belonging to the pak file ID being marked — matched by content against
+  that file ID's retained source — instead of the entry-wide cache union
+  (#241). A mod carrying a second pak-kind file ID (no real mod ships one
+  today) would previously have had the first file ID's pak silently
+  attributed to the second as well, feeding wrong provenance into
+  deploy/prune decisions.
 - Install-plan dependency resolution now fetches dependencies using the
   LMM game ID (translated through `source_ids` like every other fetch)
   instead of feeding the source's own stamped game ID back into the

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -466,27 +466,34 @@ func (s *Service) reconcilePakManifests(ctx context.Context, game *domain.Game, 
 					return warnings, fmt.Errorf("flipping %s to merged-claimed: %w", ref, werr)
 				}
 			} else {
-				// Assumes one pak-kind fileID per mod (today's only real
-				// shape): members claims EVERY file in the cache entry
-				// (gameCache.ListFiles' full union), not just this fileID's
-				// own file. deployableFiles unions every recorded
-				// manifest's members before narrowing (internal/core/
-				// deployable.go), so if a mod ever carried a SECOND pak
-				// fileID, this branch's mark would double-claim the first
-				// fileID's member as if it belonged to the second too.
-				members, lerr := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+				// #241 fix: claim ONLY the member(s) belonging to THIS
+				// fileID, never gameCache.ListFiles' entry-wide union.
+				// deployableFiles unions every recorded manifest's members
+				// before narrowing (internal/core/deployable.go), so a mod
+				// carrying a SECOND pak fileID would have had the first
+				// fileID's member claimed as if it belonged to the second
+				// too. ListFiles still supplies the candidates;
+				// rawPakMembers narrows them to this fileID's own member(s)
+				// by content identity with its retained source - see its
+				// doc comment for why that is the one attribution that
+				// survives a convert flip.
+				files, lerr := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
 				if lerr != nil {
 					return warnings, lerr
 				}
+				members, aerr := rawPakMembers(versionDir, retained, files)
+				if aerr != nil {
+					return warnings, aerr
+				}
 				// #221 partial-failure fix: a manifest-shape match alone
-				// (recorded + member count) does not prove the raw pak is
-				// ACTUALLY deployed - the mark below must be written BEFORE
-				// Install (Installer.Install's deployableFiles narrowing
-				// reads THIS manifest to decide what to deploy, so writing
-				// the target members first is what makes Install deploy
-				// the right file at all; unlike the participating branch
-				// above, this order can't be flipped). That means a PRIOR
-				// pass's Install could have failed AFTER the mark was
+				// (recorded + matching member set) does not prove the raw
+				// pak is ACTUALLY deployed - the mark below must be written
+				// BEFORE Install (Installer.Install's deployableFiles
+				// narrowing reads THIS manifest to decide what to deploy,
+				// so writing the target members first is what makes Install
+				// deploy the right file at all; unlike the participating
+				// branch above, this order can't be flipped). That means a
+				// PRIOR pass's Install could have failed AFTER the mark was
 				// already written, leaving the manifest saying "raw" while
 				// nothing is actually on disk - a shape-only check would
 				// then treat that as converged forever. Confirming every
@@ -494,7 +501,7 @@ func (s *Service) reconcilePakManifests(ctx context.Context, game *domain.Game, 
 				// (mirroring syncMergedPak's own outer fast-path stat
 				// check for the merged artifact) closes that gap: the next
 				// reconcile pass retries instead of masking it.
-				if recorded && len(currentMembers) == len(members) && len(members) > 0 && allMembersDeployed(game.ModPath, currentMembers) {
+				if recorded && len(members) > 0 && sameMemberSet(currentMembers, members) && allMembersDeployed(game.ModPath, currentMembers) {
 					continue // already converged (raw)
 				}
 				if werr := cache.MarkFileCompleteWithMembers(versionDir, fileID, members); werr != nil {
@@ -522,6 +529,77 @@ func allMembersDeployed(modPath string, members []string) bool {
 		if _, err := os.Stat(filepath.Join(modPath, m)); err != nil {
 			return false
 		}
+	}
+	return true
+}
+
+// rawPakMembers returns the version-dir-relative cache members that belong
+// to ONE pak fileID (#241): the candidate entry files whose content matches
+// the fileID's retained source at retainedPath. Ingest stages a
+// convert-eligible pak's deployable copy from the SAME bytes as its
+// retained source (DownloadModToCache and Import both copy the one archive
+// to both names), and that copy is the only member a pak fileID ever
+// contributes - so content identity with the retained source IS the
+// cache's fileID->member attribution. It is also the only attribution that
+// survives a convert flip: the participating branch's members=nil mark
+// erases the ingest-time manifest, so the way BACK to raw cannot simply
+// read the mapping from FileManifests.
+//
+// Size is compared before hashing, so unrelated candidates (sibling
+// fileIDs' members) are skipped without reading their bytes; the retained
+// source itself is hashed at most once. Two pak fileIDs with byte-identical
+// content would each claim both copies - degenerate but harmless: the
+// claimed union (what deploy and prune consume) is identical either way.
+func rawPakMembers(versionDir, retainedPath string, candidates []string) ([]string, error) {
+	retainedInfo, err := os.Stat(retainedPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading retained source: %w", err)
+	}
+	var retainedSum string
+	var members []string
+	for _, f := range candidates {
+		fullPath := filepath.Join(versionDir, f)
+		info, err := os.Stat(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading cache member %s: %w", f, err)
+		}
+		if info.Size() != retainedInfo.Size() {
+			continue
+		}
+		if retainedSum == "" {
+			if retainedSum, err = md5File(retainedPath); err != nil {
+				return nil, fmt.Errorf("hashing retained source: %w", err)
+			}
+		}
+		sum, err := md5File(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("hashing cache member %s: %w", f, err)
+		}
+		if sum == retainedSum {
+			members = append(members, f)
+		}
+	}
+	return members, nil
+}
+
+// sameMemberSet reports whether a and b claim the same members, ignoring
+// order: the two sides come from different producers (a manifest read back
+// in mark-time order vs a fresh ListFiles walk), and "same claim" is a set
+// property. Duplicates are counted, not collapsed, so a doubled entry on
+// one side can never mask a missing one.
+func sameMemberSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, m := range a {
+		counts[m]++
+	}
+	for _, m := range b {
+		if counts[m] == 0 {
+			return false
+		}
+		counts[m]--
 	}
 	return true
 }

--- a/internal/core/merged_pak_test.go
+++ b/internal/core/merged_pak_test.go
@@ -334,6 +334,78 @@ func TestReconcilePakManifests_ConvertedPath_UninstallFailureRetries(t *testing.
 	require.Empty(t, manifests["pak"].Members, "the retry must converge to merged-claimed")
 }
 
+// TestReconcilePakManifests_TwoPakFileIDs_EachClaimsOwnMember proves the
+// #241 fix: the raw-fallback branch must claim ONLY the member(s) belonging
+// to the fileID being marked, never the entry-wide cache union. No real mod
+// carries two pak-kind fileIDs today, so this constructs the synthetic shape
+// the assumption breaks under: one mod, two pak fileIDs, each with its own
+// retained source and deployable copy, both manifests in the post-convert
+// state (members=nil - the state a flip BACK to raw starts from, where the
+// ingest-time attribution has already been erased). Pre-#241, reconcile
+// marked each fileID with gameCache.ListFiles' full union, double-claiming
+// the sibling's member.
+//
+// Member names are deliberately unrelated to the fileIDs (the download path
+// names members after DownloadableFile.FileName, which bears no relation to
+// the fileID), and both paks are the SAME size with different content, so
+// only content identity with the fileID's own retained source can attribute
+// them - not name matching, not size matching.
+func TestReconcilePakManifests_TwoPakFileIDs_EachClaimsOwnMember(t *testing.T) {
+	svc, game, _ := newMergedPakTestGame(t)
+	// game.ConvertPaks stays false: every pak fileID takes the raw-fallback
+	// branch (opted out at game level), no failedByRef needed.
+
+	const (
+		sourceID   = "fake-compiler"
+		modID      = "twopak"
+		version    = "1.0"
+		mainFileID = "pak"      // download-path shape: the literal icarus fileID
+		liteFileID = "lite.pak" // a hypothetical second pak variant ("lite" build)
+	)
+	// Same length, different bytes - size alone cannot tell them apart.
+	mainContent := []byte("main-pak-bytes")
+	liteContent := []byte("lite-pak-bytes")
+
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, cache.RetainedSourceName(mainFileID), mainContent))
+	require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, "MainMod.pak", mainContent))
+	require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, cache.RetainedSourceName(liteFileID), liteContent))
+	require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, "LiteMod.pak", liteContent))
+
+	versionDir := gameCache.ModPath(game.ID, sourceID, modID, version)
+	require.NoError(t, cache.MarkFileCompleteWithMembers(versionDir, mainFileID, nil))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(versionDir, liteFileID, nil))
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: sourceID, Name: modID, Version: version, GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		FileIDs:      []string{mainFileID, liteFileID},
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: sourceID, ModID: modID, Version: version, FileIDs: []string{mainFileID, liteFileID}}))
+
+	gc := svc.GetGameCache(game)
+	inst := core.NewInstaller(gc, linker.New(game.LinkMethod), nil)
+	_, err := svc.ReconcilePakManifestsForTest(context.Background(), game, "default", inst, nil)
+	require.NoError(t, err)
+
+	manifests, err := gameCache.FileManifests(game.ID, sourceID, modID, version)
+	require.NoError(t, err)
+	require.Equal(t, []string{"MainMod.pak"}, manifests[mainFileID].Members,
+		"each pak fileID's manifest must claim exactly its own member, not the entry-wide union (#241)")
+	require.Equal(t, []string{"LiteMod.pak"}, manifests[liteFileID].Members,
+		"the second pak fileID must not double-claim the first's member (#241)")
+
+	// Both raw paks must still actually deploy - narrowing the claim must
+	// not narrow the deployed set.
+	_, err = os.Stat(filepath.Join(game.ModPath, "MainMod.pak"))
+	require.NoError(t, err, "the first fileID's raw pak must be deployed")
+	_, err = os.Stat(filepath.Join(game.ModPath, "LiteMod.pak"))
+	require.NoError(t, err, "the second fileID's raw pak must be deployed")
+}
+
 // TestReconcilePakManifests_RawFallbackPath_InstallFailureRetries proves
 // the #221 fix for the raw-fallback branch: a manifest that already
 // records the target ("raw") member shape is not trusted as proof of an


### PR DESCRIPTION
Fixes #241.

## Problem

`reconcilePakManifests`' raw-fallback branch (internal/core/merged_pak.go) marked a pak fileID's manifest with `gameCache.ListFiles(...)` — the **entry-wide union** of every file in the mod's cache entry, not just the file belonging to the fileID being marked. Since `deployableFiles` unions every recorded manifest's members before narrowing, a mod carrying a second pak-kind fileID would have the first fileID's member silently claimed as though it also belonged to the second, feeding wrong provenance into deploy/prune decisions. The assumption ("one pak fileID per mod") was documented only in a code comment, accepted at #221 merge time because no real mod ships that shape.

## How the fix attributes members

The cache's fileID→member mapping is the marker manifest (`cache.FileManifests`), written at ingest — but reconcile's own *participating* branch erases it when a pak converts (`MarkFileCompleteWithMembers(..., nil)`), so the flip **back** to raw (opt-out or merge failure after a successful convert — the main raw-fallback scenario) cannot read the mapping back.

The one durable per-fileID anchor is the **retained source** (`.lmm-source-<Base(fileID)>`): ingest stages a convert-eligible pak's deployable copy from the *same bytes* as its retained source (`DownloadModToCache` and `Import` both `copyFileStreaming` the one archive to both names), and that copy is the only member a pak fileID ever contributes. The new `rawPakMembers` therefore claims exactly the entry files whose content matches the fileID's retained source (size prefilter, then MD5 via the existing `md5File`; the retained source is hashed at most once). This is the same md5-per-sync cost class `currentMergedFingerprint` already accepts for participating retained paks — and it is only paid on non-converged passes (an actual flip), never on the converged fast path.

The convergence pre-check's member-count comparison becomes a set comparison against the per-fileID members (`sameMemberSet`), since "entry gained a file" no longer means "this fileID must re-claim it" — a new entry file belongs to whichever fileID ingested it.

## Tests (test-first)

`TestReconcilePakManifests_TwoPakFileIDs_EachClaimsOwnMember` constructs the synthetic two-pak-fileID shape (no real mod has it): one mod, two pak fileIDs, each with its own retained source + deployable copy, both manifests in the post-convert `members=nil` state; member names deliberately unrelated to the fileIDs and both paks the same size with different bytes, so only content identity can attribute them. **Verbatim failure on pre-fix code:**

```
--- FAIL: TestReconcilePakManifests_TwoPakFileIDs_EachClaimsOwnMember (0.00s)
    	Error:      	Not equal:
    	            	expected: []string{"MainMod.pak"}
    	            	actual  : []string{"LiteMod.pak", "MainMod.pak"}
    	Messages:   	each pak fileID's manifest must claim exactly its own member, not the entry-wide union (#241)
```

The ordinary one-pak path is pinned unchanged by the existing suite: `TestPakConvertEndToEnd` step 2 (convert → opt-out must restore `["pakmod.pak"]` exactly), `TestReconcilePakManifests_RawFallbackPath_InstallFailureRetries` (convergence never trusts manifest shape alone), and `TestDownloadPakRetainsAndDeploysRaw` (ingest-time sole-member manifest) — all pass unmodified.

## Verification

- `gofmt -l ./cmd ./internal` → clean
- `go vet ./...` → clean
- `go test ./...` → all 18 packages pass, no failures

No version bump (story PR); CHANGELOG entry added under `[Unreleased]` → `### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)