### PR TITLE
fix(cache): keep a converted pak's raw-fallback copy through prune; heal pruned entries (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Icarus: cache pruning no longer deletes a converted pak's deployable
+  copy when a sibling file of the same mod+version is downloaded or
+  re-ingested (#250). The copy is unclaimed by design while the merged
+  pak carries the mod's content, but it is still the designated
+  raw-fallback artifact — pruning it left a later conversion opt-out or
+  merge failure deploying nothing, silently. Pruning now exempts any
+  unclaimed file whose content matches a retained source, and the raw
+  fallback additionally self-heals entries already damaged by released
+  versions: the deployable copy is restored from the retained source
+  (under its original archive name for imports, or a `<mod-id>_P.pak`
+  name for catalog downloads, where the original name is unrecoverable)
+  and redeployed.
+
 ## [1.30.0] - 2026-08-08
 
 ### Added

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -485,6 +485,22 @@ func (s *Service) reconcilePakManifests(ctx context.Context, game *domain.Game, 
 				if aerr != nil {
 					return warnings, aerr
 				}
+				if len(members) == 0 {
+					// #250 heal: no cache member matches the retained
+					// source - the deployable copy was pruned while this pak
+					// was converted (members=nil made it unclaimed, and
+					// released PruneUnclaimed versions deleted it on any
+					// sibling-file re-ingest). The retained source still
+					// holds the exact bytes, so restore the copy and claim
+					// it. Without this, the mark below would record an EMPTY
+					// member set and Install would deploy nothing, silently
+					// - the raw fallback's whole purpose defeated.
+					restoredName, herr := restoreRawPakCopy(versionDir, retained, fileID, mod.ID)
+					if herr != nil {
+						return warnings, fmt.Errorf("restoring pruned raw pak for %s: %w", ref, herr)
+					}
+					members = []string{restoredName}
+				}
 				// #221 partial-failure fix: a manifest-shape match alone
 				// (recorded + matching member set) does not prove the raw
 				// pak is ACTUALLY deployed - the mark below must be written
@@ -580,6 +596,48 @@ func rawPakMembers(versionDir, retainedPath string, candidates []string) ([]stri
 		}
 	}
 	return members, nil
+}
+
+// rawPakRestoreName picks the on-disk name restoreRawPakCopy publishes a
+// healed deployable pak copy under (#250). An import-path fileID IS the
+// original archive filename (Importer.Import stages the deployable copy
+// under exactly that name), so the restore is name-exact. A download-path
+// fileID (the literal icarus "pak") never carried the deployable name: it
+// came from the download URL's basename at ingest time, the convert flip
+// erased the manifest that recorded it, and nothing else durably stores it
+// - so a deterministic mod-scoped name in Icarus's "_P.pak" override
+// convention (the old compiledFileName convention) is synthesized instead.
+// Both inputs are source-controlled, so both are Base'd before use as a
+// path component.
+func rawPakRestoreName(fileID, modID string) string {
+	base := filepath.Base(fileID)
+	if strings.EqualFold(filepath.Ext(base), ".pak") {
+		return base
+	}
+	return filepath.Base(modID) + "_P.pak"
+}
+
+// restoreRawPakCopy re-creates fileID's deployable pak copy in versionDir
+// from its retained source at retainedPath and returns the restored name
+// (#250) - the heal for a cache entry a released PruneUnclaimed damaged
+// (deployable copy missing, retained source present, manifest still in the
+// post-convert members=nil state). It refuses to overwrite an existing
+// file at the target name: such a file necessarily holds DIFFERENT content
+// (rawPakMembers just matched nothing), and it could be a sibling fileID's
+// claimed member - failing loudly beats corrupting it, and the next
+// reconcile pass retries.
+func restoreRawPakCopy(versionDir, retainedPath, fileID, modID string) (string, error) {
+	name := rawPakRestoreName(fileID, modID)
+	target := filepath.Join(versionDir, name)
+	if _, err := os.Stat(target); err == nil {
+		return "", fmt.Errorf("restore target %s already exists with content not matching the retained source; refusing to overwrite", name)
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("checking restore target %s: %w", name, err)
+	}
+	if err := copyFileStreaming(retainedPath, target); err != nil {
+		return "", fmt.Errorf("restoring deployable copy %s: %w", name, err)
+	}
+	return name, nil
 }
 
 // sameMemberSet reports whether a and b claim the same members, ignoring

--- a/internal/core/merged_pak_test.go
+++ b/internal/core/merged_pak_test.go
@@ -445,3 +445,137 @@ func TestReconcilePakManifests_RawFallbackPath_InstallFailureRetries(t *testing.
 	_, statErr = os.Stat(deployedPath)
 	require.NoError(t, statErr, "the retry must actually deploy the raw pak")
 }
+
+// TestReconcilePakManifests_RawFallback_RestoresPrunedDeployableCopy proves
+// the #250 heal: a cache entry damaged by a released version's prune - the
+// deployable pak copy missing, the retained source still present, the
+// manifest in the post-convert members=nil state - must be RESTORED by the
+// raw-fallback branch, not silently marked empty. Pre-fix, rawPakMembers
+// found no member to claim, reconcile recorded an empty member set, and
+// Install deployed nothing - silently, forever.
+//
+// The restored copy's name depends on the fileID's origin: an import-path
+// fileID IS the original archive filename (ingest names the deployable copy
+// identically), so it restores byte- and name-exact; a download-path fileID
+// (the literal icarus "pak") never carried the original name - the manifest
+// flip erased it and nothing else records it - so a deterministic mod-scoped
+// name in Icarus's "_P.pak" override convention is synthesized.
+func TestReconcilePakManifests_RawFallback_RestoresPrunedDeployableCopy(t *testing.T) {
+	cases := []struct {
+		name         string
+		fileID       string
+		restoredName string
+	}{
+		{"download-shape fileID synthesizes a mod-scoped name", "pak", "dmgmod_P.pak"},
+		{"import-shape fileID restores its own archive name", "DamagedMod.pak", "DamagedMod.pak"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, game, _ := newMergedPakTestGame(t)
+			// game.ConvertPaks stays false: the pak takes the raw-fallback
+			// branch (the issue's "user opts out of conversion" leg).
+			const (
+				sourceID = "fake-compiler"
+				modID    = "dmgmod"
+				version  = "1.0"
+			)
+			pakBytes := []byte("prebuilt-pak-bytes")
+
+			gameCache := svc.GetGameCache(game)
+			require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, cache.RetainedSourceName(tc.fileID), pakBytes))
+			versionDir := gameCache.ModPath(game.ID, sourceID, modID, version)
+			// The #250 damaged shape: converted manifest, no deployable copy.
+			require.NoError(t, cache.MarkFileCompleteWithMembers(versionDir, tc.fileID, nil))
+
+			require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+				Mod:          domain.Mod{ID: modID, SourceID: sourceID, Name: modID, Version: version, GameID: game.ID},
+				ProfileName:  "default",
+				Enabled:      true,
+				FileIDs:      []string{tc.fileID},
+				UpdatePolicy: domain.UpdateNotify,
+			}))
+			pm := svc.NewProfileManager()
+			require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: sourceID, ModID: modID, Version: version, FileIDs: []string{tc.fileID}}))
+
+			inst := core.NewInstaller(gameCache, linker.New(game.LinkMethod), nil)
+			_, err := svc.ReconcilePakManifestsForTest(context.Background(), game, "default", inst, nil)
+			require.NoError(t, err)
+
+			manifests, err := gameCache.FileManifests(game.ID, sourceID, modID, version)
+			require.NoError(t, err)
+			require.Equal(t, []string{tc.restoredName}, manifests[tc.fileID].Members,
+				"the healed manifest must claim the restored copy, never an empty member set (#250)")
+
+			restored, err := os.ReadFile(filepath.Join(versionDir, tc.restoredName))
+			require.NoError(t, err, "the deployable copy must be restored into the cache entry from the retained source")
+			require.Equal(t, pakBytes, restored)
+
+			deployed, err := os.ReadFile(filepath.Join(game.ModPath, tc.restoredName))
+			require.NoError(t, err, "the restored raw pak must actually deploy - the silent-empty deploy is the bug")
+			require.Equal(t, pakBytes, deployed)
+
+			// A second pass must converge as a no-op, not loop re-restoring.
+			_, err = svc.ReconcilePakManifestsForTest(context.Background(), game, "default", inst, nil)
+			require.NoError(t, err)
+			manifests, err = gameCache.FileManifests(game.ID, sourceID, modID, version)
+			require.NoError(t, err)
+			require.Equal(t, []string{tc.restoredName}, manifests[tc.fileID].Members, "the second pass must keep the healed claim stable")
+		})
+	}
+}
+
+// TestSyncMergedPak_OptOutAfterPrunedConvertedPak_RestoresRawDeploy is the
+// #250 heal driven through the full SyncMergedPak flow, matching the issue's
+// repro step 3 exactly: the user opts out of conversion game-wide AFTER a
+// released prune already deleted the converted pak's deployable copy. The
+// damaged state is seeded realistically: the merge DID happen once (that is
+// the only way the manifest flipped to members=nil), so the merged-pak
+// cache entry exists and its artifact is deployed. Zero merge sources
+// remain after the opt-out, so syncMergedPak takes its uninstall-to-zero
+// branch and reconciles - which must restore the raw deploy from the
+// retained source instead of deploying nothing. (An ABSENT merged entry in
+// this state trips the pre-existing, unrelated #260 instead.)
+func TestSyncMergedPak_OptOutAfterPrunedConvertedPak_RestoresRawDeploy(t *testing.T) {
+	svc, game, _ := newMergedPakTestGame(t)
+	// game.ConvertPaks stays false: opted out game-wide.
+
+	const (
+		sourceID = "fake-compiler"
+		modID    = "optout"
+		version  = "1.0"
+	)
+	pakBytes := []byte("prebuilt-pak-bytes")
+
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, cache.RetainedSourceName("pak"), pakBytes))
+	versionDir := gameCache.ModPath(game.ID, sourceID, modID, version)
+	require.NoError(t, cache.MarkFileCompleteWithMembers(versionDir, "pak", nil))
+
+	// The prior successful merge's leftovers: a merged-pak cache entry and
+	// its deployed artifact (a symlink into the cache - the profile's
+	// effective link method here, matching what Install actually leaves).
+	require.NoError(t, gameCache.Store(game.ID, domain.SourceMerged, "merged-pak", "merged", "zzz_LMM_Merged_P.pak", []byte("merged-bytes")))
+	mergedDeployedPath := filepath.Join(game.ModPath, "zzz_LMM_Merged_P.pak")
+	require.NoError(t, os.Symlink(gameCache.GetFilePath(game.ID, domain.SourceMerged, "merged-pak", "merged", "zzz_LMM_Merged_P.pak"), mergedDeployedPath))
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: sourceID, Name: modID, Version: version, GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		FileIDs:      []string{"pak"},
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: sourceID, ModID: modID, Version: version, FileIDs: []string{"pak"}}))
+
+	warnings, err := svc.SyncMergedPak(context.Background(), game, "default")
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+
+	deployed, err := os.ReadFile(filepath.Join(game.ModPath, "optout_P.pak"))
+	require.NoError(t, err, "opting out after the prune must restore and deploy the raw pak (#250), not silently deploy nothing")
+	require.Equal(t, pakBytes, deployed)
+
+	_, err = os.Stat(mergedDeployedPath)
+	require.True(t, os.IsNotExist(err), "the opt-out must still remove the deployed merged pak (uninstall-to-zero)")
+}

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -787,6 +787,69 @@ func TestService_DownloadMod_OrganicPrune_PreConvergencePakClaimedThenExmodzReta
 	require.True(t, os.IsNotExist(err), "the unclaimed compiled pak must actually be gone from disk")
 }
 
+// TestService_DownloadMod_SiblingReingestKeepsConvertedPakCopy reproduces
+// #250: a converted pak's manifest is deliberately members=nil (the merged
+// pak claims its content - reconcilePakManifests' participating branch), so
+// its deployable cache copy is unclaimed by every recorded manifest. A later
+// ingest of a SIBLING file ID into the same version directory opens
+// PruneUnclaimed's gate (staging is seeded from the existing entry, every
+// marker reads Recorded, retained sources are present) - and pre-fix, the
+// converted pak's copy was deleted as if it were stale pre-#197 content.
+// It is not stale: it is the designated raw-fallback artifact, and pruning
+// it left a later opt-out or failed merge deploying nothing, silently.
+func TestService_DownloadMod_SiblingReingestKeepsConvertedPakCopy(t *testing.T) {
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	mock := &compilerMockSource{mockSourceWithDownloads: newMockSourceWithDownloads("test-compiler")}
+	defer mock.Close()
+	svc.RegisterSource(mock)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), DeployMode: domain.DeployCompile, ConvertPaks: true}
+	require.NoError(t, svc.AddGame(game))
+	mod := &domain.Mod{ID: "123", SourceID: "test-compiler", Name: "Mod", Version: "1.0.0", GameID: "testgame"}
+
+	gameCache := svc.GetGameCache(game)
+	dir := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
+
+	// Generation 1: the pak variant ingests via the validate+retain branch -
+	// a retained source plus a claimed deployable copy (#221's raw-deploy
+	// default state).
+	mock.AddDownload("pak", []byte("prebuilt-pak-bytes"))
+	_, err = svc.DownloadMod(context.Background(), "test-compiler", game, mod, &domain.DownloadableFile{ID: "pak", FileName: "Mod_P.pak"}, nil)
+	require.NoError(t, err)
+
+	manifests, err := gameCache.FileManifests(game.ID, mod.SourceID, mod.ID, mod.Version)
+	require.NoError(t, err)
+	require.Equal(t, []string{"Mod_P.pak"}, manifests["pak"].Members, "precondition: ingest claims the deployable pak copy")
+
+	// The first successful merge flips the pak's manifest to members=nil -
+	// the merged pak claims its content (reconcilePakManifests'
+	// participating branch). The copy is now unclaimed but NOT stale.
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "pak", nil))
+
+	// Generation 2: a sibling file ID of the same mod+version is ingested
+	// afterward (the issue's repro: an optional patch file, a verify --fix
+	// re-download, ...). This commit runs PruneUnclaimed with its gate open.
+	mock.AddDownload("exmodz", []byte("fake-exmodz-bytes"))
+	_, err = svc.DownloadMod(context.Background(), "test-compiler", game, mod, &domain.DownloadableFile{ID: "exmodz", FileName: "Mod.exmodz"}, nil)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "Mod_P.pak"))
+	require.NoError(t, err, "the converted pak's deployable copy is the designated raw-fallback artifact (#250) and must survive a sibling ingest's prune")
+	assert.Equal(t, "prebuilt-pak-bytes", string(data))
+
+	_, err = os.Stat(filepath.Join(dir, cache.RetainedSourceName("pak")))
+	require.NoError(t, err, "the pak's retained source must survive as before")
+	_, err = os.Stat(filepath.Join(dir, cache.RetainedSourceName("exmodz")))
+	require.NoError(t, err, "the sibling's retained source must survive as before")
+}
+
 // TestService_DownloadMod_ForgedCacheMarkerInArchiveIsRejected is the
 // integration-level guard for the #96 round 2 review finding, reproducing its
 // probe exactly: an archive downloaded for file1 that smuggles in a member

--- a/internal/storage/cache/cache.go
+++ b/internal/storage/cache/cache.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/fs"
@@ -323,6 +325,19 @@ func HasRetainedSource(versionDir string) (bool, error) {
 // versionDir makes the whole call a no-op. Reserved (ReservedPrefix) entries
 // are never candidates. Callers invoke it on a STAGING directory at commit
 // time, so a prune can never race a deploy.
+//
+// An unclaimed file whose content matches a retained source is EXEMPT
+// (#250): "unclaimed" has two distinct causes prune must tell apart.
+// Stale/superseded content - #210's actual target - matches no retained
+// source. A converted pak's deployable copy, by contrast, is unclaimed only
+// because a successful merge suppressed it (its manifest reads members=nil;
+// the merged pak claims its content), yet it remains the designated
+// raw-fallback artifact an opt-out or failed merge must be able to
+// redeploy. Content identity with the retained source is the one signal
+// that separates the two: ingest stages the deployable copy from the SAME
+// bytes as the retained source, and the convert flip erases the manifest
+// that once recorded the mapping (see internal/core's rawPakMembers, which
+// relies on the same attribution to find the way back to raw).
 func PruneUnclaimed(versionDir string) error {
 	manifests, err := fileManifestsAt(versionDir)
 	if err != nil {
@@ -346,11 +361,11 @@ func PruneUnclaimed(versionDir string) error {
 			claimed[member] = true
 		}
 	}
-	hasRetained, err := HasRetainedSource(versionDir)
+	retained, err := retainedSourceRefs(versionDir)
 	if err != nil {
 		return fmt.Errorf("checking retained source for prune: %w", err)
 	}
-	if !hasRetained {
+	if len(retained) == 0 {
 		return nil
 	}
 	files, err := walkEntries(versionDir, false) // same walker ListFiles uses
@@ -361,12 +376,104 @@ func PruneUnclaimed(versionDir string) error {
 		if claimed[f] {
 			continue
 		}
+		suppressed, err := matchesRetainedSource(filepath.Join(versionDir, f), retained)
+		if err != nil {
+			return fmt.Errorf("matching %s against retained sources for prune: %w", f, err)
+		}
+		if suppressed {
+			continue // a converted pak's raw-fallback copy, not stale debris (#250)
+		}
 		if err := os.Remove(filepath.Join(versionDir, f)); err != nil {
 			return fmt.Errorf("pruning unclaimed %s: %w", f, err)
 		}
 	}
 	removeEmptyDirs(versionDir)
 	return nil
+}
+
+// retainedSourceRef tracks one retained compile source during a prune pass:
+// full path, size, and its MD5, computed lazily (at most once, and only if
+// some unclaimed candidate's size matches - the common all-claimed entry
+// never hashes anything).
+type retainedSourceRef struct {
+	path string
+	size int64
+	sum  string
+}
+
+// retainedSourceRefs lists versionDir's retained compile sources (every
+// entry named by RetainedSourceName, for any fileID) with their sizes -
+// PruneUnclaimed's gate (#210: at least one must exist) and its #250
+// content-identity exemption both read from this. A missing versionDir is
+// not an error - it reports empty, same as an entry with none.
+func retainedSourceRefs(versionDir string) ([]retainedSourceRef, error) {
+	entries, err := os.ReadDir(versionDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var refs []retainedSourceRef
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), retainedSourcePrefix) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		refs = append(refs, retainedSourceRef{path: filepath.Join(versionDir, entry.Name()), size: info.Size()})
+	}
+	return refs, nil
+}
+
+// matchesRetainedSource reports whether the file at fullPath is
+// byte-identical to one of the entry's retained sources: size compared
+// first, MD5 only on a size match, each side hashed at most once. The MD5
+// (not a cryptographic guarantee - fine for self-owned cache bookkeeping)
+// mirrors internal/core's md5File attribution convention (#241).
+func matchesRetainedSource(fullPath string, retained []retainedSourceRef) (bool, error) {
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return false, err
+	}
+	var fileSum string
+	for i := range retained {
+		if info.Size() != retained[i].size {
+			continue
+		}
+		if retained[i].sum == "" {
+			if retained[i].sum, err = md5File(retained[i].path); err != nil {
+				return false, err
+			}
+		}
+		if fileSum == "" {
+			if fileSum, err = md5File(fullPath); err != nil {
+				return false, err
+			}
+		}
+		if fileSum == retained[i].sum {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// md5File returns the hex MD5 of path's content. Duplicates internal/core's
+// helper of the same name (core depends on this package, so importing it
+// back would cycle); used only for prune's content-identity check above.
+func md5File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close() //nolint:errcheck
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // removeEmptyDirs removes every empty subdirectory under versionDir

--- a/internal/storage/cache/cache_test.go
+++ b/internal/storage/cache/cache_test.go
@@ -633,3 +633,36 @@ func TestPruneUnclaimed_NeverTouchesReservedEntries(t *testing.T) {
 	_, err := os.Stat(filepath.Join(dir, cache.RetainedSourceName("exmodz")))
 	require.NoError(t, err, "reserved entries are never pruned")
 }
+
+// TestPruneUnclaimed_KeepsUnclaimedFileMatchingRetainedSource proves the
+// #250 fix: an unclaimed file whose content matches a retained source is
+// NOT stale debris - it is the retained source's own deployable copy,
+// currently suppressed because the merged pak claims its content
+// (members=nil), and it is still the designated raw-fallback artifact.
+// Pruning it left an opt-out/failed-merge fallback with nothing to deploy.
+// Content identity (not name, not size alone) is the test: the genuinely
+// stale file below has the SAME size as the retained pak source but
+// different bytes, and must still be pruned.
+func TestPruneUnclaimed_KeepsUnclaimedFileMatchingRetainedSource(t *testing.T) {
+	c := cache.New(t.TempDir())
+	pakBytes := []byte("prebuilt-pak-bytes")
+	staleBytes := []byte("stale-pak-bytes123") // same length as pakBytes, different content
+	require.Len(t, staleBytes, len(pakBytes), "fixture invariant: size alone must not distinguish the two")
+
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "SuperMod_P.pak", pakBytes)) // suppressed raw-fallback copy, unclaimed
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "stale.pak", staleBytes))    // genuine debris, unclaimed
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "claimed.txt", []byte("sibling-content")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("pak")), pakBytes, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("exmodz")), []byte("exmodz-zip"), 0o644))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "pak", nil)) // converted: the merged pak claims its content
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "sibling", []string{"claimed.txt"}))
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	files, err := c.ListFiles("g", "s", "m", "1.0")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"SuperMod_P.pak", "claimed.txt"}, files,
+		"the converted pak's deployable copy matches its retained source and must survive (#250); the same-size stale file must still be pruned")
+}


### PR DESCRIPTION
Fixes #250.

## The bug

`cache.PruneUnclaimed` conflated two causes of "unclaimed": stale/superseded content — #210's actual target — and a converted pak's deployable copy, which is unclaimed only because the merged pak claims its content (`members=nil`, `reconcilePakManifests`' participating branch) while it remains the designated raw-fallback artifact. Any sibling-file ingest into the same version directory opened the prune gate (`commitStagedCacheWithMarker` → `PruneUnclaimed(stagePath)`; staging is seeded from the existing entry, so every marker reads `Recorded` and the retained source is present) and deleted the copy. If the user later opted out of conversion, or the next merge failed for that mod, the raw-fallback branch found no member to claim, recorded an **empty** member set, and deployed nothing — silently, with the exact bytes still sitting in `.lmm-source-<fileID>`.

## The fix — both directions from the issue

**Prevent** (`internal/storage/cache`): `PruneUnclaimed` now exempts any unclaimed file whose content matches a retained source (size compared first, MD5 only on a size match, each side hashed at most once). This is the same content-identity attribution `rawPakMembers` uses (#241) — the one identity that survives the convert flip erasing the ingest-time manifest. Genuinely stale files (including same-size/different-bytes ones) are still pruned; #210's behavior is otherwise unchanged.

**Heal** (`internal/core`): the raw-fallback branch of `reconcilePakManifests` restores the deployable copy from the fileID's retained source when no cache member matches it, then claims and deploys it — so entries **already damaged by released versions** converge on the next sync instead of staying silently broken forever. Restore naming:

- import-path fileIDs restore name-exact (the fileID *is* the archive filename, and ingest names the deployable copy identically);
- download-path fileIDs (the literal icarus `"pak"`) get a deterministic `<mod-id>_P.pak` name — the original URL-derived name is durably recorded nowhere (the convert flip erased the manifest that carried it, and the DB stores only fileIDs), which I verified across domain/DB/fingerprint before settling on synthesis.

The restore refuses to overwrite an existing same-named file (it necessarily holds different content and could be a sibling's claimed member) — failing loudly beats corrupting it, and the next reconcile pass retries.

## Tests (written first, run failing before any implementation)

- `TestPruneUnclaimed_KeepsUnclaimedFileMatchingRetainedSource` — unit-level prevent: the suppressed copy survives, a same-size/different-content stale file is still pruned (content, not size, decides).
- `TestService_DownloadMod_SiblingReingestKeepsConvertedPakCopy` — the issue's repro shape end-to-end through `DownloadMod`: pak ingest → convert flip → sibling exmodz ingest → copy survives.
- `TestReconcilePakManifests_RawFallback_RestoresPrunedDeployableCopy` — table-driven heal over both fileID shapes, asserting manifest claim, restored cache bytes, actual deploy, and second-pass convergence.
- `TestSyncMergedPak_OptOutAfterPrunedConvertedPak_RestoresRawDeploy` — the already-damaged case through the full `SyncMergedPak` opt-out flow (merged entry seeded present, as in any real damaged state).

## Adjacent bug found and filed, not fixed here

Writing the sync-level test surfaced a pre-existing, unrelated bug: `syncMergedPak`'s uninstall-to-zero branch hard-errors whenever the merged-pak cache entry is absent — which is the steady state after its own first zero-sources pass deletes the entry. Filed as #260 (in the zero branch since #197/v1.28.0; reproduced with a one-line probe). It interacts with #250's opt-out leg (sync 1 heals fine; later syncs on a fully opted-out profile error loudly) but is a separate defect with its own fix-direction trade-offs, so it stays out of this PR.

## Verification

`go build ./... && go vet ./... && gofmt -l . && go test ./...` — all green, `gofmt -l` empty, `trunk check` on changed files: no new issues. CHANGELOG entry added under `[Unreleased]`; no version bump per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
