### PR TITLE
docs: archive the v1.30.0 plan docs

### DIFF
--- a/docs/plans/archive/2026-08-05-icarus-pak-to-exmod-spike-design.md
+++ b/docs/plans/archive/2026-08-05-icarus-pak-to-exmod-spike-design.md
@@ -1,0 +1,181 @@
+# Spike Design: Icarus PAK → EXMOD Internal Conversion
+
+**Date:** 2026-08-05
+**Status:** Approved design — spike not yet executed
+**Type:** Spike (feasibility investigation; throwaway prototype + findings doc; no production code lands)
+**Branch:** `spike/pak-to-exmod` (unmerged; per the plan-doc durability convention)
+
+## Problem
+
+Prebuilt PAK mods cannot participate in the profile-level merged pak
+(`zzz_LMM_Merged_P.pak`). The merged pak deliberately sorts last so it wins
+same-path conflicts — which means a pak mod's table override is silently
+discarded whenever the merged pak touches the same table. Only ~41 of ~538
+catalog mods ship an `.exmodz` alternative; the rest are pak-only and locked
+out of the merge model entirely.
+
+**Spike question:** can lmm internally convert a prebuilt PAK mod into an
+EXMOD-equivalent form (a synthesized `.exmodz`) so pak mods participate in the
+merged pak exactly like exmodz mods?
+
+## What recon established (2026-08-05, from archived docs + current code)
+
+- **Reading mod paks is solved.** `internal/unrealpak.Reader` enumerates and
+  extracts arbitrary v11 paks (`Files()`, `ReadFile()`); proven against
+  173k entries across 34 paks and against real third-party mod paks. Every
+  prebuilt mod pak inspected declared an _empty_ CompressionMethods table
+  (all entries stored) — no decompression needed; Zlib is covered anyway.
+- **The injection seam is clean.** Merge membership is discovered solely by a
+  retained-source cache marker (`enabledExmodzSources` →
+  `cache.RetainedSourceName(fileID)`). If ingest retains a synthesized
+  `.exmodz` for a pak, everything downstream (merge, fingerprint,
+  manifest-aware deploy, purge) works unchanged.
+- **No diff-derive code exists.** The entire pipeline is diff-_apply_
+  (`ParseExmod`, `ApplyRowPatch`). The differ is the spike's genuinely new
+  work.
+- **Ground truth exists.** ~41 dual-form mods (pak + author's own exmodz);
+  additionally some paks embed the original `.EXMOD` inside the pak
+  (e.g. Intreegs4XP's `data.EXMOD` entry) — an exact, zero-inference check.
+- **Known hazards:**
+  - Prebuilt tables are _stale whole-table snapshots_ (measured: 167 rows in
+    a mod pak's table vs 374 in live base). A converter must diff against the
+    live base `data.pak` and treat base-rows-absent-from-the-pak as
+    staleness, never deletions (EXMOD has no delete verb).
+  - The `data/` boundary floats between mount point and entry path per mod
+    (Intreegs4XP: mount `.../Content/` + entry `data/Experience/…`;
+    FloofLevelCap: mount `.../Content/data/Character/` + entry
+    `D_CharacterGrowth.json`). Normalization must treat mount+entry as a pair.
+  - Asset-bearing prebuilt paks were never dissected; their layout is
+    inferred only.
+  - EXMOD cannot express: row deletions, `Defaults`/`RowStruct` changes,
+    sub-field-level nested partials (shallow row-field merge only).
+  - Pak entry names are untrusted; same sanitation discipline as
+    `sanitizeAssetPath` applies.
+
+## Spike Questions
+
+1. **Path normalization** — can mount-point + entry-path pairs be normalized
+   reliably across real mod paks to base-table mount-relative paths?
+2. **Differ fidelity** — does a `Name`-keyed row differ against the _live_
+   base tables reproduce author intent? (Ground truth: dual-form mods +
+   embedded `data.EXMOD` where present.)
+3. **Convertibility census** — what fraction of corpus paks are convertible
+   (tables-only) vs asset-bearing vs unreadable (encrypted/odd version/Oodle)?
+4. **Asset probe** — does the inferred asset layout hold in 1–2 real
+   asset-heavy paks? Could assets pass through as exmodz-style assets
+   (`.uasset`/`.uexp`)? _Probe + report only; no asset conversion prototype
+   unless it turns out trivial._
+5. **Expressiveness gaps** — how often do inexpressible changes
+   (`Defaults` edits, apparent deletions, nested partials) occur in practice?
+6. **Seam validation** — does a synthesized `.exmodz` flow through the real
+   `ParseExmodz` → `MergeCompile` pipeline with zero pipeline changes?
+
+## Deliverable
+
+- Throwaway prototype (converter + validation harness) on `spike/pak-to-exmod`.
+- Findings doc `docs/plans/<date>-icarus-pak-to-exmod-spike-findings.md`
+  (dated when written) with a **go / partial-go / no-go** recommendation and, on go/partial-go,
+  the seams + constraints a feature design would need.
+- No production code lands. The spike branch is never PR'd into develop.
+
+## Harness Design (Approach A — throwaway in-module package)
+
+New `spike/pakconvert/` package inside the repo module (so it imports
+`internal/unrealpak` and `internal/source/icarus` directly), driven by
+explicit integration tests that **skip** unless env vars provide:
+
+- `LMM_SPIKE_ICARUS_DIR` — real Icarus install (for live `data.pak`)
+- `LMM_SPIKE_CORPUS_DIR` — local corpus of downloaded mod files
+
+Four parts:
+
+### 1. Converter (the new work)
+
+`pak → synthesized .exmodz`:
+
+1. Open pak with `unrealpak.Open`; refuse encrypted/unsupported politely.
+2. Normalize each entry: join mount point + entry path, strip
+   `../../../Icarus/Content/` + `data/` (wherever the boundary falls) →
+   base-table mount-relative path. Non-JSON entries → classified for the
+   census (assets, `data.EXMOD`, junk).
+3. For each JSON table: load the corresponding live base table
+   (`Reader.ReadFile` on installed `data.pak`); index both `Rows` by `Name`.
+   - Row in pak, not in base → new row: emit verbatim (upsert append).
+   - Row in both, fields differ → emit `Name` + changed top-level fields
+     (whole-field replacement; nested structures replaced whole).
+   - Row in base, not in pak → **ignore** (staleness; EXMOD can't delete).
+   - `Defaults`/`RowStruct`/other top-level differences → recorded as
+     findings, not converted.
+   - Table path present in pak but absent from base → finding (census).
+4. Emit `.EXMOD` JSON (`CurrentFile` = mount path with `/`→`-`;
+   `EndOfMod` sentinel; metadata from the mod's catalog identity) and zip as
+   `Extracted Mods/<name>.EXMOD` → synthesized `.exmodz`.
+5. All pak entry names treated as untrusted input (same discipline as
+   `sanitizeAssetPath`).
+
+### 2. Validator (ground truth + pipeline)
+
+- **Semantic equivalence:** apply the converted diff and the author's own
+  exmodz each to the live base tables (via the real `ApplyRowPatch`);
+  compare resulting tables row-by-row. Residual differences must be
+  individually classified (staleness noise vs real divergence).
+- **Exact check:** where the pak embeds `data.EXMOD`, compare our derived
+  diff against it directly.
+- **Pipeline check:** run the real `ParseExmodz` on the synthesized file,
+  then the real `MergeCompile` against the live base pak with the synthesized
+  exmodz alongside a genuine exmodz mod; assert clean compile and sensible
+  output (spot-check merged tables).
+
+### 3. Asset probe (report only)
+
+Dissect 1–2 asset-heavy paks (candidates: Larkwell Care Package, Turret
+Variants): mount points, entry paths, compression, whether the inferred
+"assets unprefixed under `Icarus/Content/`" model holds, and whether their
+assets would fit the exmodz asset filter (`.uasset`/`.uexp`).
+
+### 4. Corpus census
+
+Sweep every corpus pak: version/encryption/compression, tables vs assets vs
+mixed, normalization success, differ outcome. Stats feed the findings doc.
+
+## Corpus
+
+Downloaded fresh via lmm against the live catalog into a git-ignored local
+dir (mod files are copyrighted — **never committed**):
+
+- FloofLevelCap + Intreegs4XP (previously dissected pure-JSON paks).
+- ~5–8 of the 41 dual-form mods (ground truth).
+- 1–2 asset-heavy paks (probe).
+- Broader pak sweep if cheap, for census stats.
+
+## Go / No-Go Rubric
+
+- **Go:** semantic equivalence on at least 3 of 4 sampled dual-form mods,
+  with every residual difference individually explained (staleness noise is
+  acceptable; unexplained divergence is not); clean `MergeCompile`; seam
+  validated end-to-end.
+- **Partial go:** table conversion sound but assets blocked → recommend a
+  feature scoped to table-only paks, assets as follow-up.
+- **No-go:** differ cannot reproduce author intent, or format variance
+  across paks is unmanageable.
+
+Either way the findings doc records the evidence, the census numbers, and —
+on go/partial-go — the open product questions a feature design must answer
+(pak/exmodz mutual-exclusion validation, `IsPrimary` defaults, fingerprint
+membership for converted paks, double-apply prevention via the
+manifest-aware deploy resolver).
+
+## Out of Scope
+
+- Any production code, CLI/TUI surface, DB/schema changes.
+- Asset conversion implementation (probe only, unless trivially free).
+- Product decisions (selection UX, defaults) — recorded as open questions.
+- Oodle support, encrypted paks, non-Icarus games.
+
+## Logistics
+
+- GitHub `Spike:` issue tracks the work.
+- Branch `spike/pak-to-exmod` holds spike code + findings; never merged.
+  This design doc + findings doc force-added there for durability.
+- Execution: subagent-driven (standing default), empirically — real files
+  first, conclusions second (the Icarus epic's core lesson).

--- a/docs/plans/archive/2026-08-05-icarus-pak-to-exmod-spike-findings.md
+++ b/docs/plans/archive/2026-08-05-icarus-pak-to-exmod-spike-findings.md
@@ -1,0 +1,275 @@
+# Icarus PAK → EXMOD Conversion Spike — Findings
+
+**Date:** 2026-08-05 **Spike issue:** #220 **Branch:** `spike/pak-to-exmod`
+**Design doc:** [2026-08-05-icarus-pak-to-exmod-spike-design.md](2026-08-05-icarus-pak-to-exmod-spike-design.md)
+**Prototype:** `spike/pakconvert/` (throwaway; never merged)
+
+## Verdict: PARTIAL GO
+
+The design rubric's strict GO bar — semantic equivalence on ≥3 of 4 sampled
+dual-form mods with every residual explained — was **not met by blind
+diff-derivation**: of 11 dual-form mods, 2 PASS outright, 1 is genuinely
+explained (a pure asset-only pak), and **8 DIVERGED** (final round-3
+harness numbers; an audit-then-fixed normalization blind spot had briefly
+made this look like 6). The failures decompose cleanly into (a) one
+**mechanical normalization gap** (case-sensitivity — found by audit, fixed
+in the harness, which flipped Eye Colors Expanded! into an ordinary
+processed-but-drifted mod), (b) one **conversion-robustness gap** (a pak
+whose table sits at `Content/` root with no recoverable directory
+structure is structurally unconvertible by this approach), and (c) three
+**inherent expressiveness gaps** of diffing a stale whole-table snapshot
+against a live base — and 5 of the 8 DIVERGED paks embed the author's
+original `data.EXMOD`, which sidesteps (c) entirely. The pipeline
+seam is proven end-to-end (`ValidateSource` + `MergeCompile` accept a
+synthesized `.exmodz` with zero changes), asset pass-through is empirically
+viable (0 Oodle entries, all assets `.uasset`/`.uexp`), and `MergeCompile`
+output was verified row-by-row. **Recommendation: proceed with a feature
+scoped in tiers** — Tier 1 (high fidelity): convert paks that embed a
+`data.EXMOD` by extracting it verbatim; Tier 2 (best effort, warn):
+diff-derived conversion for the remainder, with the drift hazards below
+surfaced to the user. Blind diff-derivation as a silent default is NO-GO.
+
+## Evidence Summary
+
+Ground truth = convert the mod's pak, apply our diff and the author's own
+exmodz each to the **live** base tables via the real `icarus.ApplyRowPatch`,
+deep-compare results. Final (round-3 harness: case-insensitive
+normalization + unverifiable-guard on the benign branch; commit a02840d):
+
+| Mod                          | Verdict   | Residuals | Breakdown                                                  | Notes                                                                                                                                  |
+| ---------------------------- | --------- | --------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Cry's Lvl 120 Cap - 25%      | PASS      | 0         | —                                                          | clean conversion (tables + `data/`-mounted assets)                                                                                     |
+| Cry's Lvl 120 Cap - 50%      | PASS      | 0         | —                                                          | clean conversion (tables + `data/`-mounted assets)                                                                                     |
+| Turret Variants              | EXPLAINED | 139       | all table-absent-from-pak (verified; `Census["other"]==0`) | genuine: pure asset-only pak; exmodz variant is broader                                                                                |
+| Floofs QOL                   | DIVERGED  | 1804      | 13 diverged / 1791 stale-pak-change                        | expressiveness gaps (embedded `.EXMOD` present)                                                                                        |
+| Dextermod: Tactical Backpack | DIVERGED  | 59        | 7 / 52                                                     | expressiveness gaps (embedded `.EXMOD` present)                                                                                        |
+| Dyls123's Horse Cart         | DIVERGED  | 1849      | 136 / 1713                                                 | expressiveness gaps (embedded `.EXMOD` present)                                                                                        |
+| Dextermod: Stronger HVAC     | DIVERGED  | 132       | 73 / 59                                                    | expressiveness gaps (embedded `.EXMOD` present)                                                                                        |
+| Intreeg's 4XP                | DIVERGED  | 27        | 26 / 1                                                     | expressiveness gaps (embedded `.EXMOD` present)                                                                                        |
+| Eye Colors Expanded!         | DIVERGED  | 25        | 2 / 23                                                     | capital-`Data/` mount (audit-caught, harness-fixed); now genuinely processed (50 stale rows) — ordinary stale-drift divergence         |
+| Intreeg's More Resources     | DIVERGED  | 21        | 21 / 0                                                     | **structurally unconvertible**: table at `Content/` root, no recoverable directory structure; unverifiable-guard refuses a benign call |
+| Extraction 5 Seconds         | DIVERGED  | 7         | 7 / 0                                                      | expressiveness gaps (no embedded `.EXMOD`)                                                                                             |
+
+Totals across 4,063 residuals: 3,639 `stale-pak-change` (machine-verified:
+our value provably traces to the pak's stale snapshot while the author's
+matches live), 139 `exmodz-newer-than-pak` (whole-table absence, all
+Turret Variants, verified), 285 `diverged`. The classifier's branch-5
+harness tripwire (pak touched a row but the converter emitted no patch)
+fired **zero** times in 4,063 residuals — the row-level differ itself
+dropped nothing it could see. The two normalization blind spots this
+spike's own audit surfaced (capital `Data/`, bare `Content/`) were fixed
+in the harness (case-insensitive `NormalizeEntry` preserving original
+case, plus a `Census["other"]>0` guard that blocks the benign
+classification whenever unclassified entries exist) and the corpus re-run
+— the numbers above are post-fix.
+
+**Pipeline seam (Task 7): PASS.** A synthesized "Floofs QOL" `.exmodz`
+passed the real `icarus.ValidateSource`, merged via the real
+`icarus.MergeCompile` alongside a genuine author exmodz ("Dextermod:
+Enhanced Tactical Backpack") with **zero warnings**, and the output pak had
+the correct mount point (`../../../Icarus/Content/`), `data/`-prefixed
+tables, and every converted row/field verified present. Zero changes to
+`internal/` were needed anywhere in the spike.
+
+**Embedded-`.EXMOD` oracle:** all 5 paks carrying a `data.EXMOD` showed
+`EmbeddedMatch: mismatch` against our derived diff — expected by design
+(the embedded diff was authored against the build-time base; ours diffs
+against today's live base). The embedded file is the author's original
+field-scoped intent and is the highest-fidelity conversion source
+available (it is exactly what `ParseExmod` consumes).
+
+## Census
+
+- **Catalog:** 539 mods total (live Firestore catalog at fetch time).
+  Sampled census (fetcher stops at quota; full sweep not run): of 115
+  scanned mods — 25 pak-only, 78 exmodz-only, 12 dual-form, 0 neither.
+  (The archived 2026-08 research counted 41 dual-form across the full
+  ~538; this sample is consistent with that order of magnitude.)
+- **Corpus:** 14 mods fetched (~38 MB): named targets + dual-form quota.
+  11 had a usable pak (3 entries had `Pak: ""` — one Larkwell pak URL
+  404'd; `""` means unavailable, conflating catalog-absent with
+  download-failed).
+- **Convertibility:** all 11 corpus paks opened and read cleanly with
+  `internal/unrealpak` — v11, unencrypted, **zero Oodle/unreadable
+  entries**. Extension census: JSON tables in 9 paks, `.uasset`/`.uexp`
+  assets in 3, embedded `.exmod` in 5. No unsafe entry paths, no
+  hyphenated table paths, no duplicate row names anywhere in the corpus.
+
+## Answers to the Six Spike Questions
+
+### 1. Path normalization
+
+_Can mount-point + entry-path pairs be normalized reliably?_ **Yes for
+every structured layout observed — with case-insensitivity required and
+one structurally unresolvable layout.** The floating `data/` boundary
+(mount `.../Content/` + entry `data/X/Y.json` vs mount
+`.../Content/data/X/` + entry `Y.json`) is handled correctly by joining
+the pair before classifying. The corpus produced two variants the
+archived research never saw: a **capital `Data/`** segment (Eye Colors
+Expanded!) — initially misclassified, then fixed with case-insensitive
+matching (original case preserved) and re-proven on the corpus — and a
+table mounted **directly at `Content/` root with no `data/` segment at
+all** (Intreeg's More Resources), which carries no recoverable directory
+structure and is **structurally unconvertible** by path normalization
+alone (a basename-fallback against base tables is a candidate future
+mitigation; not attempted in this spike). Either way, "unclassifiable
+JSON" must be a loud signal, never a silent skip — the spike harness now
+enforces this via a `Census["other"]>0` guard.
+
+### 2. Differ fidelity
+
+_Does a Name-keyed row differ against the live base reproduce author
+intent?_ **Only when the pak is fresh relative to the base.** The differ
+mechanism itself is sound (branch-5 tripwire: 0 hits in 4,063 residuals;
+the 2 PASS mods, whose paks target base tables that barely drift, convert
+byte-equivalently). But because prebuilt tables are **stale whole-table
+snapshots**, per-field diffing against today's base sweeps every
+independently-drifted field into the diff alongside the author's real
+change (dominant pattern: 3,639 residuals). Author intent per-row is
+recoverable only from the embedded `.EXMOD` (when present) — not from the
+snapshot alone.
+
+### 3. Convertibility census
+
+_What fraction of paks are convertible?_ **In this corpus: 11/11 readable,
+9/11 table-bearing, 3/11 asset-bearing, 5/11 embed the author's
+`data.EXMOD`.** No Oodle, no encryption, no format obstacles at all — the
+reading layer is a non-issue. Convertibility is limited by semantics
+(staleness/expressiveness), not by format.
+
+### 4. Asset probe
+
+_Does the inferred asset layout hold; do assets fit the exmodz filter?_
+**Layout inference held for 9/11 paks and was violated by 2** (Cry's Lvl
+120 Cap 25%/50%: the mount itself carries `data/Character/`, so their
+`.uasset`/`.uexp` land under a `data/` prefix — assets do NOT always mount
+"unprefixed under Content/"). All probed assets are `.uasset`/`.uexp`
+(fit `ParseExmodz`'s filter), all stored/Zlib. Pass-through works when the
+asset's **Content-relative joined path** is preserved as the exmodz asset
+path — the Cry's pair, converted exactly that way, are the spike's two
+PASS mods. Layout variance is handled by the same pair-normalization as
+tables; it is a naming expectation broken, not a blocker.
+
+### 5. Expressiveness gaps
+
+_What can't EXMOD express, and how often does it occur?_ Corpus
+frequencies: `field-removed` **795** (fields present in the live base row
+but absent from the pak's stale row — schema drift, correctly ignored,
+inexpressible either way), `defaults-changed` **8** (Defaults edits are
+inexpressible in EXMOD), `rowstruct-changed` / `top-level-changed` /
+`duplicate-row-name` / `hyphen-path` / `table-not-in-base` /
+`unreadable-entry` / `unsafe-asset-path`: **0**. Two further
+representation gaps surfaced that EXMOD-the-format can hold but
+diff-derivation gets wrong: tool-auto-populated fields on new rows (e.g.
+`EventDescription: NSLOCTEXT(...)` captured by whole-row new-row emission
+but absent from the author's own exmod) and localized-text representation
+(`INVTEXT("[DNT] ...")` raw structure vs the author tooling's resolved
+string). Row deletions never appeared (and are inexpressible regardless).
+
+### 6. Seam validation
+
+_Does a synthesized `.exmodz` flow through the real pipeline unchanged?_
+**Yes — proven.** Real `ValidateSource` + real `MergeCompile` + verified
+merged output, zero pipeline modifications, zero warnings (§ Evidence
+Summary). The ingest-time "synthesize a retained `.exmodz`" seam works
+exactly as the design predicted.
+
+## Expressiveness-Gap Frequencies
+
+| Gap                                                       | Count                       | Production consequence                                                                                                                                                                                                                         |
+| --------------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stale-drift sweep-in (`stale-pak-change` residuals)       | 3,639                       | The dominant hazard: a derived diff silently reverts base-game updates in every field that drifted since the pak was built. Must be mitigated (embedded-EXMOD preference, drift heuristics, or explicit user warning), never silently shipped. |
+| Structurally unconvertible layout (bare-`Content/` mount) | 1 mod (21 residuals)        | A pak with no recoverable directory structure cannot be converted by normalization alone — must be detected and refused loudly (basename-fallback is a candidate future mitigation).                                                           |
+| `field-removed` (schema drift, base-only fields)          | 795                         | Correctly ignorable (staleness), but confirms snapshots routinely predate schema changes.                                                                                                                                                      |
+| Whole-table absence from pak vs exmodz (verified)         | 139                         | Pak and exmodz variants of the same mod can differ in **feature scope** — conversion fidelity vs the exmodz is not always achievable from the pak alone.                                                                                       |
+| Tool-auto-populated new-row fields                        | ~26 rows (Intreeg's 4XP)    | Harmless-looking extra fields ride along on new rows; cosmetic in the cases inspected but unverified in general.                                                                                                                               |
+| Localized-text representation (INVTEXT/NSLOCTEXT)         | spot-confirmed (Floofs QOL) | JSON-level conversion cannot reproduce resolved localized strings; affects display-name fields.                                                                                                                                                |
+| `defaults-changed`                                        | 8                           | Rare but real; inexpressible in EXMOD — must be a loud per-mod warning when detected.                                                                                                                                                          |
+
+## Constraints a Feature Design Must Honor
+
+1. **Diff against the live base only; base-absent rows are staleness, not
+   deletions** — confirmed empirically (795 field-removed, 3,494 stale
+   rows) and EXMOD has no delete verb anyway.
+2. **Derived diffs go stale too.** A diff synthesized at ingest freezes
+   live-base values from that day; the next weekly base update recreates
+   the exact Friday problem one level up. Either retain the **raw pak**
+   and re-derive at merge/recompile time (the merged-pak pipeline already
+   recompiles on base-staleness, #196), or re-derive the retained exmodz
+   on the same trigger. The embedded-`data.EXMOD` path does not have this
+   problem (field-scoped author intent, exactly like a published exmodz).
+3. **Prefer the embedded `data.EXMOD` whenever the pak carries one**
+   (5/11 corpus paks, including 5 of the 8 DIVERGED) — it converts the
+   hardest cases exactly and needs zero inference. Verify embedded ≡
+   published-exmodz on dual-form mods before trusting it blindly (not
+   done in this spike).
+4. **Mount + entry normalized as a pair, case-insensitively** (original
+   case preserved) — the corpus contains capital-`Data/` mounts,
+   bare-`Content/` mounts, and `data/`-prefixed asset mounts (Cry's).
+   Case-insensitivity is proven necessary and sufficient for the
+   capital-`Data/` case (harness-fixed and corpus-re-proven);
+   bare-`Content/` paks are structurally unconvertible without a
+   basename-fallback (future mitigation) and must be refused loudly.
+   "Unclassifiable JSON entry" must be a loud finding; `ClassOther` as a
+   silent third outcome briefly mislabeled 2 mods as EXPLAINED before the
+   spike's own audit caught and fixed it.
+5. **Four unexported upstream values must be exported** (or a conversion
+   API added to `internal/source/icarus`) before production work:
+   `endOfModSentinel`, `icarusContentMountPoint`, `icarusDataTablePrefix`,
+   and the `-`↔`/` CurrentFile flatten rule. The spike duplicated all
+   four as literals; production code must not.
+6. **Fingerprint membership:** converted paks must contribute to
+   `MergedFingerprint` (e.g. MD5 of the retained artifact — and if
+   re-derivation lands, the raw pak's bytes) or pak-mod
+   enable/disable/reorder/update leaves the merged pak invisibly stale.
+7. **Alternate-form validation & #211:** `ValidateInstallFileSelection`'s
+   "pak and exmodz are alternate forms — select one" and exmodz
+   `IsPrimary` defaults need rethinking once a pak is itself mergeable;
+   Turret Variants shows the two forms can differ in feature scope, so
+   "alternate forms" is not always true.
+8. **Double-apply prevention:** when a converted pak's diff enters the
+   merge, the original `.pak` must simultaneously stop deploying — the
+   manifest-aware `deployableFiles` resolver + `PruneUnclaimed` (#210) is
+   the existing mechanism; the retained-source marker keeps the rest of
+   the pipeline (membership, purge, deploy) working unchanged, as Task 7
+   proved.
+9. **Warning surface:** `defaults-changed` detection, drift-suspect
+   conversions (large `changed` sets on old paks), and scope differences
+   vs a known exmodz variant should surface through the existing
+   `MergeCompile` → CLI/TUI warnings plumbing.
+10. **Report/diagnostic hygiene** (spike lessons): keep finding `Table`
+    fields consistently normalized (the spike mixed normalized and raw
+    entry paths); don't overload availability semantics the way
+    `CorpusMod.Pak == ""` conflated catalog-absent with download-failed.
+
+## Open Product Questions
+
+- Is conversion **opt-in per mod, default-on for pak-only mods, or a
+  game-level setting**? What does the TUI/CLI selection look like now that
+  "pak" can mean "mergeable via conversion"?
+- What happens to **already-installed pak mods** on upgrade — auto-migrate
+  into the merged pak (with the deploy-convergence machinery removing the
+  old per-mod link), or only on reinstall?
+- Tier-2 UX: is a drift-suspect conversion **blocked, warned, or shipped
+  silently**? Where is the threshold (e.g. changed-fields count vs pak
+  age/week delta)?
+- Should `lmm` verify **embedded `data.EXMOD` ≡ published exmodz** on
+  dual-form mods and prefer the published one when both exist?
+- Does Tier 2 justify shipping at all for **asset-only paks** (nothing to
+  diff — pass-through is effectively exact), making them Tier 1?
+- Where does the differ live long-term — `internal/source/icarus`, or the
+  future public unrealpak module (#170)?
+
+## Raw Data
+
+Corpus and generated evidence live **outside the repo** (copyrighted mod
+content; never committed): `~/.cache/lmm-spike-corpus/` — downloaded mod
+files under `<docID>/`, `manifest.json`, `catalog-census.json`, and
+per-mod `reports/<id>-groundtruth.json` + `reports/<id>-assetprobe.json`
+(regenerated by the round-3 harness re-run; asset-probe deltas confined to
+Eye Colors' entry flipping `other`→`table` as expected).
+The spike prototype and its tests are on branch `spike/pak-to-exmod`
+(`spike/pakconvert/`; round-3 harness fix a02840d); the env-gated
+ground-truth test intentionally fails on DIVERGED verdicts by design —
+that failure is the recorded evidence, not a defect. SDD execution ledger:
+`.superpowers/sdd/2026-08-05-icarus-pak-to-exmod-spike-plan/progress.md`.

--- a/docs/plans/archive/2026-08-05-icarus-pak-to-exmod-spike-plan.md
+++ b/docs/plans/archive/2026-08-05-icarus-pak-to-exmod-spike-plan.md
@@ -1,0 +1,2321 @@
+# Icarus PAK → EXMOD Conversion Spike Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove (or refute) that lmm can internally convert a prebuilt Icarus PAK mod into a synthesized `.exmodz` that flows through the real `ParseExmodz` → `MergeCompile` pipeline, validated against author-shipped exmodz ground truth.
+
+**Architecture:** A throwaway in-module package `spike/pakconvert/` (spike branch only, never merged) with four parts: a corpus fetcher CLI (public Firestore catalog, no auth), a pure converter chain (path normalization → row differ → EXMOD emitter), env-gated integration tests (ground truth, pipeline seam, asset probe), and JSON reports feeding a findings doc. Design doc: `docs/plans/2026-08-05-icarus-pak-to-exmod-spike-design.md`.
+
+**Tech Stack:** Go 1.25.6, stdlib only (archive/zip, encoding/json, net/http), plus in-repo `internal/unrealpak` and `internal/source/icarus`.
+
+## Global Constraints
+
+- Module `github.com/DonovanMods/linux-mod-manager`, Go 1.25.6. `spike/pakconvert` imports `internal/...` freely (same module root).
+- ALL new code lives under `spike/pakconvert/`. `internal/` and `cmd/` are READ-ONLY — zero production changes.
+- Branch `spike/pak-to-exmod`. Commit after each task with prefix `spike:`. Plan/design docs are gitignored (`docs/plans/*`) — force-add with `git add -f` when a task says to commit docs.
+- Run `gofmt -l spike/` (expect no output) and `go vet ./spike/...` before every commit.
+- NEVER pipe `go test` inside a `&&` chain. Run `go test` as its own command and read its real output.
+- Integration tests MUST skip cleanly when `LMM_SPIKE_ICARUS_DIR` / `LMM_SPIKE_CORPUS_DIR` are unset, so plain `go test ./...` stays green everywhere.
+- Corpus mod files and generated reports are copyrighted / derived content: they live OUTSIDE the repo (user-supplied dir) and are NEVER committed.
+- Four upstream values are unexported and MUST be duplicated as literals with a `// duplicated from internal/source/icarus (unexported)` comment: `"EndOfMod"`, `"../../../Icarus/Content/"`, `"data/"`, and the `-`↔`/` CurrentFile flattening rule.
+- `unrealpak.Create` opens its file eagerly and `Writer` has no abort: when writing a pak or any file that may fail mid-way, use the `defer os.Remove`-on-error pattern.
+- Catalog access is the public Firestore REST API via `icarus.New(nil, "projectdaedalus-fb09f")` — no auth, no API keys.
+- Wire schema for an emitted `.EXMOD` (from `ParseExmod`'s anonymous struct, `internal/source/icarus/exmod.go:35`): lowercase `name`/`author`/`version`/`description`; capitalized `Rows` / `CurrentFile` / `File_Items`; each `File_Items` entry is a FLAT object (`"Name"` + sibling fields); terminal row `{"CurrentFile":"EndOfMod"}` carries NO `File_Items` key. A non-sentinel row with empty `File_Items` is a hard error at merge time — never emit one.
+
+---
+
+### Task 1: Corpus fetcher CLI
+
+**Files:**
+
+- Create: `spike/pakconvert/corpus.go` (pure selection/manifest logic)
+- Create: `spike/pakconvert/corpus_test.go`
+- Create: `spike/pakconvert/cmd/fetchcorpus/main.go` (I/O shell)
+
+**Interfaces:**
+
+- Produces: `type CorpusMod struct { ID, Name, Version, Week, Pak, Exmodz string }` (Pak/Exmodz are corpus-relative file paths, `""` if absent); `type Manifest struct { Mods []CorpusMod }`; `type CensusEntry struct { ID, Name string; HasPak, HasExmodz bool }`; `func MatchTargets(mods []domain.Mod, substrings []string) []domain.Mod`; `func LoadManifest(dir string) (*Manifest, error)`; `func SaveJSON(path string, v any) error`. Tasks 6–8 consume `LoadManifest` + `CorpusMod`.
+
+- [ ] **Step 1: Write the failing test**
+
+`spike/pakconvert/corpus_test.go`:
+
+```go
+package pakconvert
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+func TestMatchTargets(t *testing.T) {
+	mods := []domain.Mod{
+		{ID: "a1", Name: "FloofLevelCap"},
+		{ID: "b2", Name: "Intreeg's 4XP"},
+		{ID: "c3", Name: "Unrelated Mod"},
+		{ID: "d4", Name: "larkwell care package"},
+	}
+	got := MatchTargets(mods, []string{"flooflevelcap", "intreeg", "larkwell", "turret variants"})
+	if len(got) != 3 {
+		t.Fatalf("MatchTargets returned %d mods, want 3", len(got))
+	}
+	wantIDs := map[string]bool{"a1": true, "b2": true, "d4": true}
+	for _, m := range got {
+		if !wantIDs[m.ID] {
+			t.Errorf("unexpected mod selected: %s (%s)", m.ID, m.Name)
+		}
+	}
+}
+
+func TestManifestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := Manifest{Mods: []CorpusMod{
+		{ID: "a1", Name: "FloofLevelCap", Version: "1.2", Week: "w57",
+			Pak: "a1/FloofLevelCap.pak", Exmodz: ""},
+	}}
+	if err := SaveJSON(filepath.Join(dir, "manifest.json"), want); err != nil {
+		t.Fatalf("SaveJSON: %v", err)
+	}
+	got, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if len(got.Mods) != 1 || got.Mods[0] != want.Mods[0] {
+		t.Fatalf("round trip mismatch: got %+v want %+v", got.Mods, want.Mods)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./spike/pakconvert/ -run 'TestMatchTargets|TestManifestRoundTrip' -v`
+Expected: FAIL (compile error) with `undefined: MatchTargets`, `undefined: Manifest`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`spike/pakconvert/corpus.go`:
+
+```go
+// Package pakconvert is a THROWAWAY spike (#220): converting prebuilt Icarus
+// PAK mods into synthesized .exmodz form. Never merged into develop.
+package pakconvert
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// CorpusMod is one downloaded mod in the local corpus. Pak/Exmodz are
+// corpus-relative paths ("" when the catalog has no such file).
+type CorpusMod struct {
+	ID      string
+	Name    string
+	Version string
+	Week    string
+	Pak     string
+	Exmodz  string
+}
+
+// Manifest indexes the corpus dir; written by cmd/fetchcorpus, read by the
+// env-gated integration tests.
+type Manifest struct {
+	Mods []CorpusMod
+}
+
+// CensusEntry records pak/exmodz availability for one catalog mod.
+type CensusEntry struct {
+	ID        string
+	Name      string
+	HasPak    bool
+	HasExmodz bool
+}
+
+// MatchTargets returns mods whose Name contains any of the given substrings,
+// case-insensitively. Order follows the input mods slice.
+func MatchTargets(mods []domain.Mod, substrings []string) []domain.Mod {
+	var out []domain.Mod
+	for _, m := range mods {
+		lower := strings.ToLower(m.Name)
+		for _, s := range substrings {
+			if strings.Contains(lower, strings.ToLower(s)) {
+				out = append(out, m)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// SaveJSON writes v as indented JSON, creating parent dirs.
+func SaveJSON(path string, v any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating dir for %s: %w", path, err)
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", path, err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// LoadManifest reads <dir>/manifest.json.
+func LoadManifest(dir string) (*Manifest, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
+	if err != nil {
+		return nil, fmt.Errorf("reading corpus manifest: %w", err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing corpus manifest: %w", err)
+	}
+	return &m, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./spike/pakconvert/ -run 'TestMatchTargets|TestManifestRoundTrip' -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Write the fetcher main (manual-run I/O shell, no unit test)**
+
+`spike/pakconvert/cmd/fetchcorpus/main.go`:
+
+```go
+// fetchcorpus downloads a spike corpus of Icarus mods (pak + exmodz files)
+// from the public Firestore catalog into -dir (OUTSIDE the repo; never
+// committed). Manual usage:
+//
+//	go run ./spike/pakconvert/cmd/fetchcorpus -dir ~/lmm-spike-corpus [-dual 8] [-census-all]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/source/icarus"
+	"github.com/DonovanMods/linux-mod-manager/spike/pakconvert"
+)
+
+// Named spike targets (design doc "Corpus" section), matched case-insensitively.
+var targets = []string{"flooflevelcap", "intreeg", "larkwell", "turret"}
+
+func main() {
+	dir := flag.String("dir", "", "corpus directory (required, outside the repo)")
+	dual := flag.Int("dual", 8, "number of dual-form (pak+exmodz) mods to fetch")
+	censusAll := flag.Bool("census-all", false, "sweep GetModFiles for the WHOLE catalog census")
+	flag.Parse()
+	if *dir == "" {
+		log.Fatal("-dir is required")
+	}
+
+	ctx := context.Background()
+	src := icarus.New(nil, "projectdaedalus-fb09f") // public catalog, no auth
+
+	// PageSize 2000 >> catalog size (~540) so one page holds everything.
+	res, err := src.Search(ctx, source.SearchQuery{PageSize: 2000})
+	if err != nil {
+		log.Fatalf("catalog search: %v", err)
+	}
+	fmt.Printf("catalog: %d mods\n", len(res.Mods))
+
+	selected := pakconvert.MatchTargets(res.Mods, targets)
+	selectedIDs := map[string]bool{}
+	for _, m := range selected {
+		selectedIDs[m.ID] = true
+	}
+
+	// Deterministic scan order for the dual-form quota and census.
+	byID := append([]domain.Mod(nil), res.Mods...)
+	sort.Slice(byID, func(i, j int) bool { return byID[i].ID < byID[j].ID })
+
+	var census []pakconvert.CensusEntry
+	var manifest pakconvert.Manifest
+	dualFound := 0
+	for _, m := range byID {
+		needDual := dualFound < *dual
+		if !*censusAll && !needDual && !selectedIDs[m.ID] {
+			continue
+		}
+		time.Sleep(200 * time.Millisecond) // be polite to the public API
+		files, err := src.GetModFiles(ctx, &m)
+		if err != nil {
+			log.Printf("WARN GetModFiles %s (%s): %v", m.ID, m.Name, err)
+			continue
+		}
+		var pakFile, exmodzFile *domain.DownloadableFile
+		for i := range files {
+			switch files[i].ID {
+			case "pak":
+				pakFile = &files[i]
+			case "exmodz":
+				exmodzFile = &files[i]
+			}
+		}
+		census = append(census, pakconvert.CensusEntry{
+			ID: m.ID, Name: m.Name,
+			HasPak: pakFile != nil, HasExmodz: exmodzFile != nil,
+		})
+
+		isDual := pakFile != nil && exmodzFile != nil
+		fetch := selectedIDs[m.ID] || (isDual && dualFound < *dual)
+		if !fetch {
+			continue
+		}
+		if isDual && !selectedIDs[m.ID] {
+			dualFound++
+		}
+		cm := pakconvert.CorpusMod{ID: m.ID, Name: m.Name, Version: m.Version, Week: m.Category}
+		if pakFile != nil {
+			cm.Pak = download(ctx, src, &m, pakFile, *dir)
+		}
+		if exmodzFile != nil {
+			cm.Exmodz = download(ctx, src, &m, exmodzFile, *dir)
+		}
+		manifest.Mods = append(manifest.Mods, cm)
+		fmt.Printf("fetched %s (%s) pak=%q exmodz=%q\n", m.Name, m.ID, cm.Pak, cm.Exmodz)
+	}
+
+	if err := pakconvert.SaveJSON(filepath.Join(*dir, "manifest.json"), manifest); err != nil {
+		log.Fatalf("writing manifest: %v", err)
+	}
+	if err := pakconvert.SaveJSON(filepath.Join(*dir, "catalog-census.json"), census); err != nil {
+		log.Fatalf("writing census: %v", err)
+	}
+	fmt.Printf("done: %d mods fetched, %d census rows -> %s\n", len(manifest.Mods), len(census), *dir)
+}
+
+// download fetches one file and returns its corpus-relative path ("" on failure).
+func download(ctx context.Context, src *icarus.Icarus, m *domain.Mod, f *domain.DownloadableFile, dir string) string {
+	url, err := src.GetDownloadURL(ctx, m, f.ID)
+	if err != nil {
+		log.Printf("WARN GetDownloadURL %s/%s: %v", m.ID, f.ID, err)
+		return ""
+	}
+	rel := filepath.Join(m.ID, f.FileName)
+	dest := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		log.Printf("WARN mkdir %s: %v", dest, err)
+		return ""
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Printf("WARN GET %s: %v", url, err)
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("WARN GET %s: status %s", url, resp.Status)
+		return ""
+	}
+	out, err := os.Create(dest)
+	if err != nil {
+		log.Printf("WARN create %s: %v", dest, err)
+		return ""
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		os.Remove(dest)
+		log.Printf("WARN saving %s: %v", dest, err)
+		return ""
+	}
+	return rel
+}
+```
+
+- [ ] **Step 6: Build + full-package test, then commit**
+
+Run: `go build ./spike/...`
+Expected: no output.
+Run: `go test ./spike/pakconvert/ -v`
+Expected: PASS.
+Run: `gofmt -l spike/` (expect no output), then `go vet ./spike/...` (expect no output).
+
+```bash
+git add spike/pakconvert/corpus.go spike/pakconvert/corpus_test.go spike/pakconvert/cmd/fetchcorpus/main.go
+git commit -m "spike: corpus fetcher for pak-to-exmod spike (#220)"
+```
+
+**Note for the human operator (not a step):** the actual fetch is a manual run — `go run ./spike/pakconvert/cmd/fetchcorpus -dir "$HOME/lmm-spike-corpus"` — performed before Task 6. Tasks 2–5 are fully offline.
+
+---
+
+### Task 2: Path normalization and entry classification
+
+**Files:**
+
+- Create: `spike/pakconvert/normalize.go`
+- Create: `spike/pakconvert/normalize_test.go`
+
+**Interfaces:**
+
+- Produces: `type EntryClass int` with consts `ClassTable`, `ClassEmbeddedExmod`, `ClassAsset`, `ClassOther` and a `String()` method; `func NormalizeEntry(mountPoint, entryPath string) (EntryClass, string, error)` — for `ClassTable` the string is the base-table mount-relative path (e.g. `"Experience/D_ExperienceEvents.json"`); for `ClassAsset`/`ClassEmbeddedExmod` it is the Content-relative remainder; for `ClassOther` it is `""`. `func CurrentFileFor(tablePath string) string`. Task 5 consumes all of these.
+
+- [ ] **Step 1: Write the failing test**
+
+`spike/pakconvert/normalize_test.go`:
+
+```go
+package pakconvert
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeEntry(t *testing.T) {
+	tests := []struct {
+		name      string
+		mount     string
+		entry     string
+		wantClass EntryClass
+		wantPath  string
+		wantErr   string
+	}{
+		{
+			// Real layout: Intreegs4XP (pak-divergence-report §1)
+			name:  "table with data prefix in entry",
+			mount: "../../../Icarus/Content/", entry: "data/Experience/D_ExperienceEvents.json",
+			wantClass: ClassTable, wantPath: "Experience/D_ExperienceEvents.json",
+		},
+		{
+			// Real layout: FloofLevelCap — data/ boundary floats into the mount point
+			name:  "table with data prefix in mount",
+			mount: "../../../Icarus/Content/data/Character/", entry: "D_CharacterGrowth.json",
+			wantClass: ClassTable, wantPath: "Character/D_CharacterGrowth.json",
+		},
+		{
+			// Real layout: Intreegs4XP ships its source .EXMOD inside the pak
+			name:  "embedded exmod",
+			mount: "../../../Icarus/Content/", entry: "data.EXMOD",
+			wantClass: ClassEmbeddedExmod, wantPath: "data.EXMOD",
+		},
+		{
+			name:  "uasset asset",
+			mount: "../../../Icarus/Content/", entry: "Larkwell/ITM/SK_Item.uasset",
+			wantClass: ClassAsset, wantPath: "Larkwell/ITM/SK_Item.uasset",
+		},
+		{
+			name:  "uexp asset case-insensitive",
+			mount: "../../../Icarus/Content/", entry: "Larkwell/ITM/SK_Item.UEXP",
+			wantClass: ClassAsset, wantPath: "Larkwell/ITM/SK_Item.UEXP",
+		},
+		{
+			name:  "json outside data dir is Other",
+			mount: "../../../Icarus/Content/", entry: "Config/whatever.json",
+			wantClass: ClassOther, wantPath: "",
+		},
+		{
+			name:  "entry outside Content mount is Other",
+			mount: "../../../", entry: "Engine/Config/Base.ini",
+			wantClass: ClassOther, wantPath: "",
+		},
+		{
+			// '-' in a table path breaks the CurrentFile '/'-to-'-' flattening
+			name:  "hyphen in table path is an error",
+			mount: "../../../Icarus/Content/", entry: "data/AI/D_Some-Table.json",
+			wantErr: "hyphen",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class, p, err := NormalizeEntry(tt.mount, tt.entry)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeEntry: %v", err)
+			}
+			if class != tt.wantClass || p != tt.wantPath {
+				t.Errorf("got (%v, %q), want (%v, %q)", class, p, tt.wantClass, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestCurrentFileFor(t *testing.T) {
+	got := CurrentFileFor("Audio/MusicConditions/D_MusicLocationConditions.json")
+	want := "Audio-MusicConditions-D_MusicLocationConditions.json"
+	if got != want {
+		t.Fatalf("CurrentFileFor = %q, want %q", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./spike/pakconvert/ -run 'TestNormalizeEntry|TestCurrentFileFor' -v`
+Expected: FAIL (compile error) with `undefined: EntryClass`, `undefined: NormalizeEntry`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`spike/pakconvert/normalize.go`:
+
+```go
+package pakconvert
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// Duplicated from internal/source/icarus (unexported there):
+// icarusContentMountPoint (compile.go:128) and icarusDataTablePrefix
+// (compile.go:138). The '-'<->'/' CurrentFile flattening rule is
+// matchMountPath (compile.go:169).
+const (
+	contentMount = "../../../Icarus/Content/"
+	dataPrefix   = "data/"
+)
+
+// EntryClass classifies one mod-pak entry for conversion.
+type EntryClass int
+
+const (
+	ClassOther EntryClass = iota
+	ClassTable
+	ClassEmbeddedExmod
+	ClassAsset
+)
+
+func (c EntryClass) String() string {
+	switch c {
+	case ClassTable:
+		return "table"
+	case ClassEmbeddedExmod:
+		return "embedded-exmod"
+	case ClassAsset:
+		return "asset"
+	default:
+		return "other"
+	}
+}
+
+// NormalizeEntry joins a pak's mount point with one entry path and classifies
+// the result. The data/ boundary floats between mount point and entry path in
+// real mod paks (pak-divergence-report §1), so classification always works on
+// the JOINED path. For ClassTable the returned string is the base-table
+// mount-relative path (what unrealpak data.pak Files() report, and what
+// CurrentFileFor flattens); for ClassAsset and ClassEmbeddedExmod it is the
+// Content-relative remainder; for ClassOther it is "".
+func NormalizeEntry(mountPoint, entryPath string) (EntryClass, string, error) {
+	full := path.Join(mountPoint, entryPath) // Join cleans but keeps leading ../
+	if !strings.HasPrefix(full, contentMount) {
+		return ClassOther, "", nil
+	}
+	rest := strings.TrimPrefix(full, contentMount)
+	lower := strings.ToLower(rest)
+	switch {
+	case strings.HasSuffix(lower, ".exmod"):
+		return ClassEmbeddedExmod, rest, nil
+	case strings.HasSuffix(lower, ".uasset") || strings.HasSuffix(lower, ".uexp"):
+		return ClassAsset, rest, nil
+	case strings.HasPrefix(rest, dataPrefix) && strings.HasSuffix(lower, ".json"):
+		tablePath := strings.TrimPrefix(rest, dataPrefix)
+		if strings.Contains(tablePath, "-") {
+			// The CurrentFile encoding replaces ALL '/' with '-' and is only
+			// reversible because no real base-table path contains a hyphen
+			// (icarus compile.go:147). A hyphen here would produce an
+			// unresolvable CurrentFile.
+			return ClassTable, "", fmt.Errorf("table path %q contains a hyphen: CurrentFile flattening would be ambiguous", tablePath)
+		}
+		return ClassTable, tablePath, nil
+	default:
+		return ClassOther, "", nil
+	}
+}
+
+// CurrentFileFor flattens a base-table mount-relative path into the .EXMOD
+// CurrentFile encoding (forward direction of icarus matchMountPath).
+func CurrentFileFor(tablePath string) string {
+	return strings.ReplaceAll(tablePath, "/", "-")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./spike/pakconvert/ -run 'TestNormalizeEntry|TestCurrentFileFor' -v`
+Expected: PASS (all subtests)
+
+- [ ] **Step 5: Commit**
+
+Run: `gofmt -l spike/` (expect no output), then `go vet ./spike/...` (expect no output).
+
+```bash
+git add spike/pakconvert/normalize.go spike/pakconvert/normalize_test.go
+git commit -m "spike: pak entry normalization and classification (#220)"
+```
+
+---
+
+### Task 3: Row differ
+
+**Files:**
+
+- Create: `spike/pakconvert/diff.go`
+- Create: `spike/pakconvert/diff_test.go`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks (pure JSON in/out).
+- Produces: `type Item struct { Name string; Fields map[string]any }`; `type Finding struct { Kind, Table, Row, Detail string }`; `type TableDiff struct { Items []Item; StaleBaseOnlyRows int; Findings []Finding }`; `func DiffTable(baseJSON, modJSON []byte) (*TableDiff, error)`. Finding.Table is left `""` here — Task 5's ConvertPak fills it. Finding Kinds emitted by this task: `"defaults-changed"`, `"rowstruct-changed"`, `"top-level-changed"`, `"duplicate-row-name"`, `"field-removed"`. Tasks 4–6 consume `Item`; Tasks 5–6 consume `TableDiff`/`Finding`.
+
+- [ ] **Step 1: Write the failing test**
+
+`spike/pakconvert/diff_test.go`:
+
+```go
+package pakconvert
+
+import (
+	"testing"
+)
+
+const baseTable = `{
+	"RowStruct": "/Script/Icarus.FakeRow",
+	"Defaults": {"Speed": 1},
+	"Rows": [
+		{"Name": "Alpha", "Speed": 10, "Nested": {"A": 1, "B": 2}},
+		{"Name": "Beta", "Speed": 20},
+		{"Name": "Gamma", "Speed": 30}
+	]
+}`
+
+func mustDiff(t *testing.T, base, mod string) *TableDiff {
+	t.Helper()
+	d, err := DiffTable([]byte(base), []byte(mod))
+	if err != nil {
+		t.Fatalf("DiffTable: %v", err)
+	}
+	return d
+}
+
+func TestDiffTableIdentical(t *testing.T) {
+	d := mustDiff(t, baseTable, baseTable)
+	if len(d.Items) != 0 || d.StaleBaseOnlyRows != 0 || len(d.Findings) != 0 {
+		t.Fatalf("identical tables should produce empty diff, got %+v", d)
+	}
+}
+
+func TestDiffTableChangedField(t *testing.T) {
+	mod := `{
+		"RowStruct": "/Script/Icarus.FakeRow",
+		"Defaults": {"Speed": 1},
+		"Rows": [
+			{"Name": "Alpha", "Speed": 99, "Nested": {"A": 1, "B": 2}},
+			{"Name": "Beta", "Speed": 20},
+			{"Name": "Gamma", "Speed": 30}
+		]
+	}`
+	d := mustDiff(t, baseTable, mod)
+	if len(d.Items) != 1 {
+		t.Fatalf("want 1 item, got %+v", d.Items)
+	}
+	it := d.Items[0]
+	if it.Name != "Alpha" || len(it.Fields) != 1 || it.Fields["Speed"] != float64(99) {
+		t.Fatalf("want Alpha{Speed:99} only, got %+v", it)
+	}
+}
+
+func TestDiffTableNestedChangeIsWholeField(t *testing.T) {
+	mod := `{
+		"RowStruct": "/Script/Icarus.FakeRow",
+		"Defaults": {"Speed": 1},
+		"Rows": [
+			{"Name": "Alpha", "Speed": 10, "Nested": {"A": 1, "B": 3}},
+			{"Name": "Beta", "Speed": 20},
+			{"Name": "Gamma", "Speed": 30}
+		]
+	}`
+	d := mustDiff(t, baseTable, mod)
+	if len(d.Items) != 1 || d.Items[0].Name != "Alpha" {
+		t.Fatalf("want 1 Alpha item, got %+v", d.Items)
+	}
+	nested, ok := d.Items[0].Fields["Nested"].(map[string]any)
+	if !ok || nested["A"] != float64(1) || nested["B"] != float64(3) {
+		t.Fatalf("nested change must be emitted as the WHOLE field, got %+v", d.Items[0].Fields)
+	}
+}
+
+func TestDiffTableNewRow(t *testing.T) {
+	mod := `{
+		"RowStruct": "/Script/Icarus.FakeRow",
+		"Defaults": {"Speed": 1},
+		"Rows": [
+			{"Name": "Alpha", "Speed": 10, "Nested": {"A": 1, "B": 2}},
+			{"Name": "Beta", "Speed": 20},
+			{"Name": "Gamma", "Speed": 30},
+			{"Name": "Delta", "Speed": 40}
+		]
+	}`
+	d := mustDiff(t, baseTable, mod)
+	if len(d.Items) != 1 || d.Items[0].Name != "Delta" || d.Items[0].Fields["Speed"] != float64(40) {
+		t.Fatalf("want new-row Delta{Speed:40}, got %+v", d.Items)
+	}
+}
+
+func TestDiffTableStaleBaseOnlyRowsIgnored(t *testing.T) {
+	// Mod table is a stale snapshot missing Beta and Gamma: NOT a deletion
+	// (EXMOD cannot express deletes) — counted, not emitted.
+	mod := `{
+		"RowStruct": "/Script/Icarus.FakeRow",
+		"Defaults": {"Speed": 1},
+		"Rows": [{"Name": "Alpha", "Speed": 10, "Nested": {"A": 1, "B": 2}}]
+	}`
+	d := mustDiff(t, baseTable, mod)
+	if len(d.Items) != 0 {
+		t.Fatalf("stale snapshot must emit no items, got %+v", d.Items)
+	}
+	if d.StaleBaseOnlyRows != 2 {
+		t.Fatalf("want StaleBaseOnlyRows=2, got %d", d.StaleBaseOnlyRows)
+	}
+}
+
+func TestDiffTableFindings(t *testing.T) {
+	mod := `{
+		"RowStruct": "/Script/Icarus.OtherRow",
+		"Defaults": {"Speed": 2},
+		"Extra": true,
+		"Rows": [
+			{"Name": "Alpha", "Nested": {"A": 1, "B": 2}},
+			{"Name": "Alpha", "Speed": 10},
+			{"Name": "Beta", "Speed": 20},
+			{"Name": "Gamma", "Speed": 30}
+		]
+	}`
+	d := mustDiff(t, baseTable, mod)
+	kinds := map[string]int{}
+	for _, f := range d.Findings {
+		kinds[f.Kind]++
+	}
+	for _, want := range []string{"rowstruct-changed", "defaults-changed", "top-level-changed", "duplicate-row-name", "field-removed"} {
+		if kinds[want] == 0 {
+			t.Errorf("missing finding kind %q in %+v", want, d.Findings)
+		}
+	}
+}
+
+func TestDiffTableMalformed(t *testing.T) {
+	if _, err := DiffTable([]byte(`{"Rows": "nope"}`), []byte(baseTable)); err == nil {
+		t.Fatal("want error for malformed base table")
+	}
+	if _, err := DiffTable([]byte(baseTable), []byte(`not json`)); err == nil {
+		t.Fatal("want error for malformed mod table")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./spike/pakconvert/ -run 'TestDiffTable' -v`
+Expected: FAIL (compile error) with `undefined: TableDiff`, `undefined: DiffTable`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`spike/pakconvert/diff.go`:
+
+```go
+package pakconvert
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// Item is one upsert the converter derived: a row Name plus the changed (or,
+// for new rows, all) top-level fields. Mirrors icarus.ExmodFileItem.
+type Item struct {
+	Name   string
+	Fields map[string]any
+}
+
+// Finding records something the conversion observed but cannot (or must not)
+// express as an EXMOD upsert. Table is filled by ConvertPak (Task 5).
+type Finding struct {
+	Kind   string
+	Table  string
+	Row    string
+	Detail string
+}
+
+// TableDiff is the result of diffing one mod-pak table against the live base.
+type TableDiff struct {
+	Items             []Item
+	StaleBaseOnlyRows int
+	Findings          []Finding
+}
+
+// dataTable is the UE DataTable export shape ({"RowStruct","Defaults","Rows"}).
+type dataTable struct {
+	rows  []map[string]any
+	other map[string]any // every top-level key except Rows
+}
+
+func parseDataTable(data []byte) (*dataTable, error) {
+	var top map[string]any
+	if err := json.Unmarshal(data, &top); err != nil {
+		return nil, fmt.Errorf("parsing data table: %w", err)
+	}
+	rawRows, ok := top["Rows"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("data table has no Rows array")
+	}
+	t := &dataTable{other: top}
+	delete(top, "Rows")
+	for i, r := range rawRows {
+		row, ok := r.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("Rows[%d] is not an object", i)
+		}
+		if _, ok := row["Name"].(string); !ok {
+			return nil, fmt.Errorf("Rows[%d] has no string Name", i)
+		}
+		t.rows = append(t.rows, row)
+	}
+	return t, nil
+}
+
+// DiffTable derives the EXMOD-expressible difference between the LIVE base
+// table and a mod pak's (possibly stale) full-table snapshot.
+//
+// Rules (design doc "Converter" §3):
+//   - row in mod, not in base       -> new row, emit all fields
+//   - row in both, fields differ    -> emit Name + changed fields (whole-field)
+//   - row in base, not in mod       -> staleness, counted and IGNORED
+//   - mod row missing a base field  -> finding "field-removed" (inexpressible)
+//   - Defaults/RowStruct/other top-level changes -> findings (inexpressible)
+//   - duplicate Name in mod         -> finding, first occurrence wins
+func DiffTable(baseJSON, modJSON []byte) (*TableDiff, error) {
+	base, err := parseDataTable(baseJSON)
+	if err != nil {
+		return nil, fmt.Errorf("base: %w", err)
+	}
+	mod, err := parseDataTable(modJSON)
+	if err != nil {
+		return nil, fmt.Errorf("mod: %w", err)
+	}
+
+	d := &TableDiff{}
+
+	for _, key := range []string{"RowStruct", "Defaults"} {
+		if !reflect.DeepEqual(base.other[key], mod.other[key]) {
+			kind := "rowstruct-changed"
+			if key == "Defaults" {
+				kind = "defaults-changed"
+			}
+			d.Findings = append(d.Findings, Finding{Kind: kind,
+				Detail: fmt.Sprintf("%s differs from base (EXMOD cannot express this)", key)})
+		}
+	}
+	for key, v := range mod.other {
+		if key == "RowStruct" || key == "Defaults" {
+			continue
+		}
+		if !reflect.DeepEqual(base.other[key], v) {
+			d.Findings = append(d.Findings, Finding{Kind: "top-level-changed",
+				Detail: fmt.Sprintf("top-level key %q differs from base", key)})
+		}
+	}
+
+	baseByName := make(map[string]map[string]any, len(base.rows))
+	for _, r := range base.rows {
+		baseByName[r["Name"].(string)] = r
+	}
+
+	seen := make(map[string]bool, len(mod.rows))
+	for _, mr := range mod.rows {
+		name := mr["Name"].(string)
+		if seen[name] {
+			d.Findings = append(d.Findings, Finding{Kind: "duplicate-row-name", Row: name,
+				Detail: "duplicate row Name in mod table; first occurrence wins"})
+			continue
+		}
+		seen[name] = true
+
+		br, inBase := baseByName[name]
+		if !inBase {
+			fields := make(map[string]any, len(mr)-1)
+			for k, v := range mr {
+				if k != "Name" {
+					fields[k] = v
+				}
+			}
+			d.Items = append(d.Items, Item{Name: name, Fields: fields})
+			continue
+		}
+		changed := map[string]any{}
+		for k, v := range mr {
+			if k == "Name" {
+				continue
+			}
+			if bv, ok := br[k]; !ok || !reflect.DeepEqual(bv, v) {
+				changed[k] = v
+			}
+		}
+		for k := range br {
+			if k == "Name" {
+				continue
+			}
+			if _, ok := mr[k]; !ok {
+				d.Findings = append(d.Findings, Finding{Kind: "field-removed", Row: name,
+					Detail: fmt.Sprintf("field %q present in base but absent in mod row (EXMOD cannot remove fields)", k)})
+			}
+		}
+		if len(changed) > 0 {
+			d.Items = append(d.Items, Item{Name: name, Fields: changed})
+		}
+	}
+
+	for name := range baseByName {
+		if !seen[name] {
+			d.StaleBaseOnlyRows++
+		}
+	}
+	return d, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./spike/pakconvert/ -run 'TestDiffTable' -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+Run: `gofmt -l spike/` (expect no output), then `go vet ./spike/...` (expect no output).
+
+```bash
+git add spike/pakconvert/diff.go spike/pakconvert/diff_test.go
+git commit -m "spike: name-keyed row differ against live base tables (#220)"
+```
+
+---
+
+### Task 4: EXMOD emitter + synthesized exmodz
+
+**Files:**
+
+- Create: `spike/pakconvert/emit.go`
+- Create: `spike/pakconvert/emit_test.go`
+
+**Interfaces:**
+
+- Consumes: `Item` (Task 3).
+- Produces: `type Meta struct { Name, Author, Version, Description string }`; `type TableEntry struct { CurrentFile string; Items []Item }`; `func WriteExmod(meta Meta, tables []TableEntry) ([]byte, error)`; `func WriteExmodz(exmodName string, exmod []byte, assets map[string][]byte) ([]byte, error)` (assets keyed by Content-relative path, zipped under `<exmodName>/<path>`). Task 5 consumes all of these.
+
+- [ ] **Step 1: Write the failing test (round-trips through the REAL parsers)**
+
+`spike/pakconvert/emit_test.go`:
+
+```go
+package pakconvert
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source/icarus"
+)
+
+func TestWriteExmodRoundTrip(t *testing.T) {
+	meta := Meta{Name: "Converted Mod", Author: "spike", Version: "1.0", Description: "pak-to-exmod spike output"}
+	tables := []TableEntry{
+		{CurrentFile: "Experience-D_ExperienceEvents.json", Items: []Item{
+			{Name: "Kill_Deer", Fields: map[string]any{"Experience": float64(400)}},
+			{Name: "New_Event", Fields: map[string]any{"Experience": float64(10), "Repeatable": true}},
+		}},
+		{CurrentFile: "Character-D_CharacterGrowth.json", Items: []Item{
+			{Name: "MaxLevel", Fields: map[string]any{"Level": float64(99)}},
+		}},
+		{CurrentFile: "Empty-D_Nothing.json", Items: nil}, // must be skipped entirely
+	}
+	data, err := WriteExmod(meta, tables)
+	if err != nil {
+		t.Fatalf("WriteExmod: %v", err)
+	}
+
+	diff, err := icarus.ParseExmod(data) // the REAL parser is the round-trip oracle
+	if err != nil {
+		t.Fatalf("icarus.ParseExmod rejected our output: %v\n%s", err, data)
+	}
+	if diff.Name != meta.Name || diff.Author != meta.Author || diff.Version != meta.Version {
+		t.Errorf("metadata mismatch: %+v", diff)
+	}
+	// ParseExmod does NOT consume the sentinel (that happens at compile/merge
+	// time), so it comes back as a parsed row: 2 tables + sentinel = 3.
+	// The empty table must have been skipped entirely.
+	if len(diff.Rows) != 3 {
+		t.Fatalf("want 3 parsed rows (2 tables + sentinel; empty table skipped), got %d: %+v", len(diff.Rows), diff.Rows)
+	}
+	if diff.Rows[0].CurrentFile != "Experience-D_ExperienceEvents.json" || len(diff.Rows[0].FileItems) != 2 {
+		t.Errorf("row 0 mismatch: %+v", diff.Rows[0])
+	}
+	if diff.Rows[0].FileItems[1].Fields["Repeatable"] != true {
+		t.Errorf("flat File_Items fields lost: %+v", diff.Rows[0].FileItems[1])
+	}
+	last := diff.Rows[len(diff.Rows)-1]
+	if last.CurrentFile != "EndOfMod" || len(last.FileItems) != 0 {
+		t.Errorf("last row must be the bare EndOfMod sentinel, got %+v", last)
+	}
+	// Every non-sentinel row must carry items (empty ones are a merge-time
+	// hard error upstream).
+	for _, r := range diff.Rows {
+		if r.CurrentFile != "EndOfMod" && len(r.FileItems) == 0 {
+			t.Errorf("emitted a non-sentinel row with no File_Items (merge-time hard error): %+v", r)
+		}
+	}
+	if !strings.Contains(string(data), `"CurrentFile": "EndOfMod"`) &&
+		!strings.Contains(string(data), `"CurrentFile":"EndOfMod"`) {
+		t.Error("terminal EndOfMod sentinel row missing from emitted JSON")
+	}
+}
+
+func TestWriteExmodEmptyItemName(t *testing.T) {
+	_, err := WriteExmod(Meta{Name: "x"}, []TableEntry{
+		{CurrentFile: "A-B.json", Items: []Item{{Name: "", Fields: map[string]any{"F": 1}}}},
+	})
+	if err == nil {
+		t.Fatal("want error for empty item Name")
+	}
+}
+
+func TestWriteExmodzRoundTrip(t *testing.T) {
+	exmod, err := WriteExmod(Meta{Name: "Bundle"}, []TableEntry{
+		{CurrentFile: "AI-D_AIGrowth.json", Items: []Item{{Name: "R1", Fields: map[string]any{"V": float64(1)}}}},
+	})
+	if err != nil {
+		t.Fatalf("WriteExmod: %v", err)
+	}
+	assets := map[string][]byte{
+		"ITM/SK_Saddle.uasset": []byte("uasset-bytes"),
+		"ITM/SK_Saddle.uexp":   []byte("uexp-bytes"),
+	}
+	zipData, err := WriteExmodz("Bundle", exmod, assets)
+	if err != nil {
+		t.Fatalf("WriteExmodz: %v", err)
+	}
+
+	bundle, err := icarus.ParseExmodz(zipData) // REAL parser as oracle
+	if err != nil {
+		t.Fatalf("icarus.ParseExmodz rejected our zip: %v", err)
+	}
+	if bundle.Diff == nil || bundle.Diff.Name != "Bundle" {
+		t.Fatalf("manifest not parsed: %+v", bundle.Diff)
+	}
+	if len(bundle.Assets) != 2 {
+		t.Fatalf("want 2 assets, got %v", bundle.Assets)
+	}
+	if string(bundle.Assets["Bundle/ITM/SK_Saddle.uasset"]) != "uasset-bytes" {
+		t.Errorf("asset content/path mismatch: keys %v", bundle.Assets)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./spike/pakconvert/ -run 'TestWriteExmod' -v`
+Expected: FAIL (compile error) with `undefined: Meta`, `undefined: WriteExmod`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`spike/pakconvert/emit.go`:
+
+```go
+package pakconvert
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// endOfModSentinel is duplicated from internal/source/icarus (unexported
+// const, compile.go:146). A terminal row {"CurrentFile":"EndOfMod"} with no
+// File_Items key matches what real author-built .EXMODs ship.
+const endOfModSentinel = "EndOfMod"
+
+// Meta is the synthesized .EXMOD's metadata block.
+type Meta struct {
+	Name        string
+	Author      string
+	Version     string
+	Description string
+}
+
+// TableEntry is one table's derived upserts, keyed by its flattened
+// CurrentFile encoding (see CurrentFileFor).
+type TableEntry struct {
+	CurrentFile string
+	Items       []Item
+}
+
+// exmodDoc mirrors ParseExmod's anonymous wire struct
+// (internal/source/icarus/exmod.go:35): lowercase metadata keys, capitalized
+// structural keys. icarus.ExmodDiff itself is tag-free and CANNOT be used to
+// emit — json.Marshal on it produces the wrong keys.
+type exmodDoc struct {
+	Name        string           `json:"name"`
+	Author      string           `json:"author"`
+	Version     string           `json:"version"`
+	Description string           `json:"description"`
+	Rows        []map[string]any `json:"Rows"`
+}
+
+// WriteExmod emits a .EXMOD JSON document readable by icarus.ParseExmod.
+// Tables with zero items are skipped (a non-sentinel row with empty
+// File_Items is a merge-time hard error upstream).
+func WriteExmod(meta Meta, tables []TableEntry) ([]byte, error) {
+	doc := exmodDoc{Name: meta.Name, Author: meta.Author, Version: meta.Version, Description: meta.Description}
+	for _, te := range tables {
+		if len(te.Items) == 0 {
+			continue
+		}
+		items := make([]map[string]any, 0, len(te.Items))
+		for _, it := range te.Items {
+			if it.Name == "" {
+				return nil, fmt.Errorf("table %s: item with empty Name", te.CurrentFile)
+			}
+			flat := make(map[string]any, len(it.Fields)+1)
+			flat["Name"] = it.Name
+			for k, v := range it.Fields {
+				if k == "Name" {
+					continue // Name is positional, never a payload field
+				}
+				flat[k] = v
+			}
+			items = append(items, flat)
+		}
+		doc.Rows = append(doc.Rows, map[string]any{
+			"CurrentFile": te.CurrentFile,
+			"File_Items":  items,
+		})
+	}
+	// Terminal sentinel row, File_Items key ABSENT (matches real manifests).
+	doc.Rows = append(doc.Rows, map[string]any{"CurrentFile": endOfModSentinel})
+	return json.MarshalIndent(doc, "", "  ")
+}
+
+// WriteExmodz zips a synthesized .exmodz: the manifest at
+// "Extracted Mods/<exmodName>.EXMOD" plus assets under "<exmodName>/<path>",
+// mirroring the real bundle layout (icarus exmodz_test.go fixture).
+func WriteExmodz(exmodName string, exmod []byte, assets map[string][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	w, err := zw.Create("Extracted Mods/" + exmodName + ".EXMOD")
+	if err != nil {
+		return nil, fmt.Errorf("creating manifest entry: %w", err)
+	}
+	if _, err := w.Write(exmod); err != nil {
+		return nil, fmt.Errorf("writing manifest entry: %w", err)
+	}
+
+	paths := make([]string, 0, len(assets))
+	for p := range assets {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths) // deterministic zip layout
+	for _, p := range paths {
+		w, err := zw.Create(exmodName + "/" + p)
+		if err != nil {
+			return nil, fmt.Errorf("creating asset entry %s: %w", p, err)
+		}
+		if _, err := w.Write(assets[p]); err != nil {
+			return nil, fmt.Errorf("writing asset entry %s: %w", p, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("finalizing exmodz zip: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./spike/pakconvert/ -run 'TestWriteExmod' -v`
+Expected: PASS (3 tests). If `ParseExmod` rejects the output, the wire schema in emit.go is wrong — fix emit.go, never touch internal/.
+
+- [ ] **Step 5: Commit**
+
+Run: `gofmt -l spike/` (expect no output), then `go vet ./spike/...` (expect no output).
+
+```bash
+git add spike/pakconvert/emit.go spike/pakconvert/emit_test.go
+git commit -m "spike: EXMOD/exmodz emitter round-tripping through real parsers (#220)"
+```
+
+---
+
+### Task 5: Converter orchestration (ConvertPak)
+
+**Files:**
+
+- Create: `spike/pakconvert/convert.go`
+- Create: `spike/pakconvert/convert_test.go`
+
+**Interfaces:**
+
+- Consumes: `NormalizeEntry`, `CurrentFileFor`, `EntryClass` consts (Task 2); `DiffTable`, `TableDiff`, `Finding`, `Item` (Task 3); `Meta`, `TableEntry`, `WriteExmod`, `WriteExmodz` (Task 4); `unrealpak.Open/Reader`, `unrealpak.Create/AddFile/WithMountPoint` (fixtures).
+- Produces: `type Report struct { PakPath, MountPoint string; Census map[string]int; Tables map[string]*TableDiff; EmbeddedExmods map[string][]byte; Findings []Finding; StaleRows int }`; `func ConvertPak(pakPath, basePakPath string, meta Meta) ([]byte, *Report, error)`. Report finding kinds added by this task: `"table-not-in-base"`, `"unreadable-entry"`, `"hyphen-path"`, `"unsafe-asset-path"`. Tasks 6–7 consume `ConvertPak`; Task 6 consumes `Report.EmbeddedExmods`.
+
+- [ ] **Step 1: Write the failing test (fully offline, synthetic paks)**
+
+`spike/pakconvert/convert_test.go`:
+
+```go
+package pakconvert
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source/icarus"
+	"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"
+)
+
+// writePak builds a synthetic pak fixture. Mirrors icarus's own test style:
+// unrealpak.Writer output is readable by unrealpak.Reader.
+func writePak(t *testing.T, path, mount string, entries map[string][]byte) {
+	t.Helper()
+	var opts []unrealpak.Option
+	if mount != "" {
+		opts = append(opts, unrealpak.WithMountPoint(mount))
+	}
+	w, err := unrealpak.Create(path, opts...)
+	if err != nil {
+		t.Fatalf("Create %s: %v", path, err)
+	}
+	for p, data := range entries {
+		if err := w.AddFile(p, data); err != nil {
+			t.Fatalf("AddFile %s: %v", p, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close %s: %v", path, err)
+	}
+}
+
+const fixtureBaseTable = `{
+	"RowStruct": "/Script/Icarus.FakeRow",
+	"Defaults": {},
+	"Rows": [
+		{"Name": "Alpha", "Speed": 10},
+		{"Name": "Beta", "Speed": 20}
+	]
+}`
+
+// The mod pak carries a full-table snapshot: Alpha changed, Delta added,
+// Beta absent (stale snapshot, must be ignored).
+const fixtureModTable = `{
+	"RowStruct": "/Script/Icarus.FakeRow",
+	"Defaults": {},
+	"Rows": [
+		{"Name": "Alpha", "Speed": 99},
+		{"Name": "Delta", "Speed": 40}
+	]
+}`
+
+func TestConvertPak(t *testing.T) {
+	dir := t.TempDir()
+	basePak := filepath.Join(dir, "data.pak")
+	modPak := filepath.Join(dir, "mod.pak")
+
+	// Base data.pak: default mount, tables at bare mount-relative paths
+	// (matching the real data.pak layout, e.g. "Test/D_Fake.json").
+	writePak(t, basePak, "", map[string][]byte{
+		"Test/D_Fake.json": []byte(fixtureBaseTable),
+	})
+	// Mod pak: real prebuilt layout — Content mount + data/-prefixed table,
+	// plus an asset and an embedded .EXMOD.
+	writePak(t, modPak, "../../../Icarus/Content/", map[string][]byte{
+		"data/Test/D_Fake.json":  []byte(fixtureModTable),
+		"Mod/ITM/SK_Hat.uasset":  []byte("asset-bytes"),
+		"data.EXMOD":             []byte(`{"Rows":[]}`),
+		"README.txt":             []byte("junk"),
+	})
+
+	meta := Meta{Name: "TestMod", Author: "spike", Version: "1.0"}
+	exmodz, report, err := ConvertPak(modPak, basePak, meta)
+	if err != nil {
+		t.Fatalf("ConvertPak: %v", err)
+	}
+
+	// Census: one of each class.
+	for class, want := range map[string]int{"table": 1, "asset": 1, "embedded-exmod": 1, "other": 1} {
+		if report.Census[class] != want {
+			t.Errorf("census[%s] = %d, want %d (census: %v)", class, report.Census[class], want, report.Census)
+		}
+	}
+	if report.StaleRows != 1 { // Beta missing from mod snapshot
+		t.Errorf("StaleRows = %d, want 1", report.StaleRows)
+	}
+	if _, ok := report.EmbeddedExmods["data.EXMOD"]; !ok {
+		t.Errorf("embedded .EXMOD not captured: %v", report.EmbeddedExmods)
+	}
+	td, ok := report.Tables["Test/D_Fake.json"]
+	if !ok {
+		t.Fatalf("table diff missing: %v", report.Tables)
+	}
+	if len(td.Items) != 2 {
+		t.Fatalf("want 2 items (Alpha changed, Delta new), got %+v", td.Items)
+	}
+
+	// The synthesized bundle must parse with the REAL parser and contain
+	// exactly the derived upserts + the passed-through asset.
+	bundle, err := icarus.ParseExmodz(exmodz)
+	if err != nil {
+		t.Fatalf("icarus.ParseExmodz rejected ConvertPak output: %v", err)
+	}
+	// 1 table row + the EndOfMod sentinel (ParseExmod keeps the sentinel).
+	if len(bundle.Diff.Rows) != 2 || bundle.Diff.Rows[0].CurrentFile != "Test-D_Fake.json" {
+		t.Fatalf("diff rows mismatch: %+v", bundle.Diff.Rows)
+	}
+	items := bundle.Diff.Rows[0].FileItems
+	if len(items) != 2 || items[0].Name != "Alpha" || items[0].Fields["Speed"] != float64(99) ||
+		items[1].Name != "Delta" || items[1].Fields["Speed"] != float64(40) {
+		t.Fatalf("upserts mismatch: %+v", items)
+	}
+	if string(bundle.Assets["TestMod/Mod/ITM/SK_Hat.uasset"]) != "asset-bytes" {
+		t.Errorf("asset not passed through: keys %v", bundle.Assets)
+	}
+}
+
+func TestConvertPakTableNotInBase(t *testing.T) {
+	dir := t.TempDir()
+	basePak := filepath.Join(dir, "data.pak")
+	modPak := filepath.Join(dir, "mod.pak")
+	writePak(t, basePak, "", map[string][]byte{
+		"Test/D_Fake.json": []byte(fixtureBaseTable),
+	})
+	writePak(t, modPak, "../../../Icarus/Content/", map[string][]byte{
+		"data/Test/D_Unknown.json": []byte(fixtureModTable),
+	})
+	_, report, err := ConvertPak(modPak, basePak, Meta{Name: "X"})
+	if err != nil {
+		t.Fatalf("ConvertPak: %v", err)
+	}
+	found := false
+	for _, f := range report.Findings {
+		if f.Kind == "table-not-in-base" && f.Table == "Test/D_Unknown.json" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("want table-not-in-base finding, got %+v", report.Findings)
+	}
+	if len(report.Tables) != 0 {
+		t.Errorf("unknown table must not be diffed: %v", report.Tables)
+	}
+}
+
+func TestSanitizeAssetPath(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: `Mod\ITM\SK_Hat.uasset`, want: "Mod/ITM/SK_Hat.uasset"},
+		{in: "Mod/./ITM/SK_Hat.uasset", want: "Mod/ITM/SK_Hat.uasset"},
+		{in: "../escape.uasset", wantErr: true},
+		{in: "/abs/path.uasset", wantErr: true},
+		{in: "C:/abs/path.uasset", wantErr: true},
+		{in: "nul\x00byte.uasset", wantErr: true},
+	}
+	for _, tt := range tests {
+		got, err := sanitizeAssetPath(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("sanitizeAssetPath(%q): want error, got %q", tt.in, got)
+			}
+			continue
+		}
+		if err != nil || got != tt.want {
+			t.Errorf("sanitizeAssetPath(%q) = %q, %v; want %q", tt.in, got, err, tt.want)
+		}
+	}
+}
+
+func TestConvertPakMissingFiles(t *testing.T) {
+	if _, _, err := ConvertPak(filepath.Join(t.TempDir(), "nope.pak"), os.DevNull, Meta{}); err == nil {
+		t.Fatal("want error for missing pak")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./spike/pakconvert/ -run 'TestConvertPak|TestSanitizeAssetPath' -v`
+Expected: FAIL (compile error) with `undefined: ConvertPak`, `undefined: sanitizeAssetPath`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`spike/pakconvert/convert.go`:
+
+```go
+package pakconvert
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"
+)
+
+// Report is ConvertPak's full account of what it saw and did — the raw
+// material for the spike findings doc.
+type Report struct {
+	PakPath        string
+	MountPoint     string
+	Census         map[string]int        // EntryClass.String() -> count
+	Tables         map[string]*TableDiff // tablePath -> diff vs live base
+	EmbeddedExmods map[string][]byte     // Content-relative path -> raw bytes
+	Findings       []Finding
+	StaleRows      int
+}
+
+// sanitizeAssetPath reimplements (minimally) the discipline of icarus's
+// unexported sanitizeAssetPath (compile.go:196): pak entry names are
+// untrusted input. Backslashes normalize to '/', then NUL, absolute paths
+// (POSIX and drive-letter), and any path escaping its root are rejected.
+func sanitizeAssetPath(raw string) (string, error) {
+	if strings.ContainsRune(raw, 0) {
+		return "", fmt.Errorf("asset path contains NUL byte")
+	}
+	p := strings.ReplaceAll(raw, `\`, "/")
+	if strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("asset path %q is absolute", raw)
+	}
+	if len(p) >= 2 && p[1] == ':' {
+		return "", fmt.Errorf("asset path %q is drive-absolute", raw)
+	}
+	clean := path.Clean(p)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("asset path %q escapes its root", raw)
+	}
+	return clean, nil
+}
+
+// ConvertPak converts one prebuilt mod pak into a synthesized .exmodz by
+// diffing its full-table snapshots against the LIVE base data.pak (never
+// adopting the pak's tables wholesale — they are stale snapshots, see the
+// design doc's hazards). Assets pass through; embedded .EXMODs are captured
+// for ground-truth comparison, not used for conversion.
+func ConvertPak(pakPath, basePakPath string, meta Meta) ([]byte, *Report, error) {
+	mod, err := unrealpak.Open(pakPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening mod pak: %w", err)
+	}
+	defer mod.Close()
+	base, err := unrealpak.Open(basePakPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening base pak: %w", err)
+	}
+	defer base.Close()
+
+	report := &Report{
+		PakPath:        pakPath,
+		MountPoint:     mod.MountPoint(),
+		Census:         map[string]int{},
+		Tables:         map[string]*TableDiff{},
+		EmbeddedExmods: map[string][]byte{},
+	}
+	assets := map[string][]byte{}
+	var tables []TableEntry
+
+	for _, entry := range mod.Files() {
+		class, rel, nerr := NormalizeEntry(mod.MountPoint(), entry.Path)
+		report.Census[class.String()]++
+		if nerr != nil {
+			report.Findings = append(report.Findings, Finding{Kind: "hyphen-path",
+				Table: entry.Path, Detail: nerr.Error()})
+			continue
+		}
+		if class == ClassOther {
+			continue
+		}
+		data, rerr := mod.ReadFile(entry.Path)
+		if rerr != nil {
+			// Oodle or other unsupported compression: record, keep going.
+			report.Findings = append(report.Findings, Finding{Kind: "unreadable-entry",
+				Table: entry.Path, Detail: rerr.Error()})
+			continue
+		}
+		switch class {
+		case ClassEmbeddedExmod:
+			report.EmbeddedExmods[rel] = data
+		case ClassAsset:
+			safe, serr := sanitizeAssetPath(rel)
+			if serr != nil {
+				report.Findings = append(report.Findings, Finding{Kind: "unsafe-asset-path",
+					Table: entry.Path, Detail: serr.Error()})
+				continue
+			}
+			assets[safe] = data
+		case ClassTable:
+			baseData, berr := base.ReadFile(rel)
+			if berr != nil {
+				report.Findings = append(report.Findings, Finding{Kind: "table-not-in-base",
+					Table: rel, Detail: berr.Error()})
+				continue
+			}
+			td, derr := DiffTable(baseData, data)
+			if derr != nil {
+				return nil, nil, fmt.Errorf("diffing %s: %w", rel, derr)
+			}
+			for i := range td.Findings {
+				td.Findings[i].Table = rel
+			}
+			report.Findings = append(report.Findings, td.Findings...)
+			report.StaleRows += td.StaleBaseOnlyRows
+			report.Tables[rel] = td
+			if len(td.Items) > 0 {
+				tables = append(tables, TableEntry{CurrentFile: CurrentFileFor(rel), Items: td.Items})
+			}
+		}
+	}
+
+	exmod, err := WriteExmod(meta, tables)
+	if err != nil {
+		return nil, nil, fmt.Errorf("emitting .EXMOD: %w", err)
+	}
+	exmodName := strings.ReplaceAll(meta.Name, "/", "_")
+	if exmodName == "" {
+		exmodName = "converted"
+	}
+	exmodz, err := WriteExmodz(exmodName, exmod, assets)
+	if err != nil {
+		return nil, nil, fmt.Errorf("emitting .exmodz: %w", err)
+	}
+	return exmodz, report, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./spike/pakconvert/ -run 'TestConvertPak|TestSanitizeAssetPath' -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Run the whole spike package + commit**
+
+Run: `go test ./spike/pakconvert/ -v`
+Expected: PASS (all tests, Tasks 1–5).
+Run: `gofmt -l spike/` (expect no output), then `go vet ./spike/...` (expect no output).
+
+```bash
+git add spike/pakconvert/convert.go spike/pakconvert/convert_test.go
+git commit -m "spike: ConvertPak orchestration - pak to synthesized exmodz (#220)"
+```
+
+---
+
+### Task 6: Ground-truth harness (env-gated integration)
+
+**Files:**
+
+- Create: `spike/pakconvert/reports.go`
+- Create: `spike/pakconvert/groundtruth_test.go`
+
+**Interfaces:**
+
+- Consumes: `LoadManifest`, `CorpusMod`, `SaveJSON` (Task 1); `ConvertPak`, `Report` (Task 5); `icarus.ParseExmodz`, `icarus.ParseExmod`, `icarus.ApplyRowPatch`; `unrealpak.Open`.
+- Produces: `func spikeEnv(t *testing.T) (icarusDir, corpusDir string)` (t.Skip when unset — Tasks 7–8 reuse it); `type GroundTruthReport struct { ModID, ModName, Verdict string; Residuals []Residual; EmbeddedMatch string }`; `type Residual struct { Table, Row, Class, Detail string }`. Verdict values: `"PASS"`, `"EXPLAINED"`, `"DIVERGED"`. Residual Class values: `"stale-pak-change"`, `"exmodz-newer-than-pak"`, `"diverged"`.
+
+- [ ] **Step 1: Write reports.go (trivial, no separate test — exercised by this task's test)**
+
+`spike/pakconvert/reports.go`:
+
+```go
+package pakconvert
+
+// GroundTruthReport is one dual-form mod's conversion-vs-author comparison,
+// written to <corpus>/reports/<id>-groundtruth.json.
+type GroundTruthReport struct {
+	ModID         string
+	ModName       string
+	Verdict       string // "PASS" | "EXPLAINED" | "DIVERGED"
+	Residuals     []Residual
+	EmbeddedMatch string // "" (no embedded .EXMOD) | "match" | "mismatch: <detail>"
+	StaleRows     int
+	Findings      []Finding
+}
+
+// Residual is one row where our conversion and the author's exmodz produce
+// different final table states, with its classification.
+type Residual struct {
+	Table  string
+	Row    string
+	Class  string // "stale-pak-change" | "exmodz-newer-than-pak" | "diverged"
+	Detail string
+}
+```
+
+- [ ] **Step 2: Write the failing/skipping integration test**
+
+`spike/pakconvert/groundtruth_test.go`:
+
+```go
+package pakconvert
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source/icarus"
+	"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"
+)
+
+// spikeEnv gates the corpus-driven integration tests. Plain `go test ./...`
+// must stay green on any machine, so absence of the env vars is a SKIP.
+func spikeEnv(t *testing.T) (icarusDir, corpusDir string) {
+	t.Helper()
+	icarusDir = os.Getenv("LMM_SPIKE_ICARUS_DIR")
+	corpusDir = os.Getenv("LMM_SPIKE_CORPUS_DIR")
+	if icarusDir == "" || corpusDir == "" {
+		t.Skip("set LMM_SPIKE_ICARUS_DIR and LMM_SPIKE_CORPUS_DIR to run spike integration tests")
+	}
+	return icarusDir, corpusDir
+}
+
+func basePakPath(icarusDir string) string {
+	// Mirrors core.resolveBasePak (unexported, service.go:1040).
+	return filepath.Join(icarusDir, "Icarus", "Content", "Data", "data.pak")
+}
+
+// applyItems applies EXMOD rows to base tables, returning tablePath -> final
+// decoded table. Uses the REAL icarus.ApplyRowPatch.
+func applyItems(t *testing.T, base *unrealpak.Reader, rows []icarus.ExmodRow) map[string]map[string]any {
+	t.Helper()
+	state := map[string][]byte{}
+	for _, row := range rows {
+		if row.CurrentFile == "EndOfMod" { // duplicated: unexported upstream const
+			continue
+		}
+		// Reverse of CurrentFileFor — same rule as icarus matchMountPath.
+		tablePath := replaceAllDashes(row.CurrentFile)
+		cur, ok := state[tablePath]
+		if !ok {
+			data, err := base.ReadFile(tablePath)
+			if err != nil {
+				t.Fatalf("base table %s (from CurrentFile %s): %v", tablePath, row.CurrentFile, err)
+			}
+			cur = data
+		}
+		next, err := icarus.ApplyRowPatch(cur, row)
+		if err != nil {
+			t.Fatalf("ApplyRowPatch %s: %v", row.CurrentFile, err)
+		}
+		state[tablePath] = next
+	}
+	out := map[string]map[string]any{}
+	for p, data := range state {
+		var decoded map[string]any
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("decoding patched %s: %v", p, err)
+		}
+		out[p] = decoded
+	}
+	return out
+}
+
+// replaceAllDashes reverses CurrentFileFor — same rule as icarus
+// matchMountPath (unexported upstream).
+func replaceAllDashes(currentFile string) string {
+	return strings.ReplaceAll(currentFile, "-", "/")
+}
+
+// rowsByName extracts Rows keyed by Name from a decoded table.
+func rowsByName(table map[string]any) map[string]map[string]any {
+	out := map[string]map[string]any{}
+	rows, _ := table["Rows"].([]any)
+	for _, r := range rows {
+		if m, ok := r.(map[string]any); ok {
+			if n, ok := m["Name"].(string); ok {
+				out[n] = m
+			}
+		}
+	}
+	return out
+}
+
+func TestGroundTruthDualFormMods(t *testing.T) {
+	icarusDir, corpusDir := spikeEnv(t)
+	basePak := basePakPath(icarusDir)
+	base, err := unrealpak.Open(basePak)
+	if err != nil {
+		t.Fatalf("opening live base pak: %v", err)
+	}
+	defer base.Close()
+
+	manifest, err := LoadManifest(corpusDir)
+	if err != nil {
+		t.Fatalf("corpus manifest (run cmd/fetchcorpus first): %v", err)
+	}
+
+	diverged := 0
+	for _, cm := range manifest.Mods {
+		if cm.Pak == "" || cm.Exmodz == "" {
+			continue // ground truth needs BOTH forms
+		}
+		cm := cm
+		t.Run(cm.Name, func(t *testing.T) {
+			pakPath := filepath.Join(corpusDir, cm.Pak)
+			meta := Meta{Name: cm.Name, Author: "spike-converted", Version: cm.Version, Description: "converted from pak"}
+			synthesized, report, err := ConvertPak(pakPath, basePak, meta)
+			if err != nil {
+				t.Fatalf("ConvertPak: %v", err)
+			}
+			ours, err := icarus.ParseExmodz(synthesized)
+			if err != nil {
+				t.Fatalf("ParseExmodz(ours): %v", err)
+			}
+			authorData, err := os.ReadFile(filepath.Join(corpusDir, cm.Exmodz))
+			if err != nil {
+				t.Fatalf("reading author exmodz: %v", err)
+			}
+			author, err := icarus.ParseExmodz(authorData)
+			if err != nil {
+				t.Fatalf("ParseExmodz(author): %v", err)
+			}
+
+			oursFinal := applyItems(t, base, ours.Diff.Rows)
+			authorFinal := applyItems(t, base, author.Diff.Rows)
+
+			// The stale pak snapshot, for residual classification.
+			modPak, err := unrealpak.Open(pakPath)
+			if err != nil {
+				t.Fatalf("reopening mod pak: %v", err)
+			}
+			defer modPak.Close()
+
+			gt := GroundTruthReport{ModID: cm.ID, ModName: cm.Name,
+				StaleRows: report.StaleRows, Findings: report.Findings}
+			tables := map[string]bool{}
+			for p := range oursFinal {
+				tables[p] = true
+			}
+			for p := range authorFinal {
+				tables[p] = true
+			}
+			sorted := make([]string, 0, len(tables))
+			for p := range tables {
+				sorted = append(sorted, p)
+			}
+			sort.Strings(sorted)
+
+			for _, tablePath := range sorted {
+				liveData, err := base.ReadFile(tablePath)
+				if err != nil {
+					t.Fatalf("live base %s: %v", tablePath, err)
+				}
+				var live map[string]any
+				if err := json.Unmarshal(liveData, &live); err != nil {
+					t.Fatalf("decoding live %s: %v", tablePath, err)
+				}
+				liveRows := rowsByName(live)
+				oursRows := rowsByName(oursFinal[tablePath])
+				authorRows := rowsByName(authorFinal[tablePath])
+				if oursFinal[tablePath] == nil {
+					oursRows = liveRows // we didn't touch this table
+				}
+				if authorFinal[tablePath] == nil {
+					authorRows = liveRows
+				}
+
+				// Stale pak snapshot rows for this table, if present in the pak.
+				staleRows := map[string]map[string]any{}
+				for _, e := range modPak.Files() {
+					class, rel, nerr := NormalizeEntry(modPak.MountPoint(), e.Path)
+					if nerr == nil && class == ClassTable && rel == tablePath {
+						if data, rerr := modPak.ReadFile(e.Path); rerr == nil {
+							var snap map[string]any
+							if json.Unmarshal(data, &snap) == nil {
+								staleRows = rowsByName(snap)
+							}
+						}
+					}
+				}
+
+				names := map[string]bool{}
+				for n := range oursRows {
+					names[n] = true
+				}
+				for n := range authorRows {
+					names[n] = true
+				}
+				for n := range names {
+					o, a := oursRows[n], authorRows[n]
+					if reflect.DeepEqual(o, a) {
+						continue
+					}
+					res := Residual{Table: tablePath, Row: n, Class: "diverged",
+						Detail: fmt.Sprintf("ours=%v author=%v", o, a)}
+					l, s := liveRows[n], staleRows[n]
+					switch {
+					case reflect.DeepEqual(a, l) && reflect.DeepEqual(o, s):
+						// Author's current exmodz no longer changes this row;
+						// the (older) pak did. Pak is stale relative to exmodz.
+						res.Class = "stale-pak-change"
+					case reflect.DeepEqual(o, l) && a != nil:
+						// We suppressed (pak matches live base); author's
+						// exmodz is newer than the pak build.
+						res.Class = "exmodz-newer-than-pak"
+					}
+					gt.Residuals = append(gt.Residuals, res)
+				}
+			}
+
+			gt.Verdict = "PASS"
+			for _, r := range gt.Residuals {
+				if r.Class == "diverged" {
+					gt.Verdict = "DIVERGED"
+					break
+				}
+				gt.Verdict = "EXPLAINED"
+			}
+
+			// Embedded data.EXMOD: exact-oracle check of the differ itself.
+			for _, raw := range report.EmbeddedExmods {
+				embedded, perr := icarus.ParseExmod(raw)
+				if perr != nil {
+					gt.EmbeddedMatch = "mismatch: embedded .EXMOD unparseable: " + perr.Error()
+					continue
+				}
+				gt.EmbeddedMatch = compareRowSets(embedded.Rows, ours.Diff.Rows)
+			}
+
+			if err := SaveJSON(filepath.Join(corpusDir, "reports", cm.ID+"-groundtruth.json"), gt); err != nil {
+				t.Fatalf("writing report: %v", err)
+			}
+			t.Logf("%s: %s (%d residuals, %d stale rows)", cm.Name, gt.Verdict, len(gt.Residuals), gt.StaleRows)
+			if gt.Verdict == "DIVERGED" {
+				diverged++
+				t.Errorf("DIVERGED: %+v", gt.Residuals)
+			}
+		})
+	}
+	if diverged > 0 {
+		t.Errorf("%d dual-form mods DIVERGED — see <corpus>/reports/", diverged)
+	}
+}
+
+// compareRowSets reports whether two EXMOD row sets touch the same
+// CurrentFiles with the same item Names (field-level detail goes to the
+// ground-truth comparison; this is the embedded-oracle sanity check).
+func compareRowSets(a, b []icarus.ExmodRow) string {
+	key := func(rows []icarus.ExmodRow) map[string][]string {
+		out := map[string][]string{}
+		for _, r := range rows {
+			if r.CurrentFile == "EndOfMod" {
+				continue
+			}
+			var names []string
+			for _, it := range r.FileItems {
+				names = append(names, it.Name)
+			}
+			sort.Strings(names)
+			out[r.CurrentFile] = names
+		}
+		return out
+	}
+	ka, kb := key(a), key(b)
+	if reflect.DeepEqual(ka, kb) {
+		return "match"
+	}
+	return fmt.Sprintf("mismatch: embedded=%v ours=%v", ka, kb)
+}
+```
+
+- [ ] **Step 3: Verify skip-cleanliness and compilation**
+
+Run: `go test ./spike/pakconvert/ -run TestGroundTruth -v`
+Expected: `--- SKIP: TestGroundTruthDualFormMods` with the skip reason (env vars unset). Compilation itself is the test here.
+
+- [ ] **Step 4: Manual gate — fetch corpus, then run for real**
+
+Prerequisite (once, manual): `go run ./spike/pakconvert/cmd/fetchcorpus -dir "$HOME/lmm-spike-corpus"`
+
+Run (as ONE command, not a chain):
+`LMM_SPIKE_ICARUS_DIR="<your Icarus install root>" LMM_SPIKE_CORPUS_DIR="$HOME/lmm-spike-corpus" go test ./spike/pakconvert/ -run TestGroundTruth -v`
+Expected: per-mod `PASS`/`EXPLAINED` verdict lines and reports under `$HOME/lmm-spike-corpus/reports/`. `DIVERGED` verdicts fail the test — each one is a spike finding to investigate (differ bug vs genuine inexpressibility), not something to paper over.
+
+- [ ] **Step 5: Commit**
+
+Run: `gofmt -l spike/` (expect no output), then `go vet ./spike/...` (expect no output).
+
+```bash
+git add spike/pakconvert/reports.go spike/pakconvert/groundtruth_test.go
+git commit -m "spike: ground-truth harness vs dual-form author exmodz (#220)"
+```
+
+---
+
+### Task 7: Pipeline seam check (env-gated integration)
+
+**Files:**
+
+- Create: `spike/pakconvert/pipeline_test.go`
+
+**Interfaces:**
+
+- Consumes: `spikeEnv`, `basePakPath` (Task 6); `LoadManifest` (Task 1); `ConvertPak` (Task 5); `icarus.ValidateSource`, `icarus.MergeCompile`, `icarus.MergeSource`; `unrealpak.Open`.
+- Produces: nothing new — this is the seam-validation evidence for spike question 6.
+
+- [ ] **Step 1: Write the integration test**
+
+`spike/pakconvert/pipeline_test.go`:
+
+```go
+package pakconvert
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/source/icarus"
+	"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"
+)
+
+// TestPipelineSeam proves the design's Seam A: a synthesized .exmodz is
+// indistinguishable to the real pipeline — icarus.ValidateSource accepts it
+// and icarus.MergeCompile merges it alongside a genuine author exmodz with
+// zero pipeline changes.
+func TestPipelineSeam(t *testing.T) {
+	icarusDir, corpusDir := spikeEnv(t)
+	basePak := basePakPath(icarusDir)
+
+	manifest, err := LoadManifest(corpusDir)
+	if err != nil {
+		t.Fatalf("corpus manifest (run cmd/fetchcorpus first): %v", err)
+	}
+
+	// Pick one mod with a pak to convert, and one DIFFERENT mod's genuine
+	// author exmodz to merge alongside it.
+	var convertMod, authorMod *CorpusMod
+	for i := range manifest.Mods {
+		m := &manifest.Mods[i]
+		if convertMod == nil && m.Pak != "" {
+			convertMod = m
+			continue
+		}
+		if authorMod == nil && m.Exmodz != "" && (convertMod == nil || m.ID != convertMod.ID) {
+			authorMod = m
+		}
+	}
+	if convertMod == nil || authorMod == nil {
+		t.Skip("corpus needs at least one pak mod and one other exmodz mod")
+	}
+
+	meta := Meta{Name: convertMod.Name, Author: "spike-converted", Version: convertMod.Version}
+	synthesized, report, err := ConvertPak(filepath.Join(corpusDir, convertMod.Pak), basePak, meta)
+	if err != nil {
+		t.Fatalf("ConvertPak: %v", err)
+	}
+
+	dir := t.TempDir()
+	synthPath := filepath.Join(dir, "converted.exmodz")
+	if err := os.WriteFile(synthPath, synthesized, 0o644); err != nil {
+		t.Fatalf("writing synthesized exmodz: %v", err)
+	}
+
+	// Gate 1: the ingest-time validation hook.
+	if err := icarus.ValidateSource(synthPath); err != nil {
+		t.Fatalf("icarus.ValidateSource rejected the synthesized exmodz: %v", err)
+	}
+
+	// Gate 2: the real merge, author exmodz first, converted mod second
+	// (load-order semantics: later wins conflicting fields).
+	outPak := filepath.Join(dir, "zzz_LMM_Merged_P.pak")
+	sources := []icarus.MergeSource{
+		{ModRef: "icarus:" + authorMod.ID, ExmodzPath: filepath.Join(corpusDir, authorMod.Exmodz)},
+		{ModRef: "icarus:" + convertMod.ID + "-converted", ExmodzPath: synthPath},
+	}
+	warnings, err := icarus.MergeCompile(context.Background(), basePak, sources, outPak)
+	if err != nil {
+		t.Fatalf("MergeCompile: %v", err)
+	}
+	for _, w := range warnings {
+		// Asset collisions across the two mods are legitimate; anything else
+		// is unexpected for this corpus pairing.
+		if !strings.Contains(w, "is bundled by both") {
+			t.Errorf("unexpected merge warning: %s", w)
+		}
+	}
+
+	// Gate 3: output pak shape — mount point, data/-prefixed tables, and the
+	// converted mod's changed rows actually present.
+	out, err := unrealpak.Open(outPak)
+	if err != nil {
+		t.Fatalf("opening merged pak: %v", err)
+	}
+	defer out.Close()
+	// Duplicated literal: icarusContentMountPoint (unexported upstream).
+	if got := out.MountPoint(); got != "../../../Icarus/Content/" {
+		t.Errorf("merged pak mount point = %q", got)
+	}
+	for tablePath, td := range report.Tables {
+		if len(td.Items) == 0 {
+			continue
+		}
+		// Duplicated literal: icarusDataTablePrefix "data/" (unexported upstream).
+		data, err := out.ReadFile("data/" + tablePath)
+		if err != nil {
+			t.Errorf("converted table %s missing from merged pak: %v", tablePath, err)
+			continue
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Errorf("merged table %s is not JSON: %v", tablePath, err)
+			continue
+		}
+		merged := rowsByName(decoded)
+		for _, item := range td.Items {
+			row, ok := merged[item.Name]
+			if !ok {
+				t.Errorf("row %s missing from merged %s", item.Name, tablePath)
+				continue
+			}
+			for field, want := range item.Fields {
+				if got, ok := row[field]; !ok || !jsonEqual(got, want) {
+					t.Errorf("merged %s row %s field %s = %v, want %v", tablePath, item.Name, field, got, want)
+				}
+			}
+		}
+	}
+	t.Logf("seam validated: converted %q merged alongside %q, %d warnings", convertMod.Name, authorMod.Name, len(warnings))
+}
+
+// jsonEqual compares two decoded-JSON values via re-marshaling (normalizes
+// map ordering and numeric formatting).
+func jsonEqual(a, b any) bool {
+	ja, errA := json.Marshal(a)
+	jb, errB := json.Marshal(b)
+	return errA == nil && errB == nil && string(ja) == string(jb)
+}
+```
+
+- [ ] **Step 2: Verify skip-cleanliness and compilation**
+
+Run: `go test ./spike/pakconvert/ -run TestPipelineSeam -v`
+Expected: `--- SKIP: TestPipelineSeam` (env vars unset).
+
+- [ ] **Step 3: Run for real**
+
+Run (one command):
+`LMM_SPIKE_ICARUS_DIR="<your Icarus install root>" LMM_SPIKE_CORPUS_DIR="$HOME/lmm-spike-corpus" go test ./spike/pakconvert/ -run TestPipelineSeam -v`
+Expected: PASS with the `seam validated:` log line. A failure here is a core spike finding (the seam is NOT clean) — record it, do not patch internal/.
+
+- [ ] **Step 4: Commit**
+
+Run: `gofmt -l spike/` (expect no output), then `go vet ./spike/...` (expect no output).
+
+```bash
+git add spike/pakconvert/pipeline_test.go
+git commit -m "spike: pipeline seam check - synthesized exmodz through real MergeCompile (#220)"
+```
+
+---
+
+### Task 8: Asset probe (env-gated, report-only)
+
+**Files:**
+
+- Create: `spike/pakconvert/assetprobe_test.go`
+
+**Interfaces:**
+
+- Consumes: `spikeEnv` (Task 6), `LoadManifest`/`SaveJSON` (Task 1), `NormalizeEntry` (Task 2), `unrealpak.Open`, `unrealpak.ErrUnsupportedFormat`.
+- Produces: `type AssetProbeReport struct { ModID, ModName, MountPoint string; Entries []ProbeEntry; ExtensionCensus map[string]int; LayoutMatchesInference bool }`; `type ProbeEntry struct { Path string; Size int64; Class, TablePath, ReadError string; Readable bool }`. Report-only: this test NEVER fails on pak content — only on I/O plumbing errors.
+
+- [ ] **Step 1: Write the probe test**
+
+`spike/pakconvert/assetprobe_test.go`:
+
+```go
+package pakconvert
+
+import (
+	"errors"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"
+)
+
+// AssetProbeReport records the empirical dissection of one mod pak —
+// answering spike question 4 (does the inferred asset layout hold?).
+type AssetProbeReport struct {
+	ModID                  string
+	ModName                string
+	MountPoint             string
+	Entries                []ProbeEntry
+	ExtensionCensus        map[string]int
+	LayoutMatchesInference bool // all assets join under Icarus/Content/ WITHOUT a data/ prefix
+}
+
+// ProbeEntry is one pak entry's classification + readability.
+type ProbeEntry struct {
+	Path      string
+	Size      int64
+	Class     string
+	TablePath string
+	Readable  bool
+	ReadError string // "" | "oodle-or-unsupported" | raw error text
+}
+
+// TestAssetProbe dissects EVERY corpus pak (the asset-heavy ones are the
+// point, but census data on all of them is free) and writes
+// <corpus>/reports/<id>-assetprobe.json. Report-only: pak content never
+// fails the test.
+func TestAssetProbe(t *testing.T) {
+	_, corpusDir := spikeEnv(t)
+	manifest, err := LoadManifest(corpusDir)
+	if err != nil {
+		t.Fatalf("corpus manifest (run cmd/fetchcorpus first): %v", err)
+	}
+	for _, cm := range manifest.Mods {
+		if cm.Pak == "" {
+			continue
+		}
+		cm := cm
+		t.Run(cm.Name, func(t *testing.T) {
+			r, err := unrealpak.Open(filepath.Join(corpusDir, cm.Pak))
+			if err != nil {
+				// Unreadable pak IS a census result, not a test failure.
+				report := AssetProbeReport{ModID: cm.ID, ModName: cm.Name,
+					ExtensionCensus: map[string]int{"UNOPENABLE: " + err.Error(): 1}}
+				if serr := SaveJSON(filepath.Join(corpusDir, "reports", cm.ID+"-assetprobe.json"), report); serr != nil {
+					t.Fatalf("writing report: %v", serr)
+				}
+				t.Logf("%s: pak unopenable: %v", cm.Name, err)
+				return
+			}
+			defer r.Close()
+
+			report := AssetProbeReport{
+				ModID: cm.ID, ModName: cm.Name, MountPoint: r.MountPoint(),
+				ExtensionCensus:        map[string]int{},
+				LayoutMatchesInference: true,
+			}
+			for _, e := range r.Files() {
+				pe := ProbeEntry{Path: e.Path, Size: e.Size}
+				ext := strings.ToLower(path.Ext(e.Path))
+				if ext == "" {
+					ext = "(none)"
+				}
+				report.ExtensionCensus[ext]++
+
+				class, rel, nerr := NormalizeEntry(r.MountPoint(), e.Path)
+				pe.Class = class.String()
+				if nerr != nil {
+					pe.Class = "hyphen-error"
+				} else if class == ClassTable {
+					pe.TablePath = rel
+				}
+
+				if _, rerr := r.ReadFile(e.Path); rerr != nil {
+					pe.Readable = false
+					if errors.Is(rerr, unrealpak.ErrUnsupportedFormat) {
+						pe.ReadError = "oodle-or-unsupported"
+					} else {
+						pe.ReadError = rerr.Error()
+					}
+				} else {
+					pe.Readable = true
+				}
+
+				if class == ClassAsset {
+					// Inference under probe (pak-divergence-report §2): assets
+					// join under Icarus/Content/ with NO data/ prefix.
+					full := path.Join(r.MountPoint(), e.Path)
+					if !strings.HasPrefix(full, "../../../Icarus/Content/") ||
+						strings.HasPrefix(strings.TrimPrefix(full, "../../../Icarus/Content/"), "data/") {
+						report.LayoutMatchesInference = false
+					}
+				}
+				report.Entries = append(report.Entries, pe)
+			}
+			if err := SaveJSON(filepath.Join(corpusDir, "reports", cm.ID+"-assetprobe.json"), report); err != nil {
+				t.Fatalf("writing report: %v", err)
+			}
+			t.Logf("%s: %d entries, mount %q, extensions %v, layoutMatchesInference=%v",
+				cm.Name, len(report.Entries), report.MountPoint, report.ExtensionCensus, report.LayoutMatchesInference)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Verify skip-cleanliness and compilation**
+
+Run: `go test ./spike/pakconvert/ -run TestAssetProbe -v`
+Expected: `--- SKIP: TestAssetProbe` (env vars unset).
+
+- [ ] **Step 3: Run for real**
+
+Run (one command):
+`LMM_SPIKE_ICARUS_DIR="<your Icarus install root>" LMM_SPIKE_CORPUS_DIR="$HOME/lmm-spike-corpus" go test ./spike/pakconvert/ -run TestAssetProbe -v`
+Expected: PASS with per-mod log lines; reports under `$HOME/lmm-spike-corpus/reports/`. Pay attention to the Larkwell / Turret Variants lines — their `LayoutMatchesInference` and extension census answer spike question 4.
+
+- [ ] **Step 4: Full offline suite sanity + commit**
+
+Run: `go test ./spike/pakconvert/ -v`
+Expected: unit tests PASS, the three integration tests SKIP (no env vars in this invocation).
+Run: `go test ./...`
+Expected: whole repo green (spike package included, integration skipped).
+Run: `gofmt -l spike/` (expect no output), then `go vet ./spike/...` (expect no output).
+
+```bash
+git add spike/pakconvert/assetprobe_test.go
+git commit -m "spike: asset-bearing pak probe, report-only (#220)"
+```
+
+---
+
+### Task 9: Findings doc + wrap-up
+
+**Files:**
+
+- Create: `docs/plans/<today's date>-icarus-pak-to-exmod-spike-findings.md` (gitignored — force-add)
+- Read: every `$LMM_SPIKE_CORPUS_DIR/reports/*.json`, `$LMM_SPIKE_CORPUS_DIR/catalog-census.json`, and the design doc `docs/plans/2026-08-05-icarus-pak-to-exmod-spike-design.md`
+
+**Interfaces:**
+
+- Consumes: all reports from Tasks 6–8. Produces the spike's durable deliverable. No new Go code.
+
+- [ ] **Step 1: Aggregate the numbers**
+
+Read `catalog-census.json` and every `reports/*.json`. Compute: total catalog mods; pak-only / exmodz-only / dual-form counts; per-verdict counts (PASS / EXPLAINED / DIVERGED); total residuals by class; finding-kind frequencies (`defaults-changed`, `field-removed`, `table-not-in-base`, `hyphen-path`, `unreadable-entry`, `duplicate-row-name`, `top-level-changed`, `unsafe-asset-path`); asset-probe layout confirmations; stale-row totals.
+
+- [ ] **Step 2: Write the findings doc**
+
+Structure (real section headings — fill every one; a section with nothing to report says so explicitly):
+
+```markdown
+# Icarus PAK → EXMOD Conversion Spike — Findings
+
+**Date:** <today> **Spike issue:** #220 **Branch:** spike/pak-to-exmod
+**Design doc:** 2026-08-05-icarus-pak-to-exmod-spike-design.md
+
+## Verdict: GO | PARTIAL GO | NO-GO
+
+<One paragraph. Apply the design rubric verbatim: GO requires semantic
+equivalence on ≥3 of 4 sampled dual-form mods with every residual explained,
+clean MergeCompile, and the seam validated end-to-end.>
+
+## Evidence Summary
+
+<Ground-truth verdict table: mod | verdict | residuals | classification.
+MergeCompile/ValidateSource results. Embedded-.EXMOD oracle outcomes.>
+
+## Census
+
+<Catalog: N mods, X pak-only, Y dual-form, Z exmodz-only. Corpus: fetched
+counts. Convertibility: readable/unreadable, tables/assets/mixed.>
+
+## Answers to the Six Spike Questions
+
+### 1. Path normalization ### 2. Differ fidelity
+
+### 3. Convertibility census ### 4. Asset probe
+
+### 5. Expressiveness gaps ### 6. Seam validation
+
+<Each: the design doc's question restated in one line, then the empirical
+answer with numbers from the reports.>
+
+## Expressiveness-Gap Frequencies
+
+<How often Defaults-changed / field-removed / hyphen / table-not-in-base
+actually occurred, and what that means for a production converter.>
+
+## Constraints a Feature Design Must Honor
+
+<From the evidence. At minimum address: stale-snapshot diffing (live base,
+absent-rows-are-staleness); mount+entry normalized as a pair; the four
+unexported upstream values (endOfModSentinel, icarusContentMountPoint,
+icarusDataTablePrefix, the '-'/'/' flatten) that should be EXPORTED (or a
+conversion API added to internal/source/icarus) before production work;
+fingerprint membership for converted paks; pak/exmodz alternate-form
+validation and #211 IsPrimary; double-apply prevention (deployableFiles +
+PruneUnclaimed).>
+
+## Open Product Questions
+
+<Selection UX, defaults, migration of already-installed pak mods, etc. —
+questions, not answers.>
+
+## Raw Data
+
+<Corpus dir layout note + reminder reports are NOT committed.>
+```
+
+- [ ] **Step 3: Self-check the verdict against the rubric**
+
+Re-read the design doc's "Go / No-Go Rubric" section and confirm the verdict paragraph cites the actual numbers (e.g. "4/6 PASS, 2/6 EXPLAINED, 0 DIVERGED"). If any DIVERGED verdict remains unexplained, the verdict CANNOT be GO — say so honestly.
+
+- [ ] **Step 4: Commit (force-add, docs are gitignored) and update the spike issue**
+
+```bash
+git add -f docs/plans/*-icarus-pak-to-exmod-spike-findings.md
+git commit -m "spike: findings and go/no-go recommendation (#220)"
+git push origin spike/pak-to-exmod
+```
+
+Then post the summary to the issue (fill the verdict line from the doc):
+
+```bash
+gh issue comment 220 --body "Spike complete on \`spike/pak-to-exmod\`. Verdict: <GO|PARTIAL GO|NO-GO> — <one-sentence why>. Full findings: docs/plans/<date>-icarus-pak-to-exmod-spike-findings.md on the spike branch. Key numbers: <dual-form verdicts>, <census summary>, <seam result>."
+```
+
+- [ ] **Step 5: Final verification sweep**
+
+Run: `go test ./...`
+Expected: green everywhere (integration tests skip without env vars).
+Run: `git status`
+Expected: clean tree; corpus dir and reports remain OUTSIDE the repo; nothing under `spike/` or `docs/plans/` left uncommitted on the spike branch.
+
+---
+
+## Execution Notes
+
+- Tasks 1–5 are fully offline and machine-independent. Tasks 6–8 need the user's real Icarus install + a fetched corpus; coordinate the one-time `fetchcorpus` run before starting Task 6.
+- Task order is strict for 1→5 (each consumes the previous task's interfaces). Tasks 6/7/8 are independent of each other once 5 is done — parallelizable across workers IF each runs the env-gated tests on the same machine/corpus.
+- Every DIVERGED ground-truth verdict, seam failure, or layout-inference refutation is spike EVIDENCE, not a bug to silently fix around: record it in the findings doc even when a differ fix also lands.

--- a/docs/plans/archive/2026-08-05-pak-to-exmod-feature-design.md
+++ b/docs/plans/archive/2026-08-05-pak-to-exmod-feature-design.md
@@ -1,0 +1,167 @@
+# Feature Design: PAK→EXMOD Merge-Time Conversion (Icarus)
+
+**Date:** 2026-08-05
+**Status:** Approved design — implementation not started
+**Builds on:** Spike #220 (PARTIAL GO) — `docs/plans/2026-08-05-icarus-pak-to-exmod-spike-findings.md`
+on frozen branch `spike/pak-to-exmod`. Spike constraints 4 (case-insensitive
+pair normalization) and 5 (the four upstream values) are binding inputs here.
+
+## Problem and Semantics
+
+Prebuilt PAK mods are frozen in time: their tables are whole-file snapshots
+of whichever `data.pak` existed when the author built them. Deployed raw,
+they are shadowed by `zzz_LMM_Merged_P.pak` wherever tables overlap, and
+they silently revert base-game updates on every field of every row they
+touch.
+
+**The feature: rebase.** At merge time, decompile the pak, rebuild its
+changes against the game's _current_ `data.pak`, and merge it with all
+other deployed mods exactly as exmodz mods merge today.
+
+- **Tier 1 (exact):** when the pak embeds a `data.EXMOD` manifest, use it —
+  it is pure author intent, applied to the current base via the normal
+  upsert path. (Covered 5 of 8 hard cases in the spike corpus.)
+- **Tier 2 (derived):** otherwise, diff the pak's tables against the
+  current base by row `Name`, emitting changed fields whole-field and new
+  rows verbatim. Drift baked into author-touched rows is **accepted by
+  design** (user ruling 2026-08-05): it is the rebase semantic, not an
+  error. Base-only rows are staleness, never deletions.
+- **Failure is per-mod:** an irreconcilable pak produces a clear error,
+  skips the merge, and falls back to raw deploy (today's behavior). Other
+  mods continue. No partial conversion of a mod.
+
+Load-order upserts, asset whole-file last-wins with warning, merged-pak
+regeneration triggers — all downstream behavior unchanged.
+
+## Architecture (Approach A — merge-time conversion from retained raw pak)
+
+Chosen over ingest-time synthesis because the derived diff goes stale on
+every weekly base update: the raw pak is the durable source; derivation
+happens where the current base is already open.
+
+### Ingest seam
+
+For a convert-eligible pak (compile-mode game, conversion not opted out),
+ingest retains the raw `.pak` under `cache.RetainedSourceName(fileID)` —
+the same marker that drives merge membership today. The spike proved this
+seam requires zero downstream schema changes. Both ingest paths (download
+`service.go` and import `importer.go`) get the same widened predicate:
+compile-eligible = exmodz OR convert-eligible pak.
+
+The pak/exmodz mutual-exclusion validation and the exmodz-`IsPrimary`
+default (#211) are unchanged — exmodz remains the preferred form when the
+author ships one.
+
+### Merge seam
+
+`source.MergeSource.ExmodzPath` is renamed `SourcePath` (internal
+interface; update the icarus alias and all call sites). `MergeCompile`
+distinguishes source kind by file extension:
+
+- `.exmodz` → existing path, unchanged.
+- `.pak` → in-memory conversion: open pak → normalize entries
+  (case-insensitive mount+entry pair, original case preserved) → Tier 1
+  embedded-`data.EXMOD` if present, else Tier 2 table diff against the
+  already-open current base state → feed the resulting rows through the
+  same `ApplyRowPatch` sequence; assets pass through the existing
+  sanitizer and last-wins map.
+- Conversion failure → the mod contributes nothing; a structured warning
+  (mod ref + reason) is returned; remaining sources continue. Note: this
+  is a _warning_ at the MergeCompile contract level (non-empty output pak
+  still valid) but surfaced as a per-mod **error** in UX.
+
+No synthesized `.exmodz` artifact is written to disk.
+
+### Converter code
+
+Promoted into `internal/source/icarus` (new files, e.g. `convert.go` /
+`normalize.go` sibling logic), rewritten to production standard using the
+spike package as the reference implementation — not copied wholesale.
+Spike lessons that are binding: `hasPrefixFold`-style case-insensitive
+prefix matching with original-case preservation; hyphen-in-path guard;
+reuse of `sanitizeAssetPath`; the four formerly-duplicated values
+(`endOfModSentinel`, mount point, `data/` prefix, `-`↔`/` flatten) are now
+intra-package — no exports needed (irrelevant to #170's timeline).
+The spike branch itself stays frozen; `spike/pakconvert` is never merged.
+
+## Irreconcilable Criteria (whole-mod failure)
+
+- Pak unreadable: encrypted index, unsupported version, unsupported
+  compression (Oodle), corrupt structure.
+- Unresolvable entry structure: table entries whose mount+path pair cannot
+  be mapped into the base's directory layout (e.g. bare-`Content/` mounts
+  with no subdirectory information — the "Intreeg's More Resources" case).
+- A pak table absent from the current base (`table-not-in-base`).
+- Hyphen-ambiguous table paths (CurrentFile flattening would be lossy).
+- `RowStruct` mismatch between the pak's table and the current base's.
+
+Per-row / per-field drift is never an error. `Defaults`-only differences:
+warning, table still converts (inexpressible in EXMOD row semantics;
+visible in output, accepted as minor loss).
+
+## Overrides and Fallback
+
+- **Per-game config:** `convert_paks: true|false` in `games.yaml`
+  (default `true` for compile-mode games; irrelevant otherwise).
+- **Per-mod opt-out:** persisted in the DB; CLI `lmm mod convert <mod>
+on|off` (naming may be refined at plan time to match existing `mod`
+  subcommand conventions) + TUI toggle (CLI/TUI parity is a standing
+  repo requirement).
+- Merge-membership discovery honors both; opted-out and conversion-failed
+  mods deploy raw through the existing manifest/convergence machinery,
+  exactly as pak mods deploy today.
+- Conversion failures surface with reasons in `deploy`, `update`,
+  `verify`, and `status` (human + JSON; JSON-contract additions are MINOR
+  per precedent).
+
+## Staleness, Fingerprint, Migration
+
+- `MergedFingerprint` already includes base `IndexHash` and per-mod
+  retained-source checksums; a retained pak's MD5 slots in identically.
+  Weekly base updates therefore regenerate the merged pak and re-derive
+  every converted pak against the new base automatically. The
+  Friday-recompile machinery (#196) composes untouched.
+- Per-mod convert flags participate in staleness: toggling a mod's
+  conversion changes merge membership and must regenerate the merged pak.
+- **Migration is lazy:** existing installed pak mods have no retained
+  source in cache. Deploy/verify convergence detects convert-eligible pak
+  mods lacking the marker and re-ingests from the cached archive (the
+  #166 stale re-ingest path). No big-bang migration step. The same path
+  heals a mod that is opted in after having been ingested without the
+  marker.
+
+## Testing
+
+- Converter unit tests in `internal/source/icarus`, adapted from the spike
+  suite: normalization variants (incl. capital-`Data/`, bare-`Content/`,
+  hyphen guard), differ rules (changed/new/stale/duplicate/inexpressible),
+  Tier 1 embedded-EXMOD extraction, irreconcilable classifications —
+  synthetic fixture paks built with `unrealpak.Create` (mod files are
+  copyrighted; nothing from the corpus is committed).
+- MergeCompile-level tests: pak + exmodz mixed sources, load-order wins,
+  failure-skip-continue, warning surfacing.
+- **CLI-seam integration tests for every mutation entry point** (install,
+  import, deploy, verify --fix, convert toggle) — the merged-pak epic's
+  hard lesson; core-level tests alone are insufficient.
+- TUI smoke test gate before merge; live in-game validation on the real
+  install before release.
+
+## Versioning / Scope
+
+- Ships as **MINOR** (new functionality; JSON additions).
+- Single story branch `feat/pak-to-exmod-convert` off `develop`, PR
+  `--base develop`; no version bump on the story PR.
+- Out of scope: non-Icarus games, Oodle support, #170 module extraction,
+  derivation caching (Approach C — add later only if conversion time is
+  measured to matter), TUI conversion-report views beyond status surfacing.
+
+## Success Criteria
+
+- A pak-only mod (no exmodz form) installs, converts, and its table
+  changes are present in `zzz_LMM_Merged_P.pak` rebased onto the current
+  base, alongside exmodz mods, honoring load order.
+- Base update → next sync re-derives automatically; no stale table wins.
+- An irreconcilable pak yields a clear per-mod error, deploys raw, and
+  does not block other mods.
+- Opt-outs honored at global and per-mod level from both CLI and TUI.
+- All existing exmodz behavior byte-identical when no pak mods are present.

--- a/docs/plans/archive/2026-08-05-pak-to-exmod-feature-plan.md
+++ b/docs/plans/archive/2026-08-05-pak-to-exmod-feature-plan.md
@@ -1,0 +1,2517 @@
+# Icarus PAK→EXMOD Merge-Time Conversion Implementation Plan (#221)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pak-only Icarus mods participate in `zzz_LMM_Merged_P.pak` by in-memory conversion at merge time — rebased onto the _current_ `data.pak` — with per-mod error-and-skip falling back to raw deploy.
+
+**Architecture:** Ingest retains the raw `.pak` (like exmodz) but also records a deployable member, so raw-deploy is the default state; `MergeCompile` dispatches per source kind and converts paks in-memory (Tier 1: embedded `data.EXMOD`; Tier 2: table diff vs the already-open current base); `syncMergedPak` learns which mods failed, records outcomes in the fingerprint, and reconciles each pak mod's cache manifest (converted → members=nil → merged-pak claims it; failed/opted-out → members=[pak] → raw deploys). Weekly base updates re-derive automatically via the existing fingerprint.
+
+**Tech Stack:** Go 1.25.6, stdlib + in-repo `internal/unrealpak`, `modernc.org/sqlite`, cobra, bubbletea. No new dependencies.
+
+## Global Constraints
+
+- Branch `feat/pak-to-exmod-convert` off `develop`; PR with explicit `--base develop`. NO version bump; CHANGELOG entries under `[Unreleased]`.
+- Conventional commits: `feat:` / `refactor:` / `test:` / `docs:`, referencing `(#221)`.
+- Before EVERY commit: `gofmt -l .` (expect no output beyond pre-existing), `go vet ./...`, full `go test ./...` green. NEVER pipe `go test` inside a `&&` chain — run it as its own command and read its real output.
+- `internal/core` must NEVER import `internal/source/icarus` (alias pattern via `source.MergeSource` — see internal/source/icarus/merge.go:12-21).
+- The spike branch `spike/pak-to-exmod` is a frozen, read-only reference: consult with `git show spike/pak-to-exmod:<path>`, never checkout, never merge. Port logic; do not copy files wholesale. The spike's `WriteExmod`/`WriteExmodz` wire-schema emitters are NOT ported (conversion is in-memory; no synthesized artifact on disk).
+- Existing exmodz behavior must remain byte-identical when no pak mods participate (exmodz error policy stays FATAL; warnings text unchanged).
+- Rebase semantics are BY DESIGN (user ruling 2026-08-05): drift baked into author-touched rows is not an error. Irreconcilable paks fail whole-mod: error + skip + raw deploy; other mods continue.
+- Test fixtures are synthetic paks built with `unrealpak.Create` in `t.TempDir()` — nothing from the mod corpus is ever committed (copyrighted).
+- JSON output-contract additions are MINOR (established precedent) — additive fields only, `omitempty` where a field is conditional.
+- SQLite tests use `:memory:`; filesystem tests use `t.TempDir()`.
+
+---
+
+### Task 1: Rename MergeSource.ExmodzPath → SourcePath (+ membership function rename)
+
+The field is about to hold `.pak` paths too; the name must stop lying before any behavior changes. Pure mechanical refactor — the compiler is the test.
+
+**Files:**
+
+- Modify: `internal/source/source.go:168-173`
+- Modify: `internal/source/icarus/merge.go` (3 sites: 71, 73, 77 + doc comments)
+- Modify: `internal/core/merged_pak.go` (sites 113-137 incl. function rename, 143, 294, 296, 313, 315)
+- Modify (tests, mechanical): `cmd/lmm/install_compile_test.go:62`, `internal/core/merged_pak_import_flow_test.go:74`, `internal/core/merged_pak_test.go:69`, `internal/core/service_icarus_compile_test.go:88`, `internal/tui/service_core_recompile_test.go:65`, `internal/source/icarus/merge_test.go` (11 sites), plus any `EnabledExmodzSourcesForTest` callers in `internal/core/*_test.go`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `source.MergeSource{ModRef string; SourcePath string}`; `Service.enabledMergeSources` (was `enabledExmodzSources`); `Service.EnabledMergeSourcesForTest` (was `EnabledExmodzSourcesForTest`). Every later task uses these names.
+
+- [ ] **Step 1: Rename the struct field**
+
+In `internal/source/source.go`, change the `MergeSource` declaration to:
+
+```go
+// MergeSource identifies one mod's contribution to a merge, in the order it
+// must be applied (profile load order).
+type MergeSource struct {
+	ModRef     string // "sourceID:modID" - identity used in collision warnings
+	SourcePath string // the retained source archive to read (.exmodz, or a raw .pak eligible for conversion - #221)
+}
+```
+
+- [ ] **Step 2: Chase compile errors**
+
+Run: `go build ./...`
+Expected: FAIL with `unknown field ExmodzPath` / `undefined: ... ExmodzPath` in the files listed above.
+
+Fix every site mechanically (`ExmodzPath:` → `SourcePath:`, `.ExmodzPath` → `.SourcePath`). Enumerate with:
+
+Run: `grep -rn 'ExmodzPath' --include='*.go' .`
+Expected after fixing: no output.
+
+- [ ] **Step 3: Rename the membership function**
+
+In `internal/core/merged_pak.go`: rename `enabledExmodzSources` → `enabledMergeSources` and `EnabledExmodzSourcesForTest` → `EnabledMergeSourcesForTest`. Update the doc comments: the function returns "every enabled mod's retained merge-source files" (drop "exmodz" specificity; the retained-marker semantics text stays). Update the caller in `currentMergedFingerprint` (merged_pak.go:294) and its error string `"listing enabled exmodz mods"` → `"listing enabled merge sources"`. Fix test callers:
+
+Run: `grep -rn 'EnabledExmodzSourcesForTest\|enabledExmodzSources' --include='*.go' .`
+Expected after fixing: no output.
+
+- [ ] **Step 4: Full verification**
+
+Run: `gofmt -l .` → expected: no output.
+Run: `go vet ./...` → expected: no output.
+Run: `go test ./...`
+Expected: PASS everywhere (behavior-preserving rename).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: rename MergeSource.ExmodzPath to SourcePath (#221)"
+```
+
+---
+
+### Task 2: Converter core — pak entry normalization (internal/source/icarus)
+
+Port the spike's classification logic (case-insensitive, original-case-preserving, hyphen guard) into the icarus package as unexported production code. Reference: `git show spike/pak-to-exmod:spike/pakconvert/normalize.go`.
+
+**Files:**
+
+- Create: `internal/source/icarus/pakconvert.go`
+- Create: `internal/source/icarus/pakconvert_test.go`
+
+**Interfaces:**
+
+- Consumes: existing unexported consts `icarusContentMountPoint` (compile.go:131), `icarusDataTablePrefix` (compile.go:140).
+- Produces (unexported, same package): `type entryClass int` with `classOther, classTable, classEmbeddedExmod, classAsset` and `String() string`; `func hasPrefixFold(s, prefix string) bool`; `func normalizeEntry(mountPoint, entryPath string) (entryClass, string, error)`; `func currentFileFor(tablePath string) string`. Tasks 3-4 consume all of these.
+
+- [ ] **Step 1: Write the failing test**
+
+`internal/source/icarus/pakconvert_test.go`:
+
+```go
+package icarus
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeEntry(t *testing.T) {
+	tests := []struct {
+		name      string
+		mount     string
+		entry     string
+		wantClass entryClass
+		wantPath  string
+		wantErr   string
+	}{
+		{
+			// Intreegs4XP layout: data/ boundary in the entry path.
+			name: "table with data prefix in entry", mount: "../../../Icarus/Content/",
+			entry: "data/Experience/D_ExperienceEvents.json",
+			wantClass: classTable, wantPath: "Experience/D_ExperienceEvents.json",
+		},
+		{
+			// FloofLevelCap layout: data/ boundary inside the mount point.
+			name: "table with data prefix in mount", mount: "../../../Icarus/Content/data/Character/",
+			entry: "D_CharacterGrowth.json",
+			wantClass: classTable, wantPath: "Character/D_CharacterGrowth.json",
+		},
+		{
+			// Eye Colors Expanded! layout: capital Data/ segment (spike round-3
+			// audit) - classification must be case-insensitive but the returned
+			// path must preserve ORIGINAL case for base.ReadFile lookups.
+			name: "capital Data segment", mount: "../../../Icarus/Content/Data/",
+			entry: "Inventory/D_InventoryInfo.json",
+			wantClass: classTable, wantPath: "Inventory/D_InventoryInfo.json",
+		},
+		{
+			name: "embedded exmod", mount: "../../../Icarus/Content/",
+			entry: "data.EXMOD",
+			wantClass: classEmbeddedExmod, wantPath: "data.EXMOD",
+		},
+		{
+			name: "uasset asset", mount: "../../../Icarus/Content/",
+			entry: "Mods/Bear/SK_Saddle.uasset",
+			wantClass: classAsset, wantPath: "Mods/Bear/SK_Saddle.uasset",
+		},
+		{
+			name: "uexp asset", mount: "../../../Icarus/Content/",
+			entry: "Mods/Bear/SK_Saddle.uexp",
+			wantClass: classAsset, wantPath: "Mods/Bear/SK_Saddle.uexp",
+		},
+		{
+			// Intreeg's More Resources layout: bare Content/, no Icarus/ segment
+			// - unmappable, classifies other (Task 4 turns json-others into a
+			// whole-mod error).
+			name: "bare content json is other", mount: "../../../Content/",
+			entry: "D_ProcessorRecipes.json",
+			wantClass: classOther, wantPath: "",
+		},
+		{
+			name: "json outside data dir is other", mount: "../../../Icarus/Content/",
+			entry: "Readme/notes.json",
+			wantClass: classOther, wantPath: "",
+		},
+		{
+			name: "hyphenated table path errors", mount: "../../../Icarus/Content/",
+			entry: "data/AI/D_AI-Growth.json",
+			wantClass: classTable, wantErr: "hyphen",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class, rel, err := normalizeEntry(tt.mount, tt.entry)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if class != tt.wantClass || rel != tt.wantPath {
+				t.Fatalf("got (%v, %q), want (%v, %q)", class, rel, tt.wantClass, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestCurrentFileFor(t *testing.T) {
+	got := currentFileFor("Audio/MusicConditions/D_MusicLocationConditions.json")
+	want := "Audio-MusicConditions-D_MusicLocationConditions.json"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/icarus/ -run 'TestNormalizeEntry|TestCurrentFileFor' -v`
+Expected: FAIL — `undefined: normalizeEntry` (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+`internal/source/icarus/pakconvert.go`:
+
+```go
+package icarus
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// entryClass classifies one mod-pak entry for pak→exmod conversion (#221).
+type entryClass int
+
+const (
+	classOther entryClass = iota
+	classTable
+	classEmbeddedExmod
+	classAsset
+)
+
+func (c entryClass) String() string {
+	switch c {
+	case classTable:
+		return "table"
+	case classEmbeddedExmod:
+		return "embedded-exmod"
+	case classAsset:
+		return "asset"
+	default:
+		return "other"
+	}
+}
+
+// hasPrefixFold reports whether s starts with prefix, ASCII-case-insensitively.
+// UE virtual paths are case-insensitive (the game loads paks regardless of
+// "Data/" vs "data/"), so a case-sensitive match silently misclassifies real
+// mod paks - the spike's ground-truth audit caught a capital "Data/" mount
+// segment doing exactly that (spike findings doc, constraint 4).
+func hasPrefixFold(s, prefix string) bool {
+	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+}
+
+// normalizeEntry joins a mod pak's mount point with one entry path and
+// classifies the result. The data/ boundary floats between mount point and
+// entry path in real mod paks, so classification always works on the JOINED
+// path. For classTable the returned string is the base-table mount-relative
+// path (what data.pak's Files() report, and what currentFileFor flattens);
+// for classAsset/classEmbeddedExmod it is the Content-relative remainder;
+// for classOther it is "". Prefix matching is case-insensitive, but the
+// ORIGINAL case of the returned path is preserved - it must match the live
+// base pak's actual entry casing for base.ReadFile lookups.
+func normalizeEntry(mountPoint, entryPath string) (entryClass, string, error) {
+	full := path.Join(mountPoint, entryPath) // Join cleans but keeps leading ../
+	if !hasPrefixFold(full, icarusContentMountPoint) {
+		return classOther, "", nil
+	}
+	rest := full[len(icarusContentMountPoint):] // slice, not TrimPrefix: preserve original case
+	lower := strings.ToLower(rest)
+	switch {
+	case strings.HasSuffix(lower, ".exmod"):
+		return classEmbeddedExmod, rest, nil
+	case strings.HasSuffix(lower, ".uasset") || strings.HasSuffix(lower, ".uexp"):
+		return classAsset, rest, nil
+	case hasPrefixFold(rest, icarusDataTablePrefix) && strings.HasSuffix(lower, ".json"):
+		tablePath := rest[len(icarusDataTablePrefix):] // slice: preserve original case
+		if strings.Contains(tablePath, "-") {
+			// The CurrentFile encoding replaces ALL '/' with '-' and is only
+			// reversible because no real base-table path contains a hyphen
+			// (matchMountPath, compile.go). A hyphen here would produce an
+			// unresolvable CurrentFile.
+			return classTable, "", fmt.Errorf("icarus: table path %q contains a hyphen: CurrentFile flattening would be ambiguous", tablePath)
+		}
+		return classTable, tablePath, nil
+	default:
+		return classOther, "", nil
+	}
+}
+
+// currentFileFor flattens a base-table mount-relative path into the .EXMOD
+// CurrentFile encoding (forward direction of matchMountPath's reversal).
+func currentFileFor(tablePath string) string {
+	return strings.ReplaceAll(tablePath, "/", "-")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/icarus/ -run 'TestNormalizeEntry|TestCurrentFileFor' -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Full suite + commit**
+
+Run: `gofmt -l .` → no output. Run: `go vet ./...` → no output.
+Run: `go test ./...`
+Expected: PASS.
+
+```bash
+git add internal/source/icarus/pakconvert.go internal/source/icarus/pakconvert_test.go
+git commit -m "feat: pak entry normalization for pak-to-exmod conversion (#221)"
+```
+
+---
+
+### Task 3: Converter core — table differ producing ExmodFileItem upserts
+
+Diff a pak's (stale, whole-file) table snapshot against the CURRENT base table, emitting `ExmodFileItem` upserts directly — no wire-schema JSON round-trip. Reference: `git show spike/pak-to-exmod:spike/pakconvert/diff.go`, with feature-grade policy changes: RowStruct mismatch is now a hard error (irreconcilable, per design §4); Defaults/top-level/field-removed/duplicate-name are warnings.
+
+**Files:**
+
+- Modify: `internal/source/icarus/pakconvert.go` (append)
+- Modify: `internal/source/icarus/pakconvert_test.go` (append)
+
+**Interfaces:**
+
+- Consumes: `ExmodFileItem{Name string; Fields map[string]any}` (exmod.go:29-33).
+- Produces (unexported): `func diffTable(tableRef string, baseJSON, modJSON []byte) (items []ExmodFileItem, warnings []string, err error)`. Task 4 consumes it. `tableRef` is used only to prefix warning/error text.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/source/icarus/pakconvert_test.go`:
+
+```go
+func TestDiffTable(t *testing.T) {
+	base := []byte(`{
+		"RowStruct": "/Script/Icarus.Growth",
+		"Defaults": {"XP": 1},
+		"Rows": [
+			{"Name": "RowA", "XP": 10, "Level": 1},
+			{"Name": "RowB", "XP": 20, "Level": 2},
+			{"Name": "BaseOnly", "XP": 30}
+		]
+	}`)
+
+	t.Run("changed field emits whole field, new row emits all fields, base-only ignored", func(t *testing.T) {
+		mod := []byte(`{
+			"RowStruct": "/Script/Icarus.Growth",
+			"Defaults": {"XP": 1},
+			"Rows": [
+				{"Name": "RowA", "XP": 99, "Level": 1},
+				{"Name": "NewRow", "XP": 5, "Nested": {"Value": "x"}}
+			]
+		}`)
+		items, warnings, err := diffTable("Test/D_Growth.json", base, mod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("unexpected warnings: %v", warnings)
+		}
+		if len(items) != 2 {
+			t.Fatalf("want 2 items, got %d: %+v", len(items), items)
+		}
+		if items[0].Name != "RowA" || len(items[0].Fields) != 1 || items[0].Fields["XP"] != float64(99) {
+			t.Fatalf("RowA item wrong: %+v", items[0])
+		}
+		if items[1].Name != "NewRow" || len(items[1].Fields) != 2 {
+			t.Fatalf("NewRow item wrong: %+v", items[1])
+		}
+	})
+
+	t.Run("identical row emits nothing", func(t *testing.T) {
+		mod := []byte(`{
+			"RowStruct": "/Script/Icarus.Growth",
+			"Defaults": {"XP": 1},
+			"Rows": [{"Name": "RowA", "XP": 10, "Level": 1}]
+		}`)
+		items, warnings, err := diffTable("Test/D_Growth.json", base, mod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(items) != 0 || len(warnings) != 0 {
+			t.Fatalf("want no items/warnings, got %+v / %v", items, warnings)
+		}
+	})
+
+	t.Run("rowstruct mismatch is a hard error", func(t *testing.T) {
+		mod := []byte(`{
+			"RowStruct": "/Script/Icarus.SomethingElse",
+			"Defaults": {"XP": 1},
+			"Rows": [{"Name": "RowA", "XP": 10, "Level": 1}]
+		}`)
+		_, _, err := diffTable("Test/D_Growth.json", base, mod)
+		if err == nil || !strings.Contains(err.Error(), "RowStruct") {
+			t.Fatalf("want RowStruct error, got %v", err)
+		}
+	})
+
+	t.Run("defaults and field-removed and duplicate are warnings", func(t *testing.T) {
+		mod := []byte(`{
+			"RowStruct": "/Script/Icarus.Growth",
+			"Defaults": {"XP": 2},
+			"Rows": [
+				{"Name": "RowA", "XP": 10},
+				{"Name": "RowA", "XP": 11, "Level": 1}
+			]
+		}`)
+		items, warnings, err := diffTable("Test/D_Growth.json", base, mod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// RowA first occurrence: XP unchanged (10), Level field REMOVED vs
+		// base -> warning, no item (nothing changed that EXMOD can express).
+		if len(items) != 0 {
+			t.Fatalf("want 0 items, got %+v", items)
+		}
+		var haveDefaults, haveRemoved, haveDup bool
+		for _, w := range warnings {
+			if strings.Contains(w, "Defaults") {
+				haveDefaults = true
+			}
+			if strings.Contains(w, "cannot remove fields") {
+				haveRemoved = true
+			}
+			if strings.Contains(w, "duplicate row") {
+				haveDup = true
+			}
+		}
+		if !haveDefaults || !haveRemoved || !haveDup {
+			t.Fatalf("missing expected warnings: %v", warnings)
+		}
+	})
+
+	t.Run("malformed table errors", func(t *testing.T) {
+		_, _, err := diffTable("Test/D_Growth.json", base, []byte(`{"NoRows": true}`))
+		if err == nil {
+			t.Fatal("want error for table without Rows")
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/icarus/ -run TestDiffTable -v`
+Expected: FAIL — `undefined: diffTable`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `internal/source/icarus/pakconvert.go` (add `"encoding/json"`, `"reflect"`, `"sort"` to imports):
+
+```go
+// pakDataTable is the UE DataTable export shape {"RowStruct","Defaults","Rows"}.
+type pakDataTable struct {
+	rows  []map[string]any
+	other map[string]any // every top-level key except Rows
+}
+
+func parsePakDataTable(data []byte) (*pakDataTable, error) {
+	var top map[string]any
+	if err := json.Unmarshal(data, &top); err != nil {
+		return nil, fmt.Errorf("parsing data table: %w", err)
+	}
+	rawRows, ok := top["Rows"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("data table has no Rows array")
+	}
+	t := &pakDataTable{other: top}
+	delete(top, "Rows")
+	for i, r := range rawRows {
+		row, ok := r.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("Rows[%d] is not an object", i)
+		}
+		if _, ok := row["Name"].(string); !ok {
+			return nil, fmt.Errorf("Rows[%d] has no string Name", i)
+		}
+		t.rows = append(t.rows, row)
+	}
+	return t, nil
+}
+
+// diffTable derives the EXMOD-expressible difference between the CURRENT base
+// table and a mod pak's (possibly stale) full-table snapshot - the Tier 2
+// rebase (#221 design §1):
+//
+//   - row in pak, not in base      -> new row: emit all fields
+//   - row in both, fields differ   -> emit Name + changed fields (whole-field;
+//     this is the accepted rebase semantic - drift in author-touched rows
+//     rides along BY DESIGN, user ruling 2026-08-05)
+//   - row in base, not in pak      -> staleness: ignored (EXMOD has no delete)
+//   - RowStruct mismatch           -> hard error (irreconcilable: the table's
+//     schema changed under the pak; a field-level rebase is meaningless)
+//   - Defaults/top-level changes, pak row missing a base field, duplicate
+//     Names (first wins)           -> warnings; conversion proceeds
+func diffTable(tableRef string, baseJSON, modJSON []byte) (items []ExmodFileItem, warnings []string, err error) {
+	base, err := parsePakDataTable(baseJSON)
+	if err != nil {
+		return nil, nil, fmt.Errorf("icarus: %s: base: %w", tableRef, err)
+	}
+	mod, err := parsePakDataTable(modJSON)
+	if err != nil {
+		return nil, nil, fmt.Errorf("icarus: %s: pak table: %w", tableRef, err)
+	}
+
+	if !reflect.DeepEqual(base.other["RowStruct"], mod.other["RowStruct"]) {
+		return nil, nil, fmt.Errorf("icarus: %s: RowStruct differs from current base (pak schema is irreconcilable)", tableRef)
+	}
+
+	// Non-Rows top-level keys: union of both sides, sorted for deterministic
+	// warning order.
+	otherKeys := make(map[string]bool)
+	for key := range base.other {
+		if key != "RowStruct" {
+			otherKeys[key] = true
+		}
+	}
+	for key := range mod.other {
+		if key != "RowStruct" {
+			otherKeys[key] = true
+		}
+	}
+	sortedKeys := make([]string, 0, len(otherKeys))
+	for key := range otherKeys {
+		sortedKeys = append(sortedKeys, key)
+	}
+	sort.Strings(sortedKeys)
+	for _, key := range sortedKeys {
+		if !reflect.DeepEqual(base.other[key], mod.other[key]) {
+			warnings = append(warnings, fmt.Sprintf("%s: top-level key %q (e.g. Defaults) differs from base - EXMOD cannot express this; base value kept", tableRef, key))
+		}
+	}
+
+	baseByName := make(map[string]map[string]any, len(base.rows))
+	for _, r := range base.rows {
+		baseByName[r["Name"].(string)] = r
+	}
+
+	seen := make(map[string]bool, len(mod.rows))
+	for _, mr := range mod.rows {
+		name := mr["Name"].(string)
+		if seen[name] {
+			warnings = append(warnings, fmt.Sprintf("%s: duplicate row %q in pak table; first occurrence wins", tableRef, name))
+			continue
+		}
+		seen[name] = true
+
+		br, inBase := baseByName[name]
+		if !inBase {
+			fields := make(map[string]any, len(mr)-1)
+			for k, v := range mr {
+				if k != "Name" {
+					fields[k] = v
+				}
+			}
+			items = append(items, ExmodFileItem{Name: name, Fields: fields})
+			continue
+		}
+		changed := map[string]any{}
+		for k, v := range mr {
+			if k == "Name" {
+				continue
+			}
+			if bv, ok := br[k]; !ok || !reflect.DeepEqual(bv, v) {
+				changed[k] = v
+			}
+		}
+		for k := range br {
+			if k == "Name" {
+				continue
+			}
+			if _, ok := mr[k]; !ok {
+				warnings = append(warnings, fmt.Sprintf("%s: row %q: field %q present in base but absent in pak (EXMOD cannot remove fields; base value kept)", tableRef, name, k))
+			}
+		}
+		if len(changed) > 0 {
+			items = append(items, ExmodFileItem{Name: name, Fields: changed})
+		}
+	}
+	// Base-only rows are staleness (the pak predates them) - deliberately
+	// ignored, never deletions.
+	return items, warnings, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/icarus/ -run TestDiffTable -v`
+Expected: PASS (all 5 subtests).
+
+- [ ] **Step 5: Full suite + commit**
+
+Run: `gofmt -l .` → no output. Run: `go vet ./...` → no output.
+Run: `go test ./...`
+Expected: PASS.
+
+```bash
+git add internal/source/icarus/pakconvert.go internal/source/icarus/pakconvert_test.go
+git commit -m "feat: table differ deriving exmod upserts from pak snapshots (#221)"
+```
+
+---
+
+### Task 4: convertPakToBundle — Tier 1 / Tier 2 orchestration
+
+Convert one pak into an in-memory `*ExmodzBundle` (the exact shape `MergeCompile`'s loops already consume). Tier 1: exactly one embedded `.EXMOD` → `ParseExmod` its rows verbatim (pure author intent, rebased by the normal upsert path). Tier 2: diff every table snapshot. Whole-mod failure on: unreadable pak, unreadable/hyphenated/unmapped-json entries, table absent from current base, RowStruct mismatch, multiple embedded manifests.
+
+**Files:**
+
+- Modify: `internal/source/icarus/pakconvert.go` (append)
+- Modify: `internal/source/icarus/pakconvert_test.go` (append)
+
+**Interfaces:**
+
+- Consumes: `normalizeEntry`, `currentFileFor`, `diffTable` (Tasks 2-3); `ExmodzBundle{Diff *ExmodDiff; Assets map[string][]byte}` (exmodz.go:13-16); `ExmodDiff`/`ExmodRow`/`ExmodFileItem` (exmod.go:11-33); `ParseExmod(data []byte) (*ExmodDiff, error)` (exmod.go:35); `unrealpak.Open/Reader`.
+- Produces (unexported): `func convertPakToBundle(pakPath string, base *unrealpak.Reader) (*ExmodzBundle, []string, error)`. Task 5 consumes it. Asset map keys are Content-relative paths, fed through the merge loop's existing `sanitizeAssetPath` gate unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/source/icarus/pakconvert_test.go` (add imports `"os"`, `"path/filepath"`, and `"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"`):
+
+```go
+// buildTestPak writes a synthetic pak with the given mount point and entries.
+func buildTestPak(t *testing.T, dir, name, mount string, entries map[string][]byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	w, err := unrealpak.Create(p, unrealpak.WithMountPoint(mount))
+	if err != nil {
+		t.Fatalf("creating %s: %v", name, err)
+	}
+	for path, data := range entries {
+		if err := w.AddFile(path, data); err != nil {
+			t.Fatalf("adding %s: %v", path, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing %s: %v", name, err)
+	}
+	return p
+}
+
+// testBaseTable is a minimal real-shape UE DataTable.
+const testBaseTable = `{"RowStruct":"/Script/Icarus.Growth","Defaults":{},"Rows":[{"Name":"RowA","XP":10},{"Name":"RowB","XP":20}]}`
+
+func openTestBase(t *testing.T, dir string) *unrealpak.Reader {
+	t.Helper()
+	// Base data.pak entries are mount-relative WITHOUT a data/ prefix
+	// (matchMountPath resolves "Test/D_Growth.json" against Files()).
+	basePath := buildTestPak(t, dir, "data.pak", "../../../Icarus/Content/Data/", map[string][]byte{
+		"Test/D_Growth.json": []byte(testBaseTable),
+	})
+	base, err := unrealpak.Open(basePath)
+	if err != nil {
+		t.Fatalf("opening base: %v", err)
+	}
+	t.Cleanup(func() { _ = base.Close() })
+	return base
+}
+
+func TestConvertPakToBundleTier2(t *testing.T) {
+	dir := t.TempDir()
+	base := openTestBase(t, dir)
+	modTable := `{"RowStruct":"/Script/Icarus.Growth","Defaults":{},"Rows":[{"Name":"RowA","XP":99},{"Name":"RowNew","XP":5}]}`
+	pak := buildTestPak(t, dir, "mod.pak", "../../../Icarus/Content/", map[string][]byte{
+		"data/Test/D_Growth.json":     []byte(modTable),
+		"Mods/Thing/SK_Thing.uasset":  {0x01, 0x02},
+		"readme.txt":                  []byte("ignore me"),
+	})
+
+	bundle, warnings, err := convertPakToBundle(pak, base)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if len(bundle.Diff.Rows) != 1 {
+		t.Fatalf("want 1 row, got %+v", bundle.Diff.Rows)
+	}
+	row := bundle.Diff.Rows[0]
+	if row.CurrentFile != "Test-D_Growth.json" {
+		t.Fatalf("CurrentFile = %q", row.CurrentFile)
+	}
+	if len(row.FileItems) != 2 {
+		t.Fatalf("want 2 items (changed RowA + new RowNew), got %+v", row.FileItems)
+	}
+	if _, ok := bundle.Assets["Mods/Thing/SK_Thing.uasset"]; !ok {
+		t.Fatalf("asset missing: %+v", bundle.Assets)
+	}
+}
+
+func TestConvertPakToBundleTier1EmbeddedExmod(t *testing.T) {
+	dir := t.TempDir()
+	base := openTestBase(t, dir)
+	embedded := `{"Rows":[{"CurrentFile":"Test-D_Growth.json","File_Items":[{"Name":"RowA","XP":42}]},{"CurrentFile":"EndOfMod"}]}`
+	// The pak ALSO carries a stale table snapshot - Tier 1 must ignore it in
+	// favor of the embedded manifest (exact author intent).
+	staleTable := `{"RowStruct":"/Script/Icarus.Growth","Defaults":{},"Rows":[{"Name":"RowA","XP":42},{"Name":"Ancient","XP":1}]}`
+	pak := buildTestPak(t, dir, "mod.pak", "../../../Icarus/Content/", map[string][]byte{
+		"data.EXMOD":              []byte(embedded),
+		"data/Test/D_Growth.json": []byte(staleTable),
+	})
+
+	bundle, _, err := convertPakToBundle(pak, base)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 2 rows: the real one + the EndOfMod sentinel ParseExmod preserves.
+	if len(bundle.Diff.Rows) != 2 {
+		t.Fatalf("want embedded manifest's 2 rows, got %+v", bundle.Diff.Rows)
+	}
+	if bundle.Diff.Rows[0].FileItems[0].Fields["XP"] != float64(42) {
+		t.Fatalf("embedded row not used: %+v", bundle.Diff.Rows[0])
+	}
+}
+
+func TestConvertPakToBundleIrreconcilable(t *testing.T) {
+	dir := t.TempDir()
+	base := openTestBase(t, dir)
+
+	t.Run("table not in current base", func(t *testing.T) {
+		pak := buildTestPak(t, dir, "gone.pak", "../../../Icarus/Content/", map[string][]byte{
+			"data/Removed/D_Gone.json": []byte(testBaseTable),
+		})
+		_, _, err := convertPakToBundle(pak, base)
+		if err == nil || !strings.Contains(err.Error(), "not present in current base") {
+			t.Fatalf("want table-not-in-base error, got %v", err)
+		}
+	})
+
+	t.Run("unmappable json entry", func(t *testing.T) {
+		pak := buildTestPak(t, dir, "bare.pak", "../../../Content/", map[string][]byte{
+			"D_ProcessorRecipes.json": []byte(testBaseTable),
+		})
+		_, _, err := convertPakToBundle(pak, base)
+		if err == nil || !strings.Contains(err.Error(), "unresolvable") {
+			t.Fatalf("want unresolvable-layout error, got %v", err)
+		}
+	})
+
+	t.Run("multiple embedded manifests", func(t *testing.T) {
+		pak := buildTestPak(t, dir, "multi.pak", "../../../Icarus/Content/", map[string][]byte{
+			"a.EXMOD": []byte(`{"Rows":[]}`),
+			"b.EXMOD": []byte(`{"Rows":[]}`),
+		})
+		_, _, err := convertPakToBundle(pak, base)
+		if err == nil || !strings.Contains(err.Error(), "multiple embedded") {
+			t.Fatalf("want multiple-embedded error, got %v", err)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/icarus/ -run TestConvertPakToBundle -v`
+Expected: FAIL — `undefined: convertPakToBundle`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `internal/source/icarus/pakconvert.go` (add `"sort"` already present; add `"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"` to imports):
+
+```go
+// convertPakToBundle converts one prebuilt mod pak into the in-memory
+// ExmodzBundle shape MergeCompile's loops already consume - the pak→exmod
+// REBASE (#221): rebuild the pak's changes against the CURRENT base.
+//
+// Tier 1: when the pak embeds exactly one *.EXMOD manifest, its rows are
+// used verbatim (pure author intent; the merge loop's resolveCurrentFile +
+// ApplyRowPatch rebase them onto the current base). Tier 2: otherwise every
+// table snapshot is diffed against the current base via diffTable.
+//
+// A non-nil error means the WHOLE mod is irreconcilable (design §4): the
+// caller must skip it (it falls back to raw deploy) - never partially
+// convert. Warnings are non-fatal observations (inexpressible details).
+func convertPakToBundle(pakPath string, base *unrealpak.Reader) (*ExmodzBundle, []string, error) {
+	mod, err := unrealpak.Open(pakPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("icarus: opening pak %s: %w", pakPath, err)
+	}
+	defer mod.Close() //nolint:errcheck
+
+	type tableSnapshot struct {
+		rel  string
+		data []byte
+	}
+	var (
+		warnings  []string
+		tables    []tableSnapshot
+		embedded  [][]byte
+		assets    = map[string][]byte{}
+	)
+
+	for _, entry := range mod.Files() {
+		class, rel, nerr := normalizeEntry(mod.MountPoint(), entry.Path)
+		if nerr != nil {
+			return nil, nil, nerr // hyphen-ambiguous table path: irreconcilable
+		}
+		if class == classOther {
+			if strings.HasSuffix(strings.ToLower(entry.Path), ".json") {
+				// A JSON entry we cannot place under Icarus/Content/data is
+				// almost certainly a table with an unresolvable layout (e.g.
+				// a bare Content/ mount with no directory structure) - a
+				// silent skip would drop the mod's actual content.
+				return nil, nil, fmt.Errorf("icarus: pak layout unresolvable: entry %q (mount %q) does not map into Icarus/Content/data", entry.Path, mod.MountPoint())
+			}
+			continue // readme, images, etc.
+		}
+		data, rerr := mod.ReadFile(entry.Path)
+		if rerr != nil {
+			if class == classAsset {
+				warnings = append(warnings, fmt.Sprintf("asset %q unreadable (%v) - skipped", entry.Path, rerr))
+				continue
+			}
+			// Unreadable table or embedded manifest: the mod's content is
+			// unrecoverable - irreconcilable.
+			return nil, nil, fmt.Errorf("icarus: reading pak entry %q: %w", entry.Path, rerr)
+		}
+		switch class {
+		case classEmbeddedExmod:
+			embedded = append(embedded, data)
+		case classAsset:
+			assets[rel] = data
+		case classTable:
+			tables = append(tables, tableSnapshot{rel: rel, data: data})
+		}
+	}
+
+	if len(embedded) > 1 {
+		return nil, nil, fmt.Errorf("icarus: pak %s carries multiple embedded .EXMOD manifests - ambiguous", pakPath)
+	}
+
+	if len(embedded) == 1 {
+		diff, perr := ParseExmod(embedded[0])
+		if perr != nil {
+			return nil, nil, fmt.Errorf("icarus: embedded .EXMOD in %s: %w", pakPath, perr)
+		}
+		return &ExmodzBundle{Diff: diff, Assets: assets}, warnings, nil
+	}
+
+	// Tier 2: diff-derive. Deterministic row order: sort snapshots by path.
+	sort.Slice(tables, func(i, j int) bool { return tables[i].rel < tables[j].rel })
+	diff := &ExmodDiff{}
+	for _, snap := range tables {
+		baseData, berr := base.ReadFile(snap.rel)
+		if berr != nil {
+			return nil, nil, fmt.Errorf("icarus: pak table %q not present in current base: %w", snap.rel, berr)
+		}
+		items, tblWarnings, derr := diffTable(snap.rel, baseData, snap.data)
+		if derr != nil {
+			return nil, nil, derr
+		}
+		warnings = append(warnings, tblWarnings...)
+		if len(items) == 0 {
+			continue // nothing expressible changed; never emit an empty row
+		}
+		diff.Rows = append(diff.Rows, ExmodRow{CurrentFile: currentFileFor(snap.rel), FileItems: items})
+	}
+	return &ExmodzBundle{Diff: diff, Assets: assets}, warnings, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/source/icarus/ -run TestConvertPakToBundle -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Full suite + commit**
+
+Run: `gofmt -l .` → no output. Run: `go vet ./...` → no output.
+Run: `go test ./...`
+Expected: PASS.
+
+```bash
+git add internal/source/icarus/pakconvert.go internal/source/icarus/pakconvert_test.go
+git commit -m "feat: convertPakToBundle with embedded-EXMOD tier and diff tier (#221)"
+```
+
+---
+
+### Task 5: MergeCompile pak dispatch, per-mod failure policy, MergeFailure interface change
+
+`MergeCompile` gains a per-source kind dispatch and a structured `failed` return so core can reconcile manifests. Exmodz error policy stays FATAL and byte-identical; pak failures are per-mod (warning + skip + report). Pak application is transactional per mod (scratch state, committed only on success) so a failing pak cannot half-pollute the merge.
+
+**Files:**
+
+- Modify: `internal/source/source.go` (MergeCompiler interface, new MergeFailure type, MergeSource.Kind field)
+- Modify: `internal/source/icarus/merge.go` (dispatch + apply refactor)
+- Modify: `internal/source/icarus/icarus.go:50-51` (method wrapper signature)
+- Modify: `internal/core/merged_pak.go:236-240` (call site — minimal adaptation; full use in Task 8)
+- Modify (test doubles, mechanical signature updates): `cmd/lmm/install_compile_test.go`, `internal/core/flows_variant_exclusivity_test.go`, `internal/core/merged_pak_import_flow_test.go`, `internal/core/service_icarus_compile_test.go`, `internal/core/service_test.go`, `internal/tui/service_core_recompile_test.go`
+- Test: `internal/source/icarus/merge_test.go` (new cases; existing cases updated for signature)
+
+**Interfaces:**
+
+- Consumes: `convertPakToBundle` (Task 4).
+- Produces:
+  - `source.MergeSource{ModRef, SourcePath string; Kind string}` with consts `source.MergeSourceExmodz = "exmodz"`, `source.MergeSourcePak = "pak"` (empty Kind = exmodz, back-compat).
+  - `source.MergeFailure{ModRef string; Reason string}`.
+  - Interface + package func + method signature: `MergeCompile(ctx context.Context, basePakPath string, sources []MergeSource, outputPakPath string) (warnings []string, failed []MergeFailure, err error)`.
+  - `icarus.ValidateSource` widened: `.pak` files validate via `unrealpak.Open` + non-empty `Files()`.
+    Tasks 8-9 consume all of these.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/source/icarus/merge_test.go` (it already builds synthetic base paks and exmodz files — reuse its existing helpers; the new test builds a pak with Task 4's `buildTestPak` helper from `pakconvert_test.go`, same package):
+
+```go
+func TestMergeCompilePakSource(t *testing.T) {
+	dir := t.TempDir()
+	basePath := buildTestPak(t, dir, "data.pak", "../../../Icarus/Content/Data/", map[string][]byte{
+		"Test/D_Growth.json": []byte(testBaseTable),
+	})
+	modTable := `{"RowStruct":"/Script/Icarus.Growth","Defaults":{},"Rows":[{"Name":"RowA","XP":99}]}`
+	pakPath := buildTestPak(t, dir, "mod.pak", "../../../Icarus/Content/", map[string][]byte{
+		"data/Test/D_Growth.json": []byte(modTable),
+	})
+	out := filepath.Join(dir, "merged.pak")
+
+	warnings, failed, err := MergeCompile(context.Background(), basePath, []MergeSource{
+		{ModRef: "icarus:pakmod", SourcePath: pakPath, Kind: source.MergeSourcePak},
+	}, out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(failed) != 0 || len(warnings) != 0 {
+		t.Fatalf("unexpected failed/warnings: %v / %v", failed, warnings)
+	}
+	merged, err := unrealpak.Open(out)
+	if err != nil {
+		t.Fatalf("opening merged: %v", err)
+	}
+	defer merged.Close()
+	data, err := merged.ReadFile("data/Test/D_Growth.json")
+	if err != nil {
+		t.Fatalf("merged table missing: %v", err)
+	}
+	if !strings.Contains(string(data), `"XP":99`) {
+		t.Fatalf("converted change not applied: %s", data)
+	}
+}
+
+func TestMergeCompilePakFailureSkipsModOnly(t *testing.T) {
+	dir := t.TempDir()
+	basePath := buildTestPak(t, dir, "data.pak", "../../../Icarus/Content/Data/", map[string][]byte{
+		"Test/D_Growth.json": []byte(testBaseTable),
+	})
+	// Irreconcilable pak: its table does not exist in the current base.
+	badPak := buildTestPak(t, dir, "bad.pak", "../../../Icarus/Content/", map[string][]byte{
+		"data/Removed/D_Gone.json": []byte(testBaseTable),
+	})
+	goodTable := `{"RowStruct":"/Script/Icarus.Growth","Defaults":{},"Rows":[{"Name":"RowB","XP":77}]}`
+	goodPak := buildTestPak(t, dir, "good.pak", "../../../Icarus/Content/", map[string][]byte{
+		"data/Test/D_Growth.json": []byte(goodTable),
+	})
+	out := filepath.Join(dir, "merged.pak")
+
+	warnings, failed, err := MergeCompile(context.Background(), basePath, []MergeSource{
+		{ModRef: "icarus:bad", SourcePath: badPak, Kind: source.MergeSourcePak},
+		{ModRef: "icarus:good", SourcePath: goodPak, Kind: source.MergeSourcePak},
+	}, out)
+	if err != nil {
+		t.Fatalf("per-mod failure must not be fatal: %v", err)
+	}
+	if len(failed) != 1 || failed[0].ModRef != "icarus:bad" {
+		t.Fatalf("want icarus:bad failed, got %+v", failed)
+	}
+	var haveWarning bool
+	for _, w := range warnings {
+		if strings.Contains(w, "icarus:bad") && strings.Contains(w, "deploying raw") {
+			haveWarning = true
+		}
+	}
+	if !haveWarning {
+		t.Fatalf("want a deploying-raw warning for icarus:bad, got %v", warnings)
+	}
+	merged, err := unrealpak.Open(out)
+	if err != nil {
+		t.Fatalf("opening merged: %v", err)
+	}
+	defer merged.Close()
+	data, err := merged.ReadFile("data/Test/D_Growth.json")
+	if err != nil {
+		t.Fatalf("good mod's table missing: %v", err)
+	}
+	if !strings.Contains(string(data), `"XP":77`) {
+		t.Fatalf("good mod's change not applied: %s", data)
+	}
+	if _, err := merged.ReadFile("data/Removed/D_Gone.json"); err == nil {
+		t.Fatal("failed mod's table must not be in the merged pak")
+	}
+}
+
+func TestValidateSourcePak(t *testing.T) {
+	dir := t.TempDir()
+	pakPath := buildTestPak(t, dir, "ok.pak", "../../../Icarus/Content/", map[string][]byte{
+		"data/Test/D_Growth.json": []byte(testBaseTable),
+	})
+	if err := ValidateSource(pakPath); err != nil {
+		t.Fatalf("valid pak rejected: %v", err)
+	}
+	badPath := filepath.Join(dir, "not-a.pak")
+	if err := os.WriteFile(badPath, []byte("junk"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateSource(badPath); err == nil {
+		t.Fatal("junk .pak must fail validation")
+	}
+}
+```
+
+(Add imports as needed: `"context"`, `"os"`, `"path/filepath"`, `"strings"`, `"github.com/DonovanMods/linux-mod-manager/internal/source"`, `"github.com/DonovanMods/linux-mod-manager/internal/unrealpak"` — some already present in merge_test.go.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/source/icarus/ -run 'TestMergeCompilePak|TestValidateSourcePak' -v`
+Expected: FAIL — `undefined: source.MergeSourcePak` / wrong result count (compile errors).
+
+- [ ] **Step 3: Update source.go**
+
+In `internal/source/source.go`, extend `MergeSource`, add `MergeFailure`, and change the interface:
+
+```go
+// Merge-source kinds (#221). An empty Kind means MergeSourceExmodz - every
+// pre-#221 constructor built exmodz-only sources and never set a kind.
+const (
+	MergeSourceExmodz = "exmodz"
+	MergeSourcePak    = "pak"
+)
+
+// MergeSource identifies one mod's contribution to a merge, in the order it
+// must be applied (profile load order).
+type MergeSource struct {
+	ModRef     string // "sourceID:modID" - identity used in collision warnings
+	SourcePath string // the retained source archive to read (.exmodz, or a raw .pak eligible for conversion - #221)
+	Kind       string // MergeSourceExmodz (default when empty) or MergeSourcePak
+}
+
+// MergeFailure records one source that could not participate in a merge
+// (#221: an irreconcilable pak). The merge itself still succeeds - the
+// failed mod is skipped and falls back to raw deploy; core uses this list
+// to reconcile cache manifests and record outcomes in the fingerprint.
+type MergeFailure struct {
+	ModRef string
+	Reason string
+}
+```
+
+Change the `MergeCompiler` interface method (keep the doc comment, append to it):
+
+```go
+	// MergeCompile applies every entry in sources, in order (profile load
+	// order), against basePakPath's tables, and writes the merged result to
+	// outputPakPath. Returns non-fatal warnings (e.g. same-path asset
+	// collisions - last-applied wins) alongside a nil error; a nil error
+	// with warnings is still a fully-written, deployable pak. Pak-kind
+	// sources that cannot be converted are skipped per-mod and reported in
+	// failed (#221) - only exmodz-source errors and I/O failures are fatal.
+	MergeCompile(ctx context.Context, basePakPath string, sources []MergeSource, outputPakPath string) (warnings []string, failed []MergeFailure, err error)
+```
+
+- [ ] **Step 4: Rework icarus MergeCompile**
+
+In `internal/source/icarus/merge.go`, replace the function body's per-source region (lines 70-118) and the signature. The apply logic is extracted so both kinds share it, with pak sources applying to SCRATCH state committed only on success:
+
+```go
+func MergeCompile(ctx context.Context, basePakPath string, sources []MergeSource, outputPakPath string) (warnings []string, failed []source.MergeFailure, err error) {
+	base, err := unrealpak.Open(basePakPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("icarus: opening base pak %s: %w", basePakPath, err)
+	}
+	defer base.Close() //nolint:errcheck
+
+	tableState := make(map[string][]byte) // mountPath -> current (possibly already patched) JSON bytes
+	assets := make(map[string][]byte)     // final asset path -> data (last source wins)
+	assetOwner := make(map[string]string) // asset path -> ModRef that last set it
+
+	for _, src := range sources {
+		if src.Kind == source.MergeSourcePak {
+			bundle, convWarnings, cerr := convertPakToBundle(src.SourcePath, base)
+			if cerr != nil {
+				failed = append(failed, source.MergeFailure{ModRef: src.ModRef, Reason: cerr.Error()})
+				warnings = append(warnings, fmt.Sprintf("mod %s: pak conversion failed: %v - deploying raw", src.ModRef, cerr))
+				continue
+			}
+			for _, w := range convWarnings {
+				warnings = append(warnings, fmt.Sprintf("mod %s: %s", src.ModRef, w))
+			}
+			// Apply on scratch copies: a Tier 1 row can still fail
+			// resolveCurrentFile against the CURRENT base (the manifest may
+			// reference a since-removed table), and a half-applied mod must
+			// not pollute the merge.
+			scratch := make(map[string][]byte, len(tableState))
+			for k, v := range tableState {
+				scratch[k] = v
+			}
+			applyWarnings, aerr := applyBundle(base, scratch, assets, assetOwner, bundle, src.ModRef)
+			if aerr != nil {
+				failed = append(failed, source.MergeFailure{ModRef: src.ModRef, Reason: aerr.Error()})
+				warnings = append(warnings, fmt.Sprintf("mod %s: pak conversion failed: %v - deploying raw", src.ModRef, aerr))
+				continue
+			}
+			warnings = append(warnings, applyWarnings...)
+			tableState = scratch
+			continue
+		}
+
+		// Exmodz source: policy unchanged - any error is fatal (#197).
+		exmodzData, rerr := os.ReadFile(src.SourcePath)
+		if rerr != nil {
+			return warnings, failed, fmt.Errorf("icarus: reading %s: %w", src.SourcePath, rerr)
+		}
+		bundle, perr := ParseExmodz(exmodzData)
+		if perr != nil {
+			return warnings, failed, fmt.Errorf("icarus: %s: %w", src.SourcePath, perr)
+		}
+		applyWarnings, aerr := applyBundle(base, tableState, assets, assetOwner, bundle, src.ModRef)
+		if aerr != nil {
+			return warnings, failed, aerr
+		}
+		warnings = append(warnings, applyWarnings...)
+	}
+	// ... (writer section below unchanged except signature returns)
+```
+
+Extract the two loops (rows + assets, formerly merge.go:80-117) verbatim into:
+
+```go
+// applyBundle applies one bundle's row upserts and assets to the merge
+// state. Asset collisions across mods warn (last-applied wins); any other
+// error is returned to the caller, which decides fatality by source kind.
+func applyBundle(base *unrealpak.Reader, tableState map[string][]byte, assets map[string][]byte, assetOwner map[string]string, bundle *ExmodzBundle, modRef string) (warnings []string, err error) {
+	for _, row := range bundle.Diff.Rows {
+		if row.CurrentFile == endOfModSentinel {
+			continue
+		}
+		if len(row.FileItems) == 0 {
+			return warnings, fmt.Errorf("icarus: %s: row has no File_Items to apply (malformed .EXMOD manifest)", row.CurrentFile)
+		}
+		mountPath, merr := resolveCurrentFile(base, row.CurrentFile)
+		if merr != nil {
+			return warnings, merr
+		}
+		current, seen := tableState[mountPath]
+		if !seen {
+			var rerr error
+			current, rerr = base.ReadFile(mountPath)
+			if rerr != nil {
+				return warnings, fmt.Errorf("icarus: reading base data table %s: %w", mountPath, rerr)
+			}
+		}
+		patched, perr := ApplyRowPatch(current, row)
+		if perr != nil {
+			return warnings, perr
+		}
+		tableState[mountPath] = patched
+	}
+
+	for assetPath, data := range bundle.Assets {
+		safePath, serr := sanitizeAssetPath(assetPath)
+		if serr != nil {
+			return warnings, serr
+		}
+		if owner, exists := assetOwner[safePath]; exists && owner != modRef {
+			warnings = append(warnings, fmt.Sprintf(
+				"asset %q is bundled by both %s and %s - %s wins (last-applied, per profile load order)",
+				safePath, owner, modRef, modRef))
+		}
+		assets[safePath] = data
+		assetOwner[safePath] = modRef
+	}
+	return warnings, nil
+}
+```
+
+The writer section (merge.go:120-149) is unchanged except every `return warnings, ...` becomes `return warnings, failed, ...`. NOTE the known asset-scratch caveat: a pak mod that fails AFTER contributing assets could leave assets behind — but `applyBundle` applies ALL rows before ANY assets, and pak failures inside `applyBundle` can only occur in the rows loop or the sanitize call, so at most the failing mod's own earlier assets are at risk; to keep it strictly transactional, pak sources buffer assets too: pass fresh `scratchAssets := map[string][]byte{}` / `scratchOwner` copies the same way as `scratch` (copy both maps, commit both on success). Implement it that way — copy all three maps for the pak branch.
+
+Widen `ValidateSource` (merge.go:28-37):
+
+```go
+// ValidateSource parses sourceFilePath without compiling anything - the
+// ingest-time check. .exmodz archives fully parse (#197); .pak files (#221)
+// open + enumerate only - full conversion is checked at merge time BY
+// DESIGN (the result depends on the current base pak, which changes weekly).
+func ValidateSource(sourceFilePath string) error {
+	if strings.HasSuffix(strings.ToLower(sourceFilePath), ".pak") {
+		r, err := unrealpak.Open(sourceFilePath)
+		if err != nil {
+			return fmt.Errorf("icarus: validating %s: %w", sourceFilePath, err)
+		}
+		defer r.Close() //nolint:errcheck
+		if len(r.Files()) == 0 {
+			return fmt.Errorf("icarus: validating %s: pak contains no entries", sourceFilePath)
+		}
+		return nil
+	}
+	data, err := os.ReadFile(sourceFilePath)
+	if err != nil {
+		return fmt.Errorf("icarus: reading %s: %w", sourceFilePath, err)
+	}
+	if _, err := ParseExmodz(data); err != nil {
+		return fmt.Errorf("icarus: validating %s: %w", sourceFilePath, err)
+	}
+	return nil
+}
+```
+
+(Add `"strings"` and the `source` import to merge.go's imports if missing.)
+
+Update the method wrapper in `internal/source/icarus/icarus.go`:
+
+```go
+func (s *Icarus) MergeCompile(ctx context.Context, basePakPath string, sources []MergeSource, outputPakPath string) ([]string, []source.MergeFailure, error) {
+	return MergeCompile(ctx, basePakPath, sources, outputPakPath)
+}
+```
+
+- [ ] **Step 5: Adapt call site and test doubles**
+
+`internal/core/merged_pak.go:236` (temporary until Task 8 uses `failed`):
+
+```go
+	mergeWarnings, mergeFailed, err := mc.MergeCompile(ctx, basePakPath, sources, outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("merging %d merge source(s): %w", len(sources), err)
+	}
+	warnings = mergeWarnings
+	_ = mergeFailed // consumed in the fingerprint/manifest reconcile (#221 Task 8)
+```
+
+Update every fake MergeCompiler in the 6 test files listed above: signature gains `[]source.MergeFailure` (return `nil` for it). Compile-error-driven:
+
+Run: `go build ./...` then `go vet ./...`
+Expected after fixes: no output.
+
+Existing `merge_test.go` call sites (`MergeCompile(...)` two-value returns at lines 29, 73, 116, 154, 198, 240 vicinity) gain the middle `failed` return — assert `len(failed) == 0` in each existing happy-path test.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/source/icarus/ -v`
+Expected: PASS — all existing merge/compile tests (byte-identical exmodz behavior) plus the three new tests.
+
+Run: `go test ./...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat: MergeCompile pak dispatch with per-mod failure policy (#221)"
+```
+
+---
+
+### Task 6: Per-game convert_paks config
+
+`convert_paks: true|false` in games.yaml, default true. Follows the LinkMethod/LinkMethodExplicit precedent exactly (the only pattern that survives the selective write-back in `saveGamesLocked` — recon: any field not copied there is silently dropped on SaveGame).
+
+**Files:**
+
+- Modify: `internal/domain/game.go:50-62` (two fields)
+- Modify: `internal/storage/config/games.go` (GameConfig, loadGamesLocked, saveGamesLocked)
+- Modify: `cmd/lmm/game_list.go` (JSON + human surface)
+- Test: `internal/storage/config/games_test.go` (append), `cmd/lmm/game_list_test.go` if present (append) else fold assertion into config test
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces: `domain.Game.ConvertPaks bool` (effective value, default true), `domain.Game.ConvertPaksExplicit bool`. Tasks 8-9-11 consume `game.ConvertPaks`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/storage/config/games_test.go` (mirror the file's existing Load/Save round-trip test style — it writes YAML to a temp config dir and calls LoadGames/SaveGame):
+
+```go
+func TestConvertPaksDefaultAndRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `games:
+    icarus:
+        name: Icarus
+        install_path: /tmp/icarus
+        mod_path: /tmp/icarus/mods
+        sources:
+            icarus: icarus
+        deploy_mode: compile
+    explicit-off:
+        name: Off
+        install_path: /tmp/off
+        mod_path: /tmp/off/mods
+        sources:
+            icarus: icarus
+        deploy_mode: compile
+        convert_paks: false
+`
+	writeGamesYAML(t, dir, yaml) // use the file's existing helper for writing games.yaml; if named differently, reuse that helper
+
+	games, err := LoadGamesFrom(dir) // use the file's existing load-from-dir seam
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !games["icarus"].ConvertPaks || games["icarus"].ConvertPaksExplicit {
+		t.Fatalf("absent convert_paks must default true/implicit, got %+v", games["icarus"])
+	}
+	if games["explicit-off"].ConvertPaks || !games["explicit-off"].ConvertPaksExplicit {
+		t.Fatalf("explicit false must load false/explicit, got %+v", games["explicit-off"])
+	}
+
+	// Round-trip: saving the explicit-off game must preserve convert_paks: false.
+	g := games["explicit-off"]
+	if err := SaveGameTo(dir, &g); err != nil { // the file's existing save seam
+		t.Fatalf("save: %v", err)
+	}
+	reloaded, err := LoadGamesFrom(dir)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded["explicit-off"].ConvertPaks {
+		t.Fatal("convert_paks: false lost on save round-trip")
+	}
+}
+```
+
+NOTE: `writeGamesYAML` / `LoadGamesFrom` / `SaveGameTo` stand for the test file's EXISTING helpers and public seams — read `internal/storage/config/games_test.go` first and use its actual names (the package's public API is `LoadGames`/`SaveGame` with a config-dir parameter or env override; mirror whichever the sibling tests use). The assertions above are the requirement; the harness comes from the file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/storage/config/ -run TestConvertPaks -v`
+Expected: FAIL — `unknown field ConvertPaks` (compile error).
+
+- [ ] **Step 3: Implement**
+
+`internal/domain/game.go` — append to the `Game` struct:
+
+```go
+	ConvertPaks         bool // #221: convert prebuilt .pak mods into the merged pak (DeployCompile games; default true)
+	ConvertPaksExplicit bool // True if ConvertPaks was explicitly set in config (round-trip fidelity, like LinkMethodExplicit)
+```
+
+`internal/storage/config/games.go`:
+
+```go
+// In GameConfig:
+	ConvertPaks *bool `yaml:"convert_paks,omitempty"`
+```
+
+In `loadGamesLocked`'s per-game block (beside the ParseDeployMode handling):
+
+```go
+		convertPaks := true // default: paks convert (only meaningful for DeployCompile games)
+		convertExplicit := false
+		if gc.ConvertPaks != nil {
+			convertPaks = *gc.ConvertPaks
+			convertExplicit = true
+		}
+```
+
+and in the `domain.Game` literal: `ConvertPaks: convertPaks, ConvertPaksExplicit: convertExplicit,`.
+
+In `saveGamesLocked`'s selective write-back (beside the LinkMethodExplicit block):
+
+```go
+		if game.ConvertPaksExplicit {
+			v := game.ConvertPaks
+			gc.ConvertPaks = &v
+		}
+```
+
+`cmd/lmm/game_list.go`: add to the JSON struct `ConvertPaks *bool \`json:"convert_paks,omitempty"\``populated only when`g.DeployMode == domain.DeployCompile` (`v := g.ConvertPaks; row.ConvertPaks = &v`), and in the human output print `convert_paks: true|false`on the same detail line as`deploy_mode` for compile-mode games.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/storage/config/ -run TestConvertPaks -v` → PASS.
+Run: `go test ./...` → PASS.
+Run: `gofmt -l .` → no output. Run: `go vet ./...` → no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: per-game convert_paks config with explicit round-trip (#221)"
+```
+
+---
+
+### Task 7: Per-mod convert flag in SQLite
+
+`convert_paks INTEGER DEFAULT 1` on installed_mods, following the migrateV8/UpdateModPolicy patterns exactly. The column is EXCLUDED from SaveInstalledMod's INSERT column list entirely — the schema default governs on first insert and the ON CONFLICT update can't touch it, so a user-set flag survives reinstall (stronger than update_policy's approach, no callers need changing).
+
+**Files:**
+
+- Modify: `internal/storage/db/migrations.go` (append migrateV12 to the slice + function)
+- Modify: `internal/storage/db/mods.go` (SELECT/Scan in GetInstalledMods + GetInstalledMod; new setter; SaveInstalledMod doc note)
+- Modify: `internal/domain/mod.go:107-120` (InstalledMod field)
+- Modify: `internal/core/service.go:1286-1309` region (pass-through)
+- Test: `internal/storage/db/mods_test.go` (append; `:memory:` per existing pattern)
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces: `domain.InstalledMod.ConvertPaks bool`; `(*DB).SetModConvertPaks(sourceID, modID, gameID, profileName string, convert bool) error`; `(*Service).SetModConvertPaks(...)` same params. Tasks 8-10-12 consume these.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/storage/db/mods_test.go` (reuse the file's existing in-memory DB constructor and InstalledMod fixture helpers — read the sibling tests for exact names):
+
+```go
+func TestSetModConvertPaks(t *testing.T) {
+	d := newTestDB(t) // the file's existing :memory: constructor helper
+	mod := &domain.InstalledMod{
+		Mod:          domain.Mod{ID: "m1", SourceID: "icarus", GameID: "icarus", Name: "M", Version: "1.0"},
+		ProfileName:  "default",
+		Enabled:      true,
+	}
+	if err := d.SaveInstalledMod(mod); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := d.GetInstalledMod("icarus", "m1", "icarus", "default")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !got.ConvertPaks {
+		t.Fatal("convert_paks must default to true (schema DEFAULT 1)")
+	}
+
+	if err := d.SetModConvertPaks("icarus", "m1", "icarus", "default", false); err != nil {
+		t.Fatalf("set off: %v", err)
+	}
+	got, err = d.GetInstalledMod("icarus", "m1", "icarus", "default")
+	if err != nil {
+		t.Fatalf("get 2: %v", err)
+	}
+	if got.ConvertPaks {
+		t.Fatal("convert_paks not persisted off")
+	}
+
+	// Reinstall (SaveInstalledMod upsert) must NOT reset the user's flag.
+	if err := d.SaveInstalledMod(mod); err != nil {
+		t.Fatalf("re-save: %v", err)
+	}
+	got, err = d.GetInstalledMod("icarus", "m1", "icarus", "default")
+	if err != nil {
+		t.Fatalf("get 3: %v", err)
+	}
+	if got.ConvertPaks {
+		t.Fatal("reinstall reset convert_paks - the column must stay out of the upsert")
+	}
+
+	// Unknown mod -> domain.ErrModNotFound (targeted-setter contract).
+	if err := d.SetModConvertPaks("icarus", "nope", "icarus", "default", true); err != domain.ErrModNotFound {
+		t.Fatalf("want ErrModNotFound, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/storage/db/ -run TestSetModConvertPaks -v`
+Expected: FAIL — `undefined: (*DB).SetModConvertPaks` / `unknown field ConvertPaks`.
+
+- [ ] **Step 3: Implement**
+
+`internal/storage/db/migrations.go` — append `migrateV12` to the `migrations` slice and add:
+
+```go
+func migrateV12(d *DB) error {
+	// #221: per-mod pak-to-exmod conversion opt-out. Default 1 = convert
+	// (paks join the merged pak); 0 = deploy raw. Deliberately excluded
+	// from SaveInstalledMod's upsert so reinstall preserves the user's
+	// choice - changes go through SetModConvertPaks only.
+	_, err := d.Exec(`ALTER TABLE installed_mods ADD COLUMN convert_paks INTEGER DEFAULT 1`)
+	return err
+}
+```
+
+`internal/domain/mod.go` — append to InstalledMod:
+
+```go
+	ConvertPaks bool // #221: pak-to-exmod conversion enabled (default true; only meaningful for DeployCompile games)
+```
+
+`internal/storage/db/mods.go`:
+
+- `GetInstalledMods` SELECT gains `, convert_paks` at the end of the column list; Scan gains `&mod.ConvertPaks` in matching position. Same for `GetInstalledMod`.
+- `SaveInstalledMod`: INSERT list UNCHANGED (column absent → schema default 1). Extend the doc comment: "convert_paks is likewise never written here - the schema default covers first insert, and SetModConvertPaks is the only writer, so reinstall can't reset it."
+- New setter (exact `UpdateModPolicy` shape, mods.go:193-214):
+
+```go
+// SetModConvertPaks sets the per-mod pak-conversion flag (#221).
+func (d *DB) SetModConvertPaks(sourceID, modID, gameID, profileName string, convert bool) error {
+	result, err := d.Exec(`
+		UPDATE installed_mods SET convert_paks = ?
+		WHERE source_id = ? AND mod_id = ? AND game_id = ? AND profile_name = ?
+	`, convert, sourceID, modID, gameID, profileName)
+	if err != nil {
+		return fmt.Errorf("updating mod convert_paks: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		// A driver error here must not be read as "0 rows affected" -
+		// that would misreport a real DB failure as domain.ErrModNotFound.
+		return fmt.Errorf("updating mod convert_paks: checking rows affected: %w", err)
+	}
+	if rows == 0 {
+		return domain.ErrModNotFound
+	}
+
+	return nil
+}
+```
+
+`internal/core/service.go` — beside SetModUpdatePolicy/SetModEnabled:
+
+```go
+// SetModConvertPaks toggles per-mod pak-to-exmod conversion (#221). A local
+// DB write; the caller re-syncs the merged pak to apply the change.
+func (s *Service) SetModConvertPaks(sourceID, modID, gameID, profileName string, convert bool) error {
+	return s.db.SetModConvertPaks(sourceID, modID, gameID, profileName, convert)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/storage/db/ -run TestSetModConvertPaks -v` → PASS.
+Run: `go test ./...` → PASS (migration runs everywhere the suite opens a DB).
+Run: `gofmt -l .` → no output. Run: `go vet ./...` → no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: per-mod convert_paks column, setter, and service seam (#221)"
+```
+
+---
+
+### Task 8: Merge membership, outcome-aware fingerprint, manifest reconcile
+
+The core wiring: pak retained-sources join `enabledMergeSources` (honoring both opt-outs, carrying Kind), the fingerprint records conversion OUTCOMES without them affecting input equality (retry only when inputs change), and `syncMergedPak` reconciles each pak mod's cache manifest to the merge outcome — converted → members=nil (merged pak claims it; raw link undeployed), failed/opted-out → members=[pak] (raw deploys). Public `SyncMergedPak` signature is UNCHANGED (`[]string, error`) so its ~13 callers stay untouched.
+
+**Files:**
+
+- Modify: `internal/core/merged_pak.go` (enabledMergeSources, MergedFingerprintEntry, equality, currentMergedFingerprint, syncMergedPak, new reconcile helpers)
+- Test: `internal/core/merged_pak_test.go` (append), plus a flow test appended to `internal/core/service_icarus_compile_test.go`
+
+**Interfaces:**
+
+- Consumes: `source.MergeSourcePak/MergeSourceExmodz`, `source.MergeFailure` (Task 5); `domain.InstalledMod.ConvertPaks` (Task 7); `domain.Game.ConvertPaks` (Task 6); `cache.MarkFileCompleteWithMembers`, `cache.FileManifests`, `cache.RetainedSourceName`, `gameCache.ListFiles`.
+- Produces: `MergedFingerprintEntry{SourceID, ModID, Version, Checksum, Kind string; Converted bool; FailReason string}`; `func mergeSourceKind(fileID string) string`; stored fingerprints now carry per-mod outcomes (Task 11's verify reads them). `readMergedFingerprint` already exported enough for verify via `Service` helpers — add `(*Service).MergedPakOutcomes(game, profileName) ([]MergedFingerprintEntry, bool)` for Tasks 11-12.
+
+- [ ] **Step 1: Write the failing pure-logic tests**
+
+Append to `internal/core/merged_pak_test.go`:
+
+```go
+func TestMergeSourceKind(t *testing.T) {
+	tests := map[string]string{
+		"pak":         source.MergeSourcePak,
+		"MyMod.PAK":   source.MergeSourcePak,
+		"exmodz":      source.MergeSourceExmodz,
+		"MyMod.exmodz": source.MergeSourceExmodz,
+		"weird.zip":   source.MergeSourceExmodz, // unknown retained kind: today's behavior
+	}
+	for fileID, want := range tests {
+		if got := mergeSourceKind(fileID); got != want {
+			t.Errorf("mergeSourceKind(%q) = %q, want %q", fileID, got, want)
+		}
+	}
+}
+
+func TestFingerprintEqualityIgnoresOutcomes(t *testing.T) {
+	a := MergedFingerprint{BaseIndexHash: "h", Mods: []MergedFingerprintEntry{
+		{SourceID: "icarus", ModID: "m", Version: "1", Checksum: "c", Kind: source.MergeSourcePak, Converted: true},
+	}}
+	b := MergedFingerprint{BaseIndexHash: "h", Mods: []MergedFingerprintEntry{
+		{SourceID: "icarus", ModID: "m", Version: "1", Checksum: "c", Kind: source.MergeSourcePak, Converted: false, FailReason: "x"},
+	}}
+	eq, err := mergedFingerprintsEqual(a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !eq {
+		t.Fatal("outcome fields must not affect input equality (retry only when inputs change)")
+	}
+
+	c := b
+	c.Mods = []MergedFingerprintEntry{{SourceID: "icarus", ModID: "m", Version: "2", Checksum: "c", Kind: source.MergeSourcePak}}
+	eq, err = mergedFingerprintsEqual(a, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eq {
+		t.Fatal("input fields (Version) must affect equality")
+	}
+}
+
+func TestReadOldFingerprintMarkerCompat(t *testing.T) {
+	// A pre-#221 marker has no Kind/Converted/FailReason - it must read
+	// fine and compare EQUAL to a current computation with the same inputs
+	// (Kind "" vs "exmodz" must not force a spurious regen).
+	dir := t.TempDir()
+	old := []byte(`{"BaseIndexHash":"h","Mods":[{"SourceID":"icarus","ModID":"m","Version":"1","Checksum":"c"}]}`)
+	if err := os.WriteFile(cache.MergeFingerprintPath(dir), old, 0644); err != nil {
+		t.Fatal(err)
+	}
+	stored, ok := readMergedFingerprint(dir)
+	if !ok {
+		t.Fatal("old marker unreadable")
+	}
+	current := MergedFingerprint{BaseIndexHash: "h", Mods: []MergedFingerprintEntry{
+		{SourceID: "icarus", ModID: "m", Version: "1", Checksum: "c", Kind: source.MergeSourceExmodz, Converted: true},
+	}}
+	eq, err := mergedFingerprintsEqual(current, stored)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !eq {
+		t.Fatal("pre-#221 marker must not trigger a regen for unchanged exmodz inputs")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/ -run 'TestMergeSourceKind|TestFingerprintEquality|TestReadOldFingerprintMarker' -v`
+Expected: FAIL — `undefined: mergeSourceKind` / `unknown field Kind`.
+
+- [ ] **Step 3: Implement membership + fingerprint**
+
+In `internal/core/merged_pak.go`:
+
+```go
+// mergeSourceKind classifies a retained-source fileID (#221). Download-path
+// icarus fileIDs are literally "pak"/"exmodz"; import-path fileIDs are the
+// archive's own filename. Unknown kinds default to exmodz - the only kind
+// that existed before #221.
+func mergeSourceKind(fileID string) string {
+	lower := strings.ToLower(fileID)
+	if lower == "pak" || strings.HasSuffix(lower, ".pak") {
+		return source.MergeSourcePak
+	}
+	return source.MergeSourceExmodz
+}
+```
+
+`enabledMergeSources` loop body — after the retained-path stat succeeds:
+
+```go
+			kind := mergeSourceKind(fileID)
+			if kind == source.MergeSourcePak && (!game.ConvertPaks || !mod.ConvertPaks) {
+				continue // opted out (game- or mod-level): stays raw-deployed (#221)
+			}
+			sources = append(sources, source.MergeSource{
+				ModRef:     mod.SourceID + ":" + mod.ID,
+				SourcePath: retainedPath,
+				Kind:       kind,
+			})
+```
+
+`MergedFingerprintEntry` gains fields (input fields first, then outcomes):
+
+```go
+type MergedFingerprintEntry struct {
+	SourceID string
+	ModID    string
+	Version  string
+	Checksum string // MD5 of the retained source bytes (md5File)
+	Kind     string `json:",omitempty"` // source.MergeSourcePak for retained paks; empty/exmodz otherwise (#221)
+
+	// Outcome fields (#221): recorded AFTER the merge, ignored by input
+	// equality - a failed conversion retries only when an INPUT changes
+	// (pak bytes, base pak, membership), not on every sync.
+	Converted  bool   `json:",omitempty"`
+	FailReason string `json:",omitempty"`
+}
+
+// fingerprintInputs strips outcome fields and normalizes Kind so equality
+// judges inputs only. Kind "" and "exmodz" are the same input (pre-#221
+// markers wrote no Kind).
+func fingerprintInputs(f MergedFingerprint) MergedFingerprint {
+	out := MergedFingerprint{BaseIndexHash: f.BaseIndexHash, Mods: make([]MergedFingerprintEntry, len(f.Mods))}
+	for i, m := range f.Mods {
+		kind := m.Kind
+		if kind == "" {
+			kind = source.MergeSourceExmodz
+		}
+		out.Mods[i] = MergedFingerprintEntry{SourceID: m.SourceID, ModID: m.ModID, Version: m.Version, Checksum: m.Checksum, Kind: kind}
+	}
+	return out
+}
+```
+
+`mergedFingerprintsEqual` compares `fingerprintInputs(a)` vs `fingerprintInputs(b)` (marshal both projections, compare bytes — keep the existing nil-normalization inside marshalMergedFingerprint).
+
+`currentMergedFingerprint`'s entry construction gains `Kind: src.Kind, Converted: true` (predicted; flipped post-merge for failures).
+
+- [ ] **Step 4: Implement outcome recording + manifest reconcile in syncMergedPak**
+
+After the `mc.MergeCompile` call (Task 5 left `mergeFailed` unused):
+
+```go
+	failedByRef := make(map[string]string, len(mergeFailed))
+	for _, f := range mergeFailed {
+		failedByRef[f.ModRef] = f.Reason
+	}
+	for i := range current.Mods {
+		ref := current.Mods[i].SourceID + ":" + current.Mods[i].ModID
+		if reason, bad := failedByRef[ref]; bad {
+			current.Mods[i].Converted = false
+			current.Mods[i].FailReason = reason
+		}
+	}
+```
+
+(then fingerprint marshal/write/commit/Install as today), and after the successful `installer.Install`:
+
+```go
+	reconWarnings, rerr := s.reconcilePakManifests(ctx, game, profileName, installer, failedByRef)
+	if rerr != nil {
+		return warnings, fmt.Errorf("reconciling pak manifests: %w", rerr)
+	}
+	warnings = append(warnings, reconWarnings...)
+```
+
+Also call `s.reconcilePakManifests(ctx, game, profileName, installer, nil)` in the zero-sources early-return branch BEFORE returning (an all-opted-out profile must still flip previously-converted paks back to raw), ignoring reconcile warnings there is NOT allowed — append and return them.
+
+The reconcile helper:
+
+```go
+// reconcilePakManifests aligns every enabled pak mod's cache manifest with
+// the merge outcome (#221): a mod whose pak CONVERTED has members=nil (the
+// merged pak claims its content; the raw copy must not deploy - flipping it
+// undeploys any raw link), while a failed or opted-out mod has its raw pak
+// as the sole member (raw deploy, today's behavior). Flips are followed by
+// the matching installer action so the game dir converges immediately: the
+// first-install transient (raw deployed, then first sync converts) is
+// healed here, not left for the next verify.
+func (s *Service) reconcilePakManifests(ctx context.Context, game *domain.Game, profileName string, installer *Installer, failedByRef map[string]string) (warnings []string, err error) {
+	mods, err := s.GetInstalledModsInProfileOrder(game.ID, profileName)
+	if err != nil {
+		return nil, fmt.Errorf("loading profile mods: %w", err)
+	}
+	gameCache := s.GetGameCache(game)
+	for i := range mods {
+		mod := &mods[i]
+		if !mod.Enabled {
+			continue
+		}
+		for _, fileID := range mod.FileIDs {
+			if mergeSourceKind(fileID) != source.MergeSourcePak {
+				continue
+			}
+			versionDir := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
+			retained := filepath.Join(versionDir, cache.RetainedSourceName(fileID))
+			if _, statErr := os.Stat(retained); statErr != nil {
+				continue // nothing retained (legacy ingest): Task 11's needs_reingest covers it
+			}
+			ref := mod.SourceID + ":" + mod.ID
+			_, failed := failedByRef[ref]
+			participating := game.ConvertPaks && mod.ConvertPaks && !failed
+
+			manifests, merr := gameCache.FileManifests(game.ID, mod.SourceID, mod.ID, mod.Version)
+			if merr != nil {
+				return warnings, merr
+			}
+			var currentMembers []string
+			recorded := false
+			for _, m := range manifests {
+				if m.FileID == fileID {
+					currentMembers = m.Members
+					recorded = m.Recorded
+				}
+			}
+
+			if participating {
+				if recorded && len(currentMembers) == 0 {
+					continue // already converged
+				}
+				if werr := cache.MarkFileCompleteWithMembers(versionDir, fileID, nil); werr != nil {
+					return warnings, fmt.Errorf("flipping %s to merged-claimed: %w", ref, werr)
+				}
+				// The raw copy is now unclaimed: undeploy this mod's files
+				// (idempotent; the merged pak carries its content now).
+				if uerr := installer.Uninstall(ctx, game, &mod.Mod, profileName); uerr != nil {
+					return warnings, fmt.Errorf("undeploying raw pak for %s: %w", ref, uerr)
+				}
+			} else {
+				members, lerr := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+				if lerr != nil {
+					return warnings, lerr
+				}
+				if recorded && len(currentMembers) == len(members) && len(members) > 0 {
+					continue // already converged (raw)
+				}
+				if werr := cache.MarkFileCompleteWithMembers(versionDir, fileID, members); werr != nil {
+					return warnings, fmt.Errorf("flipping %s to raw-deploy: %w", ref, werr)
+				}
+				if ierr := installer.Install(ctx, game, &mod.Mod, profileName); ierr != nil {
+					return warnings, fmt.Errorf("deploying raw pak for %s: %w", ref, ierr)
+				}
+			}
+		}
+	}
+	return warnings, nil
+}
+```
+
+NOTE on `cache.FileManifests`: its return type carries `FileID`, `Recorded`, `Members` (see internal/storage/cache/cache.go:167-201). Confirm the field names against the actual struct and adjust the loop accordingly — the semantics above are the requirement. Likewise the `installer *Installer` parameter: use whatever concrete type `s.GetInstallerForProfile` returns (syncMergedPak already holds it at merged_pak.go:177) — pass that value through; do not construct a new installer.
+
+Add the outcomes accessor for later tasks:
+
+```go
+// MergedPakOutcomes returns the stored merge fingerprint's per-mod entries
+// (with #221 conversion outcomes), if a merged pak exists for game+profile.
+func (s *Service) MergedPakOutcomes(game *domain.Game, profileName string) ([]MergedFingerprintEntry, bool) {
+	gameCache := s.GetGameCache(game)
+	cachePath := gameCache.ModPath(game.ID, domain.SourceMerged, mergedPakModID, mergedPakVersion)
+	fp, ok := readMergedFingerprint(cachePath)
+	if !ok {
+		return nil, false
+	}
+	return fp.Mods, true
+}
+```
+
+- [ ] **Step 5: Flow-level test**
+
+Append to `internal/core/service_icarus_compile_test.go`, mirroring its existing service/fake-MergeCompiler harness (read the file first; reuse its constructors). The fake MergeCompiler for this test returns `failed = []source.MergeFailure{{ModRef: "icarus:badmod", Reason: "boom"}}` when a source list contains that ref. Scenario and required assertions:
+
+```go
+// TestSyncMergedPakReconcilesPakManifests:
+// 1. Install (via the harness) two pak-kind mods: goodmod, badmod - each
+//    with a retained pak (cache.RetainedSourceName(fileID)) AND a deployable
+//    pak copy recorded as the manifest's sole member (Task 9's ingest state).
+// 2. Run svc.SyncMergedPak.
+// 3. Assert: goodmod's manifest members are now EMPTY (converted; merged pak
+//    claims it) - via gameCache.FileManifests.
+// 4. Assert: badmod's manifest still lists its pak (raw fallback).
+// 5. Assert: the stored fingerprint (readMergedFingerprint or
+//    svc.MergedPakOutcomes) has goodmod Converted=true, badmod
+//    Converted=false with FailReason "boom".
+// 6. Assert: returned warnings contain "badmod" and "deploying raw".
+// 7. Toggle: svc.SetModConvertPaks(..., "goodmod", ..., false); re-run
+//    SyncMergedPak; assert goodmod's manifest lists its pak again (raw) and
+//    the new fingerprint omits goodmod (membership changed -> regen).
+```
+
+Write it as real code against the harness's actual helper names.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -run 'TestMergeSourceKind|TestFingerprintEquality|TestReadOldFingerprintMarker|TestSyncMergedPakReconciles' -v`
+Expected: PASS.
+Run: `go test ./...` → PASS. `gofmt -l .` / `go vet ./...` → no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat: pak merge membership, outcome fingerprint, manifest reconcile (#221)"
+```
+
+---
+
+### Task 9: Ingest — retain paks with a deployable member (download + import)
+
+Convert-eligible paks now take the compile-ingest branch: validate, retain the raw pak, AND keep a deployable copy as the manifest's sole member (raw-deploy default until the first sync converts it — Task 8 flips the manifest). Exmodz ingest is byte-identical.
+
+**Files:**
+
+- Modify: `internal/core/service.go` (download branch ~577-628; new predicate beside isExmodzFile ~1016)
+- Modify: `internal/core/importer.go` (import branch ~122-166; MarkImportedFileComplete member logic ~314-328)
+- Modify: `internal/core/flows.go:4198` (progress classification includes eligible paks)
+- Test: `internal/core/service_icarus_compile_test.go` (append), `internal/core/service_import_compile_test.go` (append)
+
+**Interfaces:**
+
+- Consumes: `icarus.ValidateSource` pak widening (Task 5, via the MergeCompiler interface); `game.ConvertPaks` (Task 6).
+- Produces: `func isConvertEligiblePakFile(game *domain.Game, fileName string) bool`. Task 11's verify consumes it (export decision there; keep unexported here, verify goes through a Service helper added in Task 11).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/core/service_icarus_compile_test.go` (reuse its download-flow harness; the existing exmodz ingest test there is the template — read it first):
+
+```go
+// TestDownloadPakRetainsAndDeploysRaw:
+// Using the harness's fake MergeCompiler source and a fake .pak download
+// (file.ID = "pak", FileName = "CoolMod.pak") into a DeployCompile game
+// with ConvertPaks: true:
+//   - assert ValidateSource was called with the archive path
+//   - assert the cache entry contains BOTH cache.RetainedSourceName("pak")
+//     AND the deployable copy "CoolMod.pak"
+//   - assert the entry's manifest for "pak" is Recorded with exactly
+//     ["CoolMod.pak"] as members (raw-deploy default)
+//   - assert DownloadModResult.FilesExtracted == 1
+// And with game.ConvertPaks = false:
+//   - assert the pak takes the LEGACY path (no retained source, normal
+//     copy/extract members) - byte-identical to pre-#221 behavior.
+```
+
+Write as real code against the harness. For the import side, append the mirrored test to `internal/core/service_import_compile_test.go` (its exmodz import test is the template): import "CoolMod.pak" → retained under `RetainedSourceName("CoolMod.pak")`, deployable copy present, manifest members `["CoolMod.pak"]`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/core/ -run 'TestDownloadPakRetains|TestImportPakRetains' -v`
+Expected: FAIL (pak currently falls through to the legacy branch: no retained source).
+
+- [ ] **Step 3: Implement**
+
+`internal/core/service.go` — beside `isExmodzFile`:
+
+```go
+// isConvertEligiblePakFile reports whether fileName is a prebuilt .pak that
+// should enter the merge-convert pipeline (#221): DeployCompile game with
+// convert_paks enabled. The per-MOD opt-out is consulted at merge-membership
+// time (enabledMergeSources), not here - ingest state is identical either
+// way (retained + raw-deployable), only participation differs.
+func isConvertEligiblePakFile(game *domain.Game, fileName string) bool {
+	return game.DeployMode == domain.DeployCompile && game.ConvertPaks &&
+		strings.HasSuffix(strings.ToLower(fileName), ".pak")
+}
+```
+
+Download branch (service.go:577) — widen and add the pak member:
+
+```go
+	if game.DeployMode == domain.DeployCompile && (isExmodzFile(safeFileName) || isConvertEligiblePakFile(game, safeFileName)) {
+		mc, ok := src.(source.MergeCompiler)
+		if !ok {
+			return nil, fmt.Errorf("source %q: game %q requires DeployCompile but source does not implement MergeCompiler", src.ID(), game.ID)
+		}
+		if err := mc.ValidateSource(archivePath); err != nil {
+			return nil, fmt.Errorf("validating %s: %w", safeFileName, err)
+		}
+		if err := os.MkdirAll(stagePath, 0755); err != nil {
+			return nil, fmt.Errorf("preparing staging: %w", err)
+		}
+		retainedPath := filepath.Join(stagePath, cache.RetainedSourceName(file.ID))
+		if err := copyFileStreaming(archivePath, retainedPath); err != nil {
+			return nil, fmt.Errorf("retaining %s: %w", safeFileName, err)
+		}
+		// exmodz: members nil (#197) - the merged pak is the only artifact.
+		// pak (#221): ALSO keep a deployable copy as the sole member, so the
+		// default state is raw-deploy (today's behavior); the first
+		// successful merge flips the manifest to nil (syncMergedPak's
+		// reconcile) and the merged pak takes over.
+		var members []string
+		if isConvertEligiblePakFile(game, safeFileName) && !isExmodzFile(safeFileName) {
+			deployablePath := filepath.Join(stagePath, safeFileName)
+			if err := copyFileStreaming(archivePath, deployablePath); err != nil {
+				return nil, fmt.Errorf("staging deployable pak %s: %w", safeFileName, err)
+			}
+			members = []string{safeFileName}
+		}
+		if err := commitStagedCacheWithMarker(cachePath, stagePath, file.ID, members); err != nil {
+			return nil, err
+		}
+		return &DownloadModResult{FilesExtracted: len(members), Checksum: downloadResult.Checksum}, nil
+	}
+```
+
+`internal/core/importer.go` (import branch at 122): widen the condition the same way (`isExmodzFile(filename) || isConvertEligiblePakFile(game, filename)`); after the retained copy, for the pak case also `copyFileStreaming(archivePath, filepath.Join(stagePath, filename))` and set `fileCount = 1`. Then read `Service.MarkImportedFileComplete` (importer.go:314-328) and make its member computation kind-aware: exmodz retained → `members = nil` (unchanged); pak retained → `members = []string{filename}`. The existing implementation derives members from the entry listing — keep its shape, just ensure the pak's deployable copy is listed and the exmodz case stays nil.
+
+`internal/core/flows.go:4198` — widen the progress classification:
+
+```go
+		if game.DeployMode == domain.DeployCompile && (isExmodzFile(file.FileName) || isConvertEligiblePakFile(game, file.FileName)) {
+			compiledFiles = append(compiledFiles, file)
+		}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/core/ -run 'TestDownloadPakRetains|TestImportPakRetains' -v` → PASS.
+Run: `go test ./...` → PASS (exmodz flows byte-identical — the existing compile-ingest tests are the regression net).
+Run: `gofmt -l .` / `go vet ./...` → no output.
+
+- [ ] **Step 5: End-to-end no-double-apply test**
+
+Append to `internal/core/service_icarus_compile_test.go` the transient-heal scenario (the design's key safety property):
+
+```go
+// TestPakInstallThenSyncNeverDoubleApplies:
+// 1. Ingest a pak mod (Task 9 state: raw member recorded).
+// 2. Deploy it (installer.Install) - raw link present in game.ModPath.
+// 3. Run SyncMergedPak with a fake MergeCompiler that SUCCEEDS.
+// 4. Assert: the raw pak link is GONE from game.ModPath (reconcile
+//    undeployed it) and zzz_LMM_Merged_P.pak is deployed.
+// 5. Re-run SyncMergedPak: fast path, nothing changes, raw link still gone.
+```
+
+Write as real code with the harness. Run it, expect PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat: pak ingest retains source with raw-deploy default (#221)"
+```
+
+---
+
+### Task 10: CLI — `lmm mod convert`, list/show surfaces
+
+Per-mod toggle following the set-update/lock pattern; convert state surfaces in `lmm list` (verbose column + JSON) and `lmm mod show` (JSON + human). JSON additions are MINOR-precedent additive fields.
+
+**Files:**
+
+- Modify: `cmd/lmm/mod.go` (new command + init wiring + doModConvert; modShowInstalled)
+- Modify: `cmd/lmm/list.go` (listModJSON + verbose column)
+- Test: `cmd/lmm/mod_convert_test.go` (create; mirror `cmd/lmm/mod_lock_test.go`'s harness)
+
+**Interfaces:**
+
+- Consumes: `Service.SetModConvertPaks` (Task 7), `InstalledMod.ConvertPaks`.
+- Produces: `lmm mod convert <mod-id> <on|off>`; `listModJSON.ConvertPaks *bool json:"convert_paks,omitempty"`; `modShowInstalled.ConvertPaks *bool json:"convert_paks,omitempty"`. Task 13 documents them; Task 12 mirrors in TUI.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/lmm/mod_convert_test.go`, mirroring the service/DB harness used by `mod_lock_test.go` (read it first; reuse its game/profile/mod fixture builders):
+
+```go
+// TestModConvertCommand:
+// - seed an installed mod in a DeployCompile game
+// - run: lmm mod convert <id> off  (via the harness's command executor)
+//   -> assert output contains "conversion: off" and the DB flag is false
+// - run: lmm mod convert <id> on -> flag true again
+// - run: lmm mod convert <id> sideways -> error "on|off"
+// - non-compile game -> output includes a note that conversion only
+//   affects merge-compile games (still persists)
+// TestListShowsConvert: verbose list row for a convert-off mod shows "off"
+// in the CONVERT column; --json includes "convert_paks": false. For a
+// non-compile game the JSON field is ABSENT (omitempty nil).
+```
+
+Write as real code with the harness.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/lmm/ -run 'TestModConvert|TestListShowsConvert' -v`
+Expected: FAIL — unknown command "convert".
+
+- [ ] **Step 3: Implement the command**
+
+`cmd/lmm/mod.go`:
+
+```go
+var modConvertCmd = &cobra.Command{
+	Use:   "convert <mod-id> <on|off>",
+	Short: "Enable or disable pak-to-exmod conversion for a mod",
+	Long: `Control whether a prebuilt .pak mod is converted into the profile's
+merged pak (rebased onto the game's current data.pak) or deployed raw.
+
+Only meaningful for merge-compile games (deploy_mode: compile) whose game
+config has convert_paks enabled (the default). Conversion is on by default
+for every mod; turn it off to keep a specific mod's prebuilt pak deployed
+as-is.
+
+This is a metadata write, not a deploy: run 'lmm deploy' (or any merge-pak
+mutation) afterward to re-sync the merged pak.
+
+Examples:
+  lmm mod convert 12345 off --game icarus
+  lmm mod convert 12345 on --game icarus`,
+	Args: cobra.ExactArgs(2),
+	RunE: runModConvert,
+}
+
+func runModConvert(cmd *cobra.Command, args []string) error {
+	var convert bool
+	switch strings.ToLower(args[1]) {
+	case "on":
+		convert = true
+	case "off":
+		convert = false
+	default:
+		return fmt.Errorf("second argument must be on|off, got %q", args[1])
+	}
+	return withGameService(cmd, func(ctx context.Context, service *core.Service, game *domain.Game) error {
+		return doModConvert(service, game, args[0], convert)
+	})
+}
+
+func doModConvert(service *core.Service, game *domain.Game, modID string, convert bool) error {
+	var err error
+	modSource, err = resolveSource(service, game, modSource, false)
+	if err != nil {
+		return err
+	}
+	profileName, err := resolveProfile(service, game.ID, modProfile)
+	if err != nil {
+		return err
+	}
+	mod, err := service.GetInstalledMod(modSource, modID, game.ID, profileName)
+	if err != nil {
+		return fmt.Errorf("mod not found: %s", modID)
+	}
+	if err := service.SetModConvertPaks(modSource, modID, game.ID, profileName, convert); err != nil {
+		return fmt.Errorf("setting pak conversion for %s: %w", mod.Name, err)
+	}
+	state := "on"
+	if !convert {
+		state = "off"
+	}
+	fmt.Printf("%s %s pak conversion: %s\n", colorGreen("✓"), mod.Name, state)
+	if game.DeployMode != domain.DeployCompile {
+		fmt.Println("  note: this game is not merge-compile (deploy_mode: compile); the flag has no effect until it is")
+	} else {
+		fmt.Println("  run 'lmm deploy' to re-sync the merged pak")
+	}
+	return nil
+}
+```
+
+Wire in `init()` (mod.go:151-161): `modCmd.AddCommand(modConvertCmd)`.
+
+`cmd/lmm/list.go`: add to `listModJSON`:
+
+```go
+	ConvertPaks *bool `json:"convert_paks,omitempty"` // #221: pak-to-exmod conversion; present only for merge-compile games
+```
+
+Populate in the JSON loop only when `game.DeployMode == domain.DeployCompile` (`v := m.ConvertPaks; row.ConvertPaks = &v`). Verbose human table: append `CONVERT` to the header/separator/row triple (list.go:186-189, 203-220); cell value `on`/`off` for compile-mode games, `-` otherwise.
+
+`cmd/lmm/mod.go` modShowInstalled (mod.go:574-580): add `ConvertPaks *bool \`json:"convert_paks,omitempty"\``+ populate for compile games + a human output line`Pak conversion: on|off` beside the update-policy line.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/lmm/ -run 'TestModConvert|TestListShowsConvert' -v` → PASS.
+Run: `go test ./...` → PASS. `gofmt -l .` / `go vet ./...` → no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: lmm mod convert command and convert state in list/show (#221)"
+```
+
+---
+
+### Task 11: verify statuses (`conversion_failed`, `needs_reingest`) + lazy migration + deploy surfacing test
+
+Verify reports conversion outcomes (from the stored fingerprint) and detects convert-eligible pak mods whose cache entry predates #221 (no retained source); `--fix` re-ingests via the existing `redownloadModFile` path — the widened ingest predicate (Task 9) heals the entry, and the sync at verify.go:683 picks it up. Also: the retain-only FILE COUNT MISMATCH carve-out becomes members-aware, and a deploy-flow test proves conversion failures surface to the user.
+
+**Files:**
+
+- Modify: `cmd/lmm/verify.go` (two new status strings; per-mod outcome rows; needs_reingest detection; carve-out fix; Long help enum text at verify.go:150)
+- Modify: `internal/core/service.go` or `internal/core/merged_pak.go` (small helper: `(*Service).PakNeedsReingest(game, mod, fileID) bool` — verify must not reimplement kind/retained logic)
+- Test: `cmd/lmm/verify_convert_test.go` (create; mirror the harness of existing verify CLI-seam tests), plus a deploy-output assertion appended to an existing deploy CLI-seam test file
+- Test: update `cmd/lmm/verify.go`'s `hasRetainedSource` carve-out coverage in the same file
+
+**Interfaces:**
+
+- Consumes: `Service.MergedPakOutcomes` (Task 8), `mergeSourceKind` semantics via the new helper, `redownloadModFile` (verify.go:1355).
+- Produces: verify JSON `Status` values `"conversion_failed"` (Note = FailReason) and `"needs_reingest"` (Note explains the fix); helper `(*Service).PakNeedsReingest(game *domain.Game, mod *domain.InstalledMod, fileID string) (bool, error)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/lmm/verify_convert_test.go` mirroring the existing verify harness (read a sibling like the stale_compile test first):
+
+```go
+// TestVerifyReportsConversionFailed:
+// - seed a compile-game profile with a pak mod; write a merged-pak cache
+//   entry whose fingerprint marker has the mod's entry Converted=false,
+//   FailReason="table X not present in current base"
+// - run lmm verify --json
+// - assert a row: {"mod_id": ..., "status": "conversion_failed",
+//   "note": "table X not present in current base"} and Warnings count +1
+// - human output contains "CONVERSION FAILED" and "deploying raw"
+//
+// TestVerifyNeedsReingest:
+// - seed a compile-game (ConvertPaks true) pak mod whose cache entry has
+//   the deployable pak but NO retained source (pre-#221 ingest state)
+// - run lmm verify --json -> row status "needs_reingest"
+// - run lmm verify --fix with the harness's fake source download available
+//   -> redownload path runs; afterward the cache entry HAS the retained
+//   source and the manifest records the pak member (Task 9 ingest state)
+// - a mod with ConvertPaks=false must NOT be flagged needs_reingest
+//
+// TestVerifyFileCountCarveOutMembersAware:
+// - a pak entry (retained + 1 member) with a stray extra file must STILL
+//   report file_count_mismatch (the old retain-only carve-out suppressed
+//   any entry with a retained source; now it suppresses only entries whose
+//   manifests record zero members).
+```
+
+Write as real code with the harness.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/lmm/ -run 'TestVerifyReportsConversionFailed|TestVerifyNeedsReingest|TestVerifyFileCountCarveOut' -v`
+Expected: FAIL (statuses don't exist; carve-out suppresses).
+
+- [ ] **Step 3: Implement**
+
+Core helper (in `internal/core/merged_pak.go`, beside mergeSourceKind):
+
+```go
+// PakNeedsReingest reports whether mod's fileID is a convert-eligible pak
+// whose cache entry predates #221 pak retention (deployable pak present,
+// no retained source) - the lazy-migration detector (#221 design §6).
+func (s *Service) PakNeedsReingest(game *domain.Game, mod *domain.InstalledMod, fileID string) (bool, error) {
+	if game.DeployMode != domain.DeployCompile || !game.ConvertPaks || !mod.ConvertPaks {
+		return false, nil
+	}
+	if mergeSourceKind(fileID) != source.MergeSourcePak {
+		return false, nil
+	}
+	gameCache := s.GetGameCache(game)
+	versionDir := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
+	if _, err := os.Stat(filepath.Join(versionDir, cache.RetainedSourceName(fileID))); err == nil {
+		return false, nil // already retained
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	// Only flag entries that actually exist (an entirely-missing cache
+	// entry is the MISSING status's business, not ours).
+	files, err := gameCache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
+	if err != nil || len(files) == 0 {
+		return false, err
+	}
+	return true, nil
+}
+```
+
+`cmd/lmm/verify.go`:
+
+- In the merged-pak block region (verify.go:361-394 vicinity), after the staleness row: read `svc.MergedPakOutcomes(game, profile)`; for each entry with `Converted == false`, emit a JSON row `{ModID, ModName (resolve via the installed-mods map the command already holds), Status: "conversion_failed", Note: entry.FailReason}` and a human line:
+  `fmt.Printf("  %s %s - CONVERSION FAILED (%s) - deploying raw; fix the mod or run 'lmm mod convert %s off' to silence\n", warnMark, name, entry.FailReason, entry.ModID)` counting it as a warning, not an issue. (`warnMark` = whatever warning-color helper verify.go's existing warning lines use — read the stale_compile block and match it exactly; do not invent a new color helper.)
+- In the per-file loop, before the cache checks: `if need, nerr := svc.PakNeedsReingest(game, &mod, fileID); nerr == nil && need { ... }` → row Status `"needs_reingest"`, Note `"pak predates conversion support - run 'lmm verify --fix' to re-ingest"`; under `verifyFix && mod.SourceID != domain.SourceLocal` call the existing `redownloadModFile(cmd, svc, game, profile, &mod, fileID)`; for local/imported mods the Note says `"re-import the archive to enable conversion"`.
+- Carve-out (verify.go:188-201 + its use): change `hasRetainedSource(...)`'s suppression condition to also require the entry's manifests to record ZERO members (retain-only entries): read `gameCache.FileManifests(...)`; if any manifest records members, do NOT suppress the file-count check.
+- Long help text (verify.go:150) and the `verifyFileJSON.Status` doc comment (verify.go:33-39) gain both new strings.
+
+`cmd/lmm/status.go` (design §5 requires status surfacing too): in `statusProfileJSON` (status.go:305-310) add `ConversionFailures int \`json:"conversion_failures,omitempty"\``; populate from `svc.MergedPakOutcomes(game, profile)`(count of entries with`Converted == false`) for DeployCompile games; in the human `showGameStatus`path print` pak conversion failures: N (see 'lmm verify')` only when N > 0. Cover with one assertion appended to the existing status CLI-seam test (seed a fingerprint marker with one failed entry, assert the JSON field and human line).
+
+- [ ] **Step 4: Deploy surfacing test**
+
+Append to an existing deploy CLI-seam test (or the compile-flow test file if deploy has none): run the deploy flow with a fake MergeCompiler returning a failure for one mod; assert stderr/output contains `pak conversion failed` and `deploying raw` (the warning threads through the existing sync-warning plumbing — this test pins that no phase swallows it).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./cmd/lmm/ -run 'TestVerify|TestDeploy' -v` → PASS (new + existing).
+Run: `go test ./...` → PASS. `gofmt -l .` / `go vet ./...` → no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat: verify conversion outcomes, needs_reingest migration, deploy surfacing (#221)"
+```
+
+---
+
+### Task 12: TUI — convert toggle, flag indicator, parity
+
+Key choice: **"m" (toggle pak merge)** — verified free in DefaultKeyMap (bound lowercase keys today: q,l,h,k,j,n,p,s,y,e,x,i,u,f,c,d,g,a,v; "m" is unbound; lowercase fits the single-screen non-destructive-toggle convention, keys.go:70-76). Confirmation-free direct toggle (the Policy-picker "choice IS the confirmation" precedent; it's a reversible metadata write).
+
+**Files:**
+
+- Modify: `internal/tui/actions_provider.go` (interface + prototypeProvider)
+- Modify: `internal/tui/service_core.go` (coreProvider.SetConvertPaks; Overview populates ModItem)
+- Modify: `internal/tui/service.go` (ModItem fields)
+- Modify: `internal/tui/keys.go` (ConvertToggle binding)
+- Modify: `internal/tui/app.go` (dispatch, help pane, modFlags)
+- Modify: `internal/tui/mutations.go` (handler)
+- Test: `internal/tui/service_core_convert_test.go` (create; mirror service_core_recompile_test.go's harness)
+
+**Interfaces:**
+
+- Consumes: `Service.SetModConvertPaks` (Task 7), `InstalledMod.ConvertPaks`.
+- Produces: `ActionProvider.SetConvertPaks(ctx context.Context, item ModItem, enabled bool) (ActionOutcome, error)`; `ModItem.ConvertPaks bool` + `ModItem.CompileGame bool` (so the view knows whether the flag is meaningful); key "m"; modFlags 3-char indicator `raw` (precedence: lck > pin > raw).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/tui/service_core_convert_test.go` mirroring the recompile test's coreProvider harness:
+
+```go
+// TestCoreProviderSetConvertPaks:
+// - seed an installed mod in a DeployCompile game via the harness
+// - p.SetConvertPaks(ctx, item, false) -> ActionOutcome.Message contains
+//   "pak conversion: off"; the DB flag reads back false
+// - Overview() items now carry ConvertPaks == false and CompileGame == true
+```
+
+Write as real code with the harness.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/tui/ -run TestCoreProviderSetConvertPaks -v`
+Expected: FAIL — `SetConvertPaks` undefined.
+
+- [ ] **Step 3: Implement**
+
+`internal/tui/service.go` ModItem (beside Locked):
+
+```go
+	// ConvertPaks reports the #221 per-mod pak-to-exmod flag (Overview
+	// only, like UpdatePolicy). Meaningful only when CompileGame is true.
+	ConvertPaks bool
+	// CompileGame is true when the current game's DeployMode is compile -
+	// gates the "m" toggle and the raw flag column.
+	CompileGame bool
+```
+
+`internal/tui/actions_provider.go`: add to the ActionProvider interface (beside SetUpdatePolicy):
+
+```go
+	// SetConvertPaks toggles #221 pak-to-exmod conversion for item. A local
+	// DB write like SetUpdatePolicy - no network, no hooks; the next merge
+	// sync applies it.
+	SetConvertPaks(ctx context.Context, item ModItem, enabled bool) (ActionOutcome, error)
+```
+
+prototypeProvider gets a stub mirroring its other mutators (record + message).
+
+`internal/tui/service_core.go` (SetUpdatePolicy template, service_core.go:1594-1606):
+
+```go
+func (p *coreProvider) SetConvertPaks(_ context.Context, item ModItem, enabled bool) (ActionOutcome, error) {
+	if err := p.svc.SetModConvertPaks(item.Source, item.ID, p.currentGame().ID, p.currentProfile(), enabled); err != nil {
+		return ActionOutcome{}, fmt.Errorf("setting pak conversion for %s: %w", item.Name, err)
+	}
+	state := "on"
+	if !enabled {
+		state = "off"
+	}
+	return ActionOutcome{Message: fmt.Sprintf("%s pak conversion: %s (deploy to apply)", item.Name, state)}, nil
+}
+```
+
+Overview (service_core.go:157-166 item literal): `ConvertPaks: m.ConvertPaks, CompileGame: game.DeployMode == domain.DeployCompile,` (use the in-scope game/mod variables per the surrounding code).
+
+`internal/tui/keys.go`: field + binding:
+
+```go
+	// ConvertToggle toggles #221 pak-to-exmod conversion for the selected
+	// mod on the Installed Mods screen. Lowercase per the single-screen
+	// non-destructive-toggle convention (see ToggleEnable's "e").
+	ConvertToggle key.Binding
+```
+
+```go
+		ConvertToggle: key.NewBinding(
+			key.WithKeys("m"),
+			key.WithHelp("m", "toggle pak merge"),
+		),
+```
+
+`internal/tui/mutations.go` (toggleSelectedModEnable's guard shape, confirmation-free like the policy picker's directness):
+
+```go
+// toggleSelectedModConvert flips #221 pak conversion for the selected mod.
+// Direct action, no confirm modal: it is a reversible metadata write (the
+// policy picker precedent - the keypress IS the confirmation).
+func (m *Model) toggleSelectedModConvert() (tea.Model, tea.Cmd) {
+	if m.screen != ScreenInstalledMods || m.actions == nil {
+		return m, nil
+	}
+	item, ok := m.selectedMod()
+	if !ok {
+		return m, nil
+	}
+	if !item.CompileGame {
+		return m.withStatus("pak conversion applies only to merge-compile games")
+	}
+	return m.runAction(func(ctx context.Context) (ActionOutcome, error) {
+		return m.actions.SetConvertPaks(ctx, item, !item.ConvertPaks)
+	})
+}
+```
+
+(Adapt `withStatus`/`runAction` to the file's ACTUAL helper names — read the sibling handlers; `toggleSelectedModEnable` and `resolvePolicyChoice` show the real async/refresh pattern. The behavioral spec: guard screen+provider, no-op message for non-compile games, invoke provider, refresh the Overview so the flag column updates.)
+
+`internal/tui/app.go`: dispatch `case key.Matches(msg, m.keys.ConvertToggle): return m.toggleSelectedModConvert()` in the installed-mods key block (app.go:938-953); help-pane entry in the installedMods group (app.go:2065-2090): `{"m", "toggle pak merge"}` matching the group's row shape; `modFlags` (app.go:2292-2319): in the 3-char slot switch, after lck/pin: `case item.CompileGame && !item.ConvertPaks: flag = "raw"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/tui/ -run TestCoreProviderSetConvertPaks -v` → PASS.
+Run: `go test ./...` → PASS (prototypeProvider + interface satisfaction everywhere).
+Run: `gofmt -l .` / `go vet ./...` → no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: TUI pak-conversion toggle with raw flag indicator (#221)"
+```
+
+---
+
+### Task 13: Documentation — README, CHANGELOG, man pages
+
+**Files:**
+
+- Modify: `README.md` (sections per the line map below)
+- Modify: `CHANGELOG.md` (`[Unreleased]` at line 8)
+- Modify: `docs/man/` via `make man` (the new `lmm mod convert` command changes generated pages; the genman test compares committed vs generated — regenerate NOW, no version bump involved)
+
+**Interfaces:** consumes everything shipped; produces the user-facing contract.
+
+- [ ] **Step 1: CHANGELOG**
+
+Under `## [Unreleased]` (CHANGELOG.md:8), add:
+
+```markdown
+### Added
+
+- Icarus: prebuilt `.pak` mods are now converted into the merged pak at
+  merge time - rebased onto the game's current `data.pak` - instead of
+  deploying raw and being shadowed (#221). Paks that embed a `data.EXMOD`
+  manifest convert exactly; others are diff-derived. Irreconcilable paks
+  produce a per-mod error and fall back to raw deploy.
+- `lmm mod convert <mod-id> <on|off>` and a per-game `convert_paks`
+  games.yaml setting control conversion; the TUI toggles it with `m`.
+- `lmm verify` reports `conversion_failed` and `needs_reingest` statuses;
+  `--fix` re-ingests pre-existing pak mods into the conversion pipeline.
+- JSON additions: `convert_paks` in `lmm list --json`, `lmm mod show
+--json`, and `lmm game list --json`.
+```
+
+- [ ] **Step 2: README**
+
+Using the recon line map (verify actual current positions before editing):
+
+- `### Games (games.yaml)` (~403-436): add `convert_paks: true` (commented as default) to the Icarus example block; extend the Merge precedence paragraph (~436) with two sentences: prebuilt paks are converted and rebased onto the current base at merge time (embedded `data.EXMOD` exact, else diff-derived; failures fall back to raw deploy with a warning), and `convert_paks: false` / `lmm mod convert ... off` keep specific paks raw.
+- After `### Locking mods to a version` (~243): new sibling section `### Pak conversion (Icarus)` — ~15 lines covering: why (frozen-in-time paks, shadowing), rebase semantics (drift in author-touched rows is expected), the three control levels (game config, per-mod toggle, automatic default), error-and-skip behavior, `needs_reingest` migration.
+- `### Terminal UI` key table: add the `m` row.
+- `### Commands` table (~906-916): row `| lmm mod convert <mod-id> <on\|off> | Toggle pak-to-exmod conversion |`.
+- `### Verify output` (~1022-1049): rows for `conversion_failed`, `needs_reingest`.
+
+- [ ] **Step 3: man pages**
+
+Run: `make man`
+Expected: regenerated pages include `lmm-mod-convert`; `git status` shows docs/man changes.
+
+Run: `go test ./cmd/lmm/ -run TestGenMan -v` (or the genman test's actual name — grep `genman_test.go`)
+Expected: PASS.
+
+- [ ] **Step 4: Full suite + commit**
+
+Run: `go test ./...` → PASS. `gofmt -l .` / `go vet ./...` → no output.
+
+```bash
+git add README.md CHANGELOG.md docs/man
+git commit -m "docs: pak-to-exmod conversion feature documentation (#221)"
+```
+
+---
+
+### Task 14: End-to-end sweep and cross-cutting regression tests
+
+The scenarios that span multiple tasks' seams — plus the final full verification.
+
+**Files:**
+
+- Test: `internal/core/pak_convert_e2e_test.go` (create; reuse the compile-flow harness)
+- Modify: none (any failure here is a defect in Tasks 1-13 — fix loops go through the owning task's files)
+
+- [ ] **Step 1: Write the e2e tests**
+
+```go
+// TestPakConvertEndToEnd (core-level, fake MergeCompiler recording its
+// inputs):
+// 1. Ingest one exmodz mod and one pak mod; SyncMergedPak.
+//    - assert MergeCompile received BOTH sources in profile order, pak with
+//      Kind=MergeSourcePak
+//    - assert pak manifest flipped to nil; raw link gone; merged deployed
+// 2. Toggle the pak mod off (SetModConvertPaks false); SyncMergedPak.
+//    - assert MergeCompile received ONLY the exmodz source
+//    - assert pak manifest lists the pak; raw deployed again
+// 3. Toggle back on; SyncMergedPak; converted state again.
+// 4. Disable the pak mod entirely (SetModEnabled false); SyncMergedPak.
+//    - assert it contributes nothing and reconcile skipped it (disabled
+//      mods are not deployed at all).
+//
+// TestNoPakModsByteIdentical: a profile with only exmodz mods produces the
+// same fingerprint marker JSON shape as pre-#221 for its inputs (Kind
+// exmodz entries; equality with a pre-#221-style marker true) and
+// MergeCompile receives sources with Kind set - the existing exmodz e2e
+// tests passing unchanged is the primary regression net; this test pins
+// the marker compat explicitly.
+```
+
+Write as real code with the harness.
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `go test ./internal/core/ -run 'TestPakConvertEndToEnd|TestNoPakModsByteIdentical' -v`
+Expected: PASS (if not, the defect belongs to an earlier task's code — fix there, not here).
+
+- [ ] **Step 3: Full verification sweep**
+
+Run: `gofmt -l .` → no output.
+Run: `go vet ./...` → no output.
+Run: `go test ./...`
+Expected: PASS, no skips beyond pre-existing.
+Run: `go build -o lmm ./cmd/lmm`
+Expected: builds; spot-check `./lmm mod convert --help` renders the Long text.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/core/pak_convert_e2e_test.go
+git commit -m "test: end-to-end pak conversion lifecycle coverage (#221)"
+```
+
+---
+
+## Execution Notes
+
+- Tasks are strictly sequential; each builds on the previous task's interfaces. No parallel implementers.
+- Test-harness helper names in Tasks 6-12 marked "read the file first" are deliberate: the harnesses exist (recon-verified files/lines) and their exact constructor names are the implementer's first read, not an invention license. The ASSERTIONS specified are the requirement.
+- The spike branch is consulted read-only: `git show spike/pak-to-exmod:spike/pakconvert/<file>`.
+- In-game validation on the user's real Icarus install is a RELEASE gate, not a task: after the final review, the user smoke-tests (install a real pak-only mod, verify merged behavior in-game) before the PR merges. Build `./lmm` for them.
+- Failures discovered mid-plan that trace to a design gap stop the line (BLOCKED) rather than being patched around.

--- a/docs/plans/archive/2026-08-06-tui-verify-surface-design.md
+++ b/docs/plans/archive/2026-08-06-tui-verify-surface-design.md
@@ -1,0 +1,185 @@
+# TUI Verify/Health Surface — Design (#224)
+
+**Date:** 2026-08-06
+**Issue:** #224 (from the 2026-08-06 CLI↔TUI parity audit)
+**Status:** Approved design, pending implementation plan
+**Follows:** #221 (pak conversion — verify is now the lazy-migration/repair story), #217 (convergence always runs)
+**Feeds:** #86 (TUI mod details view) — the screen-7 host built here is its landing zone
+
+## Problem
+
+`lmm verify` / `verify --fix` is the entire health-and-repair story — missing
+files, checksums, version records, merged-pak freshness, stale-deployment
+convergence, and #221's `conversion_failed` / `needs_reingest` lazy
+migration — yet it has no TUI surface at all. A user living in the TUI never
+learns a pak failed conversion or that their deployment has drifted, and has
+no repair action. This is the largest genuine CLI↔TUI parity gap found by the
+2026-08-06 audit.
+
+Structural constraint: `doVerify` is ~700 lines in `cmd/lmm/verify.go`
+(package `main`, not importable) that orchestrates ~19 core seams but owns
+all classification, repair sequencing, and output itself. The TUI cannot
+reuse it without an extraction.
+
+## Decisions (user-ratified)
+
+1. **Cost model — local auto + full on demand.** Plain verify is
+   network-bound (the per-mod version pre-pass calls `GetModFiles` upstream
+   even without `--fix`), so the TUI must not run a full verify implicitly.
+   Verify splits into a **Local** tier (disk/DB only) and a **Full** tier
+   (adds the network version pass). The dashboard auto-runs Local; Full runs
+   only on explicit user action.
+2. **Surface — screen 7 as a generic context-view host** with Verify/Health
+   as its _home content_ (revised from a bespoke verify screen at user
+   request, to pre-pay #86's landing zone). See TUI section.
+3. **Fix flow — batch fix behind the standard confirmation modal**, exactly
+   mirroring CLI `--fix` semantics (same repairs, same ordering, same
+   locked-mod refusals). Per-finding fix is out of scope (same posture as
+   #74's deferral).
+4. **Architecture — Approach A: full extraction** of the verify engine into
+   `internal/core`, findings + progress events; the CLI becomes a renderer
+   with byte-identical output enforced by capture tests (the 5a/5b recipe;
+   the pre-refactor CLI output is the spec). Parity directive satisfied with
+   no CLI-vs-TUI twins.
+
+## Architecture
+
+### Core verify engine (`internal/core/verify.go`)
+
+```go
+type VerifyTier int          // VerifyLocal | VerifyFull
+type VerifyOptions struct {
+    Tier      VerifyTier
+    Fix       bool           // apply repairs (CLI --fix semantics, identical ordering)
+    ModFilter string         // CLI's optional [mod-id] argument
+}
+type VerifyFinding struct {  // same vocabulary as today's verify JSON rows
+    ModID   string
+    ModName string
+    FileID  string           // file ID, or game-dir path for stale_deployment rows (shipped v1.29.0 contract)
+    Status  string           // ok|missing|no_checksum|file_count_mismatch|skipped|version_mismatch|
+                             // version_unverifiable|stale_compile|stale_deployment|fixed_stale_deployment|
+                             // conversion_failed|needs_reingest|fixed_needs_reingest (+ fix variants per today's contract)
+    Note    string
+}
+type VerifyResult struct {
+    Findings         []VerifyFinding
+    Issues, Warnings int      // counting rules live HERE — single source of truth
+}
+func (s *Service) Verify(ctx context.Context, game *domain.Game, profile string,
+    opts VerifyOptions, progress func(VerifyEvent)) (*VerifyResult, error)
+```
+
+- **Local tier:** checksum/missing-file walk, file-count check, merged-pak
+  staleness + conversion outcomes (`MergedPakOutcomes`), pak re-ingest
+  detection (`PakNeedsReingest`), stale-deployment convergence
+  (`ConvergeDeployedFiles`, dry-run unless Fix). No network — guaranteed by
+  test (a source mock that fails the test if called).
+- **Full tier:** Local + the per-mod upstream version pre-pass (the only
+  network consumer; `skipped` finding on source-unreachable, never fatal).
+- **Fix mode:** the same engine applying today's repairs in today's order —
+  re-download → checksum fill → version re-key (incl. cross-profile sibling
+  repair) → merged-pak resync → pak re-ingest → convergence removal — with
+  identical locked-mod refusal semantics.
+- **Events:** the engine emits typed `VerifyEvent`s as work happens
+  (finding-produced, phase progress e.g. "checking versions i/N",
+  stderr-bound sync warnings). Output ORDER is part of the CLI contract, so
+  findings are emitted in exactly today's production order. Follows the
+  existing flows-events pattern (`internal/core/flows.go`).
+- `reportConvergencePass` (#217) and the rest of `doVerify`'s inline logic
+  fold INTO the engine; the JSON contract is the completeness proof (text
+  and JSON already render from the same data points — findings formalize
+  those points).
+
+### CLI (`cmd/lmm/verify.go`) — pure renderer
+
+`doVerify` keeps flag/profile resolution, then calls the engine with a
+progress callback that prints exactly today's lines (colors, remedy hints,
+plain-vs-fix variants) from event fields; `--json` collects findings into
+the unchanged `verifyJSONOutput` shape. **Golden capture transcripts of the
+pre-refactor binary are recorded FIRST** (plain / `--fix` / `--json` across
+representative scenarios) and pinned by capture tests; the existing dense
+verify suite stays untouched and green.
+
+### TUI
+
+**Screen-7 context-view host** (`internal/tui`): the 7th nav slot (digit
+`7`, tab-cycle after Conflicts) is a host component rendering pluggable
+content that satisfies a small interface — title, body render, keymap,
+help-panel group. The host owns chrome, scrolling, and single-flight wiring
+once; content views stay small.
+
+- **Verify/Health is the home content:** digit 7, tab-cycle, and the
+  dashboard jump land there when nothing contextual is pushed.
+- **One-deep view stack now:** contextual content (e.g. #86's mod details,
+  entered from a selected mod) will be _pushed_ onto the host; `esc` pops
+  back to the originating screen; popping empty shows home (verify).
+  **YAGNI boundary:** no content registry, no multi-level stack — just the
+  interface, the home view, and esc-back semantics #86 will exercise.
+- Nav label: **"Health"** (theme layouts may restyle, but the semantic name
+  is Health); help panel gains the group; nav digit handling extends to 7.
+
+**Verify home content** (all Section-3 semantics as approved):
+
+- Two panes like Conflicts: findings list (`STATUS / MOD / FILE`,
+  status-tinted rows) + detail pane (full note and the CLI's remedy
+  guidance). Header shows last scan tier + relative age. Empty state:
+  "no findings (local) — run a full check (c)".
+- `c` — run the Full (network) check with live status-line progress;
+  single-flight; cancellable by quit-drain.
+- `F` — batch fix: standard confirmation modal summarizing repairs (counts
+  by category, detail lines capped "+N more"), then engine fix mode with
+  progress; completion shows per-item results in the info overlay (update-
+  batch pattern), then auto re-runs the Local scan so screen + dashboard
+  refresh.
+
+**Dashboard:** health line in the summary block — `Health: N issue(s), M
+warning(s) (local)` / `Health: OK (local)` — computed by an async Local scan
+on load and on game/profile rebind (conflicts-count pattern; `?` until it
+lands). Command menu gains a "Verify Integrity" entry jumping to screen 7.
+
+**Help-text staleness (recurring trap):** `cmd/lmm/tui.go` `Long` help,
+README TUI section, and the help panel all gain the verify capability in the
+same change.
+
+## Error handling
+
+Same posture as the CLI: per-mod source-unreachable → `skipped` findings,
+never aborts; locked-mod repair refusals are findings (`version_mismatch` +
+`locked` note); per-item fix failures surface as findings and the run
+continues (joined-error semantics). Only environmental failures (DB/config
+unreadable) abort — TUI status line, CLI error. Context cancellation is
+honored between per-mod steps (quit-drain works mid-network-pass). A failed
+dashboard auto-scan is non-fatal: health shows `?`, error on the status
+line.
+
+## Testing
+
+| Layer       | Approach                                                                                                                                                                          |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Core engine | Table-driven per status (in-memory SQLite, `t.TempDir()`); fix-mode fault-injection (existing patterns); Local-tier never-touches-network proof via failing mock source           |
+| CLI         | Golden capture tests recorded from the PRE-refactor binary — byte-identical stdout for plain/`--fix`/`--json` representative scenarios; existing verify suite untouched and green |
+| TUI         | Model tests in existing `internal/tui` style: host push/pop + esc-back, verify rendering, key gating, fix confirm flow, single-flight refusals; dashboard-scan-is-Local seam test |
+| Process     | SDD per-task reviews, final whole-branch live review, README/CHANGELOG, **user interactive smoke test gates the merge** (TUI work)                                                |
+
+## Out of scope
+
+- Per-finding fix (deferred like #74's per-item selection).
+- #86/#87 content views themselves (this story only builds their host).
+- Any change to CLI verify behavior or its JSON contract (byte-identical is
+  a hard requirement).
+- Verify row-reachability for fully-uninstalled mods (#217's noted second
+  gap — unfiled by decision).
+
+## Success criteria
+
+1. CLI verify output (text and JSON, plain and `--fix`) is byte-identical to
+   pre-refactor across the capture scenarios.
+2. TUI dashboard shows the local health signal automatically; screen 7 home
+   shows findings; `c` runs the full pass; `F` repairs with confirmation —
+   all against the same core engine, no duplicated classification logic.
+3. #221's `conversion_failed`/`needs_reingest` states are visible and
+   repairable from the TUI.
+4. The host interface supports pushing a second content view (proven by
+   test, not by building #86).
+5. Full suite green; user smoke test passes.

--- a/docs/plans/archive/2026-08-06-tui-verify-surface-plan.md
+++ b/docs/plans/archive/2026-08-06-tui-verify-surface-plan.md
@@ -1,0 +1,688 @@
+# TUI Verify/Health Surface (#224) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `doVerify`'s ~700-line orchestration into a core verify engine (Local/Full tiers, findings + ordered events, fix mode), make the CLI a byte-identical renderer over it, and give the TUI a screen-7 context-view host whose home content is a Verify/Health surface with a dashboard health signal, full-check action (`c`), and batch-fix action (`F`).
+
+**Architecture:** `internal/core/verify.go` gains `Service.Verify(ctx, game, profile, opts, progress)` emitting typed `VerifyEvent`s in exactly today's production order; `cmd/lmm/verify.go` becomes a renderer (goldens recorded FIRST prove byte-identity); `internal/tui` gains `ScreenHealth` (digit 7) as a pluggable context-view host with the health view as home content, `DataProvider.Health` (Local tier, rides `loadData` like Conflicts), and `ActionProvider.RunHealthCheck` (full/fix).
+
+**Tech Stack:** Go 1.25, Bubble Tea/bubbles/lipgloss, Cobra, modernc.org/sqlite (`:memory:` tests), testify.
+
+## Global Constraints
+
+- Branch `feat/tui-verify-surface` from `develop`; PR `--base develop`; merge-commit; issue refs `(#224)` in every commit subject.
+- NO version bump; CHANGELOG entries under `[Unreleased]`.
+- `gofmt -l cmd internal` clean, `go vet ./...` clean, and the FULL suite green before EVERY commit. Never pipe `go test` into another command in a `&&` chain; never commit red.
+- **Byte-identical CLI verify output is a hard requirement.** Task 1's goldens are recorded from the PRE-refactor code and are never edited afterward; any later golden-test failure is a defect in the extraction, not a golden to regenerate.
+- `internal/core` must NEVER import `internal/source/icarus` (alias types through `internal/source` — existing precedent).
+- The `--json` contract (`verifyJSONOutput`/`verifyFileJSON` shapes, statuses, note text, row order) is frozen — no additions, no reorderings.
+- `cmd/lmm/tui.go` `Long` help and the README TUI section MUST be updated in this branch (recurring staleness trap: grep for `1-6`, "conflicts)", and capability lists). `tui.go`'s Long is embedded in the committed man pages — run `make man` in the docs task.
+- TUI merge gate: the USER's interactive smoke test. Never auto-merge.
+- Existing verify tests (`cmd/lmm/verify_test.go`, `verify_converge_test.go`, `verify_convert_test.go`, and every other test touching verify) stay untouched and green through the entire branch — they are part of the byte-identity proof.
+
+---
+
+### Task 1: Golden capture harness (pre-refactor safety net)
+
+**Files:**
+
+- Create: `cmd/lmm/verify_golden_test.go`
+- Create: `cmd/lmm/testdata/verify_golden/` (generated `.golden` files, committed)
+
+**Interfaces:**
+
+- Consumes: existing test fixtures — `setupDoVerifyConvergeTest` (`verify_converge_test.go:43`), `setupDoVerifyEmptyProfileConvergeTest` (`verify_converge_test.go` #217 tests), the version-mismatch fixture `setupDoVerifyVersionTest` (`verify_test.go`), and the #221 convert fixtures in `verify_convert_test.go` — plus `captureStdout` (`auth_status_test.go:16`).
+- Produces: `runVerifyGolden(t, name, fixture func(t) (*cobra.Command, *core.Service, *domain.Game), fix, json bool)` — the harness every later task re-runs unchanged; `-update` flag support via `go test ./cmd/lmm/ -run TestVerifyGolden -update`.
+
+**Why first:** these snapshots ARE the spec for Task 7's renderer swap. They snapshot today's output through the real `doVerify` across: empty profile, convergence candidates, version mismatch (incl. locked refusal), needs-reingest/conversion statuses — each in plain, `--fix`, and `--json` modes (fix-mode runs use fresh fixtures per mode since `--fix` mutates).
+
+- [ ] **Step 1: Write the harness + scenario table**
+
+```go
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+var updateGolden = flag.Bool("update", false, "rewrite verify golden files from current output")
+
+// runVerifyGolden runs doVerify against a fresh fixture with the given
+// output-mode globals and compares (or, with -update, records) the exact
+// stdout transcript. Colors are already suppressed in tests (no TTY), so
+// the transcript is stable. Each invocation builds its OWN fixture: fix
+// mode mutates state, so scenarios can never share one.
+func runVerifyGolden(t *testing.T, name string, fixture func(*testing.T) (*cobra.Command, *core.Service, *domain.Game), fix, json bool) {
+	t.Helper()
+	cmd, svc, game := fixture(t)
+	oldFix, oldJSON := verifyFix, jsonOutput
+	verifyFix, jsonOutput = fix, json
+	t.Cleanup(func() { verifyFix, jsonOutput = oldFix, oldJSON })
+
+	out := captureStdout(t, func() error { return doVerify(cmd, svc, game, nil) })
+
+	path := filepath.Join("testdata", "verify_golden", name+".golden")
+	if *updateGolden {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(out), 0o644))
+		return
+	}
+	want, err := os.ReadFile(path)
+	require.NoError(t, err, "golden missing - run with -update on the PRE-refactor tree only")
+	require.Equal(t, string(want), out, "verify output must be byte-identical to the pre-refactor golden")
+}
+
+func TestVerifyGolden(t *testing.T) {
+	scenarios := []struct {
+		name    string
+		fixture func(*testing.T) (*cobra.Command, *core.Service, *domain.Game)
+	}{
+		{"empty_profile", func(t *testing.T) (*cobra.Command, *core.Service, *domain.Game) {
+			cmd, svc, game, _ := setupDoVerifyEmptyProfileConvergeTest(t)
+			return cmd, svc, game
+		}},
+		{"converge", setupDoVerifyConvergeTest},
+		// Version-mismatch and convert-status fixtures: adapt the setup
+		// helpers already in verify_test.go / verify_convert_test.go to this
+		// signature with thin wrappers in this file (each returns cmd, svc,
+		// game exactly like the two above).
+	}
+	for _, sc := range scenarios {
+		for _, mode := range []struct {
+			suffix    string
+			fix, json bool
+		}{{"plain", false, false}, {"fix", true, false}, {"json", false, true}, {"fix_json", true, true}} {
+			t.Run(sc.name+"_"+mode.suffix, func(t *testing.T) {
+				runVerifyGolden(t, sc.name+"_"+mode.suffix, sc.fixture, mode.fix, mode.json)
+			})
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Add the version-mismatch and convert wrappers.** Open `cmd/lmm/verify_test.go` and `cmd/lmm/verify_convert_test.go`, find their setup helpers (`setupDoVerifyVersionTest` and the needs-reingest/conversion-failed fixtures), and add thin adapter funcs in `verify_golden_test.go` matching the harness signature. If a helper returns extra values, discard them; if one takes scenario parameters, bake the values its own tests use. Include a locked-mod version-mismatch scenario (the fixture for `--fix skipped: ... is locked` exists in `verify_test.go`'s lock tests).
+- [ ] **Step 3: Record goldens** — run `go test ./cmd/lmm/ -run TestVerifyGolden -update` then `go test ./cmd/lmm/ -run TestVerifyGolden` and confirm PASS. Inspect each `.golden` by eye: every scenario must show real content (not just headers) — a golden that captured an unexpected error line is a broken fixture, fix it now.
+- [ ] **Step 4: Full gates** — gofmt, vet, full suite (run `go test ./...` on its own).
+- [ ] **Step 5: Commit** — `test: record pre-refactor verify output goldens (#224)`
+
+---
+
+### Task 2: Core verify types, skeleton, and the local per-file walk
+
+**Files:**
+
+- Create: `internal/core/verify.go`
+- Create: `internal/core/verify_test.go`
+- Modify: `cmd/lmm/verify.go` (delete `hasRetainedSource` + `sourceMappedMod`, re-point callers)
+- Create: `internal/core/verify_helpers.go` (moved helpers)
+
+**Interfaces:**
+
+- Consumes: `Service.GetFilesWithChecksums(gameID, profile string) ([]db.FileChecksum, error)`, `Service.GetInstalledMod(sourceID, modID, gameID, profile string) (*domain.InstalledMod, error)`, `Service.GetGameCache(game *domain.Game) *cache.Cache`, `cache.RetainedSourceName`, `gameCache.Exists/ListFiles/FileManifests/GetFilePath`.
+- Produces (frozen for ALL later tasks):
+
+```go
+type VerifyTier int
+
+const (
+	VerifyLocal VerifyTier = iota
+	VerifyFull
+)
+
+type VerifyOptions struct {
+	Tier      VerifyTier
+	Fix       bool
+	ModFilter string
+}
+
+type VerifyFinding struct {
+	ModID, ModName, FileID, Status, Note string
+}
+
+type VerifyResult struct {
+	Findings         []VerifyFinding
+	Issues, Warnings int
+	Checked          int  // feeds the CLI's "No files found for mod X" gate
+	HasFiles         bool // false = the #217 empty-profile path ran
+}
+
+type VerifyEventKind int
+
+const (
+	VerifyEvBegin           VerifyEventKind = iota // HasFiles
+	VerifyEvFinding                                // Finding + extras; row was appended to Findings
+	VerifyEvRepairDetail                           // indented sub-line; Detail pre-formatted, Green tone flag
+	VerifyEvSyncWarning                            // stderr-bound merged-pak sync warning (Detail)
+	VerifyEvVerbose                                // verbose-gated diagnostic (Detail)
+	VerifyEvProgress                               // Full-tier network tick (Index/Total/ModName)
+)
+
+type VerifyEvent struct {
+	Kind     VerifyEventKind
+	HasFiles bool
+	Finding  VerifyFinding // valid for VerifyEvFinding
+	// Main-line extras the CLI needs beyond the finding row itself:
+	Recorded, Effective, Version string // version_mismatch / missing
+	ExpectedCount                int    // file_count_mismatch
+	Variant                      string // "" | "checksum_populated" (ok main line) | "fixed_green" (fixed_stale_deployment whole-line green - Task 6)
+	// Sub-line / progress payload:
+	Detail       string
+	Green        bool
+	Index, Total int
+	ModName      string
+}
+
+func (s *Service) Verify(ctx context.Context, game *domain.Game, profile string, opts VerifyOptions, progress func(VerifyEvent)) (*VerifyResult, error)
+```
+
+Also produced: `internal/core/verify_helpers.go` with `hasRetainedSource(gameCache *cache.Cache, gameID, sourceID, modID, version string, fileIDs []string) bool` and `sourceMappedMod(game *domain.Game, mod *domain.Mod) *domain.Mod` — moved VERBATIM (doc comments included) from `cmd/lmm/verify.go:238` and `cmd/lmm/verify.go:977`, exported as `HasRetainedCompileSource` / kept-internal `sourceMappedMod`.
+
+**Engine internal shape (all later engine tasks extend this):** `Verify` builds a `verifyRun{svc, game, profile, opts, emit func(VerifyEvent), result *VerifyResult}` and calls phase methods in today's order. `emit` is nil-safe (no-op progress). Every finding append goes through:
+
+```go
+func (r *verifyRun) finding(f VerifyFinding, extras VerifyEvent) {
+	r.result.Findings = append(r.result.Findings, f)
+	extras.Kind, extras.Finding = VerifyEvFinding, f
+	r.emit(extras)
+}
+// and fix-resolution row rewrites through:
+func (r *verifyRun) resolveLast(status, note string) {
+	last := &r.result.Findings[len(r.result.Findings)-1]
+	last.Status, last.Note = status, note
+}
+```
+
+This task ports (from `cmd/lmm/verify.go`, keeping counting rules identical):
+
+1. `GetFilesWithChecksums` + the `len(files) == 0` early path (emit `VerifyEvBegin{HasFiles:false}`, run nothing else this task — convergence lands in Task 6; until then the empty path returns an empty result).
+2. The file-count pre-pass (lines 339-415) — statuses `skipped`/`file_count_mismatch`, `hasRetainedSource` carve-out, `reportedMismatch` dedup.
+3. The per-file loop's NON-fix branches (lines 678-854 minus fix blocks and minus `PakNeedsReingest`, which is Task 3): unknown-mod `skipped`, `missing` (Version extra), `no_checksum`, `ok`, `Checked` increments.
+
+- [ ] **Step 1: Write failing engine tests** in `internal/core/verify_test.go` (package `core_test`, in-memory service via the same builders `merged_pak_test.go` uses — `newFlowsTestService(t)` is internal, so use the exported test seams other `core_test` files use; check `pak_convert_e2e_test.go` for the external-service builder and mirror it):
+
+```go
+func TestVerify_LocalWalk_StatusesAndCounts(t *testing.T) {
+	// Fixture: game + profile with (a) one mod fully cached+checksummed -> ok,
+	// (b) one checksum row whose version dir is absent -> missing (issues=1),
+	// (c) one row with empty checksum -> no_checksum (warnings=1),
+	// (d) one checksum row for an uninstalled mod -> skipped (warnings=1).
+	// Assert result.Findings order is exactly (file-count pass first, then
+	// per-file rows in GetFilesWithChecksums order), Issues==1, Warnings==2,
+	// Checked==row count, HasFiles==true, and that a progress collector saw
+	// one VerifyEvBegin{HasFiles:true} followed by one VerifyEvFinding per row
+	// with Version set on the missing row.
+}
+
+func TestVerify_EmptyProfile_HasFilesFalse(t *testing.T) {
+	// No checksummed files: result.HasFiles==false, Findings empty,
+	// Begin event carries HasFiles=false.
+}
+
+func TestVerify_ModFilter_LimitsRows(t *testing.T) { /* filter to one mod: other rows absent, Checked matches */ }
+```
+
+- [ ] **Step 2: Run to see them fail** — `go test ./internal/core/ -run TestVerify_` → FAIL (undefined types).
+- [ ] **Step 3: Implement** `verify.go` types + skeleton + the three ported phases; move the two helpers to `verify_helpers.go` verbatim and update `cmd/lmm/verify.go` call sites (`hasRetainedSource(...)` → `core.HasRetainedCompileSource(...)`; `sourceMappedMod` stays needed by CLI paths until Task 7 — move it to core NOW and give the CLI a one-line wrapper `func sourceMappedMod(...)` delegating to an exported `core.SourceMappedMod` so nothing breaks and Task 7 just deletes the wrapper).
+- [ ] **Step 4: Run engine tests to pass, then the FULL suite including `TestVerifyGolden`** (CLI behavior unchanged — goldens must still pass).
+- [ ] **Step 5: Commit** — `feat(core): verify engine skeleton with local per-file walk (#224)`
+
+---
+
+### Task 3: Merged-pak checks, needs-reingest, lock-pending, and the Full-tier version pass
+
+**Files:**
+
+- Modify: `internal/core/verify.go`
+- Modify: `internal/core/verify_test.go`
+
+**Interfaces:**
+
+- Consumes: Task 2's `verifyRun`/`finding`/`emit`; `Service.CheckMergedPakStaleness(game, profile)`, `Service.MergedPakOutcomes(game, profile)`, `Service.PakNeedsReingest(game, mod, fileID)`, `Service.GetModFiles(ctx, sourceID, mod)`, `Service.GetInstalledMods(gameID, profile)`, `config.LoadProfile(svc.ConfigDir(), gameID, profile)`, `domain.EffectiveInstalledVersion`, `core.SourceMappedMod`.
+- Produces: the complete READ side of the engine — every status except the fix-mode resolutions and convergence. Emission order (must match `doVerify` exactly): file-count pass → merged-pak staleness (`stale_compile`) → conversion outcomes (`conversion_failed`) → per-mod version pass → per-file loop (with `needs_reingest` before the cache-existence check, `VerifyEvVerbose` on its check error).
+
+Port details (source line refs into pre-refactor `cmd/lmm/verify.go`):
+
+- Staleness (449-474): `skipped` on check error; `stale_compile` with `Note: staleUpd.RecompileReason`; `Checked++` unconditionally inside the DeployCompile branch.
+- Conversion outcomes (484-514): name fallback `entry.ModID` when the installed map misses; `conversion_failed` with `Note: entry.FailReason`.
+- Version pass (516-676) — **gated on `opts.Tier == VerifyFull`**: local-source/manual/no-fileIDs silent skip; `skipped` + note `"could not check version: %v"` on `GetModFiles` error; `version_unverifiable`; `version_mismatch` (extras `Recorded`, `Effective`) with `issues++` — the fix branch is Task 5's; the quiet-OK `Checked++` and the lock-pending-convergence informational row (`ok` + note, extras none) port here (lock state via `prof.FindRef` from the up-front `config.LoadProfile`). Emit `VerifyEvProgress{Index: i+1, Total: len(installedMods), ModName: mod.Name}` at the TOP of each mod's iteration (new — CLI ignores it; TUI status line consumes it), and honor `ctx.Err()` between mods: on cancellation return the partial result with the error.
+- `needs_reingest` (696-753 minus the fix block): note text switches on `domain.SourceLocal`; check-error emits `VerifyEvVerbose` with EXACTLY the current text `fmt.Sprintf("could not check pak-reingest status for %s (%s): %v", mod.Name, f.FileID, nerr)` (the CLI adds its own ` (verbose)` prefix).
+
+- [ ] **Step 1: Failing tests** — extend `verify_test.go`:
+
+```go
+func TestVerify_LocalTier_NeverTouchesNetwork(t *testing.T) {
+	// Register a source whose GetModFiles fails the test if called
+	// (t.Fatal via a callback), install a source-backed mod with FileIDs,
+	// run Verify with Tier: VerifyLocal. No version rows, no skipped rows,
+	// and the trap never fires. THE spec's no-network proof.
+}
+func TestVerify_FullTier_VersionStatuses(t *testing.T) {
+	// Table: reachable+matched -> quiet ok (Checked++ only);
+	// unreachable -> skipped w/ note; no matching fileID -> version_unverifiable;
+	// effective != recorded -> version_mismatch with Recorded/Effective extras
+	// and issues++; locked ref pending convergence -> ok + note row.
+	// Assert a VerifyEvProgress tick per source-backed mod.
+}
+func TestVerify_CompileGameStatuses(t *testing.T) {
+	// DeployCompile fixture (mirror merged_pak_test.go's): stale fingerprint
+	// -> stale_compile row; a non-Converted outcome entry -> conversion_failed
+	// row with FailReason note; a pre-#221 pak (deployable member, no
+	// retained source) -> needs_reingest row with the redownload note, and
+	// the SourceLocal variant note for a local mod.
+}
+func TestVerify_ContextCancelledMidVersionPass(t *testing.T) {
+	// Cancel ctx from the first mod's GetModFiles trap; Verify returns
+	// ctx.Err() with the partial result it had.
+}
+```
+
+- [ ] **Step 2: Run to fail** — `go test ./internal/core/ -run 'TestVerify_(Local|Full|Compile|Context)'`.
+- [ ] **Step 3: Implement the ports** per the line-ref map above.
+- [ ] **Step 4: Engine tests green, full suite + goldens green.**
+- [ ] **Step 5: Commit** — `feat(core): verify engine compile checks and Full-tier version pass (#224)`
+
+---
+
+### Task 4: Fix mode I — redownload repairs (missing / no-checksum / needs-reingest)
+
+**Files:**
+
+- Modify: `internal/core/verify.go`
+- Create: `internal/core/verify_repair.go`
+- Modify: `internal/core/verify_test.go`
+
+**Interfaces:**
+
+- Consumes: `Service.DownloadMod`, `Service.SaveFileChecksum`, Task 2/3's run plumbing.
+- Produces: `func (r *verifyRun) redownloadModFile(ctx context.Context, mod *domain.InstalledMod, fileID string) (persisted bool, err error)` in `verify_repair.go` — `cmd/lmm/verify.go:1544`'s body moved verbatim minus the `cmd` parameter (takes `ctx` directly), using `core.SourceMappedMod`. Resolution semantics (all inside `opts.Fix && mod.SourceID != domain.SourceLocal` guards, matching today's sites):
+  - `missing` → on error `RepairDetail{Detail: "Re-download failed: <err>", Green: false}` + last-row `Note=err`; on `persisted` → `RepairDetail{"Re-downloaded OK", Green: true}` + `resolveLast("ok", "")` + `issues--`; on not-persisted → `RepairDetail{"Re-downloaded, but no checksum was available to store - NO CHECKSUM remains"}` + `resolveLast("no_checksum", "re-downloaded, but no checksum was available to store")` + `issues--; warnings++`.
+  - `no_checksum` fix path REPLACES the plain row emission (today's code appends different rows per outcome — port the exact branching from lines 804-846, including the `ok` + `Variant: "checksum_populated"` main-line emission on success).
+  - `needs_reingest` → failure `RepairDetail{"Re-ingest failed: <err>"}` + note rewrite; success `RepairDetail{"Re-ingested for pak conversion", Green: true}` + `resolveLast("fixed_needs_reingest", "re-ingested with retained source for pak conversion")` + `warnings--`.
+
+**Sub-line contract note (applies to Tasks 4-6):** every `VerifyEvRepairDetail.Detail` string is the EXACT text inside today's `fmt.Printf("  %s\n", ...)`-style calls, WITHOUT the two-space indent and without color — the CLI renderer adds indent + `colorGreen` when `Green`. The goldens are the arbiter.
+
+- [ ] **Step 1: Failing tests** — fake source with controllable download outcomes (mirror the fake-source patterns in `service_icarus_compile_test.go`): table over {missing+success, missing+no-checksum, missing+error, no_checksum+success, needs_reingest+success, needs_reingest+error, any+SourceLocal (no repair attempted)}; assert final Findings statuses/notes, Issues/Warnings arithmetic, and the RepairDetail event sequence (Detail text + Green flags) per case.
+- [ ] **Step 2: Run to fail.**
+- [ ] **Step 3: Implement** (`verify_repair.go` + the three fix blocks in the walk).
+- [ ] **Step 4: Green: engine, full suite, goldens.**
+- [ ] **Step 5: Commit** — `feat(core): verify fix mode redownload repairs (#224)`
+
+---
+
+### Task 5: Fix mode II — version repair, siblings, locked refusals
+
+**Files:**
+
+- Modify: `internal/core/verify_repair.go` (port `repairModVersion`, `repairSiblingProfiles`, `fileIDsEqual`, `relinkDeployedRow`, `cacheDirExists` from `cmd/lmm/verify.go:998-1499`)
+- Modify: `internal/core/verify.go` (the version-mismatch fix branch, lines 583-657)
+- Modify: `internal/core/verify_test.go`
+
+**Interfaces:**
+
+- Consumes: `svc.NewProfileManager()`, `Service.SetModVersion/SetModDeployed/SetModLinkMethod/GetEffectiveLinkMethod/NewInstallerWithLinker/GetLinker`, `domain.ModReference`, profile `FindRef`.
+- Produces: `func (r *verifyRun) repairModVersion(ctx context.Context, mod *domain.InstalledMod, effective string) (note string, siblingFailures int, err error)` and helpers — bodies moved with EVERY doc comment intact; each inline `fmt.Printf` becomes a `VerifyEvRepairDetail` emission whose Detail is the current text minus indent (e.g. `"Warning: could not repair profile %s: %v"`, `"Warning: %s is locked at v%s in profile %s; run ..."` — the full remedy strings preserved verbatim). The locked-primary refusal (line 598's sentence) becomes `RepairDetail{Detail: refusal}` + last-row `Note="locked"` set ONLY for the findings slice (JSON) — the CLI text mode prints the refusal sub-line; the row keeps `version_mismatch`. Success path emits `RepairDetail{Detail: fmt.Sprintf("Repaired: %s → %s", recorded, effective), Green: true}` then, when note != "", `RepairDetail{Detail: "Note: " + note}` — and `resolveLast("ok", note)` + `issues--`. Failure path: `RepairDetail{"Repair failed: <err>"}` + note rewrite `"repair failed: <err>[; <note>]"`. `warnings += siblingFailures` regardless of outcome.
+
+**Ordering trap (spec-governs rule):** today the JSON-mode sibling/relink warnings do NOT print (jsonOutput-gated) but their text-mode prints happen DURING the repair, before the primary row's own resolution lines. Emission order must be: per-sibling/relink RepairDetail events as they occur (the CLI text renderer prints them; JSON ignores) → the final Repaired/failed detail → row rewrite. The goldens for the version-mismatch scenarios prove this ordering.
+
+- [ ] **Step 1: Failing tests** — port shapes from the existing CLI version-repair tests (read `verify_test.go`'s repair suite for fixtures): {clean repair (+cache rename), blocked rename (note, no relink), locked primary (refusal event + note "locked" + issue stays), sibling repaired, sibling differs (decline + warning count), sibling locked (decline + warning count), relink failure (Deployed cleared, error path)}; assert event Detail strings verbatim against the current code's formats.
+- [ ] **Step 2: Run to fail.**
+- [ ] **Step 3: Implement the port.**
+- [ ] **Step 4: Green: engine, full suite, goldens.**
+- [ ] **Step 5: Commit** — `feat(core): verify fix mode version repair with sibling and lock semantics (#224)`
+
+---
+
+### Task 6: Convergence, merged-pak sync, and engine completion
+
+**Files:**
+
+- Modify: `internal/core/verify.go`
+- Modify: `internal/core/verify_test.go`
+
+**Interfaces:**
+
+- Consumes: `Service.ConvergeDeployedFiles(ctx, game, profile, dryRun)`, `Service.SyncMergedPak(ctx, game, profile)`, `unwrapJoinedErrors` (move from `cmd/lmm/verify.go:990` into `verify_helpers.go`, unexported `unwrapJoined`).
+- Produces: the COMPLETE engine. Final phase order after the per-file walk: (fix only) `SyncMergedPak` — error → `VerifyEvSyncWarning{Detail: fmt.Sprintf("could not sync merged pak: %v", err)}`; each returned warning → `VerifyEvSyncWarning{Detail: w}` — then the convergence pass (port of `reportConvergencePass`, `cmd/lmm/verify.go:917-961`): `fixed_stale_deployment` rows emit with `Green: true` semantics via the MAIN line (CLI renders the whole `Fixed: removed %s (%s)` line green — give the finding event `Variant: "fixed_green"`), `stale_deployment` + `warnings++`, per-item joined errors → `skipped` rows with `Note: "convergence: <err>"`. The #217 empty-profile path now runs Begin → convergence → done (Issues always 0 there).
+
+- [ ] **Step 1: Failing tests** — {empty-profile with dangling link (dry-run row + warning; fix removes + `fixed_stale_deployment`), main-path convergence after repairs, sync warning events in fix mode (stub a compile game whose sync returns warnings), full-order integration test asserting the exact Findings sequence for a fixture combining file-count + stale_compile + conversion_failed + needs_reingest + missing + convergence rows}.
+- [ ] **Step 2: Run to fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Green everywhere; goldens still untouched and green.**
+- [ ] **Step 5: Commit** — `feat(core): complete verify engine with convergence and sync phases (#224)`
+
+---
+
+### Task 7: CLI renderer swap (byte-identity gate)
+
+**Files:**
+
+- Modify: `cmd/lmm/verify.go` — `doVerify` body replaced; DELETE `repairModVersion`, `repairSiblingProfiles`, `fileIDsEqual`, `relinkDeployedRow`, `redownloadModFile`, `cacheDirExists`, `reportConvergencePass`, `unwrapJoinedErrors`, the CLI `sourceMappedMod` wrapper, `hasRetainedSource` remnants — everything the engine absorbed.
+
+**Interfaces:**
+
+- Consumes: `core.VerifyOptions/VerifyEvent/VerifyResult`, `Service.Verify`.
+- Produces: `doVerify(cmd, svc, game, args) error` — signature unchanged (tests call it directly). Shape:
+
+```go
+func doVerify(cmd *cobra.Command, svc *core.Service, game *domain.Game, args []string) error {
+	profile, err := resolveProfile(svc, game.ID, verifyProfile)
+	if err != nil {
+		return err
+	}
+	var modFilter string
+	if len(args) > 0 {
+		modFilter = args[0]
+	}
+	opts := core.VerifyOptions{Tier: core.VerifyFull, Fix: verifyFix, ModFilter: modFilter}
+	result, err := svc.Verify(cmd.Context(), game, profile, opts, func(ev core.VerifyEvent) {
+		if jsonOutput {
+			if ev.Kind == core.VerifyEvSyncWarning {
+				fmt.Fprintf(os.Stderr, "Warning: %s\n", ev.Detail) // stderr never corrupts the JSON document
+			}
+			return // rows come from result.Findings below
+		}
+		renderVerifyEvent(ev)
+	})
+	if err != nil {
+		return err
+	}
+	if jsonOutput { /* map result.Findings -> verifyFileJSON rows, encode verifyJSONOutput exactly as today (empty-profile keeps Files: []verifyFileJSON{}) */ }
+	/* text summary: the empty-profile variant when !result.HasFiles (0-issue line + short fix hint),
+	   else blank line + "No files found for mod X" gate (result.Checked) + issue/warning summary or All-OK — moved verbatim */
+}
+```
+
+`renderVerifyEvent` is one switch reproducing every current format string (the finding main lines keyed on `Finding.Status` + `Variant` + extras; `VerifyEvRepairDetail` → `fmt.Printf("  %s\n", ...)` with `colorGreen` when `Green`; `VerifyEvVerbose` → gated on `verbose`, prefixed ` (verbose)`; `VerifyEvBegin` → the two headers). Copy each format string FROM the deleted code, not from memory.
+
+- [ ] **Step 1: Swap the implementation** (no new tests first here — the goldens and the whole existing verify suite ARE the failing-test discipline: they were green, the swap must keep them green).
+- [ ] **Step 2: Run `go test ./cmd/lmm/ -run TestVerifyGolden -v`** — every scenario byte-identical. Any diff: fix the renderer/engine, NEVER the golden.
+- [ ] **Step 3: Full suite + gofmt + vet.** Also `go build ./cmd/lmm` and eyeball `./lmm -g <any> verify` compiles/runs in a sandbox HOME if convenient.
+- [ ] **Step 4: Verify dead code is gone** — `grep -n "repairModVersion\|redownloadModFile\|reportConvergencePass" cmd/lmm/` returns nothing.
+- [ ] **Step 5: Commit** — `refactor(cli): verify renders the core engine's events, byte-identical (#224)`
+
+---
+
+### Task 8: TUI provider seams — HealthView, DataProvider.Health, ActionProvider.RunHealthCheck
+
+**Files:**
+
+- Modify: `internal/tui/service.go` (types + `DataProvider` method + prototype impl)
+- Modify: `internal/tui/actions_provider.go` (`ActionProvider` method + docs)
+- Modify: `internal/tui/service_core.go` (coreProvider impls)
+- Create: `internal/tui/health_provider_test.go`
+
+**Interfaces:**
+
+- Consumes: `core.VerifyOptions/VerifyTier/VerifyEvent/VerifyFinding`, `Service.Verify` (Tasks 2-6).
+- Produces (frozen for Tasks 9-12):
+
+```go
+// service.go
+type HealthFinding struct {
+	ModID, ModName, FileID, Status, Note string
+}
+
+type HealthView struct {
+	Findings         []HealthFinding
+	Issues, Warnings int
+	Full             bool // true when produced by the Full (network) tier
+}
+
+// DataProvider gains:
+//	// Health runs the LOCAL verify tier (disk/DB only - never the network;
+//	// core.VerifyLocal) for the dashboard signal and the Health screen's
+//	// initial content. Rides loadData like Conflicts.
+	Health(ctx context.Context) (HealthView, error)
+
+// actions_provider.go - ActionProvider gains:
+//	// RunHealthCheck runs the verify engine on demand: full=true adds the
+//	// network version pass ('c'); fix=true applies CLI --fix semantics
+//	// behind the Health screen's confirmation ('F', always full). progress
+//	// receives one line per VerifyEvProgress / RepairDetail / Finding event.
+	RunHealthCheck(ctx context.Context, full, fix bool, progress func(ActionProgress)) (HealthView, error)
+```
+
+coreProvider implementations (service_core.go):
+
+```go
+func (p *coreProvider) Health(ctx context.Context) (HealthView, error) {
+	game := p.currentGame()
+	res, err := p.svc.Verify(ctx, game, p.currentProfile(), core.VerifyOptions{Tier: core.VerifyLocal}, nil)
+	if err != nil {
+		return HealthView{}, err
+	}
+	return healthView(res, false), nil
+}
+
+func (p *coreProvider) RunHealthCheck(ctx context.Context, full, fix bool, progress func(ActionProgress)) (HealthView, error) {
+	opts := core.VerifyOptions{Tier: core.VerifyLocal, Fix: fix}
+	if full {
+		opts.Tier = core.VerifyFull
+	}
+	res, err := p.svc.Verify(ctx, p.currentGame(), p.currentProfile(), opts, func(ev core.VerifyEvent) {
+		if progress == nil {
+			return
+		}
+		switch ev.Kind {
+		case core.VerifyEvProgress:
+			progress(ActionProgress{Line: fmt.Sprintf("checking versions %d/%d: %s", ev.Index, ev.Total, ev.ModName)})
+		case core.VerifyEvFinding:
+			progress(ActionProgress{Line: fmt.Sprintf("%s: %s", ev.Finding.Status, ev.Finding.ModName)})
+		case core.VerifyEvRepairDetail, core.VerifyEvSyncWarning:
+			progress(ActionProgress{Line: ev.Detail})
+		}
+	})
+	if err != nil {
+		return HealthView{}, err
+	}
+	return healthView(res, full), nil
+}
+
+func healthView(res *core.VerifyResult, full bool) HealthView {
+	v := HealthView{Issues: res.Issues, Warnings: res.Warnings, Full: full, Findings: make([]HealthFinding, 0, len(res.Findings))}
+	for _, f := range res.Findings {
+		if f.Status == "ok" && f.Note == "" {
+			continue // quiet-ok rows carry no screen content; lock-pending (ok+note) stays
+		}
+		v.Findings = append(v.Findings, HealthFinding{ModID: f.ModID, ModName: f.ModName, FileID: f.FileID, Status: f.Status, Note: f.Note})
+	}
+	return v
+}
+```
+
+prototypeProvider: `Health` returns a canned view (two findings: one `stale_deployment`, one `conversion_failed`, Warnings: 2) so `--prototype` demos the screen; `RunHealthCheck` returns the same view after `fakeProgressTicks(progress, "checking")`, with `fix=true` returning an emptied view (all findings resolved) — no real I/O ever.
+
+- [ ] **Step 1: Failing provider tests** (`health_provider_test.go`, package `tui`, using the same real-service builders `service_core_convert_test.go` uses): {Health returns Local findings and NEVER hits the network (register the Task-3-style trap source and assert no trip), RunHealthCheck(full=true) includes version statuses + emits progress lines, RunHealthCheck(fix=true) resolves a fixable finding, ok-row filtering keeps lock-pending rows}.
+- [ ] **Step 2: Run to fail.** — `go test ./internal/tui/ -run TestHealth`
+- [ ] **Step 3: Implement all three providers.**
+- [ ] **Step 4: Green + full suite.**
+- [ ] **Step 5: Commit** — `feat(tui): health provider seams over the core verify engine (#224)`
+
+---
+
+### Task 9: ScreenHealth — context-view host + health home content
+
+**Files:**
+
+- Modify: `internal/tui/navigation.go` (ScreenHealth after ScreenConflicts, screens slice, String() "Health")
+- Create: `internal/tui/contextview.go` (host)
+- Modify: `internal/tui/keys.go` (`HealthScreen` binding, key "7")
+- Modify: `internal/tui/app.go` (Model fields, screenView case, healthView render, itemCount, helpGroups entry, updateKey: digit 7 + esc-pop)
+- Create: `internal/tui/health_screen_test.go`
+
+**Interfaces:**
+
+- Consumes: Task 8's `HealthView`; existing Model plumbing (`m.selected`, `clampLines`, `truncateLines`, theme styles, `conflictsListPane`/`conflictsDetailPane` as the layout reference).
+- Produces:
+
+```go
+// contextview.go
+// contextContent is a pluggable full-screen content view hosted by
+// ScreenHealth (#224). #86's mod-details view will be the second
+// implementation. One-deep stack by design (YAGNI): push replaces any
+// pushed content; esc pops back to the pushing screen; with nothing
+// pushed, ScreenHealth renders the health home view.
+type contextContent interface {
+	Title() string
+	// Lines renders the body for the given content box; the host owns
+	// chrome (panel, title, nav) and clamping.
+	Lines(width, height int) []string
+	// HandleKey lets pushed content consume a key before the outer
+	// switch; handled=false falls through to global handling.
+	HandleKey(msg tea.KeyMsg) (next contextContent, cmd tea.Cmd, handled bool)
+	HelpGroup() helpGroup
+}
+
+// Model gains:
+//	contextContent contextContent // nil = health home
+//	contextReturn  Screen         // pop target
+//	health         HealthView
+//	healthAt       *time.Time    // when health was produced (m.now() at receipt)
+//	healthErr      string        // last scan failure, "" when fine
+
+func (m *Model) pushContext(c contextContent, from Screen)  // sets fields, jumps to ScreenHealth
+func (m *Model) popContext() Screen                         // clears, returns pop target
+```
+
+Health home rendering (`app.go`): `healthHomeView()` mirrors `conflictsView()`'s two-pane shape — list rows `[status-glyph] STATUS  MOD (FILE)` tinted by status class (`missing`/`version_mismatch` danger; `ok` fine; everything else warning), detail pane shows the selected finding's ModName/FileID/Status/Note plus remedy copy per status (reuse the CLI's remedy phrasings: e.g. needs_reingest -> "run a fix (F) to re-ingest"). Header line: `last scan: local, 3m ago` / `full, just now` from `healthAt` (reuse `lastDeployLabel`'s relative-age helper) — or `no scan yet` when nil. Empty state: `no findings (local) — run a full check (c)`. Selection/scroll through `m.selected[ScreenHealth]` + `itemCount` returning `len(m.health.Findings)`.
+
+Key routing in `updateKey`: digit 7 → `m.gotoScreen(ScreenHealth)`; on ScreenHealth with `m.contextContent != nil`, offer the key to `HandleKey` first and handle `esc` as pop (return to `contextReturn`); helpGroups gains a "Health" group (7, c, F — c/F bindings arrive in Tasks 11/12 but the group lands here with the 7 entry and grows).
+
+- [ ] **Step 1: Failing model tests** (`health_screen_test.go`, teatest-free model-update style like `convert_test.go`): {digit 7 reaches ScreenHealth and tab-cycle includes it after Conflicts; healthHomeView renders findings + empty state + header age; a fake pushed content (test-local struct implementing contextContent) renders its lines and title, its HandleKey consumes a key, esc pops back to the pushing screen — THE spec-criterion-4 proof; popping with nothing pushed is a no-op}.
+- [ ] **Step 2: Run to fail.**
+- [ ] **Step 3: Implement** navigation/keys/host/render.
+- [ ] **Step 4: Green + full suite (nav-cycle tests elsewhere may assert 6 screens — update ONLY counts/orders, never semantics).**
+- [ ] **Step 5: Commit** — `feat(tui): ScreenHealth context-view host with health home content (#224)`
+
+---
+
+### Task 10: Dashboard health line + menu entry
+
+**Files:**
+
+- Modify: `internal/tui/service.go` (`Summary.HealthIssues`, `Summary.HealthWarnings` — int, -1 unknown sentinel, doc comment mirroring Conflicts')
+- Modify: `internal/tui/app.go` (`loadData` fetch + sentinel handling, all four dashboard layout views, `dashboardMenu`)
+- Modify: `internal/tui/app_test.go` or create `internal/tui/health_dashboard_test.go`
+
+**Interfaces:**
+
+- Consumes: `DataProvider.Health` (Task 8), Model.health fields (Task 9).
+- Produces: `loadData` calls `m.provider.Health(m.ctx)` after Conflicts; on success `summary.HealthIssues, summary.HealthWarnings = view.Issues, view.Warnings` and `dataLoadedMsg` carries the view (Model stores it + stamps `healthAt`); on error the summary keeps the -1 sentinels and the msg carries `healthErr` (load itself still succeeds — a failed health scan must NOT fail the whole load, unlike Conflicts today: wrap in its own error capture, not the early-return pattern). Dashboard line in every layout's summary block, phrased: `Health: ?` (sentinel) / `Health: OK (local)` / `Health: 1 issue(s), 2 warning(s) (local)` — suffix `(full)` when `m.health.Full`. `dashboardMenu` gains `{title: "Verify Integrity", screen: ScreenHealth}` before the Conflicts entry.
+
+- [ ] **Step 1: Failing tests**: {loadData populates health + summary counts; provider Health error → sentinels + healthErr set + the scan error surfaces on the status line (spec error posture: "health shows ?, error on the status line") + load still completes; each layout view contains the Health line (render string contains "Health:"); menu entry opens ScreenHealth via enter}.
+- [ ] **Step 2: Run to fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Green + full suite.**
+- [ ] **Step 5: Commit** — `feat(tui): dashboard health signal from the local verify tier (#224)`
+
+---
+
+### Task 11: `c` — full check action
+
+**Files:**
+
+- Modify: `internal/tui/keys.go` (`FullCheck` binding, key "c", help "full health check")
+- Modify: `internal/tui/mutations.go` (`runFullHealthCheck`)
+- Modify: `internal/tui/app.go` (updateKey case: ScreenHealth + no pushed content)
+- Modify: `internal/tui/health_screen_test.go`
+
+**Interfaces:**
+
+- Consumes: `ActionProvider.RunHealthCheck(ctx, full=true, fix=false, progress)`, `buildAction` (actions.go:285 — the single-flight/progress/drain machinery every async action uses).
+- Produces:
+
+```go
+// mutations.go
+// runFullHealthCheck dispatches the Full-tier (network) verify pass behind
+// the standard single-flight action machinery - no confirm modal (it
+// mutates nothing; mirrors checkForUpdates' fetch-then-show shape), live
+// progress on the status line, cancellable by quit-drain.
+func (m Model) runFullHealthCheck() (Model, tea.Cmd)
+```
+
+Implementation shape: follow `checkForUpdates` (mutations.go:1387) — refuse when an action is in flight ("busy"); dispatch via `buildAction`-style command that calls `RunHealthCheck(ctx, true, false, progress)`; on done, store the returned view (`m.health`, `healthAt = m.now()`, `healthErr=""`), update `summary.HealthIssues/Warnings`, status line `full check: N issue(s), M warning(s)` or `full check: all OK`; on failure, status line error + keep the previous view. Key dispatch: `case key.Matches(msg, m.keys.FullCheck)` gated on `m.screen == ScreenHealth && m.contextContent == nil` (note: "c" is CreateProfile on ScreenProfiles — per-screen dispatch keeps both).
+
+- [ ] **Step 1: Failing tests**: {c on ScreenHealth dispatches and lands the new view + status line; c while an action runs is refused; c on other screens does nothing; progress ticks reach the status line (drive actionProgressMsg)}.
+- [ ] **Step 2: Run to fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Green + full suite.**
+- [ ] **Step 5: Commit** — `feat(tui): full health check action on the Health screen (#224)`
+
+---
+
+### Task 12: `F` — batch fix behind confirmation
+
+**Files:**
+
+- Modify: `internal/tui/keys.go` (`FixHealth` binding, key "F", help "fix findings")
+- Modify: `internal/tui/mutations.go` (`fixHealthPrompt` + category-count detail builder)
+- Modify: `internal/tui/app.go` (updateKey case)
+- Modify: `internal/tui/health_screen_test.go`
+
+**Interfaces:**
+
+- Consumes: `ActionProvider.RunHealthCheck(ctx, full=true, fix=true, progress)`, `promptAction`/`buildAction` confirm-modal machinery, `infoOverlay` (the update-results pattern, actions.go), `loadData` refresh path used by actionDoneMsg.
+- Produces:
+
+```go
+// fixHealthPrompt opens the standard y/n confirmation summarizing what a
+// fix pass will attempt - counts by category from the CURRENT view
+// (m.health), detail lines capped by the modal's own "+N more" - then runs
+// the engine in fix mode (always Full: --fix parity includes the version
+// pass). Refused on the status line when the current view has nothing
+// actionable. Completion shows per-item results in an info overlay and
+// triggers the ordinary data reload so screen + dashboard refresh.
+func (m Model) fixHealthPrompt() (Model, tea.Cmd)
+```
+
+Detail lines: one per status class present, e.g. `2 missing file(s) — re-download`, `1 version mismatch — re-key records (locked mods refused)`, `1 stale deployment — remove`, `1 pak needs re-ingest`; title `Fix N finding(s)?`. "Nothing actionable" = every finding's status is one that fix cannot touch (`skipped`, `version_unverifiable`, `file_count_mismatch`, `ok`) — refuse with `nothing fixable — run a full check (c) first` when the view is empty or unfixable. On done: overlay lists the returned view's `fixed_*` rows and remaining findings (reuse the update-results overlay builder shape at actions.go:509 changelogOverlay as the layout reference), store the view, and return the loadData refresh cmd (same as actionDoneMsg's reload) so the dashboard line updates.
+
+- [ ] **Step 1: Failing tests**: {F with fixable findings opens a modal whose detail contains the category counts; confirm dispatches and the resolved view lands + overlay shows; F with empty/unfixable view refused on status line; cancel leaves state untouched; locked version_mismatch remains after fix (engine refusal surfaces in remaining findings)}.
+- [ ] **Step 2: Run to fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Green + full suite.**
+- [ ] **Step 5: Commit** — `feat(tui): batch fix action with confirmation on the Health screen (#224)`
+
+---
+
+### Task 13: Docs, help text, CHANGELOG, man pages
+
+**Files:**
+
+- Modify: `cmd/lmm/tui.go` (Long: capability list gains "verify integrity and fix findings (health)"; `1-6` → `1-7`; screen list gains health)
+- Modify: `README.md` (TUI section: screen list, keybindings table if present, #224 capability)
+- Modify: `CHANGELOG.md` (`[Unreleased]` → Added: TUI health screen + dashboard signal; core verify engine extraction noted as internal)
+- Run: `make man` (tui.go Long is embedded in committed man pages)
+
+**Interfaces:** none — documentation only, but grep-driven: `grep -rn "1-6\|dashboard, installed mods, search, profiles, sources, conflicts" cmd/ README.md docs/man/` must return only updated text afterward.
+
+- [ ] **Step 1: Update tui.go Long** (screen list + keys paragraph + capability sentence), README, CHANGELOG.
+- [ ] **Step 2: `make man`; confirm `git status` shows only expected man-page diffs.**
+- [ ] **Step 3: Staleness grep sweep** — `grep -rn "not yet\|read-only\|aren't available\|use 'lmm" internal/tui cmd/lmm/tui.go` and fix any statement the new capability falsifies.
+- [ ] **Step 4: Full gates (genman test enforces the man regen).**
+- [ ] **Step 5: Commit** — `docs: TUI health surface help, README, CHANGELOG (#224)`
+
+---
+
+### Task 14: E2E sweep + branch finalization
+
+**Files:**
+
+- Create: `internal/tui/health_e2e_test.go`
+- Modify (if gaps found): any
+
+**Interfaces:** consumes everything above.
+
+- [ ] **Step 1: Write the lifecycle e2e** (real service, compile-game fixture reusing `pak_convert_e2e_test.go`'s builders): a pre-#221 pak (needs_reingest) + a dangling game-dir symlink → `DataProvider.Health` shows both findings (local, no network) → `RunHealthCheck(full=true, fix=true)` resolves both (`fixed_needs_reingest`, `fixed_stale_deployment`) → a second `Health` call comes back clean → dashboard summary counts hit 0. This is spec success-criterion 3 end-to-end.
+- [ ] **Step 2: Run to fail / fix / pass.**
+- [ ] **Step 3: Full-suite + gofmt + vet + `go build -o lmm ./cmd/lmm` (smoke binary at repo root for the user).**
+- [ ] **Step 4: Re-run `TestVerifyGolden` one last time and `git diff --stat develop` sanity review (no unrelated files).**
+- [ ] **Step 5: Commit** — `test: health surface lifecycle e2e (#224)` — then PR `--base develop` with the smoke checklist: (1) dashboard Health line on live Icarus profile; (2) screen 7 findings vs `lmm verify` parity; (3) `c` full check (network) with progress; (4) `F` fix on a needs-reingest state, confirm merged pak regenerates and raw links clear; (5) esc/nav/help-panel behavior; (6) CLI `lmm verify` and `verify --fix` behave exactly as before.

--- a/docs/plans/archive/2026-08-07-tui-mod-details-design.md
+++ b/docs/plans/archive/2026-08-07-tui-mod-details-design.md
@@ -1,0 +1,427 @@
+# TUI mod details view — design (#86)
+
+**Issue:** [#86](https://github.com/DonovanMods/linux-mod-manager/issues/86) — TUI: mod details view (parity with `lmm mod show`)
+**Branch:** `feat/86-mod-details` → PR `--base develop`
+**Version:** no bump (bump-at-release); ships MINOR in the next batch alongside #224
+**Depends on:** #224's context-view host (`internal/tui/contextview.go`), merged at `aeff971`
+**Feeds:** #87 (mod-level changelog) — this view is its landing slot
+
+---
+
+## Problem
+
+`lmm mod show` (`cmd/lmm/mod.go:606-753`) prints a mod's full metadata; the TUI
+has no equivalent. The search detail pane (`internal/tui/app.go:1841-1897`)
+renders 8 fixed fields plus a clipped Summary, and the Installed Mods screen
+offers nothing at all. This violates the standing CLI/TUI parity directive.
+
+It is a plumbing gap, not only a rendering gap: `ModItem`
+(`internal/tui/service.go:66-162`) carries no `Description`, `PictureURL`, or
+`SourceURL`, and nothing under `internal/tui/` calls `core.Service.GetMod`
+except `AvailableVersions`.
+
+---
+
+## Ratified decisions
+
+Recorded so they are not re-litigated during implementation.
+
+1. **Fetch policy: local-first, enrich in background.** The view opens
+   instantly from the `ModItem` already in hand and fills in from the network
+   when the fetch lands. It never blocks on a spinner and never fails closed.
+   Rejected: fetch-on-open (an offline user loses data they already had) and a
+   Health-style explicit `f`-for-full tier (makes the common case two
+   keystrokes).
+2. **Description is HTML-cleaned in BOTH interfaces.** `core.CleanChangelog`
+   (`internal/core/changelog.go:28-40`) is already the shared CLI+TUI
+   HTML→terminal cleaner — built for "readable terminal/TUI display", full text
+   with truncation left to callers. It is misnamed for its job, not
+   mis-scoped. Point it at `Description` too. `lmm mod show` prints raw `<p>`
+   tags today; that is a wart, and fixing it in one interface only would create
+   exactly the divergence the parity directive forbids. The CLI keeps its
+   2000-char cap (`mod.go:709`) because it is a one-shot dump; the TUI scrolls
+   instead. **This changes `mod show` output — CHANGELOG entry required.**
+3. **The host is generalized so details renders on the screen it was opened
+   from.** Rejected: pushing onto Health as shipped (the nav bar would read
+   "Health" while showing mod details), and `infoOverlay` (it holds a static
+   `[]string` snapshot and cannot re-render as the background fetch lands —
+   it structurally fights decision 1).
+
+---
+
+## Accepted deviations (recorded during implementation)
+
+1. **Profile resolution order in `doModShow`.** The pre-refactor code called
+   `svc.GetMod` before `resolveProfile`; because `Service.ModDetail` receives an
+   already-resolved profile, the CLI now resolves the profile first. When
+   **both** the profile and the mod ID are invalid, the surfaced error changes
+   from "mod not found" to the profile error. Both are correct errors; only the
+   ordering differs, and each single-failure case still produces its own. This
+   is the only intended behavioral difference in the extraction.
+
+2. **`--json` keeps the raw description.** Decision 2's HTML cleaning applies to
+   human-readable rendering only — the CLI's terminal output and the TUI view.
+   `mod show --json` is a machine contract and a consumer may want the original
+   markup, so it emits the source's description unchanged. Pinned by
+   `TestDoModShow_JSONDescriptionStaysRaw`.
+
+3. **`m.selectedMod()` was not reusable for the Search screen.** It hardcodes
+   `m.selected[ScreenInstalledMods]` and indexes the installed list, so opening
+   details from Search would have shown an unrelated mod. Implementation added
+   `selectedModForDetails`, which branches by screen, bounds-checks, and gates
+   on `searchReady`.
+
+4. **The scroll indicator is budgeted _within_ the content height.**
+   `len(Lines(w, h)) <= h` must hold for every input: the host applies its own
+   `clampLines` on top, so a view that returns `h+1` lines gets double-clamped
+   and its truthful `↓ N more` replaced by a misleading `+N more` from clamp
+   math.
+
+---
+
+## Architecture
+
+### 1. Generalize the context-view host
+
+The host interface (`contextview.go:10-19`) is already generic. The _host_ is
+nailed to `ScreenHealth` in four places. All four edits are subtractive.
+
+| Location                              | Today                                                             | Change                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contextview.go:28-32`                | `pushContext(c, from)` sets `m.screen = ScreenHealth`             | Delete that line. Signature becomes `pushContext(c contextContent)`.                                                                                                                                                                                                                                                                                        |
+| `contextview.go:38-47` + `app.go:153` | `popContext` restores `m.contextReturn`                           | **Delete `contextReturn`.** With the screen no longer changing on push, `from` is provably always `m.screen`, so the field can only ever disagree with reality. `popContext` just clears `contextContent`.                                                                                                                                                  |
+| `app.go:1393` `screenView()`          | `case ScreenHealth: return m.healthScreenView()` consults content | Add `if m.contextContent != nil { return m.contextView() }` **after** the `picker`/`inputModal` early-returns, so modals still outrank pushed content (matches today's key precedence at `app.go:941-955`). `healthScreenView` collapses to `healthHomeView`; the chrome-rendering body of `app.go:2131-2147` moves to `contextView()` in `contextview.go`. |
+| `app.go:966`, `app.go:429`            | Both gated on `m.screen == ScreenHealth &&`                       | Drop the gate. Nav-away becomes "clear whenever `gotoScreen` runs with content pushed" — which also covers pressing the digit for the screen you are already on.                                                                                                                                                                                            |
+
+Doc comments asserting Health-specificity must be updated in three places:
+`contextview.go:5-9`, `app.go:146-152`, `internal/tui/navigation.go:15-23`.
+
+Health's own action guards (`m.contextContent == nil` at `mutations.go:130`,
+`:1554`, `:1862`) stay unchanged and still pass — they become
+defense-in-depth behind the swallow rule below.
+
+### 2. Swallow declined keys while content is pushed
+
+**This is a required part of the generalization, not a nicety.** Today, keys
+the pushed content declines fall through to the outer switch. On Health that is
+harmless (its three actions are explicitly guarded). On Installed Mods it is
+not: `↑/↓` would move `m.selected` invisibly underneath the details view, and
+`e`/`x`/`u` would enable/uninstall the row behind it.
+
+Mirror `updateOverlayKey`'s documented semantics (`overlay.go:46-60`: "every
+other key is swallowed so nothing behind the overlay can react to it"). While
+`m.contextContent != nil`, only these do anything:
+
+- keys the content itself handles (`HandleKey` returns `handled=true`)
+- `esc` — pop
+- nav digits / `tab` / `shift+tab` — navigate away (implicitly pops)
+- quit keys (`isQuitKey`)
+- help (`?`)
+
+Everything else is swallowed. This retires the whole class of
+acting-on-the-row-underneath bugs in one rule.
+
+### 3. Extract the mod-detail composition into core
+
+`doModShow` composes its Installed block from three sources plus derived
+display logic:
+
+- `svc.GetInstalledMod(...)` — `mod.go:628` (DB; failure means "not installed",
+  not an error — see `mod.go:618-621`)
+- `config.LoadProfile(...)` + `prof.FindRef(...)` — `mod.go:639-644` (lock
+  state, from profile YAML)
+- `game.DeployMode == domain.DeployCompile && svc.ModHasPakMergeSource(...)` —
+  `mod.go:635` (pak conversion, merge-compile games only)
+- the "run `lmm profile apply` to converge" hint, emitted only when the lock
+  target differs from the installed version (`mod.go:734-736`)
+
+That composition is CLI-only today. Rebuilding it inside `coreProvider` is
+precisely the duplication the parity directive forbids, so extract it:
+
+```go
+// internal/core/moddetail.go
+type ModDetail struct {
+    Mod       *domain.Mod  // source-side metadata (network)
+    Installed *InstalledDetail // nil when not installed in this profile
+}
+
+type InstalledDetail struct {
+    Version       string
+    Profile       string
+    UpdatePolicy  domain.UpdatePolicy
+    Locked        bool
+    LockedVersion string
+    ConvertPaks   *bool // nil unless merge-compile game with a pak merge source
+}
+
+func (s *Service) ModDetail(ctx context.Context, game *domain.Game,
+    profile, sourceID, modID string) (*ModDetail, error)
+```
+
+`doModShow` becomes a renderer over it (colour, ordering, the 2000-char cap,
+the converge hint's wording); `coreProvider.GetModDetails` maps it into the TUI
+view model. Same shape as #224's verify-engine extraction — engine in core,
+both surfaces render.
+
+**Drift guard:** capture `mod show`'s current human and `--json` output
+_first_, pin with tests, then extract. This is #224's byte-identity lesson at
+1/20th the scale — one ~70-line function, not 1513. The HTML-cleaning change
+of decision 2 lands **after** the capture tests are green, as its own commit,
+so the two changes are never entangled.
+
+### 4. TUI view model and provider
+
+A new struct, **not** a widened `ModItem` — `ModItem` is constructed in three
+places (`service_core.go:157` Overview, `service_core.go:407` modsToItems,
+`service.go:735` prototype) and two of them cannot supply the new fields
+without a network call per row.
+
+```go
+// internal/tui/service.go
+type ModDetails struct {
+    // Source-side; populated from the ModItem at open, enriched by the fetch.
+    ID, Name, Version, Author string
+    Summary, Description      string
+    Category                  string
+    SourceURL, PictureURL     string
+    Endorsements              int64
+    HasEndorsements           bool
+
+    // Installed block — local, present from the first frame. Nil when the mod
+    // is not installed in the active profile (parity with mod show).
+    Installed *InstalledDetails
+
+    // Fetch state. Set by the model's handler and resolvers (never by the
+    // provider); read by Lines() to pick the render state below.
+    Fetching bool
+    FetchErr string
+}
+
+// InstalledDetails is the TUI-side mirror of core.InstalledDetail, with the
+// policy already rendered to a display string (the TUI has no reason to carry
+// domain.UpdatePolicy). Deliberately a separate type rather than reusing the
+// core struct: the view model is a rendering contract, and every other TUI
+// row type follows the same rule.
+type InstalledDetails struct {
+    Version       string
+    Profile       string
+    UpdatePolicy  string
+    Locked        bool
+    LockedVersion string
+    ConvertPaks   *bool // nil = not applicable, not "off"
+}
+```
+
+New `DataProvider` method (`service.go:288` — read-only, so it belongs on
+`DataProvider`, not `ActionProvider`):
+
+```go
+GetModDetails(ctx context.Context, item ModItem) (ModDetails, error)
+```
+
+`coreProvider.GetModDetails` is modelled on `AvailableVersions`
+(`service_core.go:1674-1685`), which is already `svc.GetMod` keyed on
+`(item.Source, currentGame().ID, item.ID)` — the new method is that call plus
+the `ModDetail` join, with errors through a details-flavoured
+`mapNetworkError` (`service_core.go:1207-1216`): capability `"mod details"`,
+fallback `"run 'lmm mod show <id>' in a shell"`.
+
+`prototypeProvider.GetModDetails` returns canned data; `prototype.Mod`
+(`internal/tui/prototype/data.go:79`) gains `Description`, `SourceURL`,
+`PictureURL`. The compiler enforces both implementations.
+
+**No caching.** `core.Service.GetMod` (`internal/core/service.go:422-439`) is a
+pass-through with no cache at any layer, so each open is one round trip.
+Memoizing is deliberately out of scope (YAGNI): the fetch is user-initiated,
+one-per-open, and cancelled on the next action.
+
+---
+
+## Interaction
+
+**Binding: `enter`.** No new key. `Select` is already documented as
+context-dependent (`app.go:1079-1087`: dashboard opens a menu entry, Profiles
+switches profile), and `openSelectedMenuEntry` early-returns unless
+`ScreenDashboard` (`app.go:389-392`) — so `enter` is currently a **no-op** on
+both Installed Mods and Search. Extend the existing switch with those two
+screens.
+
+Layout (80 cols, enriched + installed):
+
+```
+┌─ Skyrim Script Extender ──────────────────────────────── fetching… ─┐
+│ ID: 12345   Version: 2.2.6   Author: SKSE Team                      │
+│ Category: Utilities                                                 │
+│ Endorsements: 84213                                                 │
+│ URL: https://www.nexusmods.com/skyrimspecialedition/mods/30379      │
+│ Image: https://staticdelivery.nexusmods.com/mods/1704/images/...    │
+│                                                                     │
+│ Summary:                                                            │
+│ A modder's resource that expands scripting capabilities.            │
+│                                                                     │
+│ Description:                                                        │
+│ <cleaned, wrapped, scrollable>                                ↓ 24  │
+│                                                                     │
+│ Installed: v2.2.3 (profile: default)                                │
+│   Update policy: notify                                             │
+│   Lock: locked at v2.2.3 — run 'lmm profile apply' to converge      │
+│   Pak conversion: on                                                │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Field order mirrors `mod show` exactly. Optional rows (Category,
+Endorsements, URL, Image, Summary, Description) are omitted when empty, as in
+the CLI. `Pak conversion` appears only for merge-compile games with a pak merge
+source.
+
+**Render states:**
+
+| State           | Header      | Description slot                 |
+| --------------- | ----------- | -------------------------------- |
+| Fetch in flight | `fetching…` | `(loading…)`                     |
+| Enriched        | —           | cleaned text, scrollable         |
+| Fetch failed    | —           | `(unavailable — <reason>)`       |
+| Not installed   | —           | Installed block omitted entirely |
+
+Name / ID / Version / Author / Endorsements come from the row instantly. On the
+Search path `Summary` is also already local (`service_core.go:415`); on the
+Installed path it is not, and arrives with the fetch.
+
+**Scrolling** uses `infoOverlay`'s offset model (`overlay.go:21-29`), not
+`windowedRows` — there is no selection in a document body. The view **must**
+consume `↑/↓`/`j`/`k` so the list selection behind it cannot drift; the swallow
+rule above is the backstop, not the primary defence.
+
+**Async idiom** — `editSelectedModLock` (`mutations.go:628-658`) verbatim:
+
+1. Guards: screen ∈ {Installed Mods, Search}, `m.actions != nil`,
+   `!m.action.running && m.action.pending == nil`, a valid `m.selectedMod()`.
+2. Cancel any prior ctx, derive `context.WithCancel(m.ctx)`, `m.action.gen++`,
+   capture `gen`, set `running` + status line.
+3. Return a plain `tea.Cmd` (no goroutine) emitting one of two gen-tagged
+   messages.
+4. Dispatch in `Model.Update`'s switch with `if msg.gen != m.action.gen {
+return m, nil }` (stale-gen drop).
+5. Both resolvers clear `running`, call and nil `m.action.cancel`, and check
+   `m.action.draining` → `resolveDrainedQuit()`. The draining check is a
+   Copilot-PR-#63 finding repeated in every resolver; do not omit it.
+
+**No progress channel.** `mutations.go:1549-1552` is explicit that a plain
+fetch needs no `ch`/`waitForActionProgress`/`tea.Batch` plumbing — that
+machinery is for mutating flows.
+
+The view is pushed **immediately** (step 1, before the fetch returns), and the
+resolver mutates the already-pushed `ModDetails`. Pushing on success instead
+would defeat local-first entirely.
+
+---
+
+## Error handling
+
+A failed fetch never closes or blocks the view. Local data stays, the
+Description slot renders `(unavailable — <reason>)`, and the mapped error goes
+to the status line. `mapNetworkError` already special-cases
+`source.ErrNotSupported` and `domain.ErrAuthRequired`, so a directory source
+that cannot serve details degrades to the local view with an explanatory line
+rather than erroring.
+
+`ModDetail`'s installed lookup follows `doModShow`'s convention: a
+`GetInstalledMod` failure means "not installed" and omits the block; a
+`resolveProfile` failure is a real error. A `config.LoadProfile` failure
+degrades to `Locked: false` (matching `mod.go:639`, which ignores `perr`).
+
+---
+
+## Testing
+
+**Host generalization** — extend #224's existing tests in
+`internal/tui/health_screen_test.go:548-658`, which currently assert push jumps
+to `ScreenHealth`; they become "screen is unchanged". New cases:
+
+- push from a non-Health screen renders there, `esc` returns to it
+- `gotoScreen` from any host screen clears pushed content (extends
+  `TestGotoScreenAwayFromHealthClearsPushedContext:614`)
+- a declined mutation key (`e`, `x`) is swallowed — the row underneath is
+  untouched, and `m.selected` does not move on `↑/↓`
+- the five existing Health guard tests (`:856`, `:883`, `:1397`,
+  `health_conflicts_test.go:304`) stay green unmodified
+
+**Provider** — `GetModDetails` on both implementations; a call counter on the
+shared recording fake (`actions_provider_test.go:761+`); new `prototype.Mod`
+fields.
+
+**Async** — following `lock_picker_test.go`'s coverage shape: wrong-screen
+no-op, nil-provider no-op, single-flight refusal, stale-gen drop, quit-drain
+cancels the ctx, success enriches the pushed view, failure keeps local data and
+sets the status line.
+
+**Layout** — the overflow assertion shape at `health_screen_test.go:503-512`
+(`lipgloss.Width(view) <= availableWidth()`), at 80x24 and a narrow terminal.
+
+**CLI** — capture tests on `mod show` human + `--json` output recorded
+**before** the core extraction, then HTML-cleaning assertions layered on top.
+`snapshot_test.go:44-51`'s `slugs` map needs no change (no new screen).
+
+---
+
+## Success criteria
+
+1. `enter` on a selected mod in Installed Mods or Search opens a full-screen
+   details view **without changing the highlighted nav entry**; `esc` returns.
+2. The view renders local data on the first frame and enriches in place; an
+   offline user still sees name/version/author/installed state.
+3. Every field `lmm mod show` prints is present, in the same order, with the
+   same omit-when-empty rules.
+4. `mod show` and the TUI render `Description` identically cleaned. Apart from
+   that one intended change, `mod show`'s human and `--json` output is
+   byte-identical to the captures recorded before the extraction.
+5. A declined key cannot mutate or move the list underneath the view.
+6. `go test ./...` green; the 24 frozen verify goldens untouched.
+
+---
+
+## File map
+
+| File                             | Change                                                                                                                                                                           |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `internal/core/moddetail.go`     | **new** — `ModDetail`, `InstalledDetail`, `Service.ModDetail`                                                                                                                    |
+| `internal/core/changelog.go`     | doc comment: the cleaner is not changelog-specific                                                                                                                               |
+| `cmd/lmm/mod.go`                 | `doModShow` becomes a renderer over `Service.ModDetail`; `CleanChangelog` applied to `Description`                                                                               |
+| `internal/tui/contextview.go`    | drop the `ScreenHealth` jump and `contextReturn`; absorb the chrome renderer as `contextView()`                                                                                  |
+| `internal/tui/moddetails.go`     | **new** — the `contextContent` implementation (`Title`/`Lines`/`HandleKey`/`HelpGroup`), scroll offset, render states                                                            |
+| `internal/tui/app.go`            | `screenView` early check; ungate key routing (`:966`) and nav-away (`:429`); swallow rule; `Select` extended to two screens; `healthScreenView` → `healthHomeView`; doc comments |
+| `internal/tui/service.go`        | `ModDetails`/`InstalledDetails`; `GetModDetails` on `DataProvider`; prototype impl                                                                                               |
+| `internal/tui/service_core.go`   | `coreProvider.GetModDetails`                                                                                                                                                     |
+| `internal/tui/mutations.go`      | handler + two gen-tagged msgs + two resolvers                                                                                                                                    |
+| `internal/tui/prototype/data.go` | `Description`/`SourceURL`/`PictureURL` on `prototype.Mod`                                                                                                                        |
+| `internal/tui/navigation.go`     | doc comment (host is no longer Health-specific)                                                                                                                                  |
+| `CHANGELOG.md`                   | Added: TUI details view. Changed: `mod show` cleans HTML.                                                                                                                        |
+
+## Task ordering
+
+The sequence is load-bearing — the CLI capture tests must exist before
+anything moves, and the two CLI changes must not entangle:
+
+1. Capture tests pinning `mod show` human + `--json` output (no production
+   change).
+2. Extract `Service.ModDetail`; `doModShow` becomes its renderer. Captures
+   stay green **unchanged** — this step is behaviour-preserving.
+3. Apply `CleanChangelog` to `Description` in the CLI. Captures updated in
+   this commit alone, so the diff shows exactly the intended change.
+4. Host generalization + swallow rule, with #224's tests updated.
+5. TUI view model, provider methods (both implementations), async handler.
+6. The `moddetails.go` content view and its `enter` binding.
+
+---
+
+## Out of scope
+
+- **#87 (mod-level changelog)** — separately scoped. This view is its landing
+  slot; the Description block's renderer is where it will sit.
+- **CurseForge `Screenshots []ModAsset`** (`curseforge/types.go:43`, dropped at
+  `curseforge.go:294-327`) — a terminal cannot render images, so the single
+  `PictureURL` carries the whole value.
+- **Details caching / memoization** — YAGNI; revisit only if re-opening the
+  same mod proves annoying in real use.
+- **Opening URLs in a browser** — no precedent in this TUI; would need a
+  platform-shell decision of its own.

--- a/docs/plans/archive/2026-08-07-tui-mod-details-plan.md
+++ b/docs/plans/archive/2026-08-07-tui-mod-details-plan.md
@@ -1,0 +1,1979 @@
+# TUI Mod Details View Implementation Plan (#86)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the TUI a full-screen mod details view with parity to `lmm mod show`, opened with `enter` from Installed Mods or Search.
+
+**Architecture:** Extract `mod show`'s three-source detail composition into `core.Service.ModDetail` so both interfaces render one set of facts; generalize #224's context-view host off `ScreenHealth` so the view renders on the screen it was opened from; open local-first and enrich from the network in the background.
+
+**Tech Stack:** Go 1.x, Bubble Tea (Elm architecture), lipgloss, testify. No new dependencies.
+
+**Design spec:** `docs/plans/2026-08-07-tui-mod-details-design.md` — read it first.
+
+## Global Constraints
+
+- **Branch:** `feat/86-mod-details`, forked from `develop`. PR with an explicit `--base develop`.
+- **No version bump.** CHANGELOG entries go under `[Unreleased]`. `version` in `cmd/lmm/root.go` stays put.
+- **Test-first, always.** Every task starts with a failing test and shows it failing before implementing.
+- **Go formatting:** tabs, `gofmt`. Run `go fmt ./...` before each commit.
+- **Never regenerate the 24 frozen verify goldens** in `cmd/lmm/testdata/verify_golden`. Nothing in this plan touches verify.
+- **Commit after every task.** Conventional-commit subjects ending in `(#86)`.
+- **Full suite green before any commit:** `go build ./... && go vet ./... && go test ./...`.
+- The CLI and TUI are equally first-class; a behavior added to one is added to both.
+
+---
+
+## File Structure
+
+| File                                | Responsibility                                                                                                                         |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `internal/core/moddetail.go`        | **new** — `ModDetail`/`InstalledDetail` types and `Service.ModDetail`, the single composition of source metadata + local install state |
+| `cmd/lmm/mod.go`                    | `doModShow` becomes a pure renderer over `Service.ModDetail`                                                                           |
+| `cmd/lmm/testdata/mod_show_golden/` | **new** — recorded pre-refactor `mod show` output, the extraction's drift guard                                                        |
+| `cmd/lmm/mod_show_golden_test.go`   | **new** — golden capture tests                                                                                                         |
+| `internal/tui/contextview.go`       | host: drop the `ScreenHealth` jump and `contextReturn`; own the chrome renderer                                                        |
+| `internal/tui/moddetails.go`        | **new** — the `contextContent` implementation: render states, scrolling, keys                                                          |
+| `internal/tui/app.go`               | `screenView` early check; ungate key routing + nav-away; swallow rule; `enter` on two screens                                          |
+| `internal/tui/service.go`           | `ModDetails`/`InstalledDetails` view models; `GetModDetails` on `DataProvider`; prototype impl                                         |
+| `internal/tui/service_core.go`      | `coreProvider.GetModDetails`                                                                                                           |
+| `internal/tui/mutations.go`         | `openSelectedModDetails` handler, two gen-tagged messages, two resolvers                                                               |
+| `internal/tui/prototype/data.go`    | `Description`/`SourceURL`/`PictureURL` on `prototype.Mod`                                                                              |
+
+---
+
+## Accepted deviation (decided, do not re-litigate)
+
+`doModShow` currently calls `svc.GetMod` **before** `resolveProfile`. Because
+`Service.ModDetail` receives an already-resolved profile name, the CLI must
+resolve the profile first. When **both** the profile and the mod ID are invalid,
+the error surfaced changes from "mod not found" to the profile error. Both are
+correct errors; only the ordering differs. Task 2 pins the single-failure cases,
+which are the ones users actually hit. This is the one intended behavioral
+difference in the extraction.
+
+---
+
+### Task 1: Pin `mod show` output with recorded goldens
+
+Records what `mod show` prints **today**, before anything moves. Tasks 2 and 3
+are judged against these files.
+
+**Files:**
+
+- Create: `cmd/lmm/mod_show_golden_test.go`
+- Create: `cmd/lmm/testdata/mod_show_golden/` (populated by the `-update` run)
+
+**Interfaces:**
+
+- Consumes: existing fixtures `setupDoModLockTest(t) (*core.Service, *domain.Game, *fakeSource)`, `seedLockableMod(t, svc, game, id, name, version)`, `captureStdout(t, func() error) string` (`cmd/lmm/auth_status_test.go:16`).
+- Produces: `testdata/mod_show_golden/*.txt` — frozen. Later tasks must not regenerate them except where this plan says so explicitly.
+
+- [ ] **Step 1: Write the golden test**
+
+```go
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// updateModShowGoldens re-records the mod show goldens. Run ONCE, before the
+// #86 core extraction:
+//
+//	go test ./cmd/lmm -run TestModShowGolden -update
+//
+// After that the files are frozen: they are the proof that extracting
+// Service.ModDetail did not change a byte of CLI output. Task 3 is the ONLY
+// later task allowed to re-record them, and only the description cases.
+var updateModShowGoldens = flag.Bool("update", false, "re-record mod show goldens")
+
+func assertModShowGolden(t *testing.T, name, actual string) {
+	t.Helper()
+	path := filepath.Join("testdata", "mod_show_golden", name+".txt")
+	if *updateModShowGoldens {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(actual), 0o644))
+		return
+	}
+	want, err := os.ReadFile(path)
+	require.NoError(t, err, "golden %s missing - record it with -update BEFORE refactoring", path)
+	assert.Equal(t, string(want), actual, "mod show output drifted from the recorded golden")
+}
+
+// richMod is the fixture every golden case shows: every optional field
+// populated, so the goldens pin the omit-when-empty branches by contrast with
+// the sparse cases below.
+func richMod(gameID string) *domain.Mod {
+	endorsements := int64(84213)
+	return &domain.Mod{
+		ID: "a", SourceID: "src", GameID: gameID,
+		Name: "Mod A", Version: "1.5", Author: "Author A",
+		Category:     "Utilities",
+		Summary:      "A short summary.",
+		Description:  "<p>Line one.</p><br/><p>Line &amp; two.</p>",
+		SourceURL:    "https://example.invalid/mods/1",
+		PictureURL:   "https://example.invalid/img/1.png",
+		Endorsements: &endorsements,
+	}
+}
+
+func TestModShowGolden_NotInstalled(t *testing.T) {
+	svc, game, src := setupDoModLockTest(t)
+	src.AddMod(richMod(game.ID), nil)
+
+	out := captureStdout(t, func() error {
+		return doModShow(context.Background(), svc, game, "a")
+	})
+	assertModShowGolden(t, "not_installed", out)
+}
+
+func TestModShowGolden_InstalledUnlocked(t *testing.T) {
+	svc, game, src := setupDoModLockTest(t)
+	seedLockableMod(t, svc, game, "a", "Mod A", "1.5")
+	src.AddMod(richMod(game.ID), nil)
+
+	out := captureStdout(t, func() error {
+		return doModShow(context.Background(), svc, game, "a")
+	})
+	assertModShowGolden(t, "installed_unlocked", out)
+}
+
+func TestModShowGolden_InstalledLockedWithConvergeHint(t *testing.T) {
+	svc, game, src := setupDoModLockTest(t)
+	seedLockableMod(t, svc, game, "a", "Mod A", "1.5")
+	src.AddMod(richMod(game.ID), nil)
+	require.NoError(t, svc.NewProfileManager().SetModLock(game.ID, "default", "src", "a", "1.2.3"))
+
+	out := captureStdout(t, func() error {
+		return doModShow(context.Background(), svc, game, "a")
+	})
+	assertModShowGolden(t, "installed_locked", out)
+}
+
+// Sparse mod: every optional field empty, pinning the omit branches.
+func TestModShowGolden_SparseMod(t *testing.T) {
+	svc, game, src := setupDoModLockTest(t)
+	src.AddMod(&domain.Mod{ID: "a", SourceID: "src", GameID: game.ID, Name: "Mod A", Version: "1.5"}, nil)
+
+	out := captureStdout(t, func() error {
+		return doModShow(context.Background(), svc, game, "a")
+	})
+	assertModShowGolden(t, "sparse", out)
+}
+
+func TestModShowGolden_JSON(t *testing.T) {
+	svc, game, src := setupDoModLockTest(t)
+	seedLockableMod(t, svc, game, "a", "Mod A", "1.5")
+	src.AddMod(richMod(game.ID), nil)
+
+	old := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = old })
+
+	out := captureStdout(t, func() error {
+		return doModShow(context.Background(), svc, game, "a")
+	})
+	assertModShowGolden(t, "json_installed", out)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails (goldens absent)**
+
+Run: `go test ./cmd/lmm -run TestModShowGolden -v`
+Expected: FAIL, five times, with "golden testdata/mod_show_golden/....txt missing - record it with -update BEFORE refactoring".
+
+- [ ] **Step 3: Record the goldens**
+
+Run: `go test ./cmd/lmm -run TestModShowGolden -update`
+Expected: PASS. Then inspect the five files — they must contain real output (a `====` banner, `ID: a  Version: 1.5  Author: Author A`, and for the rich cases raw `<p>` tags in the Description, which is the wart Task 3 fixes).
+
+Guard against recording nothing:
+
+```bash
+test -s cmd/lmm/testdata/mod_show_golden/not_installed.txt || { echo "EMPTY GOLDEN - abort"; exit 1; }
+```
+
+- [ ] **Step 4: Run without `-update` to verify they now pass**
+
+Run: `go test ./cmd/lmm -run TestModShowGolden -v`
+Expected: PASS ×5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+go fmt ./...
+git add cmd/lmm/mod_show_golden_test.go cmd/lmm/testdata/mod_show_golden
+git commit -m "test: pin mod show output with recorded goldens before extraction (#86)"
+```
+
+---
+
+### Task 2: Extract `Service.ModDetail`; `doModShow` becomes its renderer
+
+Behavior-preserving. Task 1's goldens must stay green **without being touched**.
+
+**Files:**
+
+- Create: `internal/core/moddetail.go`
+- Create: `internal/core/moddetail_test.go`
+- Modify: `cmd/lmm/mod.go:606-753` (`doModShow`)
+
+**Interfaces:**
+
+- Consumes: `Service.GetMod` (`internal/core/service.go:422`), `Service.GetInstalledMod`, `Service.ModHasPakMergeSource` (`internal/core/merged_pak.go:92`), `config.LoadProfile` (already imported by core — `internal/core/profile.go:30`).
+- Produces:
+
+  ```go
+  func (s *Service) ModDetail(ctx context.Context, game *domain.Game,
+      profile, sourceID, modID string) (*ModDetail, error)
+
+  type ModDetail struct {
+      Mod       *domain.Mod
+      Installed *InstalledDetail // nil when not installed in profile
+  }
+
+  type InstalledDetail struct {
+      Version       string
+      Profile       string
+      UpdatePolicy  domain.UpdatePolicy
+      Locked        bool
+      LockedVersion string
+      ConvertPaks   *bool // nil = not applicable (not "off")
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModDetail_NotInstalled: a mod that exists upstream but is absent from
+// the profile yields source metadata with a nil Installed block - "not
+// installed" is an ordinary state, never an error (doModShow's own
+// convention, cmd/lmm/mod.go:618-621).
+func TestModDetail_NotInstalled(t *testing.T) {
+	svc, game, src := newModDetailTestService(t)
+	src.AddMod(&domain.Mod{ID: "a", SourceID: "src", GameID: game.ID, Name: "Mod A", Version: "1.5"})
+
+	detail, err := svc.ModDetail(context.Background(), game, "default", "src", "a")
+	require.NoError(t, err)
+	require.NotNil(t, detail.Mod)
+	assert.Equal(t, "Mod A", detail.Mod.Name)
+	assert.Nil(t, detail.Installed, "an uninstalled mod must not carry an Installed block")
+}
+
+// TestModDetail_InstalledCarriesPolicyAndProfile joins the DB row.
+func TestModDetail_InstalledCarriesPolicyAndProfile(t *testing.T) {
+	svc, game, src := newModDetailTestService(t)
+	src.AddMod(&domain.Mod{ID: "a", SourceID: "src", GameID: game.ID, Name: "Mod A", Version: "1.5"})
+	seedModDetailInstalled(t, svc, game, "a", "1.5")
+
+	detail, err := svc.ModDetail(context.Background(), game, "default", "src", "a")
+	require.NoError(t, err)
+	require.NotNil(t, detail.Installed)
+	assert.Equal(t, "1.5", detail.Installed.Version)
+	assert.Equal(t, "default", detail.Installed.Profile)
+	assert.Equal(t, domain.UpdatePolicyNotify, detail.Installed.UpdatePolicy)
+	assert.False(t, detail.Installed.Locked)
+	assert.Nil(t, detail.Installed.ConvertPaks, "a non-compile game must leave ConvertPaks unset, not false")
+}
+
+// TestModDetail_LockJoinedFromProfileYAML: the lock lives in the profile YAML,
+// not the DB, and LockedVersion is the lock's TARGET (which may differ from
+// the installed version - that difference is what drives mod show's converge
+// hint).
+func TestModDetail_LockJoinedFromProfileYAML(t *testing.T) {
+	svc, game, src := newModDetailTestService(t)
+	src.AddMod(&domain.Mod{ID: "a", SourceID: "src", GameID: game.ID, Name: "Mod A", Version: "1.5"})
+	seedModDetailInstalled(t, svc, game, "a", "1.5")
+	require.NoError(t, svc.NewProfileManager().SetModLock(game.ID, "default", "src", "a", "1.2.3"))
+
+	detail, err := svc.ModDetail(context.Background(), game, "default", "src", "a")
+	require.NoError(t, err)
+	require.NotNil(t, detail.Installed)
+	assert.True(t, detail.Installed.Locked)
+	assert.Equal(t, "1.2.3", detail.Installed.LockedVersion)
+}
+
+// TestModDetail_UnknownModErrors: a source lookup failure is a real error.
+func TestModDetail_UnknownModErrors(t *testing.T) {
+	svc, game, _ := newModDetailTestService(t)
+
+	_, err := svc.ModDetail(context.Background(), game, "default", "src", "nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mod not found")
+}
+```
+
+Write `newModDetailTestService(t) (*Service, *domain.Game, *mockSource)` and
+`seedModDetailInstalled(t, svc, game, modID, version)` in the same file,
+following the existing `internal/core` test-service helpers (in-memory SQLite,
+`t.TempDir()` for config/data — see `internal/core/service_test.go`). Reuse the
+package's existing `mockSource` rather than adding another double.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/core -run TestModDetail -v`
+Expected: FAIL — `svc.ModDetail undefined (type *Service has no field or method ModDetail)`.
+
+- [ ] **Step 3: Create `internal/core/moddetail.go`**
+
+```go
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/config"
+)
+
+// ModDetail is everything both interfaces need to render a mod's full detail:
+// the source-side metadata plus, when the mod is installed in the named
+// profile, its local install state. Composed here rather than in each caller
+// because the install state spans three stores - the DB row (version,
+// policy), the profile YAML (lock), and the game config (pak conversion
+// eligibility) - and the CLI/TUI parity directive forbids each surface
+// re-deriving that join for itself (#86).
+type ModDetail struct {
+	Mod       *domain.Mod
+	Installed *InstalledDetail
+}
+
+// InstalledDetail is the local install state. Nil on ModDetail when the mod
+// is not installed in the profile - an ordinary state, not an error.
+type InstalledDetail struct {
+	Version       string
+	Profile       string
+	UpdatePolicy  domain.UpdatePolicy
+	Locked        bool
+	LockedVersion string
+	// ConvertPaks is nil when pak conversion does not apply to this mod at
+	// all (not a merge-compile game, or no pak merge source) - distinct from
+	// a non-nil pointer to false, which means "applies, and is off".
+	ConvertPaks *bool
+}
+
+// ModDetail fetches modID from sourceID and joins whatever local install
+// state exists for it in profile. The source fetch is a live network call for
+// remote sources (Service.GetMod does not cache), so callers on a UI thread
+// must run this off the render path.
+func (s *Service) ModDetail(ctx context.Context, game *domain.Game, profile, sourceID, modID string) (*ModDetail, error) {
+	mod, err := s.GetMod(ctx, sourceID, game.ID, modID)
+	if err != nil {
+		return nil, fmt.Errorf("mod not found: %w", err)
+	}
+	detail := &ModDetail{Mod: mod}
+
+	// A GetInstalledMod failure means "not installed" - the ordinary case for
+	// a mod browsed from search - so it omits the block rather than failing
+	// the whole call (verbatim from doModShow's own convention).
+	installed, err := s.GetInstalledMod(sourceID, modID, game.ID, profile)
+	if err != nil {
+		return detail, nil
+	}
+
+	info := &InstalledDetail{
+		Version:      installed.Version,
+		Profile:      profile,
+		UpdatePolicy: installed.UpdatePolicy,
+	}
+	if game.DeployMode == domain.DeployCompile && s.ModHasPakMergeSource(installed) {
+		v := installed.ConvertPaks
+		info.ConvertPaks = &v
+	}
+	// Lock lives in the profile YAML, not the DB. A load failure degrades to
+	// "unlocked" rather than failing the call - same as doModShow, which
+	// ignores this error.
+	if prof, perr := config.LoadProfile(s.ConfigDir(), game.ID, profile); perr == nil {
+		if ref := prof.FindRef(sourceID, modID); ref != nil && ref.Locked {
+			info.Locked = true
+			info.LockedVersion = ref.Version
+		}
+	}
+	detail.Installed = info
+	return detail, nil
+}
+```
+
+- [ ] **Step 4: Run to verify the core tests pass**
+
+Run: `go test ./internal/core -run TestModDetail -v`
+Expected: PASS ×4.
+
+- [ ] **Step 5: Rewrite `doModShow`'s data-gathering half**
+
+In `cmd/lmm/mod.go`, replace everything from the `mod, err := svc.GetMod(...)`
+call through the end of the `installedInfo` block (currently `:613-646`) with:
+
+```go
+	// Profile resolves BEFORE the detail call now that the composition lives
+	// in core (#86) - see the plan's "Accepted deviation": when BOTH the
+	// profile and the mod ID are invalid, the profile error surfaces first.
+	profileName, err := resolveProfile(svc, game.ID, modProfile)
+	if err != nil {
+		return err
+	}
+
+	detail, err := svc.ModDetail(ctx, game, profileName, modSource, modID)
+	if err != nil {
+		return err
+	}
+	mod := detail.Mod
+
+	var installedInfo *modShowInstalled
+	if detail.Installed != nil {
+		installedInfo = &modShowInstalled{
+			Version:       detail.Installed.Version,
+			Profile:       detail.Installed.Profile,
+			UpdatePolicy:  policyToString(detail.Installed.UpdatePolicy),
+			Locked:        detail.Installed.Locked,
+			LockedVersion: detail.Installed.LockedVersion,
+			ConvertPaks:   detail.Installed.ConvertPaks,
+		}
+	}
+```
+
+Everything below (the `jsonOutput` block and the human-readable printing) is
+**unchanged** — it already reads only `mod` and `installedInfo`.
+
+- [ ] **Step 6: Verify the goldens are still byte-identical**
+
+Run: `go test ./cmd/lmm -run TestModShowGolden -v`
+Expected: PASS ×5, **with no `-update`**. If any fail, the extraction changed
+output — fix the extraction, never the golden.
+
+- [ ] **Step 7: Full suite**
+
+Run: `go build ./... && go vet ./... && go test ./...`
+Expected: all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+go fmt ./...
+git add internal/core/moddetail.go internal/core/moddetail_test.go cmd/lmm/mod.go
+git commit -m "refactor(core): extract Service.ModDetail; mod show renders over it (#86)"
+```
+
+---
+
+### Task 3: Clean HTML in `mod show`'s human output
+
+The one intended CLI behavior change. JSON is deliberately untouched.
+
+**Files:**
+
+- Modify: `cmd/lmm/mod.go` (Description block, currently `:705-714`)
+- Modify: `internal/core/changelog.go:8-22` (doc comment only)
+- Modify: `cmd/lmm/testdata/mod_show_golden/*.txt` (re-recorded — the only task allowed to)
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+
+- Consumes: `core.CleanChangelog(html string) string` (`internal/core/changelog.go:28`).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/lmm/mod_show_golden_test.go`:
+
+```go
+// TestDoModShow_DescriptionHTMLCleaned (#86): mod show printed a source's raw
+// description HTML - literal <p> tags and &amp; entities in the user's
+// terminal. It now runs through the same core.CleanChangelog the update flow
+// and the TUI already share, so both interfaces render one cleaned text.
+// JSON is deliberately NOT cleaned: it is a machine contract, and a consumer
+// may want the original markup.
+func TestDoModShow_DescriptionHTMLCleaned(t *testing.T) {
+	svc, game, src := setupDoModLockTest(t)
+	src.AddMod(richMod(game.ID), nil)
+
+	out := captureStdout(t, func() error {
+		return doModShow(context.Background(), svc, game, "a")
+	})
+
+	assert.Contains(t, out, "Line one.")
+	assert.Contains(t, out, "Line & two.")
+	assert.NotContains(t, out, "<p>", "raw HTML tags must not reach the terminal")
+	assert.NotContains(t, out, "&amp;", "HTML entities must be decoded")
+}
+
+// TestDoModShow_JSONDescriptionStaysRaw pins the deliberate asymmetry above.
+func TestDoModShow_JSONDescriptionStaysRaw(t *testing.T) {
+	svc, game, src := setupDoModLockTest(t)
+	src.AddMod(richMod(game.ID), nil)
+
+	old := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = old })
+
+	out := captureStdout(t, func() error {
+		return doModShow(context.Background(), svc, game, "a")
+	})
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "<p>Line one.</p><br/><p>Line &amp; two.</p>", got["description"],
+		"--json is a machine contract; the raw description must survive")
+}
+```
+
+Add `"encoding/json"` to the file's imports.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./cmd/lmm -run 'TestDoModShow_(DescriptionHTMLCleaned|JSONDescriptionStaysRaw)' -v`
+Expected: `TestDoModShow_DescriptionHTMLCleaned` FAILS on `<p>` still being
+present. `TestDoModShow_JSONDescriptionStaysRaw` PASSES already (regression
+guard for the next step).
+
+- [ ] **Step 3: Clean the description in the human path only**
+
+In `cmd/lmm/mod.go`, replace the Description block:
+
+```go
+	if mod.Description != "" {
+		fmt.Println("Description:")
+		// #86: descriptions are source HTML. Clean them with the same shared
+		// cleaner the update flow and the TUI already use, so all three render
+		// identically. CleanChangelog trims for us, so no TrimSpace here.
+		// The cap stays: this is a one-shot terminal dump, unlike the TUI's
+		// details view, which scrolls the full text instead.
+		desc := core.CleanChangelog(mod.Description)
+		const maxDesc = 2000
+		if len(desc) > maxDesc {
+			desc = desc[:maxDesc] + "\n... (truncated; view on site for full description)"
+		}
+		fmt.Println(desc)
+	}
+```
+
+- [ ] **Step 4: Run to verify both pass**
+
+Run: `go test ./cmd/lmm -run 'TestDoModShow_(DescriptionHTMLCleaned|JSONDescriptionStaysRaw)' -v`
+Expected: PASS ×2.
+
+- [ ] **Step 5: Broaden the cleaner's doc comment**
+
+In `internal/core/changelog.go`, the doc comment opens "CleanChangelog strips
+HTML markup from html for readable terminal/TUI display". Append one sentence:
+
+```go
+// Despite the name (it predates any other caller), this is a general
+// HTML-to-terminal cleaner, not changelog-specific: #86 also routes mod
+// descriptions through it, so `lmm mod show` and the TUI's details view
+// render a source's markup identically. Left named CleanChangelog to avoid
+// churning three unrelated call sites for a rename.
+```
+
+- [ ] **Step 6: Re-record the goldens (the only sanctioned regeneration)**
+
+Run: `go test ./cmd/lmm -run TestModShowGolden -update`
+
+Then **inspect the diff** — `git diff cmd/lmm/testdata/mod_show_golden/`. It
+must show only Description-block changes in the rich cases: `<p>`/`&amp;`
+gone, text intact. `sparse.txt` (no description) and `json_installed.txt` must
+be **unchanged**. If anything else moved, the change is wrong.
+
+- [ ] **Step 7: CHANGELOG**
+
+Under `[Unreleased]` → `### Changed`, add (create the section if absent,
+keeping Keep-a-Changelog section order — Added, Changed, Fixed):
+
+```markdown
+- `lmm mod show` now strips HTML from a mod's description before printing
+  it, using the same cleaner the update flow and TUI already share — raw
+  `<p>` tags and `&amp;` entities no longer reach the terminal (#86).
+  `--json` output is unchanged: it stays the raw source markup.
+```
+
+- [ ] **Step 8: Full suite and commit**
+
+```bash
+go build ./... && go vet ./... && go test ./...
+go fmt ./...
+git add cmd/lmm/mod.go cmd/lmm/mod_show_golden_test.go cmd/lmm/testdata/mod_show_golden internal/core/changelog.go CHANGELOG.md
+git commit -m "feat(cli): mod show cleans description HTML (#86)"
+```
+
+---
+
+### Task 4: Generalize the context-view host and swallow declined keys
+
+Both halves ship together: generalizing without the swallow rule would let
+`e`/`x`/`u` reach the mod row behind the pushed view.
+
+**Files:**
+
+- Modify: `internal/tui/contextview.go` (whole file)
+- Modify: `internal/tui/app.go:150-153`, `:429-432`, `:966-975`, `:1393+`, `:2131-2147`
+- Modify: `internal/tui/navigation.go:15-23` (doc comment)
+- Modify: `internal/tui/health_screen_test.go:548-658`
+
+**Interfaces:**
+
+- Consumes: the `contextContent` interface (unchanged), `fakeContextContent` (`health_screen_test.go:517`).
+- Produces:
+
+  ```go
+  func (m *Model) pushContext(c contextContent)  // no `from` param
+  func (m *Model) popContext()                   // no return value
+  func (m Model) contextView() string            // full-screen chrome + content
+  ```
+
+  `Model.contextReturn` is **deleted**.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/tui/health_screen_test.go`:
+
+```go
+// TestContextHostRendersOnPushingScreen (#86): pushing content no longer
+// hijacks the session to ScreenHealth. The details view opened from Installed
+// Mods must render there, with the nav bar still highlighting Installed Mods -
+// a nav bar reading "Health" over a mod details view was the whole reason the
+// host got generalized.
+func TestContextHostRendersOnPushingScreen(t *testing.T) {
+	m := sizedPrototypeModel(t, "wizardry", 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	fake := &fakeContextContent{}
+
+	m.pushContext(fake)
+
+	assert.Equal(t, ScreenInstalledMods, m.screen, "push must not move the session")
+	view := m.View()
+	assert.Contains(t, view, "FAKE DETAIL", "pushed content must render on the pushing screen")
+}
+
+// TestContextHostEscPopsToSameScreen: esc clears the content and leaves the
+// session exactly where it was.
+func TestContextHostEscPopsToSameScreen(t *testing.T) {
+	m := sizedPrototypeModel(t, "wizardry", 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	m.pushContext(&fakeContextContent{})
+
+	m, _ = updateWithMsg(m, tea.KeyMsg{Type: tea.KeyEsc})
+
+	assert.Nil(t, m.contextContent)
+	assert.Equal(t, ScreenInstalledMods, m.screen)
+	assert.NotContains(t, m.View(), "FAKE DETAIL")
+}
+
+// TestContextHostNavAwayClearsFromAnyScreen generalizes #224's stranded-
+// content regression test off ScreenHealth.
+func TestContextHostNavAwayClearsFromAnyScreen(t *testing.T) {
+	m := sizedPrototypeModel(t, "wizardry", 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	m.pushContext(&fakeContextContent{})
+
+	m, _ = updateWithMsg(m, keyRunes("3")) // Search
+
+	assert.Equal(t, ScreenSearch, m.screen)
+	assert.Nil(t, m.contextContent, "navigating away must never strand pushed content")
+	assert.NotContains(t, m.View(), "FAKE DETAIL")
+}
+
+// TestContextHostSwallowsDeclinedKeys is the safety half. A key the content
+// declines must NOT reach the screen underneath: on Installed Mods that would
+// mean arrow keys silently moving the selection behind the view, and e/x/u
+// enabling or uninstalling the row the user can no longer see.
+func TestContextHostSwallowsDeclinedKeys(t *testing.T) {
+	rec := &recordingActions{}
+	m := sizedModelWithActions(t, rec, 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	before := m.selected[ScreenInstalledMods]
+	m.pushContext(&fakeContextContent{}) // declines everything except "x"
+
+	for _, k := range []string{"j", "e", "u"} {
+		m, _ = updateWithMsg(m, keyRunes(k))
+	}
+	m, _ = updateWithMsg(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	assert.Equal(t, before, m.selected[ScreenInstalledMods], "selection must not move behind pushed content")
+	assert.Zero(t, rec.EnableModCalls, "a declined key must not trigger a mutation underneath")
+	assert.NotNil(t, m.contextContent, "declined keys must not close the view either")
+}
+
+// TestContextHostStillAllowsQuitAndHelp: the swallow rule has exits.
+func TestContextHostStillAllowsQuitAndHelp(t *testing.T) {
+	m := sizedPrototypeModel(t, "wizardry", 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	m.pushContext(&fakeContextContent{})
+
+	m2, _ := updateWithMsg(m, keyRunes("?"))
+	assert.NotEqual(t, m.showHelp, m2.showHelp, "help must still toggle over pushed content")
+
+	_, cmd := updateWithMsg(m, keyRunes("q"))
+	assert.NotNil(t, cmd, "quit must still work over pushed content")
+}
+```
+
+Update the five existing host tests at `:548-658` for the new signatures:
+`pushContext(fake)` (one arg) and, in
+`TestHealthContextHostPushRenderKeyAndEscPop`, assert the screen is
+**unchanged** rather than `ScreenHealth`. `TestPopContextNoopWhenNothingPushed`
+drops its return-value assertion.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/tui -run 'TestContextHost' -v`
+Expected: FAIL to compile — `too many arguments in call to m.pushContext`.
+
+- [ ] **Step 3: Rewrite `internal/tui/contextview.go`**
+
+```go
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// contextContent is a pluggable full-screen content view that any screen can
+// push over itself (#224, generalized in #86). One-deep by design (YAGNI):
+// push replaces any pushed content, esc pops, and navigating to another
+// screen pops implicitly. The pushing screen stays the current screen
+// throughout - the nav bar keeps highlighting it - so a mod details view
+// opened from Installed Mods reads as "Installed Mods, showing a mod",
+// not as a jump to some other screen.
+type contextContent interface {
+	Title() string
+	// Lines renders the body for the given content box; the host owns
+	// chrome (panel, title, nav) and clamping.
+	Lines(width, height int) []string
+	// HandleKey lets pushed content consume a key before the outer
+	// switch; handled=false means the host swallows it (see updateKey) -
+	// it does NOT fall through to the screen underneath.
+	HandleKey(msg tea.KeyMsg) (next contextContent, cmd tea.Cmd, handled bool)
+	HelpGroup() helpGroup
+}
+
+// pushContext replaces the current pushed content (one-deep by design) with
+// c. The session's screen is deliberately NOT changed: screenView renders
+// pushed content ahead of the per-screen switch, so the content appears over
+// whatever screen the user is on and esc simply returns them to it. Pointer
+// receiver so updateKey handlers can call it directly.
+func (m *Model) pushContext(c contextContent) {
+	m.contextContent = c
+}
+
+// popContext clears the pushed content, revealing the screen underneath. A
+// no-op when nothing is pushed, so callers need no guard.
+func (m *Model) popContext() {
+	m.contextContent = nil
+}
+
+// contextView renders pushed content full-screen: the host owns the panel,
+// the title line, truncation, and clamping, so content views stay small.
+// Moved here from healthScreenView in #86, since the host is no longer
+// Health's private machinery.
+func (m Model) contextView() string {
+	width := m.availableWidth()
+	height := m.availableContentHeight()
+	contentWidth := max(width-m.theme.Panel.GetHorizontalFrameSize(), 1)
+	contentBudget := max(height-m.theme.Panel.GetVerticalBorderSize(), 1)
+
+	lines := []string{m.theme.PanelTitle.Render(m.contextContent.Title())}
+	lines = append(lines, m.contextContent.Lines(contentWidth, max(contentBudget-1, 1))...)
+	lines = m.truncateLines(lines, contentWidth)
+	lines = m.clampLines(lines, contentBudget)
+
+	return m.panelWithHeight(width, height).Render(strings.Join(lines, "\n"))
+}
+```
+
+- [ ] **Step 4: Update `app.go`**
+
+**(a)** Delete the `contextReturn Screen` field (`:153`) and rewrite the
+`contextContent` field's doc comment (`:146-152`) to drop Health-specificity.
+
+**(b)** `screenView()` (`:1393`) — add after the `inputModal` early-return and
+before the screen switch:
+
+```go
+	// Pushed content renders over whatever screen pushed it (#86). Placed
+	// after the picker/inputModal returns above so modals still outrank it,
+	// matching updateKey's own precedence.
+	if m.contextContent != nil {
+		return m.contextView()
+	}
+```
+
+**(c)** `case ScreenHealth:` (`:1441`) now reads `return m.healthHomeView()`.
+Delete `healthScreenView` (`:2131-2147`) — `contextView` absorbed its body.
+
+**(d)** Key routing (`:966`) — drop the screen gate and add the swallow:
+
+```go
+	// Pushed content gets first refusal on every key. Anything it declines is
+	// SWALLOWED rather than falling through to the screen underneath (#86) -
+	// otherwise arrows would move a selection the user can't see and e/x/u
+	// would mutate the row behind the view. Same rule updateOverlayKey
+	// already applies for the info overlay. The exits below are the keys that
+	// must keep working over any full-screen content: leave, navigate, quit,
+	// help.
+	if m.contextContent != nil {
+		if next, cmd, handled := m.contextContent.HandleKey(msg); handled {
+			m.contextContent = next
+			return m, cmd
+		}
+		switch {
+		case key.Matches(msg, m.keys.Blur):
+			m.popContext()
+			return m, nil
+		case m.isQuitKey(msg):
+			// fall through to the outer switch's quit handling
+		case key.Matches(msg, m.keys.Help),
+			key.Matches(msg, m.keys.NextScreen), key.Matches(msg, m.keys.PrevScreen),
+			isScreenDigit(msg):
+			// fall through: navigation and help stay available
+		default:
+			return m, nil // swallowed
+		}
+	}
+```
+
+`isQuitKey` is a **method** on `Model` (`internal/tui/actions.go:619`), hence
+`m.isQuitKey(msg)` — it is deliberately narrower than
+`key.Matches(msg, m.keys.Quit)` because a plain `q` must stay typeable in some
+contexts.
+
+No `isScreenDigit` helper exists yet. Add one beside the digit handling in
+`updateKey` (`screens` is the nav slice at `internal/tui/navigation.go:26`):
+
+```go
+// isScreenDigit reports whether msg is one of the nav digits ("1".."6"), so
+// the pushed-content swallow rule can let navigation through.
+func isScreenDigit(msg tea.KeyMsg) bool {
+	if msg.Type != tea.KeyRunes || len(msg.Runes) != 1 {
+		return false
+	}
+	return msg.Runes[0] >= '1' && msg.Runes[0] <= rune('0'+len(screens))
+}
+```
+
+**(e)** Nav-away pop (`:429`) — clear whenever content is pushed:
+
+```go
+	// Navigating anywhere pops pushed content (#86: any screen can host it,
+	// so this is no longer Health-specific). gotoScreen is the single choke
+	// point every nav route funnels through, so one clear here covers them
+	// all - including pressing the digit for the screen you are already on.
+	if m.contextContent != nil {
+		m.contextContent = nil
+	}
+```
+
+**(f)** `helpGroups()` (`:2857-2866`) — drop `m.screen == ScreenHealth &&`,
+leaving `if m.contextContent != nil {`.
+
+- [ ] **Step 5: Update `navigation.go`'s doc comment**
+
+`internal/tui/navigation.go:15-23` describes `ScreenHealth` as the context-view
+host. Reword: Health is one screen among six; any screen can host pushed
+content since #86.
+
+- [ ] **Step 6: Run the TUI suite**
+
+Run: `go test ./internal/tui -v 2>&1 | tail -40`
+Expected: PASS, including all five updated #224 host tests and the five new
+ones. The Health action guards (`:856`, `:883`, `:1397`,
+`health_conflicts_test.go:304`) must pass **unmodified** — they now assert
+defense-in-depth behind the swallow rule.
+
+- [ ] **Step 7: Full suite and commit**
+
+```bash
+go build ./... && go vet ./... && go test ./...
+go fmt ./...
+git add internal/tui/contextview.go internal/tui/app.go internal/tui/navigation.go internal/tui/health_screen_test.go
+git commit -m "refactor(tui): any screen can host pushed content; declined keys swallowed (#86)"
+```
+
+---
+
+### Task 5: TUI view model and provider methods
+
+**Files:**
+
+- Modify: `internal/tui/service.go` (types, `DataProvider`, prototype impl)
+- Modify: `internal/tui/service_core.go` (`coreProvider.GetModDetails`)
+- Modify: `internal/tui/prototype/data.go:79-101`
+- Modify: `internal/tui/service_test.go` (or create `internal/tui/moddetails_provider_test.go`)
+
+**Interfaces:**
+
+- Consumes: `core.Service.ModDetail` (Task 2), `mapNetworkError` (`service_core.go:1207`), `p.currentGame()`/`p.currentProfile()`.
+- Produces:
+
+  ```go
+  // DataProvider gains:
+  GetModDetails(ctx context.Context, item ModItem) (ModDetails, error)
+
+  type ModDetails struct {
+      ID, Name, Version, Author string
+      Summary, Description      string
+      Category                  string
+      SourceURL, PictureURL     string
+      Endorsements              int64
+      HasEndorsements           bool
+      Installed                 *InstalledDetails
+      Fetching                  bool
+      FetchErr                  string
+  }
+
+  type InstalledDetails struct {
+      Version, Profile, UpdatePolicy string
+      Locked                         bool
+      LockedVersion                  string
+      ConvertPaks                    *bool
+  }
+
+  func modDetailsFromItem(item ModItem) ModDetails // the local-first seed
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/tui/moddetails_provider_test.go`:
+
+```go
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModDetailsFromItem: the local-first seed. Opening details must render
+// immediately from the row already in hand, so everything the row knows has
+// to survive the conversion - the network fetch only ADDS.
+func TestModDetailsFromItem(t *testing.T) {
+	item := ModItem{
+		ID: "a", Name: "Mod A", Version: "1.5", Author: "Author A",
+		Source: "src", Summary: "A short summary.",
+		Endorsements: 42, HasEndorsements: true,
+		UpdatePolicy: "notify", Locked: true, LockedVersion: "1.2.3",
+		Status: "installed",
+	}
+
+	d := modDetailsFromItem(item)
+
+	assert.Equal(t, "Mod A", d.Name)
+	assert.Equal(t, "1.5", d.Version)
+	assert.Equal(t, "Author A", d.Author)
+	assert.Equal(t, "A short summary.", d.Summary)
+	assert.Equal(t, int64(42), d.Endorsements)
+	assert.True(t, d.HasEndorsements)
+	require.NotNil(t, d.Installed, "an installed row must seed the Installed block locally")
+	assert.Equal(t, "1.5", d.Installed.Version)
+	assert.True(t, d.Installed.Locked)
+	assert.Equal(t, "1.2.3", d.Installed.LockedVersion)
+	assert.Empty(t, d.Description, "description is network-only; the seed must not invent one")
+}
+
+// TestModDetailsFromItem_NotInstalled: a search hit for an uninstalled mod
+// gets no Installed block, matching mod show's omit rule.
+func TestModDetailsFromItem_NotInstalled(t *testing.T) {
+	d := modDetailsFromItem(ModItem{ID: "a", Name: "Mod A", Status: "available"})
+	assert.Nil(t, d.Installed)
+}
+
+// TestPrototypeGetModDetails: the prototype provider must serve details too,
+// or `lmm tui --prototype` and most TUI tests can't exercise the view.
+func TestPrototypeGetModDetails(t *testing.T) {
+	p := newPrototypeProviderConcrete()
+	_, items, err := p.Overview(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+
+	d, err := p.GetModDetails(t.Context(), items[0])
+	require.NoError(t, err)
+	assert.Equal(t, items[0].Name, d.Name)
+	assert.NotEmpty(t, d.Description, "the prototype must serve a description, or the view has nothing to show")
+	assert.NotEmpty(t, d.SourceURL)
+}
+```
+
+If `t.Context()` is unavailable on this Go version, use `context.Background()`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/tui -run 'TestModDetailsFromItem|TestPrototypeGetModDetails' -v`
+Expected: FAIL — `undefined: modDetailsFromItem`.
+
+- [ ] **Step 3: Add the view models and the seed to `service.go`**
+
+```go
+// ModDetails is the mod-details view's render model (#86). Seeded locally
+// from the ModItem the user selected, then enriched in place by
+// GetModDetails - so the view opens instantly and fills in, rather than
+// blocking on a network round trip the user may not be able to complete.
+type ModDetails struct {
+	ID, Name, Version, Author string
+	Summary, Description      string
+	Category                  string
+	SourceURL, PictureURL     string
+	Endorsements              int64
+	HasEndorsements           bool
+
+	// Installed is nil when the mod is not installed in the active profile,
+	// matching `lmm mod show`'s omit rule.
+	Installed *InstalledDetails
+
+	// Fetching/FetchErr are set by the model's handler and resolvers, never
+	// by a provider; the view reads them to pick its render state.
+	Fetching bool
+	FetchErr string
+}
+
+// InstalledDetails mirrors core.InstalledDetail with the policy already
+// rendered to a display string - the TUI has no reason to carry a
+// domain.UpdatePolicy. A separate type because a view model is a rendering
+// contract, the convention every other TUI row type follows.
+type InstalledDetails struct {
+	Version       string
+	Profile       string
+	UpdatePolicy  string
+	Locked        bool
+	LockedVersion string
+	ConvertPaks   *bool // nil = not applicable, not "off"
+}
+
+// modDetailsFromItem seeds a details view from the row already on screen.
+// Everything here is local: no I/O, so the view can render on the very first
+// frame. Description/Category/SourceURL/PictureURL stay empty until the fetch
+// lands - inventing placeholders for them would be worse than a blank.
+func modDetailsFromItem(item ModItem) ModDetails {
+	d := ModDetails{
+		ID: item.ID, Name: item.Name, Version: item.Version, Author: item.Author,
+		Summary:         item.Summary,
+		Endorsements:    item.Endorsements,
+		HasEndorsements: item.HasEndorsements,
+	}
+	if item.Status != "available" {
+		d.Installed = &InstalledDetails{
+			Version:       item.Version,
+			UpdatePolicy:  item.UpdatePolicy,
+			Locked:        item.Locked,
+			LockedVersion: item.LockedVersion,
+		}
+		if item.CompileGame && item.HasPakSource {
+			v := item.ConvertPaks
+			d.Installed.ConvertPaks = &v
+		}
+	}
+	return d
+}
+```
+
+Add to the `DataProvider` interface (`service.go:288`):
+
+```go
+	// GetModDetails fetches full metadata for item's mod and joins local
+	// install state. A network call for remote sources - callers must run it
+	// off the render path (see mutations.go's openSelectedModDetails).
+	GetModDetails(ctx context.Context, item ModItem) (ModDetails, error)
+```
+
+- [ ] **Step 4: Implement on `coreProvider` (`service_core.go`)**
+
+Modelled on `AvailableVersions` (`:1674`):
+
+```go
+func (p *coreProvider) GetModDetails(ctx context.Context, item ModItem) (ModDetails, error) {
+	action := fmt.Sprintf("fetching details for %s", item.Name)
+	game := p.currentGame()
+	detail, err := p.svc.ModDetail(ctx, game, p.currentProfile(), item.Source, item.ID)
+	if err != nil {
+		return ModDetails{}, mapNetworkError(action, item.Source, "mod details",
+			"run 'lmm mod show "+item.ID+"' in a shell", err)
+	}
+
+	out := modDetailsFromItem(item)
+	mod := detail.Mod
+	out.Name, out.Version, out.Author = mod.Name, mod.Version, mod.Author
+	out.Summary, out.Category = mod.Summary, mod.Category
+	out.SourceURL, out.PictureURL = mod.SourceURL, mod.PictureURL
+	// Same shared cleaner the CLI's mod show and the update flow use, so all
+	// three surfaces render a source's markup identically (#86).
+	out.Description = core.CleanChangelog(mod.Description)
+	if mod.Endorsements != nil {
+		out.Endorsements, out.HasEndorsements = *mod.Endorsements, true
+	}
+
+	if detail.Installed != nil {
+		out.Installed = &InstalledDetails{
+			Version:       detail.Installed.Version,
+			Profile:       detail.Installed.Profile,
+			UpdatePolicy:  policyToString(detail.Installed.UpdatePolicy),
+			Locked:        detail.Installed.Locked,
+			LockedVersion: detail.Installed.LockedVersion,
+			ConvertPaks:   detail.Installed.ConvertPaks,
+		}
+	} else {
+		out.Installed = nil
+	}
+	return out, nil
+}
+```
+
+**`policyToString`, not a string conversion.** `domain.UpdatePolicy` is an
+`int` (`internal/domain/mod.go:29`), so `string(policy)` would compile and
+silently produce a garbage rune — `go vet` flags it. The package already has
+`policyToString(domain.UpdatePolicy) string` at
+`internal/tui/service_core.go:630`, which `Overview` uses for
+`ModItem.UpdatePolicy` (`:164`). Use it.
+
+- [ ] **Step 5: Implement on `prototypeProvider` and extend `prototype.Mod`**
+
+In `internal/tui/prototype/data.go`, add to `Mod` (after `Summary`):
+
+```go
+	// Description/SourceURL/PictureURL feed the mod details view (#86). Only
+	// a few entries set them; the view's omit-when-empty rules are exactly
+	// what the sparse entries exercise.
+	Description string
+	SourceURL   string
+	PictureURL  string
+```
+
+Populate them on at least two demo mods in the same file — one rich (multi-
+paragraph description, both URLs), one sparse (none) — so the prototype shows
+both render paths.
+
+In `internal/tui/service.go`, on `prototypeProvider`:
+
+```go
+// allMods is every prototype mod a details view can be opened on: the active
+// game's installed mods plus the search catalog - the two lists modItems is
+// fed from (Overview at service.go:427, Search at :550).
+func (p *prototypeProvider) allMods() []prototype.Mod {
+	return append(append([]prototype.Mod(nil), p.activeMods()...), p.data.SearchResults...)
+}
+
+func (p *prototypeProvider) GetModDetails(_ context.Context, item ModItem) (ModDetails, error) {
+	out := modDetailsFromItem(item)
+	for _, m := range p.allMods() {
+		if m.ID != item.ID {
+			continue
+		}
+		out.Description, out.SourceURL, out.PictureURL = m.Description, m.SourceURL, m.PictureURL
+		break
+	}
+	return out, nil
+}
+```
+
+`p.activeMods()` is at `internal/tui/service.go:394`; `p.data.SearchResults` is
+the catalog `Search` filters at `:558`.
+
+- [ ] **Step 6: Run to verify the tests pass**
+
+Run: `go test ./internal/tui -run 'TestModDetailsFromItem|TestPrototypeGetModDetails' -v`
+Expected: PASS ×3.
+
+- [ ] **Step 7: Fix every other `DataProvider` implementation**
+
+Run: `go build ./... 2>&1 | head -20`
+
+The new interface method breaks `stubProvider` (`app_test.go:1064`) and any
+bespoke test double implementing `DataProvider` in full. Add to `stubProvider`:
+
+```go
+func (stubProvider) GetModDetails(context.Context, ModItem) (ModDetails, error) {
+	return ModDetails{}, nil
+}
+```
+
+Doubles that embed `stubProvider` inherit it. Fix any that don't, individually.
+
+- [ ] **Step 8: Full suite and commit**
+
+```bash
+go build ./... && go vet ./... && go test ./...
+go fmt ./...
+git add internal/tui/service.go internal/tui/service_core.go internal/tui/prototype/data.go internal/tui/moddetails_provider_test.go internal/tui/app_test.go
+git commit -m "feat(tui): ModDetails view model and GetModDetails provider method (#86)"
+```
+
+---
+
+### Task 6: The details content view
+
+**Files:**
+
+- Create: `internal/tui/moddetails.go`
+- Create: `internal/tui/moddetails_test.go`
+
+**Interfaces:**
+
+- Consumes: `ModDetails`/`InstalledDetails` (Task 5), the `contextContent`
+  interface (Task 4), `helpGroup`/`helpRow` (`app.go:2686`, `:2692`).
+- Produces:
+
+  ```go
+  type modDetailsContent struct {
+      details ModDetails
+      offset  int
+  }
+  func newModDetailsContent(d ModDetails) *modDetailsContent
+  // satisfies contextContent: Title/Lines/HandleKey/HelpGroup
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testDetails() ModDetails {
+	return ModDetails{
+		ID: "12345", Name: "Mod A", Version: "2.2.6", Author: "Author A",
+		Category: "Utilities", Summary: "A short summary.",
+		Description:     "Line one.\n\nLine two.",
+		SourceURL:       "https://example.invalid/mods/1",
+		PictureURL:      "https://example.invalid/img/1.png",
+		Endorsements:    84213,
+		HasEndorsements: true,
+		Installed: &InstalledDetails{
+			Version: "2.2.3", Profile: "default", UpdatePolicy: "notify",
+			Locked: true, LockedVersion: "2.2.3",
+		},
+	}
+}
+
+// TestModDetailsContent_FieldOrderMatchesModShow pins CLI parity: the TUI
+// renders the same fields, in the same order, as `lmm mod show`.
+func TestModDetailsContent_FieldOrderMatchesModShow(t *testing.T) {
+	body := strings.Join(newModDetailsContent(testDetails(), DefaultKeyMap()).Lines(80, 40), "\n")
+
+	order := []string{"ID: 12345", "Category: Utilities", "Endorsements: 84213",
+		"URL: https://", "Image: https://", "Summary:", "Description:", "Installed: v2.2.3"}
+	last := -1
+	for _, want := range order {
+		at := strings.Index(body, want)
+		require.GreaterOrEqual(t, at, 0, "missing field %q in:\n%s", want, body)
+		assert.Greater(t, at, last, "field %q is out of mod show order", want)
+		last = at
+	}
+}
+
+// TestModDetailsContent_OmitsEmptyFields mirrors mod show's omit rules -
+// blank labels with nothing after them are noise.
+func TestModDetailsContent_OmitsEmptyFields(t *testing.T) {
+	d := ModDetails{ID: "a", Name: "Mod A", Version: "1.0", Author: "X"}
+	body := strings.Join(newModDetailsContent(d, DefaultKeyMap()).Lines(80, 40), "\n")
+
+	for _, absent := range []string{"Category:", "Endorsements:", "URL:", "Image:", "Summary:", "Description:", "Installed:"} {
+		assert.NotContains(t, body, absent)
+	}
+}
+
+// TestModDetailsContent_InstalledBlockRendersLockAndConverge: parity with
+// mod show's Installed section, including the converge hint's condition.
+func TestModDetailsContent_InstalledBlockRendersLockAndConverge(t *testing.T) {
+	d := testDetails()
+	d.Installed.LockedVersion = "1.0.0" // differs from installed 2.2.3
+	body := strings.Join(newModDetailsContent(d, DefaultKeyMap()).Lines(80, 40), "\n")
+
+	assert.Contains(t, body, "Installed: v2.2.3 (profile: default)")
+	assert.Contains(t, body, "Update policy: notify")
+	assert.Contains(t, body, "Lock: locked at v1.0.0 — run 'lmm profile apply' to converge")
+}
+
+func TestModDetailsContent_NoConvergeHintWhenLockMatchesInstalled(t *testing.T) {
+	body := strings.Join(newModDetailsContent(testDetails(), DefaultKeyMap()).Lines(80, 40), "\n")
+	assert.Contains(t, body, "Lock: locked at v2.2.3")
+	assert.NotContains(t, body, "converge")
+}
+
+// TestModDetailsContent_RenderStates covers the three fetch states.
+func TestModDetailsContent_RenderStates(t *testing.T) {
+	fetching := testDetails()
+	fetching.Fetching = true
+	fetching.Description = ""
+	assert.Contains(t, strings.Join(newModDetailsContent(fetching, DefaultKeyMap()).Lines(80, 40), "\n"), "(loading…)")
+
+	failed := testDetails()
+	failed.Description = ""
+	failed.FetchErr = "source unreachable"
+	assert.Contains(t, strings.Join(newModDetailsContent(failed, DefaultKeyMap()).Lines(80, 40), "\n"),
+		"(unavailable — source unreachable)")
+}
+
+// TestModDetailsContent_ScrollsAndConsumesArrows is the safety-critical half:
+// the view MUST consume up/down, or the list selection behind it drifts.
+func TestModDetailsContent_ScrollsAndConsumesArrows(t *testing.T) {
+	d := testDetails()
+	d.Description = strings.Repeat("a line of description text\n", 200)
+	c := newModDetailsContent(d, DefaultKeyMap())
+
+	first := c.Lines(80, 10)
+	next, _, handled := c.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	require.True(t, handled, "the details view must consume Down, not let it move the list behind")
+	scrolled := next.(*modDetailsContent).Lines(80, 10)
+	assert.NotEqual(t, first, scrolled, "Down must scroll the body")
+
+	_, _, handledUp := next.HandleKey(tea.KeyMsg{Type: tea.KeyUp})
+	assert.True(t, handledUp)
+	_, _, handledJ := next.HandleKey(keyRunes("j"))
+	assert.True(t, handledJ, "j/k aliases must scroll too")
+}
+
+// TestModDetailsContent_ShortBodyDoesNotScroll: no phantom scrolling.
+func TestModDetailsContent_ShortBodyDoesNotScroll(t *testing.T) {
+	c := newModDetailsContent(testDetails(), DefaultKeyMap())
+	before := c.Lines(80, 40)
+	next, _, handled := c.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	assert.True(t, handled, "arrows stay consumed even when there is nothing to scroll")
+	assert.Equal(t, before, next.(*modDetailsContent).Lines(80, 40))
+}
+
+func TestModDetailsContent_TitleIsModName(t *testing.T) {
+	assert.Equal(t, "Mod A", newModDetailsContent(testDetails(), DefaultKeyMap()).Title())
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/tui -run TestModDetailsContent -v`
+Expected: FAIL — `undefined: newModDetailsContent`.
+
+- [ ] **Step 3: Create `internal/tui/moddetails.go`**
+
+```go
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// modDetailsContent is the mod details view (#86): a contextContent pushed
+// over Installed Mods or Search, rendering the same fields as `lmm mod show`
+// in the same order. Scrolls its whole body rather than truncating, since a
+// description can run long - the CLI's 2000-char cap exists only because a
+// one-shot terminal dump cannot scroll.
+type modDetailsContent struct {
+	details ModDetails
+	// offset is the first visible body line, mirroring infoOverlay.offset.
+	// Clamped on every key and again at render time.
+	offset int
+	// keys is the session's live KeyMap, not DefaultKeyMap(), so a custom
+	// remapping of Up/Down can never desync this view's scrolling from the
+	// rest of the TUI - the same reasoning behind overlay.go matching
+	// m.keys.Files instead of a literal "f" (Copilot PR #69 finding).
+	keys KeyMap
+}
+
+func newModDetailsContent(d ModDetails, keys KeyMap) *modDetailsContent {
+	return &modDetailsContent{details: d, keys: keys}
+}
+
+func (c *modDetailsContent) Title() string { return c.details.Name }
+
+// body builds every line before windowing, so scrolling and clamping operate
+// on one flat list. Field order and omit-when-empty rules mirror doModShow
+// (cmd/lmm/mod.go) exactly - that parity is the point of the feature.
+func (c *modDetailsContent) body() []string {
+	d := c.details
+	lines := []string{
+		fmt.Sprintf("ID: %s   Version: %s   Author: %s", d.ID, d.Version, d.Author),
+	}
+	if d.Category != "" {
+		lines = append(lines, "Category: "+d.Category)
+	}
+	if d.HasEndorsements {
+		lines = append(lines, fmt.Sprintf("Endorsements: %d", d.Endorsements))
+	}
+	if d.SourceURL != "" {
+		lines = append(lines, "URL: "+d.SourceURL)
+	}
+	if d.PictureURL != "" {
+		lines = append(lines, "Image: "+d.PictureURL)
+	}
+
+	if d.Summary != "" {
+		lines = append(lines, "", "Summary:")
+		lines = append(lines, strings.Split(strings.TrimSpace(d.Summary), "\n")...)
+	}
+
+	// Description has three states. An empty description with no fetch in
+	// flight and no error is simply absent upstream - omit the block, same as
+	// mod show, rather than showing an empty heading.
+	switch {
+	case d.Description != "":
+		lines = append(lines, "", "Description:")
+		lines = append(lines, strings.Split(strings.TrimSpace(d.Description), "\n")...)
+	case d.FetchErr != "":
+		lines = append(lines, "", "Description:", "(unavailable — "+d.FetchErr+")")
+	case d.Fetching:
+		lines = append(lines, "", "Description:", "(loading…)")
+	}
+
+	if d.Installed != nil {
+		lines = append(lines, "", fmt.Sprintf("Installed: v%s (profile: %s)",
+			d.Installed.Version, d.Installed.Profile))
+		lines = append(lines, "  Update policy: "+d.Installed.UpdatePolicy)
+		if d.Installed.Locked {
+			lock := "locked at v" + d.Installed.LockedVersion
+			// Only name the converge command when the lock's target actually
+			// differs from what's installed - identical condition to
+			// doModShow's (cmd/lmm/mod.go:734-736).
+			if d.Installed.LockedVersion != d.Installed.Version {
+				lock += " — run 'lmm profile apply' to converge"
+			}
+			lines = append(lines, "  Lock: "+lock)
+		} else {
+			lines = append(lines, "  Lock: none")
+		}
+		if d.Installed.ConvertPaks != nil {
+			state := "on"
+			if !*d.Installed.ConvertPaks {
+				state = "off"
+			}
+			lines = append(lines, "  Pak conversion: "+state)
+		}
+	}
+	return lines
+}
+
+// maxOffset is the largest first-visible-line index that still fills height.
+func (c *modDetailsContent) maxOffset(height int) int {
+	over := len(c.body()) - height
+	if over < 0 {
+		return 0
+	}
+	return over
+}
+
+func (c *modDetailsContent) Lines(width, height int) []string {
+	body := c.body()
+	if height < 1 {
+		height = 1
+	}
+	offset := min(max(c.offset, 0), c.maxOffset(height))
+	end := min(offset+height, len(body))
+	visible := append([]string(nil), body[offset:end]...)
+
+	// Scroll affordance, matching windowedRows' own indicator convention.
+	if more := len(body) - end; more > 0 {
+		visible = append(visible, fmt.Sprintf("↓ %d more", more))
+	}
+	return visible
+}
+
+// HandleKey consumes scrolling. Consuming up/down is MANDATORY, not a
+// nicety: a declined arrow would move the list selection on the screen
+// underneath, which the user cannot see (#86). Every other key is declined
+// so the host's swallow rule and esc-pop can act on it.
+func (c *modDetailsContent) HandleKey(msg tea.KeyMsg) (contextContent, tea.Cmd, bool) {
+	switch {
+	case key.Matches(msg, c.keys.Down):
+		c.offset++
+		return c, nil, true
+	case key.Matches(msg, c.keys.Up):
+		if c.offset > 0 {
+			c.offset--
+		}
+		return c, nil, true
+	}
+	return c, nil, false
+}
+
+func (c *modDetailsContent) HelpGroup() helpGroup {
+	return helpGroup{
+		name: "mod details",
+		entries: []string{
+			helpRow("↑/↓", "scroll"),
+			helpRow("esc", "back"),
+		},
+	}
+}
+```
+
+`c.keys.Up` binds `up`/`k` and `c.keys.Down` binds `down`/`j`
+(`internal/tui/keys.go:190-197`), so the `j`/`k` aliases the test asserts come
+for free. `KeyMap` is the struct at `keys.go:6`; `DefaultKeyMap()` at `:172`.
+
+- [ ] **Step 4: Run to verify the tests pass**
+
+Run: `go test ./internal/tui -run TestModDetailsContent -v`
+Expected: PASS ×8.
+
+- [ ] **Step 5: Full suite and commit**
+
+```bash
+go build ./... && go vet ./... && go test ./...
+go fmt ./...
+git add internal/tui/moddetails.go internal/tui/moddetails_test.go
+git commit -m "feat(tui): mod details content view with mod show field parity (#86)"
+```
+
+---
+
+### Task 7: Open on `enter`, fetch in the background
+
+**Files:**
+
+- Modify: `internal/tui/mutations.go` (handler, messages, resolvers)
+- Modify: `internal/tui/app.go` (`Select` case, message dispatch, help entry)
+- Modify: `internal/tui/mutations_test.go` or create `internal/tui/moddetails_open_test.go`
+
+**Interfaces:**
+
+- Consumes: `newModDetailsContent` (Task 6), `modDetailsFromItem` +
+  `GetModDetails` (Task 5), `pushContext` (Task 4), `m.selectedMod()`
+  (`mutations.go:33`).
+- Produces:
+
+  ```go
+  func (m Model) openSelectedModDetails() (Model, tea.Cmd)
+  type modDetailsFetchedMsg struct { gen int; details ModDetails }
+  type modDetailsFailedMsg  struct { gen int; err error }
+  func (m Model) resolveModDetailsFetched(msg modDetailsFetchedMsg) (Model, tea.Cmd)
+  func (m Model) resolveModDetailsFailed(msg modDetailsFailedMsg) (Model, tea.Cmd)
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/tui/moddetails_open_test.go`:
+
+```go
+package tui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenModDetails_PushesImmediatelyWithLocalData is the local-first
+// contract: the view must be on screen before the fetch resolves, seeded from
+// the row, so an offline user still sees what the list already knew.
+func TestOpenModDetails_PushesImmediatelyWithLocalData(t *testing.T) {
+	m := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+
+	m, cmd := m.openSelectedModDetails()
+
+	require.NotNil(t, m.contextContent, "the view must be pushed before the fetch resolves")
+	require.NotNil(t, cmd, "a fetch must be dispatched")
+	assert.Equal(t, ScreenInstalledMods, m.screen)
+	assert.True(t, m.action.running)
+	body := m.View()
+	item, _ := m.selectedMod()
+	assert.Contains(t, body, item.Name)
+}
+
+// TestOpenModDetails_EnterBindingOnBothScreens: enter is the binding, and it
+// works from Installed Mods and Search.
+func TestOpenModDetails_EnterBindingOnBothScreens(t *testing.T) {
+	for _, screen := range []Screen{ScreenInstalledMods, ScreenSearch} {
+		m := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+		m, _ = m.gotoScreen(screen)
+		if screen == ScreenSearch {
+			// Same idiom search_test.go uses to reach a populated results
+			// list (e.g. :685) - populatedSearchPage() at search_test.go:654.
+			m.search.page = populatedSearchPage()
+		}
+		m, _ = updateWithMsg(m, tea.KeyMsg{Type: tea.KeyEnter})
+		assert.NotNil(t, m.contextContent, "enter must open details on %v", screen)
+	}
+}
+
+// TestOpenModDetails_EnterStillOpensDashboardMenu: the existing meaning of
+// enter on the dashboard must not regress.
+func TestOpenModDetails_EnterStillOpensDashboardMenu(t *testing.T) {
+	m := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	m, _ = m.gotoScreen(ScreenDashboard)
+	m, _ = updateWithMsg(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Nil(t, m.contextContent, "enter on the dashboard opens a menu entry, not details")
+}
+
+// TestOpenModDetails_SingleFlight: a second open while one is in flight is
+// refused, matching every other async fetch.
+func TestOpenModDetails_SingleFlight(t *testing.T) {
+	m := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	m, _ = m.openSelectedModDetails()
+	gen := m.action.gen
+
+	m, cmd := m.openSelectedModDetails()
+	assert.Nil(t, cmd, "a second open must be refused while one is running")
+	assert.Equal(t, gen, m.action.gen)
+}
+
+// TestOpenModDetails_StaleResultDropped
+func TestOpenModDetails_StaleResultDropped(t *testing.T) {
+	m := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	m, _ = m.openSelectedModDetails()
+
+	stale := modDetailsFetchedMsg{gen: m.action.gen - 1, details: ModDetails{Description: "STALE"}}
+	m, _ = updateWithMsg(m, stale)
+
+	assert.NotContains(t, m.View(), "STALE")
+	assert.True(t, m.action.running, "a stale result must not clear the running flag")
+}
+
+// TestOpenModDetails_SuccessEnrichesInPlace
+func TestOpenModDetails_SuccessEnrichesInPlace(t *testing.T) {
+	m := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	m, _ = m.openSelectedModDetails()
+
+	enriched := ModDetails{Name: "Mod A", ID: "a", Version: "1.0", Author: "X",
+		Description: "ENRICHED DESCRIPTION"}
+	m, _ = updateWithMsg(m, modDetailsFetchedMsg{gen: m.action.gen, details: enriched})
+
+	assert.False(t, m.action.running)
+	assert.Contains(t, m.View(), "ENRICHED DESCRIPTION")
+}
+
+// TestOpenModDetails_FailureKeepsLocalView is the degradation contract: a
+// failed fetch must never close the view or discard what was already shown.
+func TestOpenModDetails_FailureKeepsLocalView(t *testing.T) {
+	m := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	item, _ := m.selectedMod()
+	m, _ = m.openSelectedModDetails()
+
+	m, _ = updateWithMsg(m, modDetailsFailedMsg{gen: m.action.gen, err: errors.New("source unreachable")})
+
+	require.NotNil(t, m.contextContent, "a failed fetch must not close the view")
+	view := m.View()
+	assert.Contains(t, view, item.Name, "local data must survive the failure")
+	assert.Contains(t, view, "unavailable")
+	assert.False(t, m.action.running)
+	assert.True(t, m.action.statusIsError)
+}
+
+// TestOpenModDetails_NoProviderNoOp
+func TestOpenModDetails_NoProviderNoOp(t *testing.T) {
+	m := sizedModelWithActions(t, nil, 100, 30)
+	m.provider = nil
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	m, cmd := m.openSelectedModDetails()
+	assert.Nil(t, cmd)
+	assert.Nil(t, m.contextContent)
+}
+
+// TestOpenModDetails_QuitDrainCancels: quitting mid-fetch drains cleanly.
+func TestOpenModDetails_QuitDrainCancels(t *testing.T) {
+	m := sizedModelWithActions(t, &recordingActions{}, 100, 30)
+	m, _ = m.gotoScreen(ScreenInstalledMods)
+	m, _ = m.openSelectedModDetails()
+	m.action.draining = true
+
+	_, cmd := updateWithMsg(m, modDetailsFetchedMsg{gen: m.action.gen, details: ModDetails{}})
+	assert.NotNil(t, cmd, "a drained quit must produce the quit command")
+}
+
+var _ = context.Background
+```
+
+`m.provider` is the `DataProvider` field (`internal/tui/app.go:81`);
+`sizedModelWithActions` leaves it as the prototype provider, which is what
+serves `GetModDetails` in these tests.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/tui -run TestOpenModDetails -v`
+Expected: FAIL — `undefined: openSelectedModDetails`.
+
+- [ ] **Step 3: Add the messages and handler to `mutations.go`**
+
+```go
+// modDetailsFetchedMsg/modDetailsFailedMsg carry the background enrichment of
+// an ALREADY-PUSHED details view (#86). Gen-tagged like every other async
+// fetch (see this file's checkUpdatesResultMsg template) so a result that
+// lands after the user moved on is discarded.
+type modDetailsFetchedMsg struct {
+	gen     int
+	details ModDetails
+}
+
+type modDetailsFailedMsg struct {
+	gen int
+	err error
+}
+
+// openSelectedModDetails pushes the details view for the selected mod and
+// kicks off the enrichment fetch. The view is pushed FIRST, seeded from the
+// row already on screen, so it renders on the very next frame - blocking on
+// the round trip would leave an offline user with nothing, when the list
+// already knew the name, version, and install state.
+func (m Model) openSelectedModDetails() (Model, tea.Cmd) {
+	if m.screen != ScreenInstalledMods && m.screen != ScreenSearch {
+		return m, nil
+	}
+	if m.provider == nil {
+		return m, nil
+	}
+	if m.action.running || m.action.pending != nil {
+		return m, nil
+	}
+	item, ok := m.selectedMod()
+	if !ok {
+		return m, nil
+	}
+
+	seed := modDetailsFromItem(item)
+	seed.Fetching = true
+	m.pushContext(newModDetailsContent(seed, m.keys))
+
+	if m.action.cancel != nil {
+		m.action.cancel()
+	}
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.action.cancel = cancel
+	m.action.gen++
+	gen := m.action.gen
+	m.action.running = true
+	m.action.status = fmt.Sprintf("Fetching details for %s…", item.Name)
+	m.action.statusIsError = false
+
+	provider := m.provider
+	return m, func() tea.Msg {
+		details, err := provider.GetModDetails(ctx, item)
+		if err != nil {
+			return modDetailsFailedMsg{gen: gen, err: err}
+		}
+		return modDetailsFetchedMsg{gen: gen, details: details}
+	}
+}
+
+// resolveModDetailsFetched swaps the enriched details into the pushed view,
+// preserving the user's scroll position - the fetch adding a description
+// should not yank them back to the top.
+func (m Model) resolveModDetailsFetched(msg modDetailsFetchedMsg) (Model, tea.Cmd) {
+	m.action.running = false
+	if m.action.cancel != nil {
+		m.action.cancel()
+		m.action.cancel = nil
+	}
+	if m.action.draining {
+		return m.resolveDrainedQuit()
+	}
+	m.action.status = ""
+	if c, ok := m.contextContent.(*modDetailsContent); ok {
+		details := msg.details
+		details.Fetching = false
+		details.FetchErr = ""
+		c.details = details
+	}
+	return m, nil
+}
+
+// resolveModDetailsFailed degrades in place: the view stays open on its local
+// data and names the reason where the description would have been.
+func (m Model) resolveModDetailsFailed(msg modDetailsFailedMsg) (Model, tea.Cmd) {
+	m.action.running = false
+	if m.action.cancel != nil {
+		m.action.cancel()
+		m.action.cancel = nil
+	}
+	if m.action.draining {
+		return m.resolveDrainedQuit()
+	}
+	m.action.status = msg.err.Error()
+	m.action.statusIsError = true
+	if c, ok := m.contextContent.(*modDetailsContent); ok {
+		c.details.Fetching = false
+		c.details.FetchErr = msg.err.Error()
+	}
+	return m, nil
+}
+```
+
+- [ ] **Step 4: Wire dispatch and the `enter` binding in `app.go`**
+
+In `Model.Update`'s message switch, beside the other gen-guarded cases:
+
+```go
+	case modDetailsFetchedMsg:
+		if msg.gen != m.action.gen {
+			return m, nil
+		}
+		return m.resolveModDetailsFetched(msg)
+	case modDetailsFailedMsg:
+		if msg.gen != m.action.gen {
+			return m, nil
+		}
+		return m.resolveModDetailsFailed(msg)
+```
+
+Extend the `Select` case (`:1079-1087`):
+
+```go
+	case key.Matches(msg, m.keys.Select):
+		// Select ("enter") is context-dependent: Profiles switches to the
+		// selected profile, Installed Mods and Search open the selected mod's
+		// details (#86), and everywhere else it opens a dashboard menu entry.
+		switch m.screen {
+		case ScreenProfiles:
+			return m.switchSelectedProfile()
+		case ScreenInstalledMods, ScreenSearch:
+			return m.openSelectedModDetails()
+		}
+		return m.openSelectedMenuEntry()
+```
+
+Add `helpEntry(m.keys.Select)` to the Installed Mods and Search help groups in
+`helpGroups()` if they do not already list it.
+
+- [ ] **Step 5: Run to verify the tests pass**
+
+Run: `go test ./internal/tui -run TestOpenModDetails -v`
+Expected: PASS ×9.
+
+- [ ] **Step 6: Full suite and commit**
+
+```bash
+go build ./... && go vet ./... && go test ./...
+go fmt ./...
+git add internal/tui/mutations.go internal/tui/app.go internal/tui/moddetails_open_test.go
+git commit -m "feat(tui): enter opens mod details, enriched in the background (#86)"
+```
+
+---
+
+### Task 8: Docs, stale-text sweep, and final verification
+
+**Files:**
+
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`, `cmd/lmm/tui.go` (`Long` help text) — as the sweep finds
+- Modify: `docs/plans/2026-08-07-tui-mod-details-design.md` (accepted deviation)
+
+- [ ] **Step 1: CHANGELOG**
+
+Under `[Unreleased]` → `### Added`:
+
+```markdown
+- TUI: a mod details view with full `lmm mod show` parity — `enter` on a mod
+  in Installed Mods or Search opens it, `esc` returns. Opens instantly from
+  data already on screen and fills in description, category, and links from
+  the source in the background, so it stays useful offline (#86).
+```
+
+- [ ] **Step 2: Stale-text sweep**
+
+This repo's TUI help text has gone stale in two consecutive phases. Run:
+
+```bash
+rg -n "not yet|read-only|aren't available|use 'lmm|no details|mod show" README.md docs/*.md cmd/lmm/tui.go internal/tui/*.go
+```
+
+Fix anything claiming the TUI cannot show mod details. Check `cmd/lmm/tui.go`'s
+`Long` string specifically — it is the file that went stale both times.
+
+- [ ] **Step 3: Record the accepted deviation in the design doc**
+
+Append to the design's "Ratified decisions" the profile-resolution ordering
+note from this plan's "Accepted deviation" section, so the design and the
+shipped behavior agree.
+
+- [ ] **Step 4: Full verification**
+
+```bash
+go build ./... && go vet ./... && go test ./... && trunk check
+```
+
+Expected: all green. Confirm the verify goldens are untouched:
+
+```bash
+git status --short cmd/lmm/testdata/verify_golden   # must print nothing
+```
+
+- [ ] **Step 5: Build the smoke binary**
+
+```bash
+go build -o lmm ./cmd/lmm
+```
+
+The user smoke-tests TUI work before merge — this is a hard gate, not a
+formality. Hand them `./lmm` with a checklist: open details from Installed
+Mods and from Search; confirm the nav bar does **not** jump; `esc` returns to
+the right screen; arrows scroll the description and do **not** move the list
+behind; a long description scrolls; an uninstalled search hit shows no
+Installed block; and (if reachable) an offline/failed fetch still shows local
+data.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CHANGELOG.md README.md cmd/lmm/tui.go
+git commit -m "docs: mod details view changelog and help-text sweep (#86)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** decision 1 (local-first) → Tasks 5–7; decision 2 (HTML
+  cleaning both interfaces) → Task 3 (CLI) + Task 5 Step 4 (TUI); decision 3
+  (generalized host) → Task 4. Core extraction → Task 2, guarded by Task 1.
+  All six success criteria have a task; criterion 5 (declined keys) is covered
+  twice, at the host (Task 4) and in the view (Task 6).
+- **Type consistency:** `ModDetails`/`InstalledDetails` (TUI) vs
+  `ModDetail`/`InstalledDetail` (core) are deliberately distinct types; every
+  task uses the singular form for core and the plural for the TUI.
+- **Deliberate omission:** #87's changelog and CurseForge screenshots are out
+  of scope per the design; no task references them.
+- **Hedges resolved during review.** The first draft left seven "if X differs,
+  do Y" branches — the exact failure mode this plan is meant to prevent. All
+  were checked against the source and replaced with the real answer. Two were
+  outright bugs:
+  - `string(detail.Installed.UpdatePolicy)` — `domain.UpdatePolicy` is an
+    `int`, so that compiles into a garbage rune conversion. Now
+    `policyToString` (`service_core.go:630`).
+  - `isQuitKey(msg, m)` — it is a **method**, `m.isQuitKey(msg)`
+    (`actions.go:619`).
+
+  The rest: `m.provider` is the field name (`app.go:81`); `screens`
+  (`navigation.go:26`) sizes `isScreenDigit`; no such helper existed, so Task 4
+  adds it; `KeyMap`/`DefaultKeyMap()` at `keys.go:6`/`:172` with `Up`/`Down`
+  already carrying the `k`/`j` aliases; `populatedSearchPage()` at
+  `search_test.go:654`; `activeMods()`/`data.SearchResults` are the prototype's
+  two mod lists.


### PR DESCRIPTION
Moves nine completed plan docs into `docs/plans/archive/` ahead of cutting v1.30.0, per the plan-doc lifecycle (archive at release).

- `2026-08-05-icarus-pak-to-exmod-spike-{design,findings,plan}.md` (#220)
- `2026-08-05-pak-to-exmod-feature-{design,plan}.md` (#221)
- `2026-08-06-tui-verify-surface-{design,plan}.md` (#224)
- `2026-08-07-tui-mod-details-{design,plan}.md` (#86)

All four bodies of work are merged and ship in v1.30.0. Once this lands, the three `docs/` branches holding them durable (`docs/86-mod-details`, `docs/tui-verify-surface`, `docs/pak-to-exmod-feature`) can be deleted.

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)