### PR TITLE
fix(tui): auto-open a warnings overlay when an outcome collapses to (N warnings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- TUI: a mutation that completes with two or more warnings now auto-opens a
+  scrollable overlay listing every warning in full, instead of collapsing
+  them to an unreadable `(N warnings)` status suffix — on merged-pak games
+  (Icarus) those warnings are the only report of cross-mod asset conflicts
+  anywhere in the app. The one-row `(N warnings)` summary stays on the
+  status line, and a single warning still renders inline with no overlay
+  (#253).
+
 ## [1.30.0] - 2026-08-08
 
 ### Added

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -653,7 +653,10 @@ func (m Model) clampSelections() {
 // status text (rule 4): the outcome's own Message, plus its single warning
 // appended after an em dash, or an "(N warnings)" count suffix when there is
 // more than one — chosen so the status line never grows past one line
-// regardless of how many warnings a flow reports.
+// regardless of how many warnings a flow reports. The collapsed text isn't
+// lost: app.go's actionDoneMsg handler auto-opens the warnings info overlay
+// at the same "> 1" threshold (#253), so the count suffix stays the one-row
+// summary and the overlay carries the full text.
 func formatOutcomeStatus(outcome ActionOutcome) string {
 	switch len(outcome.Warnings) {
 	case 0:

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -457,7 +457,19 @@ func (p *prototypeProvider) DeployProfile(_ context.Context) (ActionOutcome, err
 			deployed++
 		}
 	}
-	return ActionOutcome{Message: fmt.Sprintf("Deployed %d mod(s)", deployed)}, nil
+	// Canned merge-time diagnostics (#253), surfaced on every prototype
+	// deploy so --prototype demo mode actually exercises the multi-warning
+	// auto-open overlay path (actionDoneMsg, app.go) - the same rationale as
+	// prototypeAllSourcesWarning (service.go): without these, no prototype
+	// mutation ever crosses formatOutcomeStatus's "> 1" collapse threshold,
+	// leaving the overlay unreachable in the one mode meant to demo every UI
+	// state. Like that constant, the strings exist purely to exercise the
+	// rendering path; they name assets no canned mod actually bundles.
+	warnings := []string{
+		`asset "textures/armor/steel.dds" is bundled by both SkyUI and Ordinator - Ordinator wins (last-applied, per profile load order)`,
+		`asset "textures/armor/steel_n.dds" is bundled by both SkyUI and Ordinator - Ordinator wins (last-applied, per profile load order)`,
+	}
+	return ActionOutcome{Message: fmt.Sprintf("Deployed %d mod(s)", deployed), Warnings: warnings}, nil
 }
 
 // activeProfileName returns the canned Profiles entry currently marked

--- a/internal/tui/actions_provider_test.go
+++ b/internal/tui/actions_provider_test.go
@@ -129,6 +129,24 @@ func TestPrototypeProviderActions_DeployProfile_ReturnsPlausibleOutcome(t *testi
 	assert.NotEmpty(t, outcome.Message)
 }
 
+// TestPrototypeProviderActions_DeployProfile_CannedMultiWarningDemo guards
+// #253's demo-mode parity: the prototype deploy must return MORE than one
+// warning so --prototype actually exercises the multi-warning auto-open
+// overlay path (actionDoneMsg, app.go) - the same rationale as
+// prototypeAllSourcesWarning (service.go), without which no prototype
+// mutation would ever cross formatOutcomeStatus's collapse threshold and the
+// overlay would be unreachable in the one mode meant to demo every UI state.
+func TestPrototypeProviderActions_DeployProfile_CannedMultiWarningDemo(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	outcome, err := actions.DeployProfile(context.Background())
+	require.NoError(t, err)
+	assert.Greater(t, len(outcome.Warnings), 1,
+		"the prototype deploy must demo the multi-warning overlay threshold")
+}
+
 func TestPrototypeProviderActions_PlanProfileSwitch_ComputesFakeConsistentPlan(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -374,6 +374,34 @@ func TestActionDoneSingleWarningOutcomeOpensNoOverlay(t *testing.T) {
 	require.Equal(t, `Enabled "SkyUI" — link method fell back to copy`, m.action.status)
 }
 
+// TestActionDoneMultiWarningOutcomeReplacesStaleReadOnlyOverlay guards the
+// Copilot PR #258 finding: a read-only overlay CAN be open when an action
+// settles (promptOverlay deliberately doesn't gate on m.action.running - the
+// Files overlay is the reachable case), and a plain m.overlay == nil guard
+// would silently drop the warnings overlay there, leaving the outcome stuck
+// at the unreadable "(N warnings)" count - the exact information loss #253
+// exists to fix. The warnings overlay must replace a stale read-only overlay;
+// it defers ONLY to the update-results overlay the same handler just opened.
+func TestActionDoneMultiWarningOutcomeReplacesStaleReadOnlyOverlay(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 1
+	model.action.running = true
+	model.overlay = &infoOverlay{title: "Files — SkyUI", lines: []string{"Data/SkyUI.esp"}}
+
+	warnings := []string{"warn a", "warn b"}
+	updated, _ := model.Update(actionDoneMsg{gen: 1, kind: actionDeploy, outcome: ActionOutcome{
+		Message:  "Deployed 2 mod(s)",
+		Warnings: warnings,
+	}})
+	m := updated.(Model)
+
+	require.NotNil(t, m.overlay)
+	require.Equal(t, "warnings", m.overlay.title, "a stale read-only overlay must not swallow the warnings")
+	require.Equal(t, warnings, m.overlay.lines)
+}
+
 // TestActionDoneResultLinesKeepPriorityOverWarningsOverlay pins the overlay
 // priority when an outcome carries BOTH ResultLines and 2+ Warnings (today
 // only the apply-updates batch can): the pre-existing "update results"

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -295,6 +295,108 @@ func TestFormatOutcomeStatusWarningSuffix(t *testing.T) {
 		formatOutcomeStatus(ActionOutcome{Message: "Deployed 3 mod(s)", Warnings: []string{"a", "b"}}))
 }
 
+// --- #253: multi-warning outcomes auto-open the warnings overlay ---
+
+// TestActionDoneMultiWarningOutcomeOpensWarningsOverlay is #253's decided
+// behavior end-to-end: an outcome whose Warnings crossed formatOutcomeStatus's
+// collapse threshold (> 1, where the status line degrades to a bare
+// "(N warnings)" count) auto-opens the info overlay listing every warning in
+// full - on a merged-pak game those collapsed warnings are the ONLY report of
+// a cross-mod asset conflict anywhere in the app, so they must stay readable.
+// The status line keeps the one-row count summary (the overlay is additive,
+// mirroring the update-results overlay), and dismissing the overlay has no
+// side effects: the mutation completed before it appeared.
+func TestActionDoneMultiWarningOutcomeOpensWarningsOverlay(t *testing.T) {
+	t.Parallel()
+
+	warnings := []string{
+		`asset "C_PlayerBlueprintGrowth.uasset" bundled by two mods - last wins`,
+		`asset "C_PlayerBlueprintGrowth.uexp" bundled by two mods - last wins`,
+	}
+	calls := 0
+	model := sizedModelWithActions(t, &recordingActions{}, 80, 24)
+	model.screen = ScreenDashboard
+	model, pa := model.buildAction(actionDeploy, "Deploy?", nil, "", func(context.Context, func(ActionProgress)) (ActionOutcome, error) {
+		calls++
+		return ActionOutcome{Message: "Deployed 2 mod(s)", Warnings: warnings}, nil
+	})
+	model = model.promptAction(pa)
+
+	confirmed, confirmCmd := model.Update(keyRunes("y"))
+	model = confirmed.(Model)
+	doneMsg := runActionCmd(t, confirmCmd)
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+
+	updated, _ := model.Update(doneMsg)
+	model = updated.(Model)
+
+	require.NotNil(t, model.overlay, "a 2+-warning outcome must auto-open the warnings overlay")
+	require.Equal(t, "warnings", model.overlay.title)
+	require.Equal(t, warnings, model.overlay.lines, "every warning must be listed in full, in order")
+	require.Contains(t, model.action.status, "(2 warnings)", "the one-row count summary is kept, not replaced")
+	require.NotContains(t, model.action.status, "\n", "status must stay one line")
+
+	// The overlay renders at 80 columns within the content height budget.
+	view := model.overlayView()
+	require.Contains(t, view, "warnings")
+	for _, w := range warnings {
+		require.Contains(t, view, w)
+	}
+	require.LessOrEqual(t, lipgloss.Height(view), model.availableContentHeight(),
+		"overlay must never render taller than the content budget")
+
+	// Dismissal is side-effect free: the action already settled.
+	model = updateWithKeyType(t, model, tea.KeyEsc)
+	require.Nil(t, model.overlay)
+	require.Equal(t, 1, calls, "dismissing the overlay must not re-run the mutation")
+	require.False(t, model.action.running)
+	require.Contains(t, model.action.status, "(2 warnings)", "dismissal must leave the status summary alone")
+}
+
+// TestActionDoneSingleWarningOutcomeOpensNoOverlay is the other side of
+// #253's threshold: one warning still renders inline after the em dash
+// (fully readable, nothing unrecoverable), so no overlay opens - the guard
+// against throwing a modal at a lone benign note.
+func TestActionDoneSingleWarningOutcomeOpensNoOverlay(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 1
+	model.action.running = true
+
+	updated, _ := model.Update(actionDoneMsg{gen: 1, kind: actionEnable, outcome: ActionOutcome{
+		Message:  `Enabled "SkyUI"`,
+		Warnings: []string{"link method fell back to copy"},
+	}})
+	m := updated.(Model)
+
+	require.Nil(t, m.overlay, "a single-warning outcome renders inline and opens nothing")
+	require.Equal(t, `Enabled "SkyUI" — link method fell back to copy`, m.action.status)
+}
+
+// TestActionDoneResultLinesKeepPriorityOverWarningsOverlay pins the overlay
+// priority when an outcome carries BOTH ResultLines and 2+ Warnings (today
+// only the apply-updates batch can): the pre-existing "update results"
+// overlay wins, and the warnings overlay defers rather than clobbering the
+// batch's per-item record.
+func TestActionDoneResultLinesKeepPriorityOverWarningsOverlay(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 1
+	model.action.running = true
+
+	updated, _ := model.Update(actionDoneMsg{gen: 1, kind: actionUpdate, outcome: ActionOutcome{
+		Message:     "Applied 1 update(s)",
+		Warnings:    []string{"warn a", "warn b"},
+		ResultLines: []string{"✓ SkyUI 5.2 → 5.3", "✗ USSEP: boom"},
+	}})
+	m := updated.(Model)
+
+	require.NotNil(t, m.overlay)
+	require.Equal(t, "update results", m.overlay.title, "the batch's per-item record keeps priority")
+}
+
 // --- Rule 5: actionFailedMsg staleness + partial-mutation contract ---
 
 func TestFreshActionFailedMsgShowsErrorRefreshesAndKeepsScreen(t *testing.T) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -587,12 +587,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// a scrollable info overlay titled "update results" listing each
 		// mod's own "✓ .../✗ ..." line. Placed AFTER the status-line
 		// assignment (the count summary is kept, not replaced) and guarded
-		// on m.overlay == nil, defensively, exactly like resolveChangelogPicked
-		// guards against clobbering an existing overlay - the modal/overlay
-		// machinery is idle whenever an action resolves, by construction, so
-		// this should never actually refuse, but costs nothing to check.
-		// The quit-drain path above already returned before this point, so
-		// draining never reaches here either.
+		// on m.overlay == nil, exactly like resolveChangelogPicked guards
+		// against clobbering an existing overlay. The MODAL machinery
+		// (pending/picker/inputModal) is idle whenever an action resolves,
+		// by construction - but a read-only overlay CAN be up, since
+		// promptOverlay deliberately doesn't gate on m.action.running (the
+		// Files overlay is the reachable case, Copilot PR #258), so this
+		// guard can genuinely refuse, leaving the overlay the user is
+		// reading in place. That tradeoff is acceptable here and NOT for
+		// the warnings block below - see its comment for why the stakes
+		// differ. The quit-drain path above already returned before this
+		// point, so draining never reaches here either.
 		openedResultsOverlay := false
 		if len(msg.outcome.ResultLines) > 0 && m.overlay == nil {
 			m.overlay = &infoOverlay{title: "update results", lines: msg.outcome.ResultLines}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -596,6 +596,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(msg.outcome.ResultLines) > 0 && m.overlay == nil {
 			m.overlay = &infoOverlay{title: "update results", lines: msg.outcome.ResultLines}
 		}
+		// #253: a multi-warning outcome auto-opens the same overlay listing
+		// every warning in full. The threshold is deliberately the SAME "> 1"
+		// formatOutcomeStatus collapses at, so the overlay opens exactly when
+		// the status line has degraded to a bare "(N warnings)" count and the
+		// text would otherwise be unrecoverable - on a merged-pak game those
+		// warnings are the ONLY report of a cross-mod asset conflict anywhere
+		// in the app. A single warning still renders inline after the em dash
+		// and opens nothing: that is the guard against throwing a modal at a
+		// lone benign note (mergeDiagnostics folds Notes in alongside real
+		// warnings), so no benign/severe classification is needed. The
+		// m.overlay == nil guard doubles as priority: an update batch's
+		// ResultLines overlay (above) keeps its per-item record, and the
+		// warnings defer to it.
+		if len(msg.outcome.Warnings) > 1 && m.overlay == nil {
+			m.overlay = &infoOverlay{title: "warnings", lines: msg.outcome.Warnings}
+		}
 		// A fresh switch's target must rebind the session's active-profile
 		// providers BEFORE the refresh below reads them (see rebindProfile
 		// and profileRebinder in actions.go) - otherwise Profiles() keeps

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -593,8 +593,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// this should never actually refuse, but costs nothing to check.
 		// The quit-drain path above already returned before this point, so
 		// draining never reaches here either.
+		openedResultsOverlay := false
 		if len(msg.outcome.ResultLines) > 0 && m.overlay == nil {
 			m.overlay = &infoOverlay{title: "update results", lines: msg.outcome.ResultLines}
+			openedResultsOverlay = true
 		}
 		// #253: a multi-warning outcome auto-opens the same overlay listing
 		// every warning in full. The threshold is deliberately the SAME "> 1"
@@ -606,10 +608,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// and opens nothing: that is the guard against throwing a modal at a
 		// lone benign note (mergeDiagnostics folds Notes in alongside real
 		// warnings), so no benign/severe classification is needed. The
-		// m.overlay == nil guard doubles as priority: an update batch's
-		// ResultLines overlay (above) keeps its per-item record, and the
-		// warnings defer to it.
-		if len(msg.outcome.Warnings) > 1 && m.overlay == nil {
+		// warnings defer ONLY to the ResultLines overlay this same handler
+		// just opened (the update batch's per-item record keeps priority) -
+		// NOT to any overlay that happens to be up: a read-only overlay CAN
+		// be open when an action settles (promptOverlay deliberately doesn't
+		// gate on m.action.running - the Files overlay is the reachable
+		// case), and deferring to it would silently re-lose the warnings
+		// (Copilot PR #258 finding), so a stale overlay is replaced instead.
+		if len(msg.outcome.Warnings) > 1 && !openedResultsOverlay {
 			m.overlay = &infoOverlay{title: "warnings", lines: msg.outcome.Warnings}
 		}
 		// A fresh switch's target must rebind the session's active-profile


### PR DESCRIPTION
Fixes #253

## What

`formatOutcomeStatus` collapses a multi-warning `ActionOutcome` to `Message (N warnings)` with no way to read the warning text. On merged-pak games (Icarus) those merge-time warnings are the **only** report of cross-mod asset conflicts anywhere in the app (`GetProfileConflicts` compares deployable cache manifests, and the colliding assets live inside the archives), so the collapsed text was a real information loss, not cosmetic.

Per the settled design in #253:

- `app.go`'s `actionDoneMsg` handler now **auto-opens** the existing info overlay (the same machinery as the update-results / fix-results overlays) listing every warning in full, whenever `len(outcome.Warnings) > 1`.
- The threshold is deliberately the **same `> 1`** the status-line collapse already uses: the overlay opens exactly when the text would otherwise be unrecoverable. A single warning still renders inline after the em dash and opens nothing — the guard against throwing a modal at a lone benign note. No benign/severe classification.
- The `(N warnings)` one-row status suffix is kept as the summary; the overlay is additive.
- Applies to every `buildAction`-routed mutation, since the fix sits in the shared `actionDoneMsg` handler.
- An update batch's `ResultLines` ("update results") overlay keeps priority via the existing `m.overlay == nil` guard — pinned by a dedicated test.
- Prototype parity: the prototype `DeployProfile` now returns two canned asset-conflict warnings so `--prototype` demo mode exercises the new path (same rationale as `prototypeAllSourcesWarning`).

## Tests (written first, shown failing)

- `TestActionDoneMultiWarningOutcomeOpensWarningsOverlay` — full confirm→done path at 80×24: a 2-warning deploy opens the overlay with every warning verbatim, status keeps the one-row `(2 warnings)` summary, the overlay respects the content-height budget, and `esc` dismisses with no side effects (the mutation ran exactly once). **Failed before the fix** (`Expected value not to be nil … a 2+-warning outcome must auto-open the warnings overlay`).
- `TestActionDoneSingleWarningOutcomeOpensNoOverlay` — 1 warning renders inline, no overlay.
- `TestActionDoneResultLinesKeepPriorityOverWarningsOverlay` — both present → "update results" wins.
- `TestPrototypeProviderActions_DeployProfile_CannedMultiWarningDemo` — **failed before** (`"0" is not greater than "1"`), pins the demo-mode parity.

## Verification

`go build ./...` ✓ · `go vet ./...` ✓ · `gofmt -l .` empty ✓ · `go test ./...` exit 0, all 18 packages ok ✓

## Not included

- The manual TUI smoke test (merge gate) — pending, coordinator/user step.
- No version bump (story PR); CHANGELOG entry added under `[Unreleased]`.
- Residual, deliberately out of scope: an update **batch** whose successful items emit ≥2 warnings still shows only the "update results" overlay (✓/✗ per-item lines), so those warnings remain unreadable there. Follow-up issue to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)