### PR TITLE
fix(deploy): label merged/raw mods and name the merged artifact in deploy output (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Deploy output on a compile-mode game (Icarus) no longer presents merged
+  mods as individual deployments (#255). The header drops the misleading
+  `using <method>` claim, each mod's `✓` line is labeled by how its content
+  actually reaches the game directory — `(merged)` for merge participants,
+  `(raw)` for a conversion-opted-out pak, unlabeled for ordinary loose-file
+  mods — and a post-sync footer finally names the one artifact that really
+  deployed (`Merged N mod(s) → zzz_LMM_Merged_P.pak`, with a
+  `(N deployed raw)` count when conversions fell back). The TUI's deploy
+  status line reports the same readout (`Deployed N mod(s) — merged N → …`).
+  `Deployed: N` still counts merge participants, and non-compile deploy
+  output is unchanged, byte for byte.
 - TUI: a mutation that completes with two or more warnings now auto-opens a
   scrollable overlay listing every warning in full, instead of collapsing
   them to an unreadable `(N warnings)` status suffix — on merged-pak games

--- a/cmd/lmm/deploy.go
+++ b/cmd/lmm/deploy.go
@@ -124,14 +124,30 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 	// per-mod progress events at all when there is nothing to deploy, which
 	// is exactly the "No mods to deploy" case the pre-extraction CLI checked
 	// via len(modsToDeploy) before it had been folded into the flow.
+	//
+	// On a DeployCompile game the header drops "using <method>" (#255): the
+	// listed mods are mostly carried by one merged artifact deployed after
+	// the loop, so claiming a per-mod link method up front asserted
+	// something untrue about most of the lines below it.
+	compileMode := game.DeployMode == domain.DeployCompile
 	deployHeaderPrinted := false
 	printDeployHeaderOnce := func(total int) {
 		if deployHeaderPrinted {
 			return
 		}
 		deployHeaderPrinted = true
-		fmt.Printf("Deploying %d mod(s) using %s...\n\n", total, methodName)
+		if compileMode {
+			fmt.Printf("Deploying %d mod(s) — compile mode...\n\n", total)
+		} else {
+			fmt.Printf("Deploying %d mod(s) using %s...\n\n", total, methodName)
+		}
 	}
+
+	// mergeFooterPrinted: a DeployMergeSynced footer was printed (#255), so
+	// the summary below skips its own leading blank line - the footer
+	// already separates the per-mod block and "Deployed: N" reads as part
+	// of the same closing readout.
+	mergeFooterPrinted := false
 
 	// progress prints every diagnostic and per-mod status line at its exact
 	// point of occurrence, driven entirely by core.DeployProfile's progress
@@ -166,6 +182,19 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 			// --purge pass; handled so a future change can't accidentally
 			// route them into printDeployHeaderOnce below.
 			return
+		case core.DeployMergeSynced:
+			// #255: the post-sync footer naming the merged artifact. Fires
+			// only after the deploy loop (some per-mod event has already
+			// printed the header), and its Total is the merge-participant
+			// count, not the deploy total - so it must not fall through to
+			// printDeployHeaderOnce below.
+			fmt.Printf("\nMerged %d mod(s) → %s", p.Total, p.Detail)
+			if p.RawFallbacks > 0 {
+				fmt.Printf(" (%d deployed raw)", p.RawFallbacks)
+			}
+			fmt.Println()
+			mergeFooterPrinted = true
+			return
 		}
 
 		printDeployHeaderOnce(p.Total)
@@ -185,7 +214,19 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 		case core.DeploySkipped:
 			fmt.Printf("  %s %s - %s\n", colorRed("✗"), p.ModName, p.Detail)
 		case core.DeployDeployed:
-			fmt.Printf("  %s %s\n", colorGreen("✓"), p.ModName)
+			// #255: on a compile game, label how the mod's content actually
+			// reaches the game dir - "(merged)" rides the merged artifact
+			// (optimistic for a pak whose conversion then fails; the
+			// conversion warning + footer carry the correction), "(raw)" is
+			// a ConvertPaks-opted-out pak deploying itself.
+			switch p.ModClass {
+			case core.DeployModMerged:
+				fmt.Printf("  %s %s (merged)\n", colorGreen("✓"), p.ModName)
+			case core.DeployModRaw:
+				fmt.Printf("  %s %s (raw)\n", colorGreen("✓"), p.ModName)
+			default:
+				fmt.Printf("  %s %s\n", colorGreen("✓"), p.ModName)
+			}
 		case core.DeployNote:
 			if verbose {
 				fmt.Printf("  %s\n", p.Detail)
@@ -212,7 +253,11 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 		return nil
 	}
 
-	fmt.Printf("\nDeployed: %d", result.Deployed)
+	if mergeFooterPrinted {
+		fmt.Printf("Deployed: %d", result.Deployed)
+	} else {
+		fmt.Printf("\nDeployed: %d", result.Deployed)
+	}
 	if failed := len(result.Skipped); failed > 0 {
 		fmt.Printf(", Failed: %d", failed)
 	}

--- a/cmd/lmm/deploy.go
+++ b/cmd/lmm/deploy.go
@@ -185,9 +185,10 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 		case core.DeployMergeSynced:
 			// #255: the post-sync footer naming the merged artifact. Fires
 			// only after the deploy loop (some per-mod event has already
-			// printed the header), and its Total is the merge-participant
-			// count, not the deploy total - so it must not fall through to
-			// printDeployHeaderOnce below.
+			// printed the header), and its Total counts the mods the merged
+			// artifact actually carries (raw fallbacks excluded - they ride
+			// RawFallbacks), not the deploy total - so it must not fall
+			// through to printDeployHeaderOnce below.
 			fmt.Printf("\nMerged %d mod(s) → %s", p.Total, p.Detail)
 			if p.RawFallbacks > 0 {
 				fmt.Printf(" (%d deployed raw)", p.RawFallbacks)

--- a/cmd/lmm/deploy_compile_test.go
+++ b/cmd/lmm/deploy_compile_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDoDeployCompileTest extends setupDoDeployTest into a DeployCompile
+// game (#255): ConvertPaks on, base pak present, merge-compiler source
+// registered under "fake-compiler", game registered (mergeCompilerForGame
+// resolves the game's configured sources).
+func setupDoDeployCompileTest(t *testing.T) (*core.Service, *domain.Game, *compilerInstallSource) {
+	t.Helper()
+	svc, game := setupDoDeployTest(t)
+	game.DeployMode = domain.DeployCompile
+	game.ConvertPaks = true
+	game.InstallPath = t.TempDir()
+	game.SourceIDs = map[string]string{"fake-compiler": "external-icarus-id"}
+	require.NoError(t, svc.AddGame(game))
+
+	basePak := filepath.Join(game.InstallPath, "Icarus", "Content", "Data", "data.pak")
+	require.NoError(t, os.MkdirAll(filepath.Dir(basePak), 0o755))
+	writeFakeBasePak(t, basePak)
+
+	compiler := &compilerInstallSource{fakeInstallSource: newFakeInstallSource("fake-compiler")}
+	svc.RegisterSource(compiler)
+	return svc, game, compiler
+}
+
+// ensureDefaultProfile creates the "default" profile if a seed helper runs
+// before any seedDeployableMod call (which otherwise creates it).
+func ensureDefaultProfile(t *testing.T, svc *core.Service, game *domain.Game) {
+	t.Helper()
+	pm := svc.NewProfileManager()
+	if _, err := pm.Get(game.ID, "default"); err != nil {
+		require.ErrorIs(t, err, domain.ErrProfileNotFound)
+		_, err := pm.Create(game.ID, "default")
+		require.NoError(t, err)
+	}
+}
+
+// seedCompileExmodzMod installs an enabled native merge-source mod: retained
+// source only, zero deployment members of its own (#197).
+func seedCompileExmodzMod(t *testing.T, svc *core.Service, game *domain.Game, modID, name, fileID string) {
+	t.Helper()
+	ensureDefaultProfile(t, svc, game)
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, "fake-compiler", modID, "1.0", cache.RetainedSourceName(fileID), []byte(name+"-bytes")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: "fake-compiler", Name: name, Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		FileIDs:      []string{fileID},
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: "fake-compiler", ModID: modID, Version: "1.0", FileIDs: []string{fileID}}))
+}
+
+// seedCompilePakMod installs an enabled convert-eligible pak mod in the
+// shape #221 ingest produces: retained source plus a deployable raw copy
+// recorded as the manifest's sole member (raw-deploy default until a merge
+// flips it). fileID must classify as a convertible kind (suffix ".pak").
+func seedCompilePakMod(t *testing.T, svc *core.Service, game *domain.Game, modID, name, fileID string) {
+	t.Helper()
+	ensureDefaultProfile(t, svc, game)
+	gameCache := svc.GetGameCache(game)
+	pakContent := []byte(name + "-pak-bytes")
+	require.NoError(t, gameCache.Store(game.ID, "fake-compiler", modID, "1.0", cache.RetainedSourceName(fileID), pakContent))
+	member := modID + ".pak"
+	require.NoError(t, gameCache.Store(game.ID, "fake-compiler", modID, "1.0", member, pakContent))
+	versionDir := gameCache.ModPath(game.ID, "fake-compiler", modID, "1.0")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(versionDir, fileID, []string{member}))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: "fake-compiler", Name: name, Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		FileIDs:      []string{fileID},
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: "fake-compiler", ModID: modID, Version: "1.0", FileIDs: []string{fileID}}))
+}
+
+// TestDoDeploy_Compile_LabelsMergedRawAndLooseAndPrintsFooter is #255's CLI
+// acceptance test: on a DeployCompile game the header stops claiming a
+// per-mod link method, merge participants are labeled "(merged)", an
+// opted-out pak deploying raw is labeled "(raw)", an ordinary loose-file
+// mod keeps its plain line, and a post-sync footer names the merged
+// artifact with its participant count, directly above "Deployed: N" (which
+// still counts merge participants).
+func TestDoDeploy_Compile_LabelsMergedRawAndLooseAndPrintsFooter(t *testing.T) {
+	svc, game, _ := setupDoDeployCompileTest(t)
+	seedCompileExmodzMod(t, svc, game, "bear-mount", "Bear Mount", "exmodz-file")
+	seedCompilePakMod(t, svc, game, "raw-pak", "Raw Pak Mod", "raw.pak")
+	require.NoError(t, svc.SetModConvertPaks("fake-compiler", "raw-pak", game.ID, "default", false))
+	seedDeployableMod(t, svc, game, "loose", "Loose Mod", "loose.esp")
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "Deploying 3 mod(s) — compile mode...\n\n", "the compile header must not claim a per-mod link method")
+	assert.NotContains(t, out, "using symlink")
+	assert.Contains(t, out, "  ✓ Bear Mount (merged)\n")
+	assert.Contains(t, out, "  ✓ Raw Pak Mod (raw)\n")
+	assert.Contains(t, out, "  ✓ Loose Mod\n")
+	assert.NotContains(t, out, "Loose Mod (", "a loose-file mod keeps its plain, unlabeled line")
+	assert.Contains(t, out, "\nMerged 1 mod(s) → zzz_LMM_Merged_P.pak\nDeployed: 3\n",
+		"the footer must name the merged artifact and sit directly above the summary")
+
+	_, err := os.Lstat(filepath.Join(game.ModPath, "zzz_LMM_Merged_P.pak"))
+	assert.NoError(t, err, "the merged artifact must actually be deployed")
+	_, err = os.Lstat(filepath.Join(game.ModPath, "raw-pak.pak"))
+	assert.NoError(t, err, "the opted-out pak must be deployed raw")
+}
+
+// pakFailCompilerSource wraps compilerInstallSource so a CLI test can script
+// per-ref pak-conversion failures, mirroring internal/source/icarus/merge.go's
+// real failure path (a "... - deploying raw" warning per skipped ref).
+type pakFailCompilerSource struct {
+	*compilerInstallSource
+	failRefs map[string]string
+}
+
+func (s *pakFailCompilerSource) MergeCompile(ctx context.Context, basePakPath string, sources []source.MergeSource, outputPath string) ([]string, []source.MergeFailure, error) {
+	var out []byte
+	var warnings []string
+	var failed []source.MergeFailure
+	for _, src := range sources {
+		if reason, bad := s.failRefs[src.ModRef]; bad {
+			failed = append(failed, source.MergeFailure{ModRef: src.ModRef, Reason: reason})
+			warnings = append(warnings, fmt.Sprintf("mod %s: pak conversion failed: %s - deploying raw", src.ModName, reason))
+			continue
+		}
+		data, err := os.ReadFile(src.SourcePath)
+		if err != nil {
+			return nil, nil, err
+		}
+		out = append(out, data...)
+	}
+	return warnings, failed, os.WriteFile(outputPath, out, 0o644)
+}
+
+var _ source.MergeCompiler = (*pakFailCompilerSource)(nil)
+
+// TestDoDeploy_Compile_ConversionFailure_FooterCorrectsOptimisticLabel covers
+// #255's accepted optimistic case end to end: an opted-in pak is labeled
+// "(merged)" inline (at ✓ time the merge hasn't run), its conversion then
+// fails during the post-loop sync - the existing warning carries the
+// correction, and the footer reports the raw fallback.
+func TestDoDeploy_Compile_ConversionFailure_FooterCorrectsOptimisticLabel(t *testing.T) {
+	svc, game, compiler := setupDoDeployCompileTest(t)
+	svc.RegisterSource(&pakFailCompilerSource{
+		compilerInstallSource: compiler,
+		failRefs:              map[string]string{"fake-compiler:flaky-pak": "irreconcilable"},
+	})
+	seedCompileExmodzMod(t, svc, game, "bear-mount", "Bear Mount", "exmodz-file")
+	seedCompilePakMod(t, svc, game, "flaky-pak", "Flaky Pak", "flaky.pak")
+
+	out := captureCombined(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "  ✓ Flaky Pak (merged)\n", "inline label is optimistic by design - the footer/warning correct it")
+	assert.Contains(t, out, "pak conversion failed", "the existing conversion-failure warning must still print")
+	assert.Contains(t, out, "\nMerged 1 mod(s) → zzz_LMM_Merged_P.pak (1 deployed raw)\nDeployed: 2\n",
+		"the footer must report the raw fallback and still sit directly above the summary")
+}
+
+// TestDoDeploy_NonCompile_NoCompileReadout guards the gate #255 must not
+// move: a non-compile deploy's output is byte-identical to before - the
+// original header, no labels, no merge footer.
+func TestDoDeploy_NonCompile_NoCompileReadout(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "Deploying 1 mod(s) using symlink...\n\n")
+	assert.Contains(t, out, "  ✓ Mod A\n")
+	assert.Contains(t, out, "\nDeployed: 1\n")
+	assert.NotContains(t, out, "compile mode")
+	assert.NotContains(t, out, "(merged)")
+	assert.NotContains(t, out, "Merged ")
+}

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -964,6 +964,54 @@ const (
 	// (4-space indent, matching ApplyProfileSwitch's own SwitchInstallNote
 	// convention).
 	ImportNote
+
+	// --- #255: compile-mode deploy readout, extending this same enum
+	// (the established "extend, don't fork" convention above). ---
+
+	// DeployMergeSynced fires once per DeployProfile on a DeployCompile
+	// game, after the post-loop merged-artifact sync succeeds with a
+	// merged artifact in place. It does not fire when the profile has no
+	// merge participants (nothing merged, nothing to report) or when the
+	// sync itself fails (that path emits a DeployWarning instead). Total
+	// carries the number of mods whose content the merged artifact
+	// carries; Detail names the artifact file
+	// (source.MergeCompiler.MergedArtifactName - the format is the
+	// source's business, never core's, #256); RawFallbacks counts
+	// participant mods that fell back to an individual raw deploy (failed
+	// conversion). No single mod is in scope (Index/ModName/ModID are
+	// zero). The same readout is recorded on DeployResult
+	// (MergedArtifact/MergedMods/RawFallbacks) for callers with no
+	// progress stream.
+	DeployMergeSynced
+)
+
+// DeployModClass classifies how a DeployDeployed mod's content reaches the
+// game directory on a DeployCompile game (#255), so callers stop rendering
+// merge participants - which individually deploy zero files by design
+// (#197) - as ordinary per-mod deployments. Classification happens BEFORE
+// the deploy loop (from enabledMergeSources), so it cannot know this sync's
+// conversion outcomes yet: an opted-in pak that goes on to fail conversion
+// is optimistically DeployModMerged here, and the correction is carried by
+// the existing conversion-failure warning plus DeployMergeSynced's
+// RawFallbacks count (issue #255's decided option (b); the stored
+// fingerprint is deliberately NOT consulted pre-loop - it describes the
+// previous sync, which is wrong on first deploy and after input changes).
+type DeployModClass int
+
+const (
+	// DeployModIndividual (the zero value): an ordinary mod deploying its
+	// own files - every mod on a non-compile game, and a loose-file mod
+	// in a compile profile.
+	DeployModIndividual DeployModClass = iota
+	// DeployModMerged: a merge participant - its content reaches the game
+	// via the profile-level merged artifact built after the deploy loop;
+	// its own install step deploys nothing (native merge sources) or its
+	// raw copy is claimed by the merge (converted artifacts).
+	DeployModMerged
+	// DeployModRaw: a convertible artifact excluded from the merge by the
+	// game- or mod-level ConvertPaks opt-out (#221) - it deploys raw,
+	// individually.
+	DeployModRaw
 )
 
 // DeployProgress reports incremental status during DeployProfile. Index and
@@ -1024,6 +1072,18 @@ type DeployProgress struct {
 	// InstallResult.FilesDeployed, which only ever tracks the STRICT path's
 	// primary. Zero for every other phase.
 	FilesExtracted int
+
+	// --- #255: compile-mode deploy readout fields ---
+
+	// ModClass classifies how ModName's content reaches the game
+	// directory on a DeployCompile game - set on DeployDeployed only;
+	// zero (DeployModIndividual) for every other phase and on non-compile
+	// games. See DeployModClass.
+	ModClass DeployModClass
+	// RawFallbacks carries DeployMergeSynced's count of participant mods
+	// that fell back to an individual raw deploy. Zero for every other
+	// phase.
+	RawFallbacks int
 }
 
 // DeployResult reports the outcome of DeployProfile. As with UninstallResult
@@ -1074,6 +1134,18 @@ type DeployResult struct {
 	Skipped  []string
 	Warnings []string
 	Notes    []string
+
+	// MergedArtifact/MergedMods/RawFallbacks mirror the DeployMergeSynced
+	// event for callers with no progress stream (#255 - the TUI passes
+	// nil): the merged artifact's file name
+	// (source.MergeCompiler.MergedArtifactName), how many mods' content it
+	// carries, and how many participants fell back to an individual raw
+	// deploy (failed conversion). All zero when the deploy produced/kept
+	// no merged artifact: non-compile games, or a compile profile with no
+	// merge participants.
+	MergedArtifact string
+	MergedMods     int
+	RawFallbacks   int
 }
 
 // errNoDeployFiles mirrors cmd/lmm's errNoDownloadableFiles for the
@@ -1793,6 +1865,12 @@ func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileN
 	// appended to at the natural point, unchanged.
 	var deferredWarnings []DeployProgress
 
+	// #255: on a compile game, classify each mod up front so its
+	// DeployDeployed event can say whether it deploys files individually or
+	// rides the merged artifact built after the loop (nil map - and
+	// therefore the zero class - everywhere else).
+	modClasses := s.classifyCompileDeployMods(game, profileName, modsToDeploy)
+
 	total := len(modsToDeploy)
 	for idx, mod := range modsToDeploy {
 		// Task 6 item d (cancel-then-drain): checked between mods, never
@@ -1856,6 +1934,7 @@ func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileN
 		result.Deployed++
 		evt := base
 		evt.Phase = DeployDeployed
+		evt.ModClass = modClasses[domain.ModKey(mod.SourceID, mod.ID)]
 		emit(evt)
 
 		if err := runHook(ctx, opts.HookRunner, &hookCtx, "install.after_each", opts.Hooks.GetInstallAfterEach()); err != nil {
@@ -1891,6 +1970,10 @@ func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileN
 			result.Warnings = append(result.Warnings, w)
 			emit(DeployProgress{Phase: DeployWarning, Detail: w})
 		}
+		// #255: the sync succeeded, so the just-written fingerprint is the
+		// authoritative record of what the merged artifact carries - report
+		// it (result fields + one DeployMergeSynced event).
+		s.recordMergeOutcome(game, profileName, result, emit)
 	}
 
 	for _, w := range deferredWarnings {

--- a/internal/core/flows_deploy_compile_readout_test.go
+++ b/internal/core/flows_deploy_compile_readout_test.go
@@ -1,0 +1,252 @@
+package core_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupCompileReadoutGame builds a DeployCompile game (ConvertPaks on, base
+// pak present, "default" profile created) for #255's deploy-readout tests,
+// mirroring service_icarus_compile_test.go's harness. The caller registers
+// its own merge-compiler source under "fake-compiler" first.
+func setupCompileReadoutGame(t *testing.T, svc *core.Service) *domain.Game {
+	t.Helper()
+
+	installDir := t.TempDir()
+	basePak := filepath.Join(installDir, "Icarus", "Content", "Data", "data.pak")
+	require.NoError(t, os.MkdirAll(filepath.Dir(basePak), 0o755))
+	writeFakeBasePak(t, basePak)
+
+	game := &domain.Game{
+		ID: "icarus", Name: "Icarus", InstallPath: installDir, ModPath: t.TempDir(),
+		DeployMode: domain.DeployCompile, LinkMethod: domain.LinkCopy, ConvertPaks: true,
+		SourceIDs: map[string]string{"fake-compiler": "external-icarus-id"},
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	return game
+}
+
+// seedExmodzMod installs an enabled native merge-source (exmodz) mod: a
+// retained source only, zero deployment members of its own (#197).
+func seedExmodzMod(t *testing.T, svc *core.Service, game *domain.Game, modID, name, fileID string) {
+	t.Helper()
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, "fake-compiler", modID, "1.0", cache.RetainedSourceName(fileID), []byte(name+"-bytes")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: "fake-compiler", Name: name, Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		FileIDs:      []string{fileID},
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: "fake-compiler", ModID: modID, Version: "1.0", FileIDs: []string{fileID}}))
+}
+
+// seedLooseMod installs an enabled ordinary loose-file mod (no retained
+// merge source): it deploys its own file individually even on a compile game.
+func seedLooseMod(t *testing.T, svc *core.Service, game *domain.Game, modID, name, fileName string) {
+	t.Helper()
+	require.NoError(t, svc.GetGameCache(game).Store(game.ID, "fake-compiler", modID, "1.0", fileName, []byte("loose-data")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: "fake-compiler", Name: name, Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: "fake-compiler", ModID: modID, Version: "1.0"}))
+}
+
+// deployRecordingProgress runs DeployProfile with a recorder and returns the
+// result, every DeployDeployed event keyed by mod name (with its position in
+// the event stream), and any DeployMergeSynced events (with positions).
+func deployRecordingProgress(t *testing.T, svc *core.Service, game *domain.Game) (*core.DeployResult, map[string]core.DeployProgress, map[string]int, []core.DeployProgress, []int) {
+	t.Helper()
+	deployed := map[string]core.DeployProgress{}
+	deployedAt := map[string]int{}
+	var mergeEvents []core.DeployProgress
+	var mergeAt []int
+	seq := 0
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		seq++
+		switch p.Phase {
+		case core.DeployDeployed:
+			deployed[p.ModName] = p
+			deployedAt[p.ModName] = seq
+		case core.DeployMergeSynced:
+			mergeEvents = append(mergeEvents, p)
+			mergeAt = append(mergeAt, seq)
+		}
+	})
+	require.NoError(t, err)
+	return result, deployed, deployedAt, mergeEvents, mergeAt
+}
+
+// TestDeployProfile_Compile_ClassifiesModsAndEmitsMergeSynced covers #255's
+// three-way classification on a DeployCompile game: a native (exmodz) merge
+// participant, a ConvertPaks-opted-out pak deploying raw, and an ordinary
+// loose-file mod - plus the post-sync DeployMergeSynced event naming the
+// merged artifact (via the source's MergedArtifactName, never a core
+// literal) and carrying the participant count, and the same readout on
+// DeployResult for progress-less callers (the TUI).
+func TestDeployProfile_Compile_ClassifiesModsAndEmitsMergeSynced(t *testing.T) {
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(&fakeCompilerSource{})
+	game := setupCompileReadoutGame(t, svc)
+
+	seedExmodzMod(t, svc, game, "bear-mount", "Bear Mount", "exmodz-file")
+	seedEnabledPakMod(t, svc, game, "fake-compiler", "raw-pak", "1.0", "raw.pak", []byte("raw-pak-bytes"))
+	require.NoError(t, svc.SetModConvertPaks("fake-compiler", "raw-pak", game.ID, "default", false))
+	seedLooseMod(t, svc, game, "loose", "Loose Mod", "loose.esp")
+
+	result, deployed, deployedAt, mergeEvents, mergeAt := deployRecordingProgress(t, svc, game)
+
+	require.Equal(t, 3, result.Deployed)
+
+	// Per-mod classification, set on each DeployDeployed event (#255).
+	require.Contains(t, deployed, "Bear Mount")
+	assert.Equal(t, core.DeployModMerged, deployed["Bear Mount"].ModClass, "a native merge source is carried by the merged artifact")
+	require.Contains(t, deployed, "raw-pak")
+	assert.Equal(t, core.DeployModRaw, deployed["raw-pak"].ModClass, "an opted-out pak deploys raw, individually")
+	require.Contains(t, deployed, "Loose Mod")
+	assert.Equal(t, core.DeployModIndividual, deployed["Loose Mod"].ModClass, "a loose-file mod is an ordinary individual deployment")
+
+	// The post-sync merge event: exactly one, after every per-mod event,
+	// naming the artifact and counting merge participants.
+	require.Len(t, mergeEvents, 1, "exactly one DeployMergeSynced event must fire")
+	evt := mergeEvents[0]
+	assert.Equal(t, 1, evt.Total, "one mod's content is carried by the merged artifact")
+	assert.Equal(t, "zzz_LMM_Merged_P.pak", evt.Detail, "Detail must name the merged artifact (MergedArtifactName)")
+	assert.Equal(t, 0, evt.RawFallbacks)
+	for name, at := range deployedAt {
+		assert.Greater(t, mergeAt[0], at, "DeployMergeSynced must fire after %s's DeployDeployed", name)
+	}
+
+	// The same readout lands on DeployResult for callers with no progress
+	// stream (the TUI passes nil).
+	assert.Equal(t, "zzz_LMM_Merged_P.pak", result.MergedArtifact)
+	assert.Equal(t, 1, result.MergedMods)
+	assert.Equal(t, 0, result.RawFallbacks)
+}
+
+// TestDeployProfile_Compile_ConversionFailure_ReportsRawFallback covers the
+// one optimistic case #255 accepts: a convert-opted-in pak is labeled a
+// merge participant at DeployDeployed time (the merge hasn't run yet), then
+// fails conversion during syncMergedPak - the existing "pak conversion
+// failed ... deploying raw" warning carries the correction, and the
+// DeployMergeSynced footer reports the raw fallback count accurately.
+func TestDeployProfile_Compile_ConversionFailure_ReportsRawFallback(t *testing.T) {
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(&pakConversionOutcomeSource{
+		fakeCompilerSource: &fakeCompilerSource{},
+		failRefs:           map[string]string{"fake-compiler:flaky-pak": "irreconcilable"},
+	})
+	game := setupCompileReadoutGame(t, svc)
+
+	seedExmodzMod(t, svc, game, "bear-mount", "Bear Mount", "exmodz-file")
+	seedEnabledPakMod(t, svc, game, "fake-compiler", "flaky-pak", "1.0", "flaky.pak", []byte("flaky-pak-bytes"))
+
+	var warnings []string
+	deployed := map[string]core.DeployProgress{}
+	var mergeEvents []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		switch p.Phase {
+		case core.DeployDeployed:
+			deployed[p.ModName] = p
+		case core.DeployWarning:
+			warnings = append(warnings, p.Detail)
+		case core.DeployMergeSynced:
+			mergeEvents = append(mergeEvents, p)
+		}
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Deployed)
+
+	// Optimistic inline label: at DeployDeployed time the pak is a merge
+	// participant - the correction comes from the warning + footer below.
+	require.Contains(t, deployed, "flaky-pak")
+	assert.Equal(t, core.DeployModMerged, deployed["flaky-pak"].ModClass)
+
+	// The existing conversion-failure warning still fires (the correction).
+	foundConversionWarning := false
+	for _, w := range warnings {
+		if strings.Contains(w, "pak conversion failed") {
+			foundConversionWarning = true
+		}
+	}
+	assert.True(t, foundConversionWarning, "the pak-conversion-failure warning must still fire; got %v", warnings)
+
+	require.Len(t, mergeEvents, 1)
+	assert.Equal(t, 1, mergeEvents[0].Total, "only the exmodz mod's content made the merged artifact")
+	assert.Equal(t, "zzz_LMM_Merged_P.pak", mergeEvents[0].Detail)
+	assert.Equal(t, 1, mergeEvents[0].RawFallbacks, "the failed pak fell back to a raw individual deploy")
+
+	assert.Equal(t, 1, result.MergedMods)
+	assert.Equal(t, 1, result.RawFallbacks)
+	assert.Equal(t, "zzz_LMM_Merged_P.pak", result.MergedArtifact)
+}
+
+// TestDeployProfile_NonCompile_NoMergeReadout guards the gate: a non-compile
+// game's deploy must carry no classification and no merge event - its output
+// contract is byte-identical to before #255.
+func TestDeployProfile_NonCompile_NoMergeReadout(t *testing.T) {
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{ID: "plain", Name: "Plain", ModPath: t.TempDir(), LinkMethod: domain.LinkCopy}
+	require.NoError(t, svc.AddGame(game))
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+
+	require.NoError(t, svc.GetGameCache(game).Store(game.ID, "src", "a", "1.0", "a.esp", []byte("data")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "a", SourceID: "src", Name: "Mod A", Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: "src", ModID: "a", Version: "1.0"}))
+
+	var mergeEvents []core.DeployProgress
+	deployed := map[string]core.DeployProgress{}
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		switch p.Phase {
+		case core.DeployDeployed:
+			deployed[p.ModName] = p
+		case core.DeployMergeSynced:
+			mergeEvents = append(mergeEvents, p)
+		}
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Deployed)
+
+	assert.Empty(t, mergeEvents, "a non-compile deploy must emit no DeployMergeSynced event")
+	assert.Equal(t, core.DeployModIndividual, deployed["Mod A"].ModClass)
+	assert.Zero(t, result.MergedArtifact)
+	assert.Zero(t, result.MergedMods)
+	assert.Zero(t, result.RawFallbacks)
+}

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -707,6 +707,100 @@ func (s *Service) ReconcilePakManifestsForTest(ctx context.Context, game *domain
 	return s.reconcilePakManifests(ctx, game, profileName, installer, failedByRef)
 }
 
+// classifyCompileDeployMods pre-classifies each mod DeployProfile is about
+// to deploy on a DeployCompile game (#255): a mod contributing at least one
+// enabled merge source is DeployModMerged (its content will ride the merged
+// artifact built after the loop); a mod holding a retained convertible file
+// that enabledMergeSources excluded - the game- or mod-level ConvertPaks
+// opt-out (#221) - is DeployModRaw (it deploys its raw copy individually);
+// everything else is the zero DeployModIndividual. Keyed by
+// domain.ModKey(sourceID, modID), the same "sourceID:modID" form
+// MergeSource.ModRef carries. Returns nil for a non-compile game and on any
+// resolution failure - classification is a readout, never a reason to fail
+// the deploy, and the zero class is always a safe rendering default.
+func (s *Service) classifyCompileDeployMods(game *domain.Game, profileName string, mods []*domain.InstalledMod) map[string]DeployModClass {
+	if game.DeployMode != domain.DeployCompile {
+		return nil
+	}
+	sources, err := s.enabledMergeSources(game, profileName)
+	if err != nil {
+		return nil
+	}
+	mergedRefs := make(map[string]bool, len(sources))
+	for _, src := range sources {
+		mergedRefs[src.ModRef] = true
+	}
+	gameCache := s.GetGameCache(game)
+	// Lazily resolved on the first retained file found, exactly like
+	// enabledMergeSources/reconcilePakManifests (#256).
+	var mc source.MergeCompiler
+	classes := make(map[string]DeployModClass, len(mods))
+	for _, mod := range mods {
+		ref := domain.ModKey(mod.SourceID, mod.ID)
+		if mergedRefs[ref] {
+			classes[ref] = DeployModMerged
+			continue
+		}
+		for _, fileID := range mod.FileIDs {
+			retained := gameCache.GetFilePath(game.ID, mod.SourceID, mod.ID, mod.Version, cache.RetainedSourceName(fileID))
+			if _, statErr := os.Stat(retained); statErr != nil {
+				continue // nothing retained for this fileID - not a merge source of any kind
+			}
+			if mc == nil {
+				var mcErr error
+				if mc, mcErr = s.mergeCompilerForGame(game); mcErr != nil {
+					return classes
+				}
+			}
+			if _, convertible := mc.ClassifyMergeSource(fileID); convertible {
+				classes[ref] = DeployModRaw
+				break
+			}
+		}
+	}
+	return classes
+}
+
+// recordMergeOutcome reports #255's post-sync merge readout: after a
+// successful syncMergedPak on a DeployCompile game, the just-written merge
+// fingerprint (MergedPakOutcomes) is the authoritative record of which
+// mods' content the merged artifact carries and which participants fell
+// back to a raw individual deploy. The artifact name and counts land on
+// result (for progress-less callers - the TUI) and as one DeployMergeSynced
+// event. A missing fingerprint means no merged artifact exists (zero merge
+// participants - the uninstall-to-zero path) so there is nothing to report;
+// resolution failures likewise skip the readout rather than fail an
+// already-successful deploy. Counts are per MOD, not per file: a mod
+// contributing both a converted and a failed file counts once on each side,
+// which is the accurate reading of that (rare) state.
+func (s *Service) recordMergeOutcome(game *domain.Game, profileName string, result *DeployResult, emit func(DeployProgress)) {
+	if game.DeployMode != domain.DeployCompile {
+		return
+	}
+	outcomes, ok := s.MergedPakOutcomes(game, profileName)
+	if !ok {
+		return
+	}
+	mc, err := s.mergeCompilerForGame(game)
+	if err != nil {
+		return
+	}
+	merged := make(map[string]bool, len(outcomes))
+	raw := make(map[string]bool)
+	for _, o := range outcomes {
+		ref := domain.ModKey(o.SourceID, o.ModID)
+		if o.Converted {
+			merged[ref] = true
+		} else {
+			raw[ref] = true
+		}
+	}
+	result.MergedArtifact = mc.MergedArtifactName()
+	result.MergedMods = len(merged)
+	result.RawFallbacks = len(raw)
+	emit(DeployProgress{Phase: DeployMergeSynced, Total: result.MergedMods, Detail: result.MergedArtifact, RawFallbacks: result.RawFallbacks})
+}
+
 // MergedPakOutcomes returns the stored merge fingerprint's per-mod entries
 // (with #221 conversion outcomes), if a merged pak exists for game+profile.
 // The game's compile source interprets the stored Kind strings (#256); a

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -715,9 +715,13 @@ func (s *Service) ReconcilePakManifestsForTest(ctx context.Context, game *domain
 // opt-out (#221) - is DeployModRaw (it deploys its raw copy individually);
 // everything else is the zero DeployModIndividual. Keyed by
 // domain.ModKey(sourceID, modID), the same "sourceID:modID" form
-// MergeSource.ModRef carries. Returns nil for a non-compile game and on any
-// resolution failure - classification is a readout, never a reason to fail
-// the deploy, and the zero class is always a safe rendering default.
+// MergeSource.ModRef carries. Best-effort by design - classification is a
+// readout, never a reason to fail the deploy, and the zero class is always
+// a safe rendering default: a non-compile game or an enabledMergeSources
+// failure returns nil, and a compiler-resolution failure mid-walk (only
+// reachable when nothing enabled is retained but a mod in mods still holds
+// a retained file, e.g. a disabled mod under --all with no compile source
+// configured) returns the classes computed so far.
 func (s *Service) classifyCompileDeployMods(game *domain.Game, profileName string, mods []*domain.InstalledMod) map[string]DeployModClass {
 	if game.DeployMode != domain.DeployCompile {
 		return nil

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -815,6 +815,18 @@ func (p *coreProvider) DeployProfile(ctx context.Context) (ActionOutcome, error)
 	if len(result.Skipped) > 0 {
 		msg += fmt.Sprintf(", %d failed", len(result.Skipped))
 	}
+	// #255: on a compile game the per-mod count alone misreads - most mods
+	// deploy nothing individually and one merged artifact carries them. The
+	// readout comes from DeployResult's own fields (progress is nil here, so
+	// there is no event stream) and stays in the one-row Message: routing it
+	// through Warnings would auto-open #253's 2+-warning overlay on every
+	// routine compile deploy.
+	if result.MergedArtifact != "" {
+		msg += fmt.Sprintf(" — merged %d → %s", result.MergedMods, result.MergedArtifact)
+		if result.RawFallbacks > 0 {
+			msg += fmt.Sprintf(" (%d raw)", result.RawFallbacks)
+		}
+	}
 	// result.Skipped carries one "<mod name>: <reason>" entry per mod that
 	// didn't deploy (see DeployResult.Skipped's doc comment); appended after
 	// the flow Warnings/Notes mergeDiagnostics already composed so the

--- a/internal/tui/service_core_deploy_compile_test.go
+++ b/internal/tui/service_core_deploy_compile_test.go
@@ -1,0 +1,31 @@
+package tui_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCoreProviderDeployProfile_CompileGame_NamesMergedArtifactInMessage is
+// #255's TUI parity test: coreProvider.DeployProfile passes nil progress
+// (no event stream), so the merge readout must come from DeployResult's own
+// fields and land in the one-row outcome Message - NOT in Warnings, whose
+// 2+-entry overlay (#253) would otherwise pop a modal on every routine
+// compile deploy. The fixture holds one enabled exmodz mod, so the merged
+// artifact carries exactly one mod.
+func TestCoreProviderDeployProfile_CompileGame_NamesMergedArtifactInMessage(t *testing.T) {
+	actions, _, mergedPakPath := newRecompileActionsFixture(t)
+
+	outcome, err := actions.DeployProfile(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, "Deployed 1 mod(s) — merged 1 → zzz_LMM_Merged_P.pak", outcome.Message,
+		"the one-row status message must name the merged artifact and its participant count")
+	require.Empty(t, outcome.Warnings,
+		"routine merge info must not ride the warnings channel (#253's overlay auto-opens on 2+ warnings)")
+
+	_, statErr := os.Stat(mergedPakPath)
+	require.NoError(t, statErr, "the merged artifact must actually be deployed")
+}


### PR DESCRIPTION
Fixes #255 — implements the issue's decided **option (b)** exactly: classify before the loop, correct in the footer.

## What changed

**Core** (`internal/core`):
- `DeployProgress.ModClass` (`DeployModClass`: individual / merged / raw), set on `DeployDeployed`. Classification runs **before** the deploy loop via `enabledMergeSources` — the stored fingerprint is deliberately not consulted (wrong on first deploy).
- New `DeployMergeSynced` phase, emitted once after a successful `syncMergedPak` when a merged artifact exists: `Total` = participant count, `Detail` = artifact name via `source.MergeCompiler.MergedArtifactName()` (no format literals in core, per #256), `RawFallbacks` = participants that fell back to raw.
- `DeployResult` gains `MergedArtifact`/`MergedMods`/`RawFallbacks` so progress-less callers (the TUI) get the same readout.

**CLI** (`cmd/lmm/deploy.go`):

```
Deploying 3 mod(s) — compile mode...

  ✓ Bear Mount (merged)
  ✓ Raw Pak Mod (raw)
  ✓ Loose Mod

Merged 1 mod(s) → zzz_LMM_Merged_P.pak
Deployed: 3
```

The optimistic case — a pak labeled `(merged)` whose conversion then fails — is corrected by the existing `pak conversion failed … deploying raw` warning plus the footer's `(N deployed raw)` count. `Deployed: N` still counts merge participants. The Warnings/Notes ↔ event invariant at `cmd/lmm/deploy.go` is untouched (the merge event is not a warning; nothing double-prints).

**TUI** (`internal/tui/service_core.go`): `Deployed 1 mod(s) — merged 1 → zzz_LMM_Merged_P.pak` in the one-row outcome `Message`, built from the new `DeployResult` fields. Deliberately **not** routed through Warnings (#253's overlay auto-opens on 2+ warnings).

## Guarantees held

- **Non-compile output byte-identical** — every pre-existing deploy test passes untouched; a new gating test additionally pins no compile text leaks into non-compile output.
- **Acceptance greps clean** — `grep -n '"[^"]*\.pak"'` and `grep -in exmodz` over non-test `internal/core` match comments only.
- TDD: all new tests written first and shown failing (core: new symbols undefined; CLI/TUI: today's lying output captured verbatim in the failure diff).

## Coverage added

- Core: three-way classification + merge event ordering/counts, conversion-failure fallback counts, non-compile no-readout gating.
- CLI: labels + footer happy path, conversion-failure correction end to end (combined stdout/stderr), non-compile gating.
- TUI: compile-game message readout + empty-warnings assertion.

## Out of scope

- #257 (TUI live deploy progress) untouched — when picked up, its stream can reuse `DeployMergeSynced` as-is.

## Verification

`go build ./... && go vet ./... && gofmt -l . && go test ./...` — all clean; `trunk check` on changed files: no new issues. Manual TUI smoke test pending (merge gate, coordinator's step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)