### PR TITLE
release: v1.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   last exmodz/pak mod, or a profile that never merged — no longer fails
   every subsequent sync/deploy/purge with a loud
   `removing merged pak: ... no such file or directory` error (#260).
+
 ## [1.30.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Icarus: cache pruning no longer deletes a converted pak's deployable
+  copy when a sibling file of the same mod+version is downloaded or
+  re-ingested (#250). The copy is unclaimed by design while the merged
+  pak carries the mod's content, but it is still the designated
+  raw-fallback artifact — pruning it left a later conversion opt-out or
+  merge failure deploying nothing, silently. Pruning now exempts any
+  unclaimed file whose content matches a retained source, and the raw
+  fallback additionally self-heals entries already damaged by released
+  versions: the deployable copy is restored from the retained source
+  (under its original archive name for imports, or a `<mod-id>_P.pak`
+  name for catalog downloads, where the original name is unrecoverable)
+  and redeployed.
+
 ## [1.30.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Deploy output on a compile-mode game (Icarus) no longer presents merged
+  mods as individual deployments (#255). The header drops the misleading
+  `using <method>` claim, each mod's `✓` line is labeled by how its content
+  actually reaches the game directory — `(merged)` for merge participants,
+  `(raw)` for a conversion-opted-out pak, unlabeled for ordinary loose-file
+  mods — and a post-sync footer finally names the one artifact that really
+  deployed (`Merged N mod(s) → zzz_LMM_Merged_P.pak`, with a
+  `(N deployed raw)` count when conversions fell back). The TUI's deploy
+  status line reports the same readout (`Deployed N mod(s) — merged N → …`).
+  `Deployed: N` still counts merge participants, and non-compile deploy
+  output is unchanged, byte for byte.
 - TUI: a mutation that completes with two or more warnings now auto-opens a
   scrollable overlay listing every warning in full, instead of collapsing
   them to an unreadable `(N warnings)` status suffix — on merged-pak games

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Uninstalling a mod whose cache entry is absent is now a no-op removal
+  (still clearing tracking rows and sweeping empty directories) instead of
+  an error. In particular, a DeployCompile profile with zero merge sources
+  and no merged-pak cache entry — the steady state after disabling the
+  last exmodz/pak mod, or a profile that never merged — no longer fails
+  every subsequent sync/deploy/purge with a loud
+  `removing merged pak: ... no such file or directory` error (#260).
+
 ## [1.30.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which now states the complete contract a second compile-mode game would
   implement (#256). The one user-visible change: rejecting a mixed
   pak+exmodz install selection now names the two colliding files
-  (`Mod_P.pak and Mod.exmodz are alternate forms of the same mod - select
-one`) instead of the generic wording.
+  (e.g. `Mod_P.pak and Mod.exmodz`) instead of the generic wording.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Internal: all Unreal/Icarus format knowledge (base-pak location, pak
   fingerprinting, the `.pak` convert test, the native `.exmodz` test,
-  merge-source kinds, and the merged artifact's filename) moved out of
-  `internal/core` and behind the `source.MergeCompiler` interface, which
-  now states the complete contract a second compile-mode game would
-  implement (#256). No user-visible change.
+  merge-source kinds, and the merged/restored artifact filenames) moved
+  out of `internal/core` and behind the `source.MergeCompiler` interface,
+  which now states the complete contract a second compile-mode game would
+  implement (#256). The one user-visible change: rejecting a mixed
+  pak+exmodz install selection now names the two colliding files
+  (`Mod_P.pak and Mod.exmodz are alternate forms of the same mod - select
+one`) instead of the generic wording.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.30.1] - 2026-08-08
+
 ### Changed
 
 - Internal: all Unreal/Icarus format knowledge (base-pak location, pak
@@ -1399,7 +1401,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for core components
 - MIT License
 
-[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.30.0...HEAD
+[Unreleased]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.30.1...HEAD
+[1.30.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.30.0...v1.30.1
 [1.30.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.29.1...v1.30.0
 [1.29.1]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.29.0...v1.29.1
 [1.29.0]: https://github.com/DonovanMods/linux-mod-manager/compare/v1.28.0...v1.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- TUI: a mutation that completes with two or more warnings now auto-opens a
+  scrollable overlay listing every warning in full, instead of collapsing
+  them to an unreadable `(N warnings)` status suffix — on merged-pak games
+  (Icarus) those warnings are the only report of cross-mod asset conflicts
+  anywhere in the app. The one-row `(N warnings)` summary stays on the
+  status line, and a single warning still renders inline with no overlay
+  (#253).
+
 ## [1.30.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TUI: warnings emitted by successful updates in an apply-updates batch are
+  now readable — they render as a trailing section (blank separator, one
+  line per distinct warning) inside the same "update results" overlay that
+  lists each update's ✓/✗ line, instead of being folded into an aggregate
+  the overlay never showed. Identical warnings repeated across the batch
+  (a merged-pak recompile re-emits the same profile-level asset-conflict
+  diagnostics for every update that triggers it) are deduped on exact text,
+  and the status line's one-row `(N warnings)` count matches the deduped
+  section (#259).
 - TUI: a mutation that completes with two or more warnings now auto-opens a
   scrollable overlay listing every warning in full, instead of collapsing
   them to an unreadable `(N warnings)` status suffix — on merged-pak games

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Internal: all Unreal/Icarus format knowledge (base-pak location, pak
+  fingerprinting, the `.pak` convert test, merge-source kinds, and the
+  merged artifact's filename) moved out of `internal/core` and behind the
+  `source.MergeCompiler` interface, which now states the complete contract
+  a second compile-mode game would implement (#256). No user-visible
+  change.
+
 ## [1.30.0] - 2026-08-08
 
 ### Added

--- a/cmd/lmm/deploy.go
+++ b/cmd/lmm/deploy.go
@@ -124,14 +124,30 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 	// per-mod progress events at all when there is nothing to deploy, which
 	// is exactly the "No mods to deploy" case the pre-extraction CLI checked
 	// via len(modsToDeploy) before it had been folded into the flow.
+	//
+	// On a DeployCompile game the header drops "using <method>" (#255): the
+	// listed mods are mostly carried by one merged artifact deployed after
+	// the loop, so claiming a per-mod link method up front asserted
+	// something untrue about most of the lines below it.
+	compileMode := game.DeployMode == domain.DeployCompile
 	deployHeaderPrinted := false
 	printDeployHeaderOnce := func(total int) {
 		if deployHeaderPrinted {
 			return
 		}
 		deployHeaderPrinted = true
-		fmt.Printf("Deploying %d mod(s) using %s...\n\n", total, methodName)
+		if compileMode {
+			fmt.Printf("Deploying %d mod(s) — compile mode...\n\n", total)
+		} else {
+			fmt.Printf("Deploying %d mod(s) using %s...\n\n", total, methodName)
+		}
 	}
+
+	// mergeFooterPrinted: a DeployMergeSynced footer was printed (#255), so
+	// the summary below skips its own leading blank line - the footer
+	// already separates the per-mod block and "Deployed: N" reads as part
+	// of the same closing readout.
+	mergeFooterPrinted := false
 
 	// progress prints every diagnostic and per-mod status line at its exact
 	// point of occurrence, driven entirely by core.DeployProfile's progress
@@ -166,6 +182,19 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 			// --purge pass; handled so a future change can't accidentally
 			// route them into printDeployHeaderOnce below.
 			return
+		case core.DeployMergeSynced:
+			// #255: the post-sync footer naming the merged artifact. Fires
+			// only after the deploy loop (some per-mod event has already
+			// printed the header), and its Total is the merge-participant
+			// count, not the deploy total - so it must not fall through to
+			// printDeployHeaderOnce below.
+			fmt.Printf("\nMerged %d mod(s) → %s", p.Total, p.Detail)
+			if p.RawFallbacks > 0 {
+				fmt.Printf(" (%d deployed raw)", p.RawFallbacks)
+			}
+			fmt.Println()
+			mergeFooterPrinted = true
+			return
 		}
 
 		printDeployHeaderOnce(p.Total)
@@ -185,7 +214,19 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 		case core.DeploySkipped:
 			fmt.Printf("  %s %s - %s\n", colorRed("✗"), p.ModName, p.Detail)
 		case core.DeployDeployed:
-			fmt.Printf("  %s %s\n", colorGreen("✓"), p.ModName)
+			// #255: on a compile game, label how the mod's content actually
+			// reaches the game dir - "(merged)" rides the merged artifact
+			// (optimistic for a pak whose conversion then fails; the
+			// conversion warning + footer carry the correction), "(raw)" is
+			// a ConvertPaks-opted-out pak deploying itself.
+			switch p.ModClass {
+			case core.DeployModMerged:
+				fmt.Printf("  %s %s (merged)\n", colorGreen("✓"), p.ModName)
+			case core.DeployModRaw:
+				fmt.Printf("  %s %s (raw)\n", colorGreen("✓"), p.ModName)
+			default:
+				fmt.Printf("  %s %s\n", colorGreen("✓"), p.ModName)
+			}
 		case core.DeployNote:
 			if verbose {
 				fmt.Printf("  %s\n", p.Detail)
@@ -212,7 +253,11 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 		return nil
 	}
 
-	fmt.Printf("\nDeployed: %d", result.Deployed)
+	if mergeFooterPrinted {
+		fmt.Printf("Deployed: %d", result.Deployed)
+	} else {
+		fmt.Printf("\nDeployed: %d", result.Deployed)
+	}
 	if failed := len(result.Skipped); failed > 0 {
 		fmt.Printf(", Failed: %d", failed)
 	}

--- a/cmd/lmm/deploy.go
+++ b/cmd/lmm/deploy.go
@@ -185,9 +185,10 @@ func doDeploy(ctx context.Context, service *core.Service, game *domain.Game, arg
 		case core.DeployMergeSynced:
 			// #255: the post-sync footer naming the merged artifact. Fires
 			// only after the deploy loop (some per-mod event has already
-			// printed the header), and its Total is the merge-participant
-			// count, not the deploy total - so it must not fall through to
-			// printDeployHeaderOnce below.
+			// printed the header), and its Total counts the mods the merged
+			// artifact actually carries (raw fallbacks excluded - they ride
+			// RawFallbacks), not the deploy total - so it must not fall
+			// through to printDeployHeaderOnce below.
 			fmt.Printf("\nMerged %d mod(s) → %s", p.Total, p.Detail)
 			if p.RawFallbacks > 0 {
 				fmt.Printf(" (%d deployed raw)", p.RawFallbacks)

--- a/cmd/lmm/deploy_compile_test.go
+++ b/cmd/lmm/deploy_compile_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/source"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDoDeployCompileTest extends setupDoDeployTest into a DeployCompile
+// game (#255): ConvertPaks on, base pak present, merge-compiler source
+// registered under "fake-compiler", game registered (mergeCompilerForGame
+// resolves the game's configured sources).
+func setupDoDeployCompileTest(t *testing.T) (*core.Service, *domain.Game, *compilerInstallSource) {
+	t.Helper()
+	svc, game := setupDoDeployTest(t)
+	game.DeployMode = domain.DeployCompile
+	game.ConvertPaks = true
+	game.InstallPath = t.TempDir()
+	game.SourceIDs = map[string]string{"fake-compiler": "external-icarus-id"}
+	require.NoError(t, svc.AddGame(game))
+
+	basePak := filepath.Join(game.InstallPath, "Icarus", "Content", "Data", "data.pak")
+	require.NoError(t, os.MkdirAll(filepath.Dir(basePak), 0o755))
+	writeFakeBasePak(t, basePak)
+
+	compiler := &compilerInstallSource{fakeInstallSource: newFakeInstallSource("fake-compiler")}
+	svc.RegisterSource(compiler)
+	return svc, game, compiler
+}
+
+// ensureDefaultProfile creates the "default" profile if a seed helper runs
+// before any seedDeployableMod call (which otherwise creates it).
+func ensureDefaultProfile(t *testing.T, svc *core.Service, game *domain.Game) {
+	t.Helper()
+	pm := svc.NewProfileManager()
+	if _, err := pm.Get(game.ID, "default"); err != nil {
+		require.ErrorIs(t, err, domain.ErrProfileNotFound)
+		_, err := pm.Create(game.ID, "default")
+		require.NoError(t, err)
+	}
+}
+
+// seedCompileExmodzMod installs an enabled native merge-source mod: retained
+// source only, zero deployment members of its own (#197).
+func seedCompileExmodzMod(t *testing.T, svc *core.Service, game *domain.Game, modID, name, fileID string) {
+	t.Helper()
+	ensureDefaultProfile(t, svc, game)
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, "fake-compiler", modID, "1.0", cache.RetainedSourceName(fileID), []byte(name+"-bytes")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: "fake-compiler", Name: name, Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		FileIDs:      []string{fileID},
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: "fake-compiler", ModID: modID, Version: "1.0", FileIDs: []string{fileID}}))
+}
+
+// seedCompilePakMod installs an enabled convert-eligible pak mod in the
+// shape #221 ingest produces: retained source plus a deployable raw copy
+// recorded as the manifest's sole member (raw-deploy default until a merge
+// flips it). fileID must classify as a convertible kind (suffix ".pak").
+func seedCompilePakMod(t *testing.T, svc *core.Service, game *domain.Game, modID, name, fileID string) {
+	t.Helper()
+	ensureDefaultProfile(t, svc, game)
+	gameCache := svc.GetGameCache(game)
+	pakContent := []byte(name + "-pak-bytes")
+	require.NoError(t, gameCache.Store(game.ID, "fake-compiler", modID, "1.0", cache.RetainedSourceName(fileID), pakContent))
+	member := modID + ".pak"
+	require.NoError(t, gameCache.Store(game.ID, "fake-compiler", modID, "1.0", member, pakContent))
+	versionDir := gameCache.ModPath(game.ID, "fake-compiler", modID, "1.0")
+	require.NoError(t, cache.MarkFileCompleteWithMembers(versionDir, fileID, []string{member}))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: "fake-compiler", Name: name, Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		FileIDs:      []string{fileID},
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: "fake-compiler", ModID: modID, Version: "1.0", FileIDs: []string{fileID}}))
+}
+
+// TestDoDeploy_Compile_LabelsMergedRawAndLooseAndPrintsFooter is #255's CLI
+// acceptance test: on a DeployCompile game the header stops claiming a
+// per-mod link method, merge participants are labeled "(merged)", an
+// opted-out pak deploying raw is labeled "(raw)", an ordinary loose-file
+// mod keeps its plain line, and a post-sync footer names the merged
+// artifact with its participant count, directly above "Deployed: N" (which
+// still counts merge participants).
+func TestDoDeploy_Compile_LabelsMergedRawAndLooseAndPrintsFooter(t *testing.T) {
+	svc, game, _ := setupDoDeployCompileTest(t)
+	seedCompileExmodzMod(t, svc, game, "bear-mount", "Bear Mount", "exmodz-file")
+	seedCompilePakMod(t, svc, game, "raw-pak", "Raw Pak Mod", "raw.pak")
+	require.NoError(t, svc.SetModConvertPaks("fake-compiler", "raw-pak", game.ID, "default", false))
+	seedDeployableMod(t, svc, game, "loose", "Loose Mod", "loose.esp")
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "Deploying 3 mod(s) — compile mode...\n\n", "the compile header must not claim a per-mod link method")
+	assert.NotContains(t, out, "using symlink")
+	assert.Contains(t, out, "  ✓ Bear Mount (merged)\n")
+	assert.Contains(t, out, "  ✓ Raw Pak Mod (raw)\n")
+	assert.Contains(t, out, "  ✓ Loose Mod\n")
+	assert.NotContains(t, out, "Loose Mod (", "a loose-file mod keeps its plain, unlabeled line")
+	assert.Contains(t, out, "\nMerged 1 mod(s) → zzz_LMM_Merged_P.pak\nDeployed: 3\n",
+		"the footer must name the merged artifact and sit directly above the summary")
+
+	_, err := os.Lstat(filepath.Join(game.ModPath, "zzz_LMM_Merged_P.pak"))
+	assert.NoError(t, err, "the merged artifact must actually be deployed")
+	_, err = os.Lstat(filepath.Join(game.ModPath, "raw-pak.pak"))
+	assert.NoError(t, err, "the opted-out pak must be deployed raw")
+}
+
+// pakFailCompilerSource wraps compilerInstallSource so a CLI test can script
+// per-ref pak-conversion failures, mirroring internal/source/icarus/merge.go's
+// real failure path (a "... - deploying raw" warning per skipped ref).
+type pakFailCompilerSource struct {
+	*compilerInstallSource
+	failRefs map[string]string
+}
+
+func (s *pakFailCompilerSource) MergeCompile(ctx context.Context, basePakPath string, sources []source.MergeSource, outputPath string) ([]string, []source.MergeFailure, error) {
+	var out []byte
+	var warnings []string
+	var failed []source.MergeFailure
+	for _, src := range sources {
+		if reason, bad := s.failRefs[src.ModRef]; bad {
+			failed = append(failed, source.MergeFailure{ModRef: src.ModRef, Reason: reason})
+			warnings = append(warnings, fmt.Sprintf("mod %s: pak conversion failed: %s - deploying raw", src.ModName, reason))
+			continue
+		}
+		data, err := os.ReadFile(src.SourcePath)
+		if err != nil {
+			return nil, nil, err
+		}
+		out = append(out, data...)
+	}
+	return warnings, failed, os.WriteFile(outputPath, out, 0o644)
+}
+
+var _ source.MergeCompiler = (*pakFailCompilerSource)(nil)
+
+// TestDoDeploy_Compile_ConversionFailure_FooterCorrectsOptimisticLabel covers
+// #255's accepted optimistic case end to end: an opted-in pak is labeled
+// "(merged)" inline (at ✓ time the merge hasn't run), its conversion then
+// fails during the post-loop sync - the existing warning carries the
+// correction, and the footer reports the raw fallback.
+func TestDoDeploy_Compile_ConversionFailure_FooterCorrectsOptimisticLabel(t *testing.T) {
+	svc, game, compiler := setupDoDeployCompileTest(t)
+	svc.RegisterSource(&pakFailCompilerSource{
+		compilerInstallSource: compiler,
+		failRefs:              map[string]string{"fake-compiler:flaky-pak": "irreconcilable"},
+	})
+	seedCompileExmodzMod(t, svc, game, "bear-mount", "Bear Mount", "exmodz-file")
+	seedCompilePakMod(t, svc, game, "flaky-pak", "Flaky Pak", "flaky.pak")
+
+	out := captureCombined(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "  ✓ Flaky Pak (merged)\n", "inline label is optimistic by design - the footer/warning correct it")
+	assert.Contains(t, out, "pak conversion failed", "the existing conversion-failure warning must still print")
+	assert.Contains(t, out, "\nMerged 1 mod(s) → zzz_LMM_Merged_P.pak (1 deployed raw)\nDeployed: 2\n",
+		"the footer must report the raw fallback and still sit directly above the summary")
+}
+
+// TestDoDeploy_NonCompile_NoCompileReadout guards the gate #255 must not
+// move: a non-compile deploy's output is byte-identical to before - the
+// original header, no labels, no merge footer.
+func TestDoDeploy_NonCompile_NoCompileReadout(t *testing.T) {
+	svc, game := setupDoDeployTest(t)
+	seedDeployableMod(t, svc, game, "a", "Mod A", "a.esp")
+
+	out := captureStdout(t, func() error {
+		return doDeploy(context.Background(), svc, game, nil)
+	})
+
+	assert.Contains(t, out, "Deploying 1 mod(s) using symlink...\n\n")
+	assert.Contains(t, out, "  ✓ Mod A\n")
+	assert.Contains(t, out, "\nDeployed: 1\n")
+	assert.NotContains(t, out, "compile mode")
+	assert.NotContains(t, out, "(merged)")
+	assert.NotContains(t, out, "Merged ")
+}

--- a/cmd/lmm/install_compile_test.go
+++ b/cmd/lmm/install_compile_test.go
@@ -32,6 +32,7 @@ func writeFakeBasePak(t *testing.T, path string) {
 // internal/core/service_icarus_compile_test.go's fakeCompilerSource, at the
 // CLI layer instead of core's).
 type compilerInstallSource struct {
+	fakeMergeFormat // #256: the format-vocabulary half of source.MergeCompiler
 	*fakeInstallSource
 	validateCalls int
 	compileCalls  int

--- a/cmd/lmm/install_test.go
+++ b/cmd/lmm/install_test.go
@@ -381,19 +381,21 @@ func TestPromptMultiSelection_Range(t *testing.T) {
 }
 
 // mixedPakExmodzValidate mirrors the shape of the real
-// Service.ValidateInstallFileSelection closure (#211): reject a selection
-// that mixes an exmodz file with any other file.
+// Service.ValidateInstallFileSelection closure (#211, message shape #256):
+// reject a selection that mixes an exmodz file with any other file, naming
+// the two colliding files the way production does.
 func mixedPakExmodzValidate(sel []domain.DownloadableFile) error {
 	var ex, other bool
+	var exName, otherName string
 	for _, f := range sel {
 		if strings.HasSuffix(strings.ToLower(f.FileName), ".exmodz") {
-			ex = true
+			ex, exName = true, f.FileName
 		} else {
-			other = true
+			other, otherName = true, f.FileName
 		}
 	}
 	if ex && other {
-		return fmt.Errorf("pak and exmodz are alternate forms of the same mod - select one")
+		return fmt.Errorf("%s and %s are alternate forms of the same mod - select one", otherName, exName)
 	}
 	return nil
 }
@@ -430,7 +432,7 @@ func TestSelectInstallFiles_FileFlagMixedRejected(t *testing.T) {
 	selected, err := selectInstallFilesFrom(strings.NewReader(""), files, mixedPakExmodzValidate)
 	require.Error(t, err)
 	assert.Nil(t, selected)
-	assert.Contains(t, err.Error(), "pak and exmodz are alternate forms of the same mod - select one")
+	assert.Contains(t, err.Error(), "Mod_P.pak and Mod.exmodz are alternate forms of the same mod - select one")
 }
 
 // TestSelectInstallFiles_EOFAfterRejectedSelection guards against a hang:

--- a/cmd/lmm/list.go
+++ b/cmd/lmm/list.go
@@ -162,7 +162,7 @@ func doList(cmd *cobra.Command, service *core.Service, game *domain.Game) error 
 				LockedVersion: lockedVersion,
 			}
 			// Populate ConvertPaks only for merge-compile games with pak merge source
-			if game.DeployMode == domain.DeployCompile && service.ModHasPakMergeSource(&mod) {
+			if game.DeployMode == domain.DeployCompile && service.ModHasPakMergeSource(game, &mod) {
 				v := mod.ConvertPaks
 				row.ConvertPaks = &v
 			}
@@ -227,7 +227,7 @@ func doList(cmd *cobra.Command, service *core.Service, game *domain.Game) error 
 				locked = lockedRef.Version
 			}
 			convert := "-"
-			if game.DeployMode == domain.DeployCompile && service.ModHasPakMergeSource(&mod) {
+			if game.DeployMode == domain.DeployCompile && service.ModHasPakMergeSource(game, &mod) {
 				if mod.ConvertPaks {
 					convert = "on"
 				} else {

--- a/cmd/lmm/merge_format_helpers_test.go
+++ b/cmd/lmm/merge_format_helpers_test.go
@@ -54,3 +54,5 @@ func (fakeMergeFormat) ClassifyMergeSource(id string) (string, bool) {
 
 func (fakeMergeFormat) MergedArtifactName() string  { return "zzz_LMM_Merged_P.pak" }
 func (fakeMergeFormat) MergedArtifactLabel() string { return "Icarus Merged Pak" }
+
+func (fakeMergeFormat) RestoredArtifactName(modID string) string { return modID + "_P.pak" }

--- a/cmd/lmm/merge_format_helpers_test.go
+++ b/cmd/lmm/merge_format_helpers_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DonovanMods/go-unrealpak"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// fakeMergeFormat supplies source.MergeCompiler's format-vocabulary methods
+// (#256) for this package's compile-source fakes, mirroring the icarus
+// conventions the fixtures already encode (writeFakeBasePak's
+// Icarus/Content/Data/data.pak path, "pak"/"exmodz" fileIDs, the
+// zzz_LMM_Merged_P.pak artifact name). Embed it in any fake that needs to
+// satisfy source.MergeCompiler. Duplicated per test package by design -
+// mirrors internal/core's identical helper.
+type fakeMergeFormat struct{}
+
+func (fakeMergeFormat) ResolveBaseArtifact(game *domain.Game) (string, error) {
+	candidate := filepath.Join(game.InstallPath, "Icarus", "Content", "Data", "data.pak")
+	if _, err := os.Stat(candidate); err != nil {
+		return "", fmt.Errorf("locating base pak for %q: %w", game.ID, err)
+	}
+	return candidate, nil
+}
+
+func (fakeMergeFormat) FingerprintBase(basePakPath string) (string, error) {
+	r, err := unrealpak.Open(basePakPath)
+	if err != nil {
+		return "", fmt.Errorf("reading base pak for compile fingerprint: %w", err)
+	}
+	defer r.Close() //nolint:errcheck
+	return r.IndexHash(), nil
+}
+
+func (fakeMergeFormat) IsConvertibleArtifact(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".pak")
+}
+
+func (fakeMergeFormat) ClassifyMergeSource(id string) (string, bool) {
+	lower := strings.ToLower(id)
+	if lower == "pak" || strings.HasSuffix(lower, ".pak") {
+		return "pak", true
+	}
+	return "exmodz", false
+}
+
+func (fakeMergeFormat) MergedArtifactName() string  { return "zzz_LMM_Merged_P.pak" }
+func (fakeMergeFormat) MergedArtifactLabel() string { return "Icarus Merged Pak" }

--- a/cmd/lmm/merge_format_helpers_test.go
+++ b/cmd/lmm/merge_format_helpers_test.go
@@ -36,6 +36,10 @@ func (fakeMergeFormat) FingerprintBase(basePakPath string) (string, error) {
 	return r.IndexHash(), nil
 }
 
+func (fakeMergeFormat) IsNativeMergeSource(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".exmodz")
+}
+
 func (fakeMergeFormat) IsConvertibleArtifact(fileName string) bool {
 	return strings.HasSuffix(strings.ToLower(fileName), ".pak")
 }

--- a/cmd/lmm/mod.go
+++ b/cmd/lmm/mod.go
@@ -787,7 +787,7 @@ func doModConvert(service *core.Service, game *domain.Game, modID string, conver
 
 	// Pak conversion only applies to mods with a pak-kind merge source.
 	// Exmodz-only mods have no pak to convert or leave raw, so reject the request.
-	if !service.ModHasPakMergeSource(mod) {
+	if !service.ModHasPakMergeSource(game, mod) {
 		return fmt.Errorf("mod %s has no pak merge source: pak conversion does not apply", modID)
 	}
 

--- a/cmd/lmm/mod_convert_test.go
+++ b/cmd/lmm/mod_convert_test.go
@@ -31,7 +31,11 @@ func setupDoModConvertTest(t *testing.T) (*core.Service, *domain.Game, *fakeInst
 
 	src := newFakeInstallSource("src")
 	t.Cleanup(src.Close)
-	svc.RegisterSource(src)
+	// #256: convert-flag surfaces (list/mod show/mod convert) classify
+	// pak-kind fileIDs via the game's MergeCompiler source, so the
+	// registered "src" must implement it - wrapping the plain fake keeps
+	// callers stubbing through the returned inner fake (shared pointer).
+	svc.RegisterSource(&compilerInstallSource{fakeInstallSource: src})
 
 	game := &domain.Game{
 		ID:          "g1",

--- a/cmd/lmm/root.go
+++ b/cmd/lmm/root.go
@@ -39,7 +39,7 @@ var ErrCancelled = errors.New("cancelled")
 var ErrReported = errors.New("already reported")
 
 var (
-	version = "1.30.0"
+	version = "1.30.1"
 
 	// buildDescribe is injected at build time via -ldflags -X (see the
 	// Makefile's `build` target) with `git describe --tags --dirty`.

--- a/cmd/lmm/uninstall_test.go
+++ b/cmd/lmm/uninstall_test.go
@@ -104,11 +104,12 @@ func TestUninstallCmd_GameNotFound(t *testing.T) {
 }
 
 // setupDoUninstallTest builds a *core.Service plus a mod that will fail to
-// undeploy (its cache directory was never created, so
-// Installer.Uninstall's cache.ListFiles call fails deterministically) and
-// resets the uninstall command's package-level flag globals to sane
-// defaults for calling doUninstall directly. Callers set globals.verbose
-// themselves.
+// undeploy (a regular file sits at the deploy destination, so the symlink
+// linker's Undeploy fails deterministically with "not a symlink" - an absent
+// cache entry no longer works as the failure fixture, since #260 made that a
+// documented no-op) and resets the uninstall command's package-level flag
+// globals to sane defaults for calling doUninstall directly. Callers set
+// globals.verbose themselves.
 func setupDoUninstallTest(t *testing.T) (*core.Service, *domain.Game) {
 	t.Helper()
 
@@ -130,6 +131,10 @@ func setupDoUninstallTest(t *testing.T) (*core.Service, *domain.Game) {
 		UpdatePolicy: domain.UpdateNotify,
 		Enabled:      true,
 	}))
+	require.NoError(t, svc.GetGameCache(game).Store("g1", "src", "1", "1.0", "plugin.esp", []byte("data")))
+	// The undeploy obstruction: a foreign regular file where the symlink
+	// linker expects its own link.
+	require.NoError(t, os.WriteFile(filepath.Join(gameDir, "plugin.esp"), []byte("not a symlink"), 0644))
 	pm := svc.NewProfileManager()
 	_, err = pm.Create("g1", "default")
 	require.NoError(t, err)

--- a/docs/man/man1/lmm-auth-login.1
+++ b/docs/man/man1/lmm-auth-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-auth-login - Authenticate with a mod source

--- a/docs/man/man1/lmm-auth-logout.1
+++ b/docs/man/man1/lmm-auth-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-auth-logout - Remove stored credentials for a mod source

--- a/docs/man/man1/lmm-auth-status.1
+++ b/docs/man/man1/lmm-auth-status.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-auth-status - Show authentication status for all sources

--- a/docs/man/man1/lmm-auth.1
+++ b/docs/man/man1/lmm-auth.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-auth - Manage authentication for mod sources

--- a/docs/man/man1/lmm-completion-bash.1
+++ b/docs/man/man1/lmm-completion-bash.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-completion-bash - Generate the autocompletion script for bash

--- a/docs/man/man1/lmm-completion-fish.1
+++ b/docs/man/man1/lmm-completion-fish.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-completion-fish - Generate the autocompletion script for fish

--- a/docs/man/man1/lmm-completion-powershell.1
+++ b/docs/man/man1/lmm-completion-powershell.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-completion-powershell - Generate the autocompletion script for powershell

--- a/docs/man/man1/lmm-completion-zsh.1
+++ b/docs/man/man1/lmm-completion-zsh.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-completion-zsh - Generate the autocompletion script for zsh

--- a/docs/man/man1/lmm-completion.1
+++ b/docs/man/man1/lmm-completion.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-completion - Generate the autocompletion script for the specified shell

--- a/docs/man/man1/lmm-conflicts.1
+++ b/docs/man/man1/lmm-conflicts.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-conflicts - Show all file conflicts in the current profile

--- a/docs/man/man1/lmm-deploy.1
+++ b/docs/man/man1/lmm-deploy.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-deploy - Deploy mods to game directory

--- a/docs/man/man1/lmm-game-add.1
+++ b/docs/man/man1/lmm-game-add.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-game-add - Add a game interactively

--- a/docs/man/man1/lmm-game-clear-default.1
+++ b/docs/man/man1/lmm-game-clear-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-game-clear-default - Clear the default game setting

--- a/docs/man/man1/lmm-game-detect.1
+++ b/docs/man/man1/lmm-game-detect.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-game-detect - Detect Steam games and add them to config

--- a/docs/man/man1/lmm-game-list.1
+++ b/docs/man/man1/lmm-game-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-game-list - List configured games

--- a/docs/man/man1/lmm-game-set-default.1
+++ b/docs/man/man1/lmm-game-set-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-game-set-default - Set the default game

--- a/docs/man/man1/lmm-game-show-default.1
+++ b/docs/man/man1/lmm-game-show-default.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-game-show-default - Show the current default game

--- a/docs/man/man1/lmm-game.1
+++ b/docs/man/man1/lmm-game.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-game - Game management commands

--- a/docs/man/man1/lmm-import.1
+++ b/docs/man/man1/lmm-import.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-import - Import mods from local files or scan mod_path

--- a/docs/man/man1/lmm-install.1
+++ b/docs/man/man1/lmm-install.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-install - Install a mod

--- a/docs/man/man1/lmm-list.1
+++ b/docs/man/man1/lmm-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-list - List installed mods

--- a/docs/man/man1/lmm-mod-convert.1
+++ b/docs/man/man1/lmm-mod-convert.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-mod-convert - Enable or disable pak-to-exmod conversion for a mod

--- a/docs/man/man1/lmm-mod-disable.1
+++ b/docs/man/man1/lmm-mod-disable.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-mod-disable - Disable a mod without uninstalling

--- a/docs/man/man1/lmm-mod-edit.1
+++ b/docs/man/man1/lmm-mod-edit.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-mod-edit - Edit mod details (name, version, author, source, ID)

--- a/docs/man/man1/lmm-mod-enable.1
+++ b/docs/man/man1/lmm-mod-enable.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-mod-enable - Enable a disabled mod

--- a/docs/man/man1/lmm-mod-files.1
+++ b/docs/man/man1/lmm-mod-files.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-mod-files - List files deployed by a mod

--- a/docs/man/man1/lmm-mod-lock.1
+++ b/docs/man/man1/lmm-mod-lock.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-mod-lock - Lock a mod at its current or a specific version

--- a/docs/man/man1/lmm-mod-set-update.1
+++ b/docs/man/man1/lmm-mod-set-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-mod-set-update - Set update policy for a mod

--- a/docs/man/man1/lmm-mod-show.1
+++ b/docs/man/man1/lmm-mod-show.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-mod-show - Show mod details

--- a/docs/man/man1/lmm-mod-unlock.1
+++ b/docs/man/man1/lmm-mod-unlock.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-mod-unlock - Unlock a mod, restoring normal update behavior

--- a/docs/man/man1/lmm-mod.1
+++ b/docs/man/man1/lmm-mod.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-mod - Manage mod settings

--- a/docs/man/man1/lmm-profile-apply.1
+++ b/docs/man/man1/lmm-profile-apply.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-profile-apply - Apply profile to system

--- a/docs/man/man1/lmm-profile-create.1
+++ b/docs/man/man1/lmm-profile-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-profile-create - Create a new profile

--- a/docs/man/man1/lmm-profile-delete.1
+++ b/docs/man/man1/lmm-profile-delete.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-profile-delete - Delete a profile

--- a/docs/man/man1/lmm-profile-export.1
+++ b/docs/man/man1/lmm-profile-export.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-profile-export - Export a profile

--- a/docs/man/man1/lmm-profile-import.1
+++ b/docs/man/man1/lmm-profile-import.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-profile-import - Import a profile

--- a/docs/man/man1/lmm-profile-list.1
+++ b/docs/man/man1/lmm-profile-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-profile-list - List all profiles

--- a/docs/man/man1/lmm-profile-reorder.1
+++ b/docs/man/man1/lmm-profile-reorder.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-profile-reorder - View or change load order

--- a/docs/man/man1/lmm-profile-switch.1
+++ b/docs/man/man1/lmm-profile-switch.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-profile-switch - Switch to a different profile

--- a/docs/man/man1/lmm-profile-sync.1
+++ b/docs/man/man1/lmm-profile-sync.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-profile-sync - Sync profile to match installed mods

--- a/docs/man/man1/lmm-profile.1
+++ b/docs/man/man1/lmm-profile.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-profile - Manage mod profiles

--- a/docs/man/man1/lmm-purge.1
+++ b/docs/man/man1/lmm-purge.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-purge - Remove all deployed mods from game directory

--- a/docs/man/man1/lmm-search.1
+++ b/docs/man/man1/lmm-search.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-search - Search for mods

--- a/docs/man/man1/lmm-source-list.1
+++ b/docs/man/man1/lmm-source-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-source-list - List all mod sources

--- a/docs/man/man1/lmm-source-validate.1
+++ b/docs/man/man1/lmm-source-validate.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-source-validate - Validate a source definition file

--- a/docs/man/man1/lmm-source.1
+++ b/docs/man/man1/lmm-source.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-source - Manage mod sources

--- a/docs/man/man1/lmm-status.1
+++ b/docs/man/man1/lmm-status.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-status - Show current status

--- a/docs/man/man1/lmm-tui.1
+++ b/docs/man/man1/lmm-tui.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-tui - Launch the interactive terminal UI

--- a/docs/man/man1/lmm-uninstall.1
+++ b/docs/man/man1/lmm-uninstall.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-uninstall - Uninstall a mod

--- a/docs/man/man1/lmm-update-rollback.1
+++ b/docs/man/man1/lmm-update-rollback.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-update-rollback - Rollback a mod to its previous version

--- a/docs/man/man1/lmm-update.1
+++ b/docs/man/man1/lmm-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-update - Check for or apply mod updates

--- a/docs/man/man1/lmm-verify.1
+++ b/docs/man/man1/lmm-verify.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm-verify - Verify cached mod files

--- a/docs/man/man1/lmm.1
+++ b/docs/man/man1/lmm.1
@@ -1,5 +1,5 @@
 .nh
-.TH "LMM" "1" "Jul 2026" "lmm 1.30.0" "User Commands"
+.TH "LMM" "1" "Jul 2026" "lmm 1.30.1" "User Commands"
 
 .SH NAME
 lmm - Linux Mod Manager \- Terminal-based mod manager for Linux

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -4157,7 +4157,7 @@ func (s *Service) applyInstallPrimary(ctx context.Context, game *domain.Game, pl
 	if err != nil {
 		return nil, fmt.Errorf("resolving source %q: %w", plan.SourceID, err)
 	}
-	_, isMergeCompiler := src.(source.MergeCompiler)
+	mc, isMergeCompiler := src.(source.MergeCompiler)
 
 	// compiledFiles accumulates every file this loop actually compiled (game
 	// DeployCompile + a ".exmodz" file - the same condition
@@ -4211,15 +4211,15 @@ func (s *Service) applyInstallPrimary(ctx context.Context, game *domain.Game, pl
 		downloadedFileIDs = append(downloadedFileIDs, file.ID)
 
 		// Copilot round 1 (PR #222): compiledFiles collects BOTH kinds -
-		// .exmodz files and convert-eligible .pak files alike - so the
+		// .exmodz files and convert-eligible raw files alike - so the
 		// InstallCompiling/"Retaining ... for merge" messaging below (and
 		// in cmd/lmm/install.go's InstallCompiling case) fires for a
 		// convert-eligible raw pak exactly as it does for a native
 		// .exmodz; len(compiledFiles) > 0 doesn't care which kind matched.
-		// #221: gate .pak files on MergeCompiler capability, matching the
+		// #221: gate raw files on MergeCompiler capability, matching the
 		// ingest path's predicate. .exmodz files are still included because
 		// they hard-error later if the source lacks MergeCompiler.
-		if game.DeployMode == domain.DeployCompile && (isExmodzFile(file.FileName) || (isMergeCompiler && isConvertEligiblePakFile(game, file.FileName))) {
+		if game.DeployMode == domain.DeployCompile && (isExmodzFile(file.FileName) || (isMergeCompiler && isConvertEligibleArtifact(game, mc, file.FileName))) {
 			compiledFiles = append(compiledFiles, file)
 		}
 	}

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -4217,9 +4217,11 @@ func (s *Service) applyInstallPrimary(ctx context.Context, game *domain.Game, pl
 		// convert-eligible raw pak exactly as it does for a native
 		// .exmodz; len(compiledFiles) > 0 doesn't care which kind matched.
 		// #221: gate raw files on MergeCompiler capability, matching the
-		// ingest path's predicate. .exmodz files are still included because
-		// they hard-error later if the source lacks MergeCompiler.
-		if game.DeployMode == domain.DeployCompile && (isExmodzFile(file.FileName) || (isMergeCompiler && isConvertEligibleArtifact(game, mc, file.FileName))) {
+		// ingest path's predicate. Native merge archives are still included
+		// when only the GAME's compile source (not this file's own source)
+		// recognizes them - isNativeMergeFile's fallback - because ingest
+		// hard-errors on exactly that mismatch later (#256).
+		if game.DeployMode == domain.DeployCompile && (s.isNativeMergeFile(game, mc, file.FileName) || (isMergeCompiler && isConvertEligibleArtifact(game, mc, file.FileName))) {
 			compiledFiles = append(compiledFiles, file)
 		}
 	}

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -964,6 +964,54 @@ const (
 	// (4-space indent, matching ApplyProfileSwitch's own SwitchInstallNote
 	// convention).
 	ImportNote
+
+	// --- #255: compile-mode deploy readout, extending this same enum
+	// (the established "extend, don't fork" convention above). ---
+
+	// DeployMergeSynced fires once per DeployProfile on a DeployCompile
+	// game, after the post-loop merged-artifact sync succeeds with a
+	// merged artifact in place. It does not fire when the profile has no
+	// merge participants (nothing merged, nothing to report) or when the
+	// sync itself fails (that path emits a DeployWarning instead). Total
+	// carries the number of mods whose content the merged artifact
+	// carries; Detail names the artifact file
+	// (source.MergeCompiler.MergedArtifactName - the format is the
+	// source's business, never core's, #256); RawFallbacks counts
+	// participant mods that fell back to an individual raw deploy (failed
+	// conversion). No single mod is in scope (Index/ModName/ModID are
+	// zero). The same readout is recorded on DeployResult
+	// (MergedArtifact/MergedMods/RawFallbacks) for callers with no
+	// progress stream.
+	DeployMergeSynced
+)
+
+// DeployModClass classifies how a DeployDeployed mod's content reaches the
+// game directory on a DeployCompile game (#255), so callers stop rendering
+// merge participants - which individually deploy zero files by design
+// (#197) - as ordinary per-mod deployments. Classification happens BEFORE
+// the deploy loop (from enabledMergeSources), so it cannot know this sync's
+// conversion outcomes yet: an opted-in pak that goes on to fail conversion
+// is optimistically DeployModMerged here, and the correction is carried by
+// the existing conversion-failure warning plus DeployMergeSynced's
+// RawFallbacks count (issue #255's decided option (b); the stored
+// fingerprint is deliberately NOT consulted pre-loop - it describes the
+// previous sync, which is wrong on first deploy and after input changes).
+type DeployModClass int
+
+const (
+	// DeployModIndividual (the zero value): an ordinary mod deploying its
+	// own files - every mod on a non-compile game, and a loose-file mod
+	// in a compile profile.
+	DeployModIndividual DeployModClass = iota
+	// DeployModMerged: a merge participant - its content reaches the game
+	// via the profile-level merged artifact built after the deploy loop;
+	// its own install step deploys nothing (native merge sources) or its
+	// raw copy is claimed by the merge (converted artifacts).
+	DeployModMerged
+	// DeployModRaw: a convertible artifact excluded from the merge by the
+	// game- or mod-level ConvertPaks opt-out (#221) - it deploys raw,
+	// individually.
+	DeployModRaw
 )
 
 // DeployProgress reports incremental status during DeployProfile. Index and
@@ -1024,6 +1072,18 @@ type DeployProgress struct {
 	// InstallResult.FilesDeployed, which only ever tracks the STRICT path's
 	// primary. Zero for every other phase.
 	FilesExtracted int
+
+	// --- #255: compile-mode deploy readout fields ---
+
+	// ModClass classifies how ModName's content reaches the game
+	// directory on a DeployCompile game - set on DeployDeployed only;
+	// zero (DeployModIndividual) for every other phase and on non-compile
+	// games. See DeployModClass.
+	ModClass DeployModClass
+	// RawFallbacks carries DeployMergeSynced's count of participant mods
+	// that fell back to an individual raw deploy. Zero for every other
+	// phase.
+	RawFallbacks int
 }
 
 // DeployResult reports the outcome of DeployProfile. As with UninstallResult
@@ -1074,6 +1134,18 @@ type DeployResult struct {
 	Skipped  []string
 	Warnings []string
 	Notes    []string
+
+	// MergedArtifact/MergedMods/RawFallbacks mirror the DeployMergeSynced
+	// event for callers with no progress stream (#255 - the TUI passes
+	// nil): the merged artifact's file name
+	// (source.MergeCompiler.MergedArtifactName), how many mods' content it
+	// carries, and how many participants fell back to an individual raw
+	// deploy (failed conversion). All zero when the deploy produced/kept
+	// no merged artifact: non-compile games, or a compile profile with no
+	// merge participants.
+	MergedArtifact string
+	MergedMods     int
+	RawFallbacks   int
 }
 
 // errNoDeployFiles mirrors cmd/lmm's errNoDownloadableFiles for the
@@ -1793,6 +1865,12 @@ func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileN
 	// appended to at the natural point, unchanged.
 	var deferredWarnings []DeployProgress
 
+	// #255: on a compile game, classify each mod up front so its
+	// DeployDeployed event can say whether it deploys files individually or
+	// rides the merged artifact built after the loop (nil map - and
+	// therefore the zero class - everywhere else).
+	modClasses := s.classifyCompileDeployMods(game, profileName, modsToDeploy)
+
 	total := len(modsToDeploy)
 	for idx, mod := range modsToDeploy {
 		// Task 6 item d (cancel-then-drain): checked between mods, never
@@ -1856,6 +1934,7 @@ func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileN
 		result.Deployed++
 		evt := base
 		evt.Phase = DeployDeployed
+		evt.ModClass = modClasses[domain.ModKey(mod.SourceID, mod.ID)]
 		emit(evt)
 
 		if err := runHook(ctx, opts.HookRunner, &hookCtx, "install.after_each", opts.Hooks.GetInstallAfterEach()); err != nil {
@@ -1891,6 +1970,10 @@ func (s *Service) DeployProfile(ctx context.Context, game *domain.Game, profileN
 			result.Warnings = append(result.Warnings, w)
 			emit(DeployProgress{Phase: DeployWarning, Detail: w})
 		}
+		// #255: the sync succeeded, so the just-written fingerprint is the
+		// authoritative record of what the merged artifact carries - report
+		// it (result fields + one DeployMergeSynced event).
+		s.recordMergeOutcome(game, profileName, result, emit)
 	}
 
 	for _, w := range deferredWarnings {

--- a/internal/core/flows_deploy_compile_readout_test.go
+++ b/internal/core/flows_deploy_compile_readout_test.go
@@ -1,0 +1,252 @@
+package core_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/linux-mod-manager/internal/core"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupCompileReadoutGame builds a DeployCompile game (ConvertPaks on, base
+// pak present, "default" profile created) for #255's deploy-readout tests,
+// mirroring service_icarus_compile_test.go's harness. The caller registers
+// its own merge-compiler source under "fake-compiler" first.
+func setupCompileReadoutGame(t *testing.T, svc *core.Service) *domain.Game {
+	t.Helper()
+
+	installDir := t.TempDir()
+	basePak := filepath.Join(installDir, "Icarus", "Content", "Data", "data.pak")
+	require.NoError(t, os.MkdirAll(filepath.Dir(basePak), 0o755))
+	writeFakeBasePak(t, basePak)
+
+	game := &domain.Game{
+		ID: "icarus", Name: "Icarus", InstallPath: installDir, ModPath: t.TempDir(),
+		DeployMode: domain.DeployCompile, LinkMethod: domain.LinkCopy, ConvertPaks: true,
+		SourceIDs: map[string]string{"fake-compiler": "external-icarus-id"},
+	}
+	require.NoError(t, svc.AddGame(game))
+
+	pm := svc.NewProfileManager()
+	_, err := pm.Create(game.ID, "default")
+	require.NoError(t, err)
+	require.NoError(t, pm.SetDefault(game.ID, "default"))
+	return game
+}
+
+// seedExmodzMod installs an enabled native merge-source (exmodz) mod: a
+// retained source only, zero deployment members of its own (#197).
+func seedExmodzMod(t *testing.T, svc *core.Service, game *domain.Game, modID, name, fileID string) {
+	t.Helper()
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, "fake-compiler", modID, "1.0", cache.RetainedSourceName(fileID), []byte(name+"-bytes")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: "fake-compiler", Name: name, Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		FileIDs:      []string{fileID},
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: "fake-compiler", ModID: modID, Version: "1.0", FileIDs: []string{fileID}}))
+}
+
+// seedLooseMod installs an enabled ordinary loose-file mod (no retained
+// merge source): it deploys its own file individually even on a compile game.
+func seedLooseMod(t *testing.T, svc *core.Service, game *domain.Game, modID, name, fileName string) {
+	t.Helper()
+	require.NoError(t, svc.GetGameCache(game).Store(game.ID, "fake-compiler", modID, "1.0", fileName, []byte("loose-data")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: "fake-compiler", Name: name, Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: "fake-compiler", ModID: modID, Version: "1.0"}))
+}
+
+// deployRecordingProgress runs DeployProfile with a recorder and returns the
+// result, every DeployDeployed event keyed by mod name (with its position in
+// the event stream), and any DeployMergeSynced events (with positions).
+func deployRecordingProgress(t *testing.T, svc *core.Service, game *domain.Game) (*core.DeployResult, map[string]core.DeployProgress, map[string]int, []core.DeployProgress, []int) {
+	t.Helper()
+	deployed := map[string]core.DeployProgress{}
+	deployedAt := map[string]int{}
+	var mergeEvents []core.DeployProgress
+	var mergeAt []int
+	seq := 0
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		seq++
+		switch p.Phase {
+		case core.DeployDeployed:
+			deployed[p.ModName] = p
+			deployedAt[p.ModName] = seq
+		case core.DeployMergeSynced:
+			mergeEvents = append(mergeEvents, p)
+			mergeAt = append(mergeAt, seq)
+		}
+	})
+	require.NoError(t, err)
+	return result, deployed, deployedAt, mergeEvents, mergeAt
+}
+
+// TestDeployProfile_Compile_ClassifiesModsAndEmitsMergeSynced covers #255's
+// three-way classification on a DeployCompile game: a native (exmodz) merge
+// participant, a ConvertPaks-opted-out pak deploying raw, and an ordinary
+// loose-file mod - plus the post-sync DeployMergeSynced event naming the
+// merged artifact (via the source's MergedArtifactName, never a core
+// literal) and carrying the participant count, and the same readout on
+// DeployResult for progress-less callers (the TUI).
+func TestDeployProfile_Compile_ClassifiesModsAndEmitsMergeSynced(t *testing.T) {
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(&fakeCompilerSource{})
+	game := setupCompileReadoutGame(t, svc)
+
+	seedExmodzMod(t, svc, game, "bear-mount", "Bear Mount", "exmodz-file")
+	seedEnabledPakMod(t, svc, game, "fake-compiler", "raw-pak", "1.0", "raw.pak", []byte("raw-pak-bytes"))
+	require.NoError(t, svc.SetModConvertPaks("fake-compiler", "raw-pak", game.ID, "default", false))
+	seedLooseMod(t, svc, game, "loose", "Loose Mod", "loose.esp")
+
+	result, deployed, deployedAt, mergeEvents, mergeAt := deployRecordingProgress(t, svc, game)
+
+	require.Equal(t, 3, result.Deployed)
+
+	// Per-mod classification, set on each DeployDeployed event (#255).
+	require.Contains(t, deployed, "Bear Mount")
+	assert.Equal(t, core.DeployModMerged, deployed["Bear Mount"].ModClass, "a native merge source is carried by the merged artifact")
+	require.Contains(t, deployed, "raw-pak")
+	assert.Equal(t, core.DeployModRaw, deployed["raw-pak"].ModClass, "an opted-out pak deploys raw, individually")
+	require.Contains(t, deployed, "Loose Mod")
+	assert.Equal(t, core.DeployModIndividual, deployed["Loose Mod"].ModClass, "a loose-file mod is an ordinary individual deployment")
+
+	// The post-sync merge event: exactly one, after every per-mod event,
+	// naming the artifact and counting merge participants.
+	require.Len(t, mergeEvents, 1, "exactly one DeployMergeSynced event must fire")
+	evt := mergeEvents[0]
+	assert.Equal(t, 1, evt.Total, "one mod's content is carried by the merged artifact")
+	assert.Equal(t, "zzz_LMM_Merged_P.pak", evt.Detail, "Detail must name the merged artifact (MergedArtifactName)")
+	assert.Equal(t, 0, evt.RawFallbacks)
+	for name, at := range deployedAt {
+		assert.Greater(t, mergeAt[0], at, "DeployMergeSynced must fire after %s's DeployDeployed", name)
+	}
+
+	// The same readout lands on DeployResult for callers with no progress
+	// stream (the TUI passes nil).
+	assert.Equal(t, "zzz_LMM_Merged_P.pak", result.MergedArtifact)
+	assert.Equal(t, 1, result.MergedMods)
+	assert.Equal(t, 0, result.RawFallbacks)
+}
+
+// TestDeployProfile_Compile_ConversionFailure_ReportsRawFallback covers the
+// one optimistic case #255 accepts: a convert-opted-in pak is labeled a
+// merge participant at DeployDeployed time (the merge hasn't run yet), then
+// fails conversion during syncMergedPak - the existing "pak conversion
+// failed ... deploying raw" warning carries the correction, and the
+// DeployMergeSynced footer reports the raw fallback count accurately.
+func TestDeployProfile_Compile_ConversionFailure_ReportsRawFallback(t *testing.T) {
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+	svc.RegisterSource(&pakConversionOutcomeSource{
+		fakeCompilerSource: &fakeCompilerSource{},
+		failRefs:           map[string]string{"fake-compiler:flaky-pak": "irreconcilable"},
+	})
+	game := setupCompileReadoutGame(t, svc)
+
+	seedExmodzMod(t, svc, game, "bear-mount", "Bear Mount", "exmodz-file")
+	seedEnabledPakMod(t, svc, game, "fake-compiler", "flaky-pak", "1.0", "flaky.pak", []byte("flaky-pak-bytes"))
+
+	var warnings []string
+	deployed := map[string]core.DeployProgress{}
+	var mergeEvents []core.DeployProgress
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		switch p.Phase {
+		case core.DeployDeployed:
+			deployed[p.ModName] = p
+		case core.DeployWarning:
+			warnings = append(warnings, p.Detail)
+		case core.DeployMergeSynced:
+			mergeEvents = append(mergeEvents, p)
+		}
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Deployed)
+
+	// Optimistic inline label: at DeployDeployed time the pak is a merge
+	// participant - the correction comes from the warning + footer below.
+	require.Contains(t, deployed, "flaky-pak")
+	assert.Equal(t, core.DeployModMerged, deployed["flaky-pak"].ModClass)
+
+	// The existing conversion-failure warning still fires (the correction).
+	foundConversionWarning := false
+	for _, w := range warnings {
+		if strings.Contains(w, "pak conversion failed") {
+			foundConversionWarning = true
+		}
+	}
+	assert.True(t, foundConversionWarning, "the pak-conversion-failure warning must still fire; got %v", warnings)
+
+	require.Len(t, mergeEvents, 1)
+	assert.Equal(t, 1, mergeEvents[0].Total, "only the exmodz mod's content made the merged artifact")
+	assert.Equal(t, "zzz_LMM_Merged_P.pak", mergeEvents[0].Detail)
+	assert.Equal(t, 1, mergeEvents[0].RawFallbacks, "the failed pak fell back to a raw individual deploy")
+
+	assert.Equal(t, 1, result.MergedMods)
+	assert.Equal(t, 1, result.RawFallbacks)
+	assert.Equal(t, "zzz_LMM_Merged_P.pak", result.MergedArtifact)
+}
+
+// TestDeployProfile_NonCompile_NoMergeReadout guards the gate: a non-compile
+// game's deploy must carry no classification and no merge event - its output
+// contract is byte-identical to before #255.
+func TestDeployProfile_NonCompile_NoMergeReadout(t *testing.T) {
+	cfg := core.ServiceConfig{ConfigDir: t.TempDir(), DataDir: t.TempDir(), CacheDir: t.TempDir()}
+	svc, err := core.NewService(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	game := &domain.Game{ID: "plain", Name: "Plain", ModPath: t.TempDir(), LinkMethod: domain.LinkCopy}
+	require.NoError(t, svc.AddGame(game))
+	pm := svc.NewProfileManager()
+	_, err = pm.Create(game.ID, "default")
+	require.NoError(t, err)
+
+	require.NoError(t, svc.GetGameCache(game).Store(game.ID, "src", "a", "1.0", "a.esp", []byte("data")))
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: "a", SourceID: "src", Name: "Mod A", Version: "1.0", GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: "src", ModID: "a", Version: "1.0"}))
+
+	var mergeEvents []core.DeployProgress
+	deployed := map[string]core.DeployProgress{}
+	result, err := svc.DeployProfile(context.Background(), game, "default", core.DeployOptions{}, func(p core.DeployProgress) {
+		switch p.Phase {
+		case core.DeployDeployed:
+			deployed[p.ModName] = p
+		case core.DeployMergeSynced:
+			mergeEvents = append(mergeEvents, p)
+		}
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Deployed)
+
+	assert.Empty(t, mergeEvents, "a non-compile deploy must emit no DeployMergeSynced event")
+	assert.Equal(t, core.DeployModIndividual, deployed["Mod A"].ModClass)
+	assert.Zero(t, result.MergedArtifact)
+	assert.Zero(t, result.MergedMods)
+	assert.Zero(t, result.RawFallbacks)
+}

--- a/internal/core/flows_test.go
+++ b/internal/core/flows_test.go
@@ -806,21 +806,25 @@ func TestService_UninstallMod_ProfileDesyncWarnsAndContinues(t *testing.T) {
 
 // TestService_UninstallMod_UndeployFailure_RecordedAsNoteWithHistoricalPrefix
 // guards the exact text (including its historical "Warning: " prefix) of the
-// undeploy-failure diagnostic. The mod is never actually cached, so
-// Installer.Uninstall's cache.ListFiles call fails deterministically
-// (directory does not exist) without relying on filesystem permissions. The
-// profile is pre-seeded so profile removal succeeds silently, isolating this
-// one diagnostic.
+// undeploy-failure diagnostic. A regular file sits where the symlink linker
+// expects its own link, so linker.Undeploy fails deterministically ("not a
+// symlink") without relying on filesystem permissions. (An absent cache
+// entry no longer works as the failure fixture here: since #260 that is a
+// documented no-op, not an error.) The profile is pre-seeded so profile
+// removal succeeds silently, isolating this one diagnostic.
 func TestService_UninstallMod_UndeployFailure_RecordedAsNoteWithHistoricalPrefix(t *testing.T) {
 	svc := newFlowsTestService(t)
 	gameDir := t.TempDir()
 	game := &domain.Game{ID: "g1", Name: "Game", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
 
-	// No cache files stored (files: nil) - Installer.Uninstall's
-	// cache.ListFiles call fails because the mod's cache directory was
-	// never created.
-	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, nil)
+	seedInstalledMod(t, svc, game, "src", "1", "1.0", true, map[string][]byte{
+		"plugin.esp": []byte("data"),
+	})
 	seedProfileWithMod(t, svc, "g1", "default", "src", "1", "1.0")
+
+	// A foreign regular file at the deploy destination: Undeploy refuses to
+	// remove anything that is not its own symlink.
+	require.NoError(t, os.WriteFile(filepath.Join(gameDir, "plugin.esp"), []byte("not a symlink"), 0644))
 
 	result, err := svc.UninstallMod(context.Background(), game, "default", "src", "1", core.UninstallOptions{})
 	require.NoError(t, err, "an undeploy failure must not fail the uninstall")

--- a/internal/core/flows_variant_exclusivity_test.go
+++ b/internal/core/flows_variant_exclusivity_test.go
@@ -142,7 +142,7 @@ func TestApplyInstall_StrictPath_TargetFileIDs_MixedVariants_Rejected(t *testing
 
 	opts := core.InstallOptions{TargetFileIDs: []string{"pak", "exmodz"}}
 	_, err = svc.ApplyInstall(context.Background(), game, plan, opts, nil)
-	require.ErrorContains(t, err, "raw pak and native merge archive are alternate forms of the same mod - select one")
+	require.ErrorContains(t, err, "raw artifact and native merge archive are alternate forms of the same mod - select one")
 
 	require.Equal(t, 0, mc.DownloadCount(), "no download may happen for a rejected mixed selection")
 	gameCache := svc.GetGameCache(game)
@@ -167,7 +167,7 @@ func TestApplyInstall_StrictPath_CallerSuppliedMixedVariantFiles_Rejected(t *tes
 	plan.Files = mc.files["mod1"]
 
 	_, err = svc.ApplyInstall(context.Background(), game, plan, core.InstallOptions{}, nil)
-	require.ErrorContains(t, err, "raw pak and native merge archive are alternate forms of the same mod - select one")
+	require.ErrorContains(t, err, "raw artifact and native merge archive are alternate forms of the same mod - select one")
 
 	require.Equal(t, 0, mc.DownloadCount(), "no download may happen for a rejected mixed selection")
 	gameCache := svc.GetGameCache(game)
@@ -204,7 +204,7 @@ func TestApplyInstall_BatchPath_TargetFileIDs_MixedVariants_Rejected(t *testing.
 
 	opts := core.InstallOptions{TargetFileIDs: []string{"pak", "exmodz"}}
 	_, err = svc.ApplyInstall(context.Background(), game, plan, opts, nil)
-	require.ErrorContains(t, err, "raw pak and native merge archive are alternate forms of the same mod - select one")
+	require.ErrorContains(t, err, "raw artifact and native merge archive are alternate forms of the same mod - select one")
 
 	require.Equal(t, 0, mc.DownloadCount(), "no download may happen for a rejected mixed selection")
 	gameCache := svc.GetGameCache(game)

--- a/internal/core/flows_variant_exclusivity_test.go
+++ b/internal/core/flows_variant_exclusivity_test.go
@@ -32,6 +32,7 @@ import (
 // because a single mod must offer BOTH a pak and an exmodz file so
 // PlanInstall/ApplyInstall can drive a real mixed selection end to end.
 type variantExclusivitySource struct {
+	fakeMergeFormat // #256: the format-vocabulary half of source.MergeCompiler
 	*mockSourceWithDownloads
 	files map[string][]domain.DownloadableFile // mod.ID -> served files, verbatim
 }

--- a/internal/core/flows_variant_exclusivity_test.go
+++ b/internal/core/flows_variant_exclusivity_test.go
@@ -142,7 +142,7 @@ func TestApplyInstall_StrictPath_TargetFileIDs_MixedVariants_Rejected(t *testing
 
 	opts := core.InstallOptions{TargetFileIDs: []string{"pak", "exmodz"}}
 	_, err = svc.ApplyInstall(context.Background(), game, plan, opts, nil)
-	require.ErrorContains(t, err, "raw artifact and native merge archive are alternate forms of the same mod - select one")
+	require.ErrorContains(t, err, "Mod_P.pak and Mod.exmodz are alternate forms of the same mod - select one")
 
 	require.Equal(t, 0, mc.DownloadCount(), "no download may happen for a rejected mixed selection")
 	gameCache := svc.GetGameCache(game)
@@ -167,7 +167,7 @@ func TestApplyInstall_StrictPath_CallerSuppliedMixedVariantFiles_Rejected(t *tes
 	plan.Files = mc.files["mod1"]
 
 	_, err = svc.ApplyInstall(context.Background(), game, plan, core.InstallOptions{}, nil)
-	require.ErrorContains(t, err, "raw artifact and native merge archive are alternate forms of the same mod - select one")
+	require.ErrorContains(t, err, "Mod_P.pak and Mod.exmodz are alternate forms of the same mod - select one")
 
 	require.Equal(t, 0, mc.DownloadCount(), "no download may happen for a rejected mixed selection")
 	gameCache := svc.GetGameCache(game)
@@ -204,7 +204,7 @@ func TestApplyInstall_BatchPath_TargetFileIDs_MixedVariants_Rejected(t *testing.
 
 	opts := core.InstallOptions{TargetFileIDs: []string{"pak", "exmodz"}}
 	_, err = svc.ApplyInstall(context.Background(), game, plan, opts, nil)
-	require.ErrorContains(t, err, "raw artifact and native merge archive are alternate forms of the same mod - select one")
+	require.ErrorContains(t, err, "Mod_P.pak and Mod.exmodz are alternate forms of the same mod - select one")
 
 	require.Equal(t, 0, mc.DownloadCount(), "no download may happen for a rejected mixed selection")
 	gameCache := svc.GetGameCache(game)

--- a/internal/core/flows_variant_exclusivity_test.go
+++ b/internal/core/flows_variant_exclusivity_test.go
@@ -142,7 +142,7 @@ func TestApplyInstall_StrictPath_TargetFileIDs_MixedVariants_Rejected(t *testing
 
 	opts := core.InstallOptions{TargetFileIDs: []string{"pak", "exmodz"}}
 	_, err = svc.ApplyInstall(context.Background(), game, plan, opts, nil)
-	require.ErrorContains(t, err, "pak and exmodz are alternate forms of the same mod - select one")
+	require.ErrorContains(t, err, "raw pak and native merge archive are alternate forms of the same mod - select one")
 
 	require.Equal(t, 0, mc.DownloadCount(), "no download may happen for a rejected mixed selection")
 	gameCache := svc.GetGameCache(game)
@@ -167,7 +167,7 @@ func TestApplyInstall_StrictPath_CallerSuppliedMixedVariantFiles_Rejected(t *tes
 	plan.Files = mc.files["mod1"]
 
 	_, err = svc.ApplyInstall(context.Background(), game, plan, core.InstallOptions{}, nil)
-	require.ErrorContains(t, err, "pak and exmodz are alternate forms of the same mod - select one")
+	require.ErrorContains(t, err, "raw pak and native merge archive are alternate forms of the same mod - select one")
 
 	require.Equal(t, 0, mc.DownloadCount(), "no download may happen for a rejected mixed selection")
 	gameCache := svc.GetGameCache(game)
@@ -204,7 +204,7 @@ func TestApplyInstall_BatchPath_TargetFileIDs_MixedVariants_Rejected(t *testing.
 
 	opts := core.InstallOptions{TargetFileIDs: []string{"pak", "exmodz"}}
 	_, err = svc.ApplyInstall(context.Background(), game, plan, opts, nil)
-	require.ErrorContains(t, err, "pak and exmodz are alternate forms of the same mod - select one")
+	require.ErrorContains(t, err, "raw pak and native merge archive are alternate forms of the same mod - select one")
 
 	require.Equal(t, 0, mc.DownloadCount(), "no download may happen for a rejected mixed selection")
 	gameCache := svc.GetGameCache(game)

--- a/internal/core/importer.go
+++ b/internal/core/importer.go
@@ -120,25 +120,33 @@ func (i *Importer) Import(ctx context.Context, archivePath string, game *domain.
 
 	// mergeEligible (.exmodz) has no other valid interpretation for a
 	// DeployCompile game - an unresolvable MergeCompiler is a hard error.
-	// convertEligiblePak (.pak) DOES have one - the legacy extract/copy path
-	// below - so a resolver failure there falls through instead of erroring
-	// the whole import (#221 I1 fix, mirrors DownloadModToCache's identical
-	// fix): resolveMergeCompiler is a GAME-level lookup (Import has no
-	// per-archive source pinned the way a download does), so "no
+	// convertEligiblePak (a raw pak) DOES have one - the legacy extract/copy
+	// path below - so a resolver failure there falls through instead of
+	// erroring the whole import (#221 I1 fix, mirrors DownloadModToCache's
+	// identical fix): resolveMergeCompiler is a GAME-level lookup (Import
+	// has no per-archive source pinned the way a download does), so "no
 	// MergeCompiler-capable source configured for this game" is exactly the
 	// same "fall through for a pak, still hard-error for an exmodz" case as
 	// the download path's "this specific source lacks MergeCompiler".
+	//
+	// #256: whether filename IS a convertible artifact is now the compile
+	// source's call (mc.IsConvertibleArtifact), so resolution is attempted
+	// for any non-exmodz import into a convert_paks game - the pre-#256
+	// static ".pak" pre-filter no longer exists in core. Resolution is a
+	// pure registry lookup, so the wider trigger changes nothing
+	// observable: a non-convertible filename still ends up with
+	// convertEligiblePak == false and the exact same fall-through.
 	mergeEligible := isExmodzFile(filename)
 	var mc source.MergeCompiler
 	var mcErr error
-	if game.DeployMode == domain.DeployCompile && (mergeEligible || isConvertEligiblePakFile(game, filename)) {
+	if game.DeployMode == domain.DeployCompile && (mergeEligible || game.ConvertPaks) {
 		if i.resolveMergeCompiler == nil {
 			mcErr = fmt.Errorf("game %q requires DeployCompile to import %q, but this Importer was constructed without service context (via core.NewImporter, not Service.NewImporter) and has no compiler resolver to consult - import via the service-backed importer instead", game.ID, filename)
 		} else {
 			mc, mcErr = i.resolveMergeCompiler(game.ID)
 		}
 	}
-	convertEligiblePak := mcErr == nil && isConvertEligiblePakFile(game, filename)
+	convertEligiblePak := mcErr == nil && mc != nil && isConvertEligibleArtifact(game, mc, filename)
 
 	// Handle based on game's deploy mode
 	if game.DeployMode == domain.DeployCompile && (mergeEligible || convertEligiblePak) {

--- a/internal/core/importer.go
+++ b/internal/core/importer.go
@@ -123,33 +123,41 @@ func (i *Importer) Import(ctx context.Context, archivePath string, game *domain.
 	// (mc.IsNativeMergeSource - the seam-routed successor to core's static
 	// ".exmodz" test) or a convertible artifact (mc.IsConvertibleArtifact)
 	// is the compile source's call, so the compiler is resolved up front
-	// for every DeployCompile import. Resolution is a pure registry
-	// lookup; when it fails, nothing can define either format, so BOTH
-	// predicates are false and the import falls through to the legacy
-	// extract/copy path: a raw pak or plain zip behaves exactly as before
-	// (#221 I1 fix - "unsupported archive format" for the pak, a normal
-	// extract for the zip), and a native archive - unextractable, since
-	// the Extractor is extension-keyed - still fails loud with
-	// "unsupported archive format" rather than the old compiler-specific
-	// message, and still caches nothing.
+	// for EVERY DeployCompile import, and a resolution failure is a hard
+	// error for every one of them - not just the native case the old
+	// static test could single out. Falling through instead would be
+	// unsafe: with no compiler, core cannot tell a native merge archive
+	// from anything else, and the legacy extract path CONTENT-SNIFFS zip
+	// magic (detectFormatFromPath), so a real, zip-backed native archive
+	// would be silently extracted and cached without ValidateSource -
+	// exactly the "never silently cache an unvalidated native archive"
+	// invariant the resolver error protects. This supersedes #221 I1's
+	// import-side pak fall-through: that was safe only while core itself
+	// knew which files were native. (The DOWNLOAD path's I1 fall-through
+	// stands - it pins eligibility to the file's own source, a per-archive
+	// signal Import does not have.) The resolver error names the fix
+	// ("map a source implementing source.MergeCompiler"), which is
+	// accurate for any import into a compile game whose compiler is
+	// missing or ambiguous.
 	//
-	// A NIL RESOLVER is different: core.NewImporter (no Service context)
-	// cannot answer the format question for ANY file, and unlike a
-	// misconfigured game there is a correct importer to use instead - so a
-	// DeployCompile import through a standalone Importer fails loud
-	// unconditionally. Production only ever constructs the service-backed
-	// importer (Service.NewImporter); this path is reachable only by
-	// direct core.NewImporter use.
+	// A NIL RESOLVER fails the same way for the same reason, with its own
+	// message: core.NewImporter (no Service context) cannot answer the
+	// format question for ANY file, and there is a correct importer to use
+	// instead. Production only ever constructs the service-backed importer
+	// (Service.NewImporter); this path is reachable only by direct
+	// core.NewImporter use.
 	var mc source.MergeCompiler
-	var mcErr error
 	if game.DeployMode == domain.DeployCompile {
 		if i.resolveMergeCompiler == nil {
 			return nil, fmt.Errorf("game %q requires DeployCompile to import %q, but this Importer was constructed without service context (via core.NewImporter, not Service.NewImporter) and has no compiler resolver to consult - import via the service-backed importer instead", game.ID, filename)
 		}
-		mc, mcErr = i.resolveMergeCompiler(game.ID)
+		var mcErr error
+		if mc, mcErr = i.resolveMergeCompiler(game.ID); mcErr != nil {
+			return nil, mcErr
+		}
 	}
-	mergeEligible := mcErr == nil && mc != nil && mc.IsNativeMergeSource(filename)
-	convertEligiblePak := mcErr == nil && mc != nil && isConvertEligibleArtifact(game, mc, filename)
+	mergeEligible := mc != nil && mc.IsNativeMergeSource(filename)
+	convertEligiblePak := mc != nil && isConvertEligibleArtifact(game, mc, filename)
 
 	// Handle based on game's deploy mode
 	if game.DeployMode == domain.DeployCompile && (mergeEligible || convertEligiblePak) {

--- a/internal/core/importer.go
+++ b/internal/core/importer.go
@@ -49,13 +49,14 @@ type Importer struct {
 	// cache. Empty means fall back to $TMPDIR — see newStagingDir.
 	stagingRoot string
 	// resolveMergeCompiler resolves the MergeCompiler-capable source mapped
-	// to a DeployCompile game's registry entry (#197), consulted only when
-	// importing a ".exmodz" archive for such a game — Import has no
-	// per-archive source pinned the way DownloadModToCache does, so it must
-	// look up the game's configured sources instead. nil when the Importer
-	// was built via the standalone NewImporter (no Service context):
-	// importing an .exmodz through such an Importer fails loud rather than
-	// silently caching an unvalidated archive.
+	// to a DeployCompile game's registry entry (#197), consulted for every
+	// import into such a game (#256: the compile source now answers the
+	// native/convertible format questions too) — Import has no per-archive
+	// source pinned the way DownloadModToCache does, so it must look up the
+	// game's configured sources instead. nil when the Importer was built
+	// via the standalone NewImporter (no Service context): a DeployCompile
+	// import through such an Importer fails loud rather than silently
+	// caching an unvalidated archive.
 	resolveMergeCompiler func(gameID string) (source.MergeCompiler, error)
 }
 
@@ -118,34 +119,36 @@ func (i *Importer) Import(ctx context.Context, archivePath string, game *domain.
 	var fileCount int
 	var retainedFileID string
 
-	// mergeEligible (.exmodz) has no other valid interpretation for a
-	// DeployCompile game - an unresolvable MergeCompiler is a hard error.
-	// convertEligiblePak (a raw pak) DOES have one - the legacy extract/copy
-	// path below - so a resolver failure there falls through instead of
-	// erroring the whole import (#221 I1 fix, mirrors DownloadModToCache's
-	// identical fix): resolveMergeCompiler is a GAME-level lookup (Import
-	// has no per-archive source pinned the way a download does), so "no
-	// MergeCompiler-capable source configured for this game" is exactly the
-	// same "fall through for a pak, still hard-error for an exmodz" case as
-	// the download path's "this specific source lacks MergeCompiler".
+	// #256: whether filename is the game's NATIVE merge format
+	// (mc.IsNativeMergeSource - the seam-routed successor to core's static
+	// ".exmodz" test) or a convertible artifact (mc.IsConvertibleArtifact)
+	// is the compile source's call, so the compiler is resolved up front
+	// for every DeployCompile import. Resolution is a pure registry
+	// lookup; when it fails, nothing can define either format, so BOTH
+	// predicates are false and the import falls through to the legacy
+	// extract/copy path: a raw pak or plain zip behaves exactly as before
+	// (#221 I1 fix - "unsupported archive format" for the pak, a normal
+	// extract for the zip), and a native archive - unextractable, since
+	// the Extractor is extension-keyed - still fails loud with
+	// "unsupported archive format" rather than the old compiler-specific
+	// message, and still caches nothing.
 	//
-	// #256: whether filename IS a convertible artifact is now the compile
-	// source's call (mc.IsConvertibleArtifact), so resolution is attempted
-	// for any non-exmodz import into a convert_paks game - the pre-#256
-	// static ".pak" pre-filter no longer exists in core. Resolution is a
-	// pure registry lookup, so the wider trigger changes nothing
-	// observable: a non-convertible filename still ends up with
-	// convertEligiblePak == false and the exact same fall-through.
-	mergeEligible := isExmodzFile(filename)
+	// A NIL RESOLVER is different: core.NewImporter (no Service context)
+	// cannot answer the format question for ANY file, and unlike a
+	// misconfigured game there is a correct importer to use instead - so a
+	// DeployCompile import through a standalone Importer fails loud
+	// unconditionally. Production only ever constructs the service-backed
+	// importer (Service.NewImporter); this path is reachable only by
+	// direct core.NewImporter use.
 	var mc source.MergeCompiler
 	var mcErr error
-	if game.DeployMode == domain.DeployCompile && (mergeEligible || game.ConvertPaks) {
+	if game.DeployMode == domain.DeployCompile {
 		if i.resolveMergeCompiler == nil {
-			mcErr = fmt.Errorf("game %q requires DeployCompile to import %q, but this Importer was constructed without service context (via core.NewImporter, not Service.NewImporter) and has no compiler resolver to consult - import via the service-backed importer instead", game.ID, filename)
-		} else {
-			mc, mcErr = i.resolveMergeCompiler(game.ID)
+			return nil, fmt.Errorf("game %q requires DeployCompile to import %q, but this Importer was constructed without service context (via core.NewImporter, not Service.NewImporter) and has no compiler resolver to consult - import via the service-backed importer instead", game.ID, filename)
 		}
+		mc, mcErr = i.resolveMergeCompiler(game.ID)
 	}
+	mergeEligible := mcErr == nil && mc != nil && mc.IsNativeMergeSource(filename)
 	convertEligiblePak := mcErr == nil && mc != nil && isConvertEligibleArtifact(game, mc, filename)
 
 	// Handle based on game's deploy mode
@@ -156,9 +159,6 @@ func (i *Importer) Import(ctx context.Context, archivePath string, game *domain.
 		// keyed by the archive's own filename instead - stable across
 		// re-imports of the same name, and the ONLY identity Import ever
 		// has for this content.
-		if mcErr != nil {
-			return nil, mcErr
-		}
 		if err := mc.ValidateSource(archivePath); err != nil {
 			return nil, fmt.Errorf("validating %s: %w", filename, err)
 		}

--- a/internal/core/installer.go
+++ b/internal/core/installer.go
@@ -432,13 +432,26 @@ func (i *Installer) Uninstall(ctx context.Context, game *domain.Game, mod *domai
 	// stale unclaimed files a pre-fix deploy linked. Narrowing this would
 	// strand those links forever.
 	//
-	// An absent cache entry is "nothing to undeploy", not an error (#260):
-	// uninstall must stay idempotent when the entry is already gone - the
-	// steady state syncMergedPak's zero branch and purge --uninstall leave
-	// behind - while still clearing tracking rows and sweeping empty dirs.
+	// An absent cache entry is not an error (#260): uninstall must stay
+	// idempotent when the entry is already gone - the steady state
+	// syncMergedPak's zero branch and purge --uninstall leave behind. The
+	// deployment can still be fully on disk, though (a copy/hardlink deploy
+	// owns real files, not links back into the cache), so fall back to the
+	// DB's tracked deployed paths rather than orphaning them while erasing
+	// the only record that they were ours. Ownership rows upsert on
+	// overwrite ("new mod takes ownership"), so the fallback never removes
+	// a path another mod has since claimed.
 	files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("listing cached files: %w", err)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("listing cached files: %w", err)
+		}
+		files = nil
+		if i.db != nil {
+			if files, err = i.db.GetDeployedFilesForMod(game.ID, profileName, mod.SourceID, mod.ID); err != nil {
+				return fmt.Errorf("listing tracked deployed files: %w", err)
+			}
+		}
 	}
 
 	// Undeploy each file

--- a/internal/core/installer.go
+++ b/internal/core/installer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
@@ -430,8 +431,13 @@ func (i *Installer) Uninstall(ctx context.Context, game *domain.Game, mod *domai
 	// removal must cover anything that might ever have been linked, including
 	// stale unclaimed files a pre-fix deploy linked. Narrowing this would
 	// strand those links forever.
+	//
+	// An absent cache entry is "nothing to undeploy", not an error (#260):
+	// uninstall must stay idempotent when the entry is already gone - the
+	// steady state syncMergedPak's zero branch and purge --uninstall leave
+	// behind - while still clearing tracking rows and sweeping empty dirs.
 	files, err := i.cache.ListFiles(game.ID, mod.SourceID, mod.ID, mod.Version)
-	if err != nil {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("listing cached files: %w", err)
 	}
 

--- a/internal/core/installer_test.go
+++ b/internal/core/installer_test.go
@@ -402,6 +402,40 @@ func TestInstaller_Uninstall_AbsentCacheEntry_CleansTrackingWithoutError(t *test
 	require.Empty(t, rows, "stale tracking rows must still be cleared when the cache entry is gone")
 }
 
+// TestInstaller_Uninstall_AbsentCacheEntry_RemovesTrackedDeployedFiles
+// (#260 review follow-up): with the cache entry gone, the deployment can
+// still be fully on disk - a copy/hardlink deploy owns real files, not
+// links back into the cache. Uninstall must fall back to the DB's tracked
+// deployed paths and remove them, not silently orphan them while erasing
+// the only record that they were ours.
+func TestInstaller_Uninstall_AbsentCacheEntry_RemovesTrackedDeployedFiles(t *testing.T) {
+	modCache := cache.New(t.TempDir())
+	gameDir := t.TempDir()
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+
+	game := &domain.Game{ID: "g", ModPath: gameDir, LinkMethod: domain.LinkCopy}
+	mod := &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g"}
+
+	// A copy-linked deployment whose cache entry has since been removed:
+	// the deployed file is real and still present.
+	deployedPath := filepath.Join(gameDir, "data", "a.esp")
+	require.NoError(t, os.MkdirAll(filepath.Dir(deployedPath), 0755))
+	require.NoError(t, os.WriteFile(deployedPath, []byte("copied"), 0644))
+	require.NoError(t, database.SaveDeployedFile("g", "default", "data/a.esp", "src", "1"))
+
+	inst := core.NewInstaller(modCache, linker.New(domain.LinkCopy), database)
+	require.NoError(t, inst.Uninstall(context.Background(), game, mod, "default"))
+
+	_, err = os.Stat(deployedPath)
+	require.True(t, os.IsNotExist(err), "the tracked deployed file must be removed via the DB fallback")
+
+	rows, err := database.GetDeployedFilesForMod("g", "default", "src", "1")
+	require.NoError(t, err)
+	require.Empty(t, rows)
+}
+
 func TestInstaller_Install_DeployFailureRollsBackAndClearsDB(t *testing.T) {
 	// When Deploy fails after some files are deployed, roll back all deployed
 	// files and clear DB records so disk and DB stay consistent.

--- a/internal/core/installer_test.go
+++ b/internal/core/installer_test.go
@@ -373,6 +373,35 @@ func (f *conditionalFailingLinker) Deploy(src, dst string) error {
 	return f.Linker.Deploy(src, dst)
 }
 
+// TestInstaller_Uninstall_AbsentCacheEntry_CleansTrackingWithoutError (#260):
+// uninstalling a mod whose cache entry no longer exists must treat the empty
+// entry as "nothing to undeploy" - succeeding, and still clearing any stale
+// DB tracking rows - rather than failing on ListFiles' lstat error. This is
+// the steady state syncMergedPak's zero branch lands in after its first
+// zero-pass deletes the merged-pak entry.
+func TestInstaller_Uninstall_AbsentCacheEntry_CleansTrackingWithoutError(t *testing.T) {
+	modCache := cache.New(t.TempDir())
+	gameDir := t.TempDir()
+	database, err := db.New(":memory:")
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+
+	game := &domain.Game{ID: "g", ModPath: gameDir, LinkMethod: domain.LinkSymlink}
+	mod := &domain.Mod{ID: "1", SourceID: "src", Version: "1.0", GameID: "g"}
+
+	// A stale tracking row left behind by a deploy whose cache entry has
+	// since been removed out from under it.
+	require.NoError(t, database.SaveDeployedFile("g", "default", "a.esp", "src", "1"))
+
+	inst := core.NewInstaller(modCache, linker.New(domain.LinkSymlink), database)
+	require.NoError(t, inst.Uninstall(context.Background(), game, mod, "default"),
+		"an absent cache entry means nothing to undeploy, not an error")
+
+	rows, err := database.GetDeployedFilesForMod("g", "default", "src", "1")
+	require.NoError(t, err)
+	require.Empty(t, rows, "stale tracking rows must still be cleared when the cache entry is gone")
+}
+
 func TestInstaller_Install_DeployFailureRollsBackAndClearsDB(t *testing.T) {
 	// When Deploy fails after some files are deployed, roll back all deployed
 	// files and clear DB records so disk and DB stay consistent.

--- a/internal/core/merge_format_helpers_test.go
+++ b/internal/core/merge_format_helpers_test.go
@@ -54,3 +54,5 @@ func (fakeMergeFormat) ClassifyMergeSource(id string) (string, bool) {
 
 func (fakeMergeFormat) MergedArtifactName() string  { return "zzz_LMM_Merged_P.pak" }
 func (fakeMergeFormat) MergedArtifactLabel() string { return "Icarus Merged Pak" }
+
+func (fakeMergeFormat) RestoredArtifactName(modID string) string { return modID + "_P.pak" }

--- a/internal/core/merge_format_helpers_test.go
+++ b/internal/core/merge_format_helpers_test.go
@@ -36,6 +36,10 @@ func (fakeMergeFormat) FingerprintBase(basePakPath string) (string, error) {
 	return r.IndexHash(), nil
 }
 
+func (fakeMergeFormat) IsNativeMergeSource(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".exmodz")
+}
+
 func (fakeMergeFormat) IsConvertibleArtifact(fileName string) bool {
 	return strings.HasSuffix(strings.ToLower(fileName), ".pak")
 }

--- a/internal/core/merge_format_helpers_test.go
+++ b/internal/core/merge_format_helpers_test.go
@@ -1,0 +1,52 @@
+package core_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DonovanMods/go-unrealpak"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// fakeMergeFormat supplies source.MergeCompiler's format-vocabulary methods
+// (#256) for this package's compile-source fakes, mirroring the icarus
+// conventions the fixtures already encode (writeFakeBasePak's
+// Icarus/Content/Data/data.pak path, "pak"/"exmodz" fileIDs, the
+// zzz_LMM_Merged_P.pak artifact name) without pulling the icarus package
+// into internal/core's tests (fakeCompilerSource's own precedent). Embed it
+// in any fake that needs to satisfy source.MergeCompiler.
+type fakeMergeFormat struct{}
+
+func (fakeMergeFormat) ResolveBaseArtifact(game *domain.Game) (string, error) {
+	candidate := filepath.Join(game.InstallPath, "Icarus", "Content", "Data", "data.pak")
+	if _, err := os.Stat(candidate); err != nil {
+		return "", fmt.Errorf("locating base pak for %q: %w", game.ID, err)
+	}
+	return candidate, nil
+}
+
+func (fakeMergeFormat) FingerprintBase(basePakPath string) (string, error) {
+	r, err := unrealpak.Open(basePakPath)
+	if err != nil {
+		return "", fmt.Errorf("reading base pak for compile fingerprint: %w", err)
+	}
+	defer r.Close() //nolint:errcheck
+	return r.IndexHash(), nil
+}
+
+func (fakeMergeFormat) IsConvertibleArtifact(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".pak")
+}
+
+func (fakeMergeFormat) ClassifyMergeSource(id string) (string, bool) {
+	lower := strings.ToLower(id)
+	if lower == "pak" || strings.HasSuffix(lower, ".pak") {
+		return "pak", true
+	}
+	return "exmodz", false
+}
+
+func (fakeMergeFormat) MergedArtifactName() string  { return "zzz_LMM_Merged_P.pak" }
+func (fakeMergeFormat) MergedArtifactLabel() string { return "Icarus Merged Pak" }

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -518,7 +518,7 @@ func (s *Service) reconcilePakManifests(ctx context.Context, game *domain.Game, 
 					// it. Without this, the mark below would record an EMPTY
 					// member set and Install would deploy nothing, silently
 					// - the raw fallback's whole purpose defeated.
-					restoredName, herr := restoreRawPakCopy(versionDir, retained, fileID, mod.ID)
+					restoredName, herr := restoreRawPakCopy(mc, versionDir, retained, fileID, mod.ID)
 					if herr != nil {
 						return warnings, fmt.Errorf("restoring pruned raw pak for %s: %w", ref, herr)
 					}
@@ -624,20 +624,25 @@ func rawPakMembers(versionDir, retainedPath string, candidates []string) ([]stri
 // rawPakRestoreName picks the on-disk name restoreRawPakCopy publishes a
 // healed deployable pak copy under (#250). An import-path fileID IS the
 // original archive filename (Importer.Import stages the deployable copy
-// under exactly that name), so the restore is name-exact. A download-path
-// fileID (the literal icarus "pak") never carried the deployable name: it
-// came from the download URL's basename at ingest time, the convert flip
-// erased the manifest that recorded it, and nothing else durably stores it
-// - so a deterministic mod-scoped name in Icarus's "_P.pak" override
-// convention (the old compiledFileName convention) is synthesized instead.
-// Both inputs are source-controlled, so both are Base'd before use as a
-// path component.
-func rawPakRestoreName(fileID, modID string) string {
+// under exactly that name), so the restore is name-exact - detected by
+// asking the compile source whether the fileID names one of its
+// convertible artifacts (#256: the format test lives behind the seam). A
+// download-path fileID (the literal icarus "pak") never carried the
+// deployable name: it came from the download URL's basename at ingest
+// time, the convert flip erased the manifest that recorded it, and
+// nothing else durably stores it - so the source synthesizes its
+// deterministic mod-scoped fallback name instead
+// (mc.RestoredArtifactName; Icarus's "_P.pak" override convention). The
+// import-vs-download provenance SPLIT stays in core - it follows from how
+// ingest keys fileIDs, which is uniform across games - while both format
+// questions inside it are the source's. Both inputs are
+// source-controlled, so both are Base'd before use as a path component.
+func rawPakRestoreName(mc source.MergeCompiler, fileID, modID string) string {
 	base := filepath.Base(fileID)
-	if strings.EqualFold(filepath.Ext(base), ".pak") {
+	if mc.IsConvertibleArtifact(base) {
 		return base
 	}
-	return filepath.Base(modID) + "_P.pak"
+	return mc.RestoredArtifactName(filepath.Base(modID))
 }
 
 // restoreRawPakCopy re-creates fileID's deployable pak copy in versionDir
@@ -649,8 +654,8 @@ func rawPakRestoreName(fileID, modID string) string {
 // (rawPakMembers just matched nothing), and it could be a sibling fileID's
 // claimed member - failing loudly beats corrupting it, and the next
 // reconcile pass retries.
-func restoreRawPakCopy(versionDir, retainedPath, fileID, modID string) (string, error) {
-	name := rawPakRestoreName(fileID, modID)
+func restoreRawPakCopy(mc source.MergeCompiler, versionDir, retainedPath, fileID, modID string) (string, error) {
+	name := rawPakRestoreName(mc, fileID, modID)
 	target := filepath.Join(versionDir, name)
 	if _, err := os.Stat(target); err == nil {
 		return "", fmt.Errorf("restore target %s already exists with content not matching the retained source; refusing to overwrite", name)

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -76,9 +76,15 @@ type mergeSourceClassifier func(id string) (kind string, convertible bool)
 // convert-toggle key - want this cheaper check, not enabledMergeSources'
 // full retained-file resolution. A game with no (or an ambiguous)
 // merge-compiler source has no merge sources of any kind, so resolution
-// failure is simply false, not an error.
+// failure is simply false, not an error. Deliberately NOT gated on
+// game.DeployMode: `lmm mod convert` persists the per-mod flag on
+// non-compile games too (with an advisory that it has no effect there,
+// TestModConvertCommand_NonCompileGame), so classification must answer
+// for any game whose compile source resolves - matching the pre-#256
+// static behavior. Callers that only care about compile games gate on
+// DeployMode themselves.
 func (s *Service) ModHasPakMergeSource(game *domain.Game, mod *domain.InstalledMod) bool {
-	if mod == nil {
+	if game == nil || mod == nil {
 		return false
 	}
 	mc, err := s.mergeCompilerForGame(game)

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -49,7 +49,7 @@ type MergedFingerprintEntry struct {
 	ModID    string
 	Version  string
 	Checksum string // MD5 of the retained source bytes (md5File)
-	Kind     string `json:",omitempty"` // source.MergeSourcePak for retained paks; empty/exmodz otherwise (#221)
+	Kind     string `json:",omitempty"` // source-defined convertible kind for retained paks; empty/native otherwise (#221, opaque to core since #256)
 
 	// Outcome fields (#221): recorded AFTER the merge, ignored by input
 	// equality - a failed conversion retries only when an INPUT changes

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -707,6 +707,100 @@ func (s *Service) ReconcilePakManifestsForTest(ctx context.Context, game *domain
 	return s.reconcilePakManifests(ctx, game, profileName, installer, failedByRef)
 }
 
+// classifyCompileDeployMods pre-classifies each mod DeployProfile is about
+// to deploy on a DeployCompile game (#255): a mod contributing at least one
+// enabled merge source is DeployModMerged (its content will ride the merged
+// artifact built after the loop); a mod holding a retained convertible file
+// that enabledMergeSources excluded - the game- or mod-level ConvertPaks
+// opt-out (#221) - is DeployModRaw (it deploys its raw copy individually);
+// everything else is the zero DeployModIndividual. Keyed by
+// domain.ModKey(sourceID, modID), the same "sourceID:modID" form
+// MergeSource.ModRef carries. Returns nil for a non-compile game and on any
+// resolution failure - classification is a readout, never a reason to fail
+// the deploy, and the zero class is always a safe rendering default.
+func (s *Service) classifyCompileDeployMods(game *domain.Game, profileName string, mods []*domain.InstalledMod) map[string]DeployModClass {
+	if game.DeployMode != domain.DeployCompile {
+		return nil
+	}
+	sources, err := s.enabledMergeSources(game, profileName)
+	if err != nil {
+		return nil
+	}
+	mergedRefs := make(map[string]bool, len(sources))
+	for _, src := range sources {
+		mergedRefs[src.ModRef] = true
+	}
+	gameCache := s.GetGameCache(game)
+	// Lazily resolved on the first retained file found, exactly like
+	// enabledMergeSources/reconcilePakManifests (#256).
+	var mc source.MergeCompiler
+	classes := make(map[string]DeployModClass, len(mods))
+	for _, mod := range mods {
+		ref := domain.ModKey(mod.SourceID, mod.ID)
+		if mergedRefs[ref] {
+			classes[ref] = DeployModMerged
+			continue
+		}
+		for _, fileID := range mod.FileIDs {
+			retained := gameCache.GetFilePath(game.ID, mod.SourceID, mod.ID, mod.Version, cache.RetainedSourceName(fileID))
+			if _, statErr := os.Stat(retained); statErr != nil {
+				continue // nothing retained for this fileID - not a merge source of any kind
+			}
+			if mc == nil {
+				var mcErr error
+				if mc, mcErr = s.mergeCompilerForGame(game); mcErr != nil {
+					return classes
+				}
+			}
+			if _, convertible := mc.ClassifyMergeSource(fileID); convertible {
+				classes[ref] = DeployModRaw
+				break
+			}
+		}
+	}
+	return classes
+}
+
+// recordMergeOutcome reports #255's post-sync merge readout: after a
+// successful syncMergedPak on a DeployCompile game, the just-written merge
+// fingerprint (MergedPakOutcomes) is the authoritative record of which
+// mods' content the merged artifact carries and which participants fell
+// back to a raw individual deploy. The artifact name and counts land on
+// result (for progress-less callers - the TUI) and as one DeployMergeSynced
+// event. A missing fingerprint means no merged artifact exists (zero merge
+// participants - the uninstall-to-zero path) so there is nothing to report;
+// resolution failures likewise skip the readout rather than fail an
+// already-successful deploy. Counts are per MOD, not per file: a mod
+// contributing both a converted and a failed file counts once on each side,
+// which is the accurate reading of that (rare) state.
+func (s *Service) recordMergeOutcome(game *domain.Game, profileName string, result *DeployResult, emit func(DeployProgress)) {
+	if game.DeployMode != domain.DeployCompile {
+		return
+	}
+	outcomes, ok := s.MergedPakOutcomes(game, profileName)
+	if !ok {
+		return
+	}
+	mc, err := s.mergeCompilerForGame(game)
+	if err != nil {
+		return
+	}
+	merged := make(map[string]bool, len(outcomes))
+	raw := make(map[string]bool)
+	for _, o := range outcomes {
+		ref := domain.ModKey(o.SourceID, o.ModID)
+		if o.Converted {
+			merged[ref] = true
+		} else {
+			raw[ref] = true
+		}
+	}
+	result.MergedArtifact = mc.MergedArtifactName()
+	result.MergedMods = len(merged)
+	result.RawFallbacks = len(raw)
+	emit(DeployProgress{Phase: DeployMergeSynced, Total: result.MergedMods, Detail: result.MergedArtifact, RawFallbacks: result.RawFallbacks})
+}
+
 // MergedPakOutcomes returns the stored merge fingerprint's per-mod entries
 // (with #221 conversion outcomes), if a merged pak exists for game+profile.
 // The game's compile source interprets the stored Kind strings (#256); a

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -14,13 +14,14 @@ import (
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
 )
 
-// mergedPakModID/mergedPakVersion/mergedPakFileName identify the merged pak
-// as a synthetic, singleton "mod" per (game, profile) - domain.SourceMerged
-// is the matching sourceID. This reuses Installer.Install/Uninstall and
-// cache.Cache verbatim (#197 design decision 2) rather than a parallel
-// deploy/tracking mechanism: zero schema changes, and the SAME
-// deployed_files ownership (and #168-class residue risk) as every other
-// deployed file.
+// mergedPakModID/mergedPakVersion identify the merged pak as a synthetic,
+// singleton "mod" per (game, profile) - domain.SourceMerged is the matching
+// sourceID. This reuses Installer.Install/Uninstall and cache.Cache
+// verbatim (#197 design decision 2) rather than a parallel deploy/tracking
+// mechanism: zero schema changes, and the SAME deployed_files ownership
+// (and #168-class residue risk) as every other deployed file. The merged
+// artifact's on-disk FILENAME is the compile source's business, not core's
+// (#256): mc.MergedArtifactName() supplies it wherever it's needed.
 const (
 	mergedPakModID = "merged-pak"
 	// mergedPakVersion is fixed ("merged", not a real upstream version) -
@@ -28,17 +29,6 @@ const (
 	// every regeneration REPLACES it outright (mirrors #166's directory-
 	// source "replace, don't overlay" precedent) rather than versioning it.
 	mergedPakVersion = "merged"
-	// mergedPakFileName sorts LAST among files UE mounts from a profile's
-	// mods directory: paks mount in filename-sort order and a later mount
-	// wins same-path conflicts (this repo's own icarusContentMountPoint doc
-	// comment, and #197's issue body, both note this) - "zzz" is a
-	// long-standing UE-modding convention for "load last, highest
-	// priority", so the merged pak's authoritative combined table state can
-	// never be silently shadowed by a plain prebuilt .pak mod that happens
-	// to also carry a table override. "LMM" makes the file greppable as
-	// lmm-owned; "_P" matches this codebase's existing override-pak suffix
-	// convention (compiledFileName).
-	mergedPakFileName = "zzz_LMM_Merged_P.pak"
 )
 
 // MergedFingerprint captures everything a merged pak was built from (#197):
@@ -68,33 +58,35 @@ type MergedFingerprintEntry struct {
 	FailReason string `json:",omitempty"`
 }
 
-// mergeSourceKind classifies a retained-source fileID (#221). Download-path
-// icarus fileIDs are literally "pak"/"exmodz"; import-path fileIDs are the
-// archive's own filename. Unknown kinds default to exmodz - the only kind
-// that existed before #221.
-func mergeSourceKind(fileID string) string {
-	lower := strings.ToLower(fileID)
-	if lower == "pak" || strings.HasSuffix(lower, ".pak") {
-		return source.MergeSourcePak
-	}
-	return source.MergeSourceExmodz
-}
+// mergeSourceClassifier is the one sliver of source.MergeCompiler the
+// package-level fingerprint helpers need: ClassifyMergeSource as a function
+// value (a method value like mc.ClassifyMergeSource assigns directly).
+// Kept narrow so the helpers stay pure and tests can exercise fingerprint
+// semantics without constructing a full source (#256).
+type mergeSourceClassifier func(id string) (kind string, convertible bool)
 
-// ModHasPakMergeSource reports whether mod carries at least one pak-kind
-// (source.MergeSourcePak) merge-source fileID, as opposed to being
-// exmodz-only (#221 round-4 fix). Pure classification over mod.FileIDs via
-// mergeSourceKind - no cache lookups or retained-source disk checks (unlike
-// enabledMergeSources, which additionally confirms ingest actually RETAINED
-// something). Callers that only need "does pak-conversion state have any
-// effect on this mod at all" - e.g. the TUI deciding whether to show the
-// "raw" flag or honor the convert-toggle key - want this cheaper check, not
-// enabledMergeSources' full retained-file resolution.
-func (s *Service) ModHasPakMergeSource(mod *domain.InstalledMod) bool {
+// ModHasPakMergeSource reports whether mod carries at least one
+// convertible-kind (raw pak) merge-source fileID, as opposed to being
+// native/exmodz-only (#221 round-4 fix). Classification over mod.FileIDs
+// via the game's compile source (#256) - no cache lookups or
+// retained-source disk checks (unlike enabledMergeSources, which
+// additionally confirms ingest actually RETAINED something). Callers that
+// only need "does pak-conversion state have any effect on this mod at all"
+// - e.g. the TUI deciding whether to show the "raw" flag or honor the
+// convert-toggle key - want this cheaper check, not enabledMergeSources'
+// full retained-file resolution. A game with no (or an ambiguous)
+// merge-compiler source has no merge sources of any kind, so resolution
+// failure is simply false, not an error.
+func (s *Service) ModHasPakMergeSource(game *domain.Game, mod *domain.InstalledMod) bool {
 	if mod == nil {
 		return false
 	}
+	mc, err := s.mergeCompilerForGame(game)
+	if err != nil {
+		return false
+	}
 	for _, fileID := range mod.FileIDs {
-		if mergeSourceKind(fileID) == source.MergeSourcePak {
+		if _, convertible := mc.ClassifyMergeSource(fileID); convertible {
 			return true
 		}
 	}
@@ -102,14 +94,15 @@ func (s *Service) ModHasPakMergeSource(mod *domain.InstalledMod) bool {
 }
 
 // fingerprintInputs strips outcome fields and normalizes Kind so equality
-// judges inputs only. Kind "" and "exmodz" are the same input (pre-#221
-// markers wrote no Kind).
-func fingerprintInputs(f MergedFingerprint) MergedFingerprint {
+// judges inputs only. A legacy pre-#221 marker entry's empty Kind and the
+// source's own default kind are the same input - classify("") returns that
+// default (icarus: "exmodz"), per the ClassifyMergeSource contract.
+func fingerprintInputs(f MergedFingerprint, classify mergeSourceClassifier) MergedFingerprint {
 	out := MergedFingerprint{BaseIndexHash: f.BaseIndexHash, Mods: make([]MergedFingerprintEntry, len(f.Mods))}
 	for i, m := range f.Mods {
 		kind := m.Kind
 		if kind == "" {
-			kind = source.MergeSourceExmodz
+			kind, _ = classify(kind)
 		}
 		out.Mods[i] = MergedFingerprintEntry{SourceID: m.SourceID, ModID: m.ModID, Version: m.Version, Checksum: m.Checksum, Kind: kind}
 	}
@@ -159,12 +152,12 @@ func marshalMergedFingerprint(f MergedFingerprint) ([]byte, error) {
 // inputs, by comparing their marshaled bytes - exactly what "compare
 // against the stored marker" needs, since the marker itself IS the
 // marshaled form.
-func mergedFingerprintsEqual(a, b MergedFingerprint) (bool, error) {
-	aBytes, err := marshalMergedFingerprint(fingerprintInputs(a))
+func mergedFingerprintsEqual(a, b MergedFingerprint, classify mergeSourceClassifier) (bool, error) {
+	aBytes, err := marshalMergedFingerprint(fingerprintInputs(a, classify))
 	if err != nil {
 		return false, err
 	}
-	bBytes, err := marshalMergedFingerprint(fingerprintInputs(b))
+	bBytes, err := marshalMergedFingerprint(fingerprintInputs(b, classify))
 	if err != nil {
 		return false, err
 	}
@@ -189,6 +182,13 @@ func (s *Service) enabledMergeSources(game *domain.Game, profileName string) ([]
 	}
 
 	gameCache := s.GetGameCache(game)
+	// The compile source is resolved lazily, on the first retained file
+	// found (#256): classification is its business now, but a profile with
+	// nothing retained has nothing to classify, and must keep working -
+	// exactly as it did pre-#256 - even for a game whose MergeCompiler
+	// source isn't configured (syncMergedPak's uninstall-to-zero path runs
+	// unconditionally from every mutation flow).
+	var mc source.MergeCompiler
 	var sources []source.MergeSource
 	for _, mod := range mods {
 		if !mod.Enabled {
@@ -199,8 +199,14 @@ func (s *Service) enabledMergeSources(game *domain.Game, profileName string) ([]
 			if _, statErr := os.Stat(retainedPath); statErr != nil {
 				continue // not a retained merge source (nothing ingested for this fileID - a legacy-ingest pak, or a non-convert-eligible one)
 			}
-			kind := mergeSourceKind(fileID)
-			if kind == source.MergeSourcePak && (!game.ConvertPaks || !mod.ConvertPaks) {
+			if mc == nil {
+				var mcErr error
+				if mc, mcErr = s.mergeCompilerForGame(game); mcErr != nil {
+					return nil, mcErr
+				}
+			}
+			kind, convertible := mc.ClassifyMergeSource(fileID)
+			if convertible && (!game.ConvertPaks || !mod.ConvertPaks) {
 				continue // opted out (game- or mod-level): stays raw-deployed (#221)
 			}
 			sources = append(sources, source.MergeSource{
@@ -225,8 +231,8 @@ func (s *Service) EnabledMergeSourcesForTest(game *domain.Game, profileName stri
 // syncMergedPak regenerates game+profileName's merged pak if its recorded
 // fingerprint no longer matches the CURRENT enabled-mod set/order/versions/
 // base pak (#197). Cheap when nothing changed: the fast path is one
-// directory read (enabledMergeSources), one base-pak footer read
-// (basePakIndexHash - never the pak's full content), and N small MD5s
+// directory read (enabledMergeSources), one base-artifact fingerprint read
+// (mc.FingerprintBase - for Icarus a pak footer, never the full content), and N small MD5s
 // (md5File over each retained .exmodz - real files here are small, see
 // #175's own research on real base-table sizes), then a byte comparison.
 // Safe to call unconditionally from ANY mutation flow regardless of game
@@ -275,15 +281,24 @@ func (s *Service) syncMergedPak(ctx context.Context, game *domain.Game, profileN
 		return reconWarnings, nil
 	}
 
-	basePakPath, err := resolveBasePak(game)
+	// Non-empty sources imply a resolvable compile source (enabledMergeSources
+	// already consulted it to classify them), so resolving here - earlier
+	// than pre-#256, which only needed the source on the slow path below -
+	// cannot newly fail a flow that used to succeed.
+	mc, err := s.mergeCompilerForGame(game)
+	if err != nil {
+		return nil, err
+	}
+
+	basePakPath, err := mc.ResolveBaseArtifact(game)
 	if err != nil {
 		return nil, err
 	}
 
 	cachePath := gameCache.ModPath(game.ID, domain.SourceMerged, mergedPakModID, mergedPakVersion)
-	deployedPath := filepath.Join(game.ModPath, mergedPakFileName)
+	deployedPath := filepath.Join(game.ModPath, mc.MergedArtifactName())
 	if stored, ok := readMergedFingerprint(cachePath); ok {
-		if eq, eqErr := mergedFingerprintsEqual(current, stored); eqErr == nil && eq {
+		if eq, eqErr := mergedFingerprintsEqual(current, stored, mc.ClassifyMergeSource); eqErr == nil && eq {
 			// #197 I5 fix: an unchanged fingerprint alone doesn't guarantee
 			// the pak is actually deployed - a PRIOR call's Install could
 			// have failed AFTER the fingerprint was already committed
@@ -324,11 +339,6 @@ func (s *Service) syncMergedPak(ctx context.Context, game *domain.Game, profileN
 		}
 	}
 
-	mc, err := s.mergeCompilerSourceForGame(game.ID)
-	if err != nil {
-		return nil, err
-	}
-
 	stagePath := cachePath + ".staging"
 	if err := os.RemoveAll(stagePath); err != nil {
 		return nil, fmt.Errorf("clearing merged pak staging: %w", err)
@@ -338,7 +348,7 @@ func (s *Service) syncMergedPak(ctx context.Context, game *domain.Game, profileN
 	}
 	defer os.RemoveAll(stagePath) //nolint:errcheck
 
-	outputPath := filepath.Join(stagePath, mergedPakFileName)
+	outputPath := filepath.Join(stagePath, mc.MergedArtifactName())
 	mergeWarnings, mergeFailed, err := mc.MergeCompile(ctx, basePakPath, sources, outputPath)
 	if err != nil {
 		return nil, fmt.Errorf("merging %d merge source(s): %w", len(sources), err)
@@ -405,19 +415,32 @@ func (s *Service) reconcilePakManifests(ctx context.Context, game *domain.Game, 
 		return nil, fmt.Errorf("loading profile mods: %w", err)
 	}
 	gameCache := s.GetGameCache(game)
+	// Lazily resolved, like enabledMergeSources (#256): only a mod with a
+	// retained file has anything to classify, so a profile with nothing
+	// retained never needs (and pre-#256 never consulted) the compile
+	// source - the retained-stat therefore runs BEFORE classification,
+	// flipping the pre-#256 order of two independent, side-effect-free
+	// filters.
+	var mc source.MergeCompiler
 	for i := range mods {
 		mod := &mods[i]
 		if !mod.Enabled {
 			continue
 		}
 		for _, fileID := range mod.FileIDs {
-			if mergeSourceKind(fileID) != source.MergeSourcePak {
-				continue
-			}
 			versionDir := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
 			retained := filepath.Join(versionDir, cache.RetainedSourceName(fileID))
 			if _, statErr := os.Stat(retained); statErr != nil {
 				continue // nothing retained (legacy ingest): Task 11's needs_reingest covers it
+			}
+			if mc == nil {
+				var mcErr error
+				if mc, mcErr = s.mergeCompilerForGame(game); mcErr != nil {
+					return warnings, mcErr
+				}
+			}
+			if _, convertible := mc.ClassifyMergeSource(fileID); !convertible {
+				continue
 			}
 			ref := mod.SourceID + ":" + mod.ID
 			_, failed := failedByRef[ref]
@@ -617,6 +640,9 @@ func (s *Service) ReconcilePakManifestsForTest(ctx context.Context, game *domain
 
 // MergedPakOutcomes returns the stored merge fingerprint's per-mod entries
 // (with #221 conversion outcomes), if a merged pak exists for game+profile.
+// The game's compile source interprets the stored Kind strings (#256); a
+// stored fingerprint implies a source produced it, so failing to resolve
+// one now (unconfigured since) reads as "no outcomes available".
 func (s *Service) MergedPakOutcomes(game *domain.Game, profileName string) ([]MergedFingerprintEntry, bool) {
 	gameCache := s.GetGameCache(game)
 	cachePath := gameCache.ModPath(game.ID, domain.SourceMerged, mergedPakModID, mergedPakVersion)
@@ -624,27 +650,31 @@ func (s *Service) MergedPakOutcomes(game *domain.Game, profileName string) ([]Me
 	if !ok {
 		return nil, false
 	}
-	return normalizeOutcomes(fp.Mods), true
+	mc, err := s.mergeCompilerForGame(game)
+	if err != nil {
+		return nil, false
+	}
+	return normalizeOutcomes(fp.Mods, mc.ClassifyMergeSource), true
 }
 
-// normalizeOutcomes forces a trivially-successful outcome on every non-pak
-// entry (#221 C1 fix): conversion failure is definitionally a pak-kind
-// concern (mergeSourceKind(fileID) == source.MergeSourcePak), but a
-// pre-#221 fingerprint marker unmarshals its (exmodz-only, at the time)
-// entries as Kind:"", Converted:false - those fields didn't exist yet, and
-// fingerprintInputs/mergedFingerprintsEqual deliberately never regenerate
-// them for an unchanged profile (input equality ignores outcomes). Without
-// this normalization, every consumer of MergedPakOutcomes (verify's
+// normalizeOutcomes forces a trivially-successful outcome on every
+// non-convertible entry (#221 C1 fix): conversion failure is definitionally
+// a convertible-kind concern, but a pre-#221 fingerprint marker unmarshals
+// its (exmodz-only, at the time) entries as Kind:"", Converted:false -
+// those fields didn't exist yet, and fingerprintInputs/
+// mergedFingerprintsEqual deliberately never regenerate them for an
+// unchanged profile (input equality ignores outcomes). Without this
+// normalization, every consumer of MergedPakOutcomes (verify's
 // conversion_failed rows, status's conversion-failure counts) would report
 // a spurious, permanent "CONVERSION FAILED" for every exmodz mod on any
 // profile that predates #221 - forever, since nothing ever rewrites the
 // stored marker's outcome fields for inputs that haven't changed. Kind==""
-// is the legacy shape; Kind==MergeSourceExmodz is the current one - both
-// are non-pak and therefore always trivially "converted".
-func normalizeOutcomes(mods []MergedFingerprintEntry) []MergedFingerprintEntry {
+// is the legacy shape and the current native kind is the modern one - the
+// classifier maps both to non-convertible, therefore trivially "converted".
+func normalizeOutcomes(mods []MergedFingerprintEntry, classify mergeSourceClassifier) []MergedFingerprintEntry {
 	out := make([]MergedFingerprintEntry, len(mods))
 	for i, m := range mods {
-		if m.Kind != source.MergeSourcePak {
+		if _, convertible := classify(m.Kind); !convertible {
 			m.Converted = true
 			m.FailReason = ""
 		}
@@ -664,7 +694,11 @@ func (s *Service) PakNeedsReingest(game *domain.Game, mod *domain.InstalledMod, 
 	if game.DeployMode != domain.DeployCompile || !game.ConvertPaks || !mod.ConvertPaks {
 		return false, nil
 	}
-	if mergeSourceKind(fileID) != source.MergeSourcePak {
+	mc, err := s.mergeCompilerForGame(game)
+	if err != nil {
+		return false, err
+	}
+	if _, convertible := mc.ClassifyMergeSource(fileID); !convertible {
 		return false, nil
 	}
 	gameCache := s.GetGameCache(game)
@@ -715,11 +749,17 @@ func (s *Service) currentMergedFingerprint(game *domain.Game, profileName string
 		return MergedFingerprint{}, sources, nil
 	}
 
-	basePakPath, err := resolveBasePak(game)
+	// Non-empty sources imply enabledMergeSources already resolved the
+	// compile source, so this cannot newly fail (#256).
+	mc, err := s.mergeCompilerForGame(game)
 	if err != nil {
 		return MergedFingerprint{}, sources, err
 	}
-	liveHash, err := basePakIndexHash(basePakPath)
+	basePakPath, err := mc.ResolveBaseArtifact(game)
+	if err != nil {
+		return MergedFingerprint{}, sources, err
+	}
+	liveHash, err := mc.FingerprintBase(basePakPath)
 	if err != nil {
 		return MergedFingerprint{}, sources, fmt.Errorf("reading base pak for merge fingerprint: %w", err)
 	}
@@ -768,6 +808,13 @@ func (s *Service) CheckMergedPakStaleness(game *domain.Game, profileName string)
 		return nil, nil
 	}
 
+	// Non-empty sources imply currentMergedFingerprint already resolved the
+	// compile source, so this cannot newly fail (#256).
+	mc, err := s.mergeCompilerForGame(game)
+	if err != nil {
+		return nil, err
+	}
+
 	gameCache := s.GetGameCache(game)
 	cachePath := gameCache.ModPath(game.ID, domain.SourceMerged, mergedPakModID, mergedPakVersion)
 	stored, ok := readMergedFingerprint(cachePath)
@@ -778,7 +825,7 @@ func (s *Service) CheckMergedPakStaleness(game *domain.Game, profileName string)
 	// the real cause is a missing artifact.
 	reason := "base pak updated"
 	if ok {
-		if eq, eqErr := mergedFingerprintsEqual(current, stored); eqErr == nil && eq {
+		if eq, eqErr := mergedFingerprintsEqual(current, stored, mc.ClassifyMergeSource); eqErr == nil && eq {
 			// #197 I5 fix: mirrors syncMergedPak's identical fast-path
 			// check - a matching fingerprint alone doesn't prove the pak
 			// is actually deployed (a prior failed Install, or a purge
@@ -786,7 +833,7 @@ func (s *Service) CheckMergedPakStaleness(game *domain.Game, profileName string)
 			// this, `lmm update`/`lmm verify` would report "up to date"
 			// for a profile whose game directory doesn't actually hold
 			// the merged pak at all - the exact wedge this fix closes.
-			if _, statErr := os.Stat(filepath.Join(game.ModPath, mergedPakFileName)); statErr == nil {
+			if _, statErr := os.Stat(filepath.Join(game.ModPath, mc.MergedArtifactName())); statErr == nil {
 				return nil, nil
 			}
 			reason = "not deployed"
@@ -797,7 +844,7 @@ func (s *Service) CheckMergedPakStaleness(game *domain.Game, profileName string)
 		InstalledMod: domain.InstalledMod{
 			Mod: domain.Mod{
 				ID: mergedPakModID, SourceID: domain.SourceMerged,
-				Name: "Icarus Merged Pak", Version: mergedPakVersion, GameID: game.ID,
+				Name: mc.MergedArtifactLabel(), Version: mergedPakVersion, GameID: game.ID,
 			},
 		},
 		NewVersion:      mergedPakVersion,
@@ -815,12 +862,20 @@ func (s *Service) CheckMergedPakStaleness(game *domain.Game, profileName string)
 // protects against).
 func (s *Service) ApplyMergedPakRegen(ctx context.Context, game *domain.Game, profileName string, progress func(DeployProgress)) (*UpdateApplyResult, error) {
 	result := &UpdateApplyResult{}
+	// Resolved up front: the Applied entry below reports the merged
+	// artifact by the name only the compile source knows (#256), and a
+	// regen request for a game without one is a misconfiguration worth
+	// failing loud on before touching anything.
+	mc, err := s.mergeCompilerForGame(game)
+	if err != nil {
+		return result, err
+	}
 	warnings, err := s.syncMergedPak(ctx, game, profileName)
 	if err != nil {
 		return result, err
 	}
 	result.Warnings = warnings
-	result.Applied = []string{mergedPakFileName}
+	result.Applied = []string{mc.MergedArtifactName()}
 	if progress != nil {
 		progress(DeployProgress{Phase: UpdateDownloadDone})
 	}

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -715,9 +715,13 @@ func (s *Service) ReconcilePakManifestsForTest(ctx context.Context, game *domain
 // opt-out (#221) - is DeployModRaw (it deploys its raw copy individually);
 // everything else is the zero DeployModIndividual. Keyed by
 // domain.ModKey(sourceID, modID), the same "sourceID:modID" form
-// MergeSource.ModRef carries. Returns nil for a non-compile game and on any
-// resolution failure - classification is a readout, never a reason to fail
-// the deploy, and the zero class is always a safe rendering default.
+// MergeSource.ModRef carries. Best-effort by design - classification is a
+// readout, never a reason to fail the deploy, and the zero class is always
+// a safe rendering default: a non-compile game or an enabledMergeSources
+// failure returns nil, and a compiler-resolution failure mid-walk (only
+// reachable when nothing enabled is retained but a mod in mods still holds
+// a retained file, e.g. a disabled mod under --all with no compile source
+// configured) returns the classes computed so far.
 func (s *Service) classifyCompileDeployMods(game *domain.Game, profileName string, mods []*domain.InstalledMod) map[string]DeployModClass {
 	if game.DeployMode != domain.DeployCompile {
 		return nil

--- a/internal/core/merged_pak.go
+++ b/internal/core/merged_pak.go
@@ -485,6 +485,22 @@ func (s *Service) reconcilePakManifests(ctx context.Context, game *domain.Game, 
 				if aerr != nil {
 					return warnings, aerr
 				}
+				if len(members) == 0 {
+					// #250 heal: no cache member matches the retained
+					// source - the deployable copy was pruned while this pak
+					// was converted (members=nil made it unclaimed, and
+					// released PruneUnclaimed versions deleted it on any
+					// sibling-file re-ingest). The retained source still
+					// holds the exact bytes, so restore the copy and claim
+					// it. Without this, the mark below would record an EMPTY
+					// member set and Install would deploy nothing, silently
+					// - the raw fallback's whole purpose defeated.
+					restoredName, herr := restoreRawPakCopy(versionDir, retained, fileID, mod.ID)
+					if herr != nil {
+						return warnings, fmt.Errorf("restoring pruned raw pak for %s: %w", ref, herr)
+					}
+					members = []string{restoredName}
+				}
 				// #221 partial-failure fix: a manifest-shape match alone
 				// (recorded + matching member set) does not prove the raw
 				// pak is ACTUALLY deployed - the mark below must be written
@@ -580,6 +596,48 @@ func rawPakMembers(versionDir, retainedPath string, candidates []string) ([]stri
 		}
 	}
 	return members, nil
+}
+
+// rawPakRestoreName picks the on-disk name restoreRawPakCopy publishes a
+// healed deployable pak copy under (#250). An import-path fileID IS the
+// original archive filename (Importer.Import stages the deployable copy
+// under exactly that name), so the restore is name-exact. A download-path
+// fileID (the literal icarus "pak") never carried the deployable name: it
+// came from the download URL's basename at ingest time, the convert flip
+// erased the manifest that recorded it, and nothing else durably stores it
+// - so a deterministic mod-scoped name in Icarus's "_P.pak" override
+// convention (the old compiledFileName convention) is synthesized instead.
+// Both inputs are source-controlled, so both are Base'd before use as a
+// path component.
+func rawPakRestoreName(fileID, modID string) string {
+	base := filepath.Base(fileID)
+	if strings.EqualFold(filepath.Ext(base), ".pak") {
+		return base
+	}
+	return filepath.Base(modID) + "_P.pak"
+}
+
+// restoreRawPakCopy re-creates fileID's deployable pak copy in versionDir
+// from its retained source at retainedPath and returns the restored name
+// (#250) - the heal for a cache entry a released PruneUnclaimed damaged
+// (deployable copy missing, retained source present, manifest still in the
+// post-convert members=nil state). It refuses to overwrite an existing
+// file at the target name: such a file necessarily holds DIFFERENT content
+// (rawPakMembers just matched nothing), and it could be a sibling fileID's
+// claimed member - failing loudly beats corrupting it, and the next
+// reconcile pass retries.
+func restoreRawPakCopy(versionDir, retainedPath, fileID, modID string) (string, error) {
+	name := rawPakRestoreName(fileID, modID)
+	target := filepath.Join(versionDir, name)
+	if _, err := os.Stat(target); err == nil {
+		return "", fmt.Errorf("restore target %s already exists with content not matching the retained source; refusing to overwrite", name)
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("checking restore target %s: %w", name, err)
+	}
+	if err := copyFileStreaming(retainedPath, target); err != nil {
+		return "", fmt.Errorf("restoring deployable copy %s: %w", name, err)
+	}
+	return name, nil
 }
 
 // sameMemberSet reports whether a and b claim the same members, ignoring

--- a/internal/core/merged_pak_import_flow_test.go
+++ b/internal/core/merged_pak_import_flow_test.go
@@ -21,6 +21,8 @@ import (
 // GetMod/GetModFiles as source.ErrNotSupported, ApplyImport's download
 // loop needs a working GetMod->GetModFiles->DownloadMod chain end to end.
 type importFlowCompilerSource struct {
+	fakeMergeFormat // #256: the format-vocabulary half of source.MergeCompiler
+
 	mod      *domain.Mod
 	fileName string
 	server   *httptest.Server

--- a/internal/core/merged_pak_internal_test.go
+++ b/internal/core/merged_pak_internal_test.go
@@ -1,13 +1,76 @@
 package core
 
 import (
+	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
 	"github.com/DonovanMods/linux-mod-manager/internal/storage/cache"
 )
+
+// testClassify mirrors the icarus classifier for the fingerprint-helper
+// tests below: core no longer owns a merge-source classification of its own
+// (#256 - ClassifyMergeSource moved behind the MergeCompiler seam), so the
+// package-level helpers take the classifier as a parameter and these tests
+// supply the canonical one.
+func testClassify(id string) (kind string, convertible bool) {
+	lower := strings.ToLower(id)
+	if lower == "pak" || strings.HasSuffix(lower, ".pak") {
+		return "pak", true
+	}
+	return "exmodz", false
+}
+
+// formatOnlyCompilerSource is the minimal source.ModSource +
+// source.MergeCompiler TestModHasPakMergeSource needs (#256):
+// classification moved behind the MergeCompiler seam, so even the cheap
+// FileIDs check resolves the game's compile source now. Only ID and the
+// format methods matter; everything else is inert.
+type formatOnlyCompilerSource struct{}
+
+func (formatOnlyCompilerSource) ID() string      { return "fake-compiler" }
+func (formatOnlyCompilerSource) Name() string    { return "Fake Compiler" }
+func (formatOnlyCompilerSource) AuthURL() string { return "" }
+func (formatOnlyCompilerSource) ExchangeToken(context.Context, string) (*source.Token, error) {
+	return nil, source.ErrNotSupported
+}
+func (formatOnlyCompilerSource) Search(context.Context, source.SearchQuery) (source.SearchResult, error) {
+	return source.SearchResult{}, source.ErrNotSupported
+}
+func (formatOnlyCompilerSource) GetMod(context.Context, string, string) (*domain.Mod, error) {
+	return nil, source.ErrNotSupported
+}
+func (formatOnlyCompilerSource) GetDependencies(context.Context, *domain.Mod) ([]domain.ModReference, error) {
+	return nil, source.ErrNotSupported
+}
+func (formatOnlyCompilerSource) GetModFiles(context.Context, *domain.Mod) ([]domain.DownloadableFile, error) {
+	return nil, source.ErrNotSupported
+}
+func (formatOnlyCompilerSource) GetDownloadURL(context.Context, *domain.Mod, string) (string, error) {
+	return "", source.ErrNotSupported
+}
+func (formatOnlyCompilerSource) CheckUpdates(context.Context, []domain.InstalledMod) ([]domain.Update, error) {
+	return nil, source.ErrNotSupported
+}
+func (formatOnlyCompilerSource) ValidateSource(string) error { return nil }
+func (formatOnlyCompilerSource) MergeCompile(context.Context, string, []source.MergeSource, string) ([]string, []source.MergeFailure, error) {
+	return nil, nil, nil
+}
+func (formatOnlyCompilerSource) ResolveBaseArtifact(*domain.Game) (string, error) {
+	return "", os.ErrNotExist
+}
+func (formatOnlyCompilerSource) FingerprintBase(string) (string, error) { return "", os.ErrNotExist }
+func (formatOnlyCompilerSource) IsConvertibleArtifact(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".pak")
+}
+func (formatOnlyCompilerSource) ClassifyMergeSource(id string) (string, bool) {
+	return testClassify(id)
+}
+func (formatOnlyCompilerSource) MergedArtifactName() string  { return "zzz_LMM_Merged_P.pak" }
+func (formatOnlyCompilerSource) MergedArtifactLabel() string { return "Icarus Merged Pak" }
 
 func TestMergedFingerprint_Deterministic(t *testing.T) {
 	f := MergedFingerprint{
@@ -35,7 +98,7 @@ func TestMergedFingerprintsEqual_IdenticalInputs(t *testing.T) {
 		BaseIndexHash: "abc123",
 		Mods:          []MergedFingerprintEntry{{SourceID: "icarus", ModID: "bear-mount", Version: "1.0", Checksum: "deadbeef"}},
 	}
-	eq, err := mergedFingerprintsEqual(f, f)
+	eq, err := mergedFingerprintsEqual(f, f, testClassify)
 	if err != nil {
 		t.Fatalf("mergedFingerprintsEqual: %v", err)
 	}
@@ -48,7 +111,7 @@ func TestMergedFingerprintsEqual_BaseHashChanged(t *testing.T) {
 	a := MergedFingerprint{BaseIndexHash: "abc123", Mods: []MergedFingerprintEntry{{SourceID: "icarus", ModID: "m1", Version: "1.0", Checksum: "x"}}}
 	b := a
 	b.BaseIndexHash = "def456"
-	eq, err := mergedFingerprintsEqual(a, b)
+	eq, err := mergedFingerprintsEqual(a, b, testClassify)
 	if err != nil {
 		t.Fatalf("mergedFingerprintsEqual: %v", err)
 	}
@@ -63,7 +126,7 @@ func TestMergedFingerprintsEqual_ModSetChanged(t *testing.T) {
 		{SourceID: "icarus", ModID: "m1", Version: "1.0", Checksum: "x"},
 		{SourceID: "icarus", ModID: "m2", Version: "1.0", Checksum: "y"},
 	}}
-	eq, err := mergedFingerprintsEqual(a, b)
+	eq, err := mergedFingerprintsEqual(a, b, testClassify)
 	if err != nil {
 		t.Fatalf("mergedFingerprintsEqual: %v", err)
 	}
@@ -81,7 +144,7 @@ func TestMergedFingerprintsEqual_LoadOrderChanged(t *testing.T) {
 		{SourceID: "icarus", ModID: "m2", Version: "1.0", Checksum: "y"},
 		{SourceID: "icarus", ModID: "m1", Version: "1.0", Checksum: "x"},
 	}}
-	eq, err := mergedFingerprintsEqual(a, b)
+	eq, err := mergedFingerprintsEqual(a, b, testClassify)
 	if err != nil {
 		t.Fatalf("mergedFingerprintsEqual: %v", err)
 	}
@@ -93,7 +156,7 @@ func TestMergedFingerprintsEqual_LoadOrderChanged(t *testing.T) {
 func TestMergedFingerprintsEqual_VersionChanged(t *testing.T) {
 	a := MergedFingerprint{BaseIndexHash: "abc", Mods: []MergedFingerprintEntry{{SourceID: "icarus", ModID: "m1", Version: "1.0", Checksum: "x"}}}
 	b := MergedFingerprint{BaseIndexHash: "abc", Mods: []MergedFingerprintEntry{{SourceID: "icarus", ModID: "m1", Version: "2.0", Checksum: "x2"}}}
-	eq, err := mergedFingerprintsEqual(a, b)
+	eq, err := mergedFingerprintsEqual(a, b, testClassify)
 	if err != nil {
 		t.Fatalf("mergedFingerprintsEqual: %v", err)
 	}
@@ -105,7 +168,7 @@ func TestMergedFingerprintsEqual_VersionChanged(t *testing.T) {
 func TestMergedFingerprintsEqual_EmptyModsBothSides(t *testing.T) {
 	a := MergedFingerprint{BaseIndexHash: "abc", Mods: nil}
 	b := MergedFingerprint{BaseIndexHash: "abc", Mods: []MergedFingerprintEntry{}}
-	eq, err := mergedFingerprintsEqual(a, b)
+	eq, err := mergedFingerprintsEqual(a, b, testClassify)
 	if err != nil {
 		t.Fatalf("mergedFingerprintsEqual: %v", err)
 	}
@@ -114,22 +177,16 @@ func TestMergedFingerprintsEqual_EmptyModsBothSides(t *testing.T) {
 	}
 }
 
-func TestMergeSourceKind(t *testing.T) {
-	tests := map[string]string{
-		"pak":          source.MergeSourcePak,
-		"MyMod.PAK":    source.MergeSourcePak,
-		"exmodz":       source.MergeSourceExmodz,
-		"MyMod.exmodz": source.MergeSourceExmodz,
-		"weird.zip":    source.MergeSourceExmodz, // unknown retained kind: today's behavior
-	}
-	for fileID, want := range tests {
-		if got := mergeSourceKind(fileID); got != want {
-			t.Errorf("mergeSourceKind(%q) = %q, want %q", fileID, got, want)
-		}
-	}
-}
+// The fileID->kind classification itself moved to the icarus package in
+// #256 (ClassifyMergeSource) - internal/source/icarus/format_test.go's
+// TestClassifyMergeSource carries the old TestMergeSourceKind table.
 
 func TestModHasPakMergeSource(t *testing.T) {
+	reg := source.NewRegistry()
+	reg.Register(formatOnlyCompilerSource{})
+	svc := &Service{registry: reg}
+	game := &domain.Game{ID: "g", SourceIDs: map[string]string{"fake-compiler": "g"}}
+
 	tests := []struct {
 		name string
 		mod  *domain.InstalledMod
@@ -142,24 +199,30 @@ func TestModHasPakMergeSource(t *testing.T) {
 		{"import-path .pak filename", &domain.InstalledMod{FileIDs: []string{"MyMod.PAK"}}, true},
 		{"mixed FileIDs, one pak", &domain.InstalledMod{FileIDs: []string{"exmodz", "pak"}}, true},
 	}
-	svc := &Service{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := svc.ModHasPakMergeSource(tt.mod); got != tt.want {
+			if got := svc.ModHasPakMergeSource(game, tt.mod); got != tt.want {
 				t.Errorf("ModHasPakMergeSource(%+v) = %v, want %v", tt.mod, got, tt.want)
 			}
 		})
+	}
+
+	// #256: with no merge-compiler-capable source mapped, there is nothing
+	// to classify against - never true, regardless of FileIDs.
+	bare := &domain.Game{ID: "bare"}
+	if svc.ModHasPakMergeSource(bare, &domain.InstalledMod{FileIDs: []string{"pak"}}) {
+		t.Error("ModHasPakMergeSource must be false for a game with no MergeCompiler source")
 	}
 }
 
 func TestFingerprintEqualityIgnoresOutcomes(t *testing.T) {
 	a := MergedFingerprint{BaseIndexHash: "h", Mods: []MergedFingerprintEntry{
-		{SourceID: "icarus", ModID: "m", Version: "1", Checksum: "c", Kind: source.MergeSourcePak, Converted: true},
+		{SourceID: "icarus", ModID: "m", Version: "1", Checksum: "c", Kind: "pak", Converted: true},
 	}}
 	b := MergedFingerprint{BaseIndexHash: "h", Mods: []MergedFingerprintEntry{
-		{SourceID: "icarus", ModID: "m", Version: "1", Checksum: "c", Kind: source.MergeSourcePak, Converted: false, FailReason: "x"},
+		{SourceID: "icarus", ModID: "m", Version: "1", Checksum: "c", Kind: "pak", Converted: false, FailReason: "x"},
 	}}
-	eq, err := mergedFingerprintsEqual(a, b)
+	eq, err := mergedFingerprintsEqual(a, b, testClassify)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,8 +231,8 @@ func TestFingerprintEqualityIgnoresOutcomes(t *testing.T) {
 	}
 
 	c := b
-	c.Mods = []MergedFingerprintEntry{{SourceID: "icarus", ModID: "m", Version: "2", Checksum: "c", Kind: source.MergeSourcePak}}
-	eq, err = mergedFingerprintsEqual(a, c)
+	c.Mods = []MergedFingerprintEntry{{SourceID: "icarus", ModID: "m", Version: "2", Checksum: "c", Kind: "pak"}}
+	eq, err = mergedFingerprintsEqual(a, c, testClassify)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,9 +255,9 @@ func TestReadOldFingerprintMarkerCompat(t *testing.T) {
 		t.Fatal("old marker unreadable")
 	}
 	current := MergedFingerprint{BaseIndexHash: "h", Mods: []MergedFingerprintEntry{
-		{SourceID: "icarus", ModID: "m", Version: "1", Checksum: "c", Kind: source.MergeSourceExmodz, Converted: true},
+		{SourceID: "icarus", ModID: "m", Version: "1", Checksum: "c", Kind: "exmodz", Converted: true},
 	}}
-	eq, err := mergedFingerprintsEqual(current, stored)
+	eq, err := mergedFingerprintsEqual(current, stored, testClassify)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/core/merged_pak_internal_test.go
+++ b/internal/core/merged_pak_internal_test.go
@@ -63,6 +63,9 @@ func (formatOnlyCompilerSource) ResolveBaseArtifact(*domain.Game) (string, error
 	return "", os.ErrNotExist
 }
 func (formatOnlyCompilerSource) FingerprintBase(string) (string, error) { return "", os.ErrNotExist }
+func (formatOnlyCompilerSource) IsNativeMergeSource(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".exmodz")
+}
 func (formatOnlyCompilerSource) IsConvertibleArtifact(fileName string) bool {
 	return strings.HasSuffix(strings.ToLower(fileName), ".pak")
 }

--- a/internal/core/merged_pak_internal_test.go
+++ b/internal/core/merged_pak_internal_test.go
@@ -74,6 +74,9 @@ func (formatOnlyCompilerSource) ClassifyMergeSource(id string) (string, bool) {
 }
 func (formatOnlyCompilerSource) MergedArtifactName() string  { return "zzz_LMM_Merged_P.pak" }
 func (formatOnlyCompilerSource) MergedArtifactLabel() string { return "Icarus Merged Pak" }
+func (formatOnlyCompilerSource) RestoredArtifactName(modID string) string {
+	return modID + "_P.pak"
+}
 
 func TestMergedFingerprint_Deterministic(t *testing.T) {
 	f := MergedFingerprint{

--- a/internal/core/merged_pak_internal_test.go
+++ b/internal/core/merged_pak_internal_test.go
@@ -191,7 +191,7 @@ func TestModHasPakMergeSource(t *testing.T) {
 	reg := source.NewRegistry()
 	reg.Register(formatOnlyCompilerSource{})
 	svc := &Service{registry: reg}
-	game := &domain.Game{ID: "g", SourceIDs: map[string]string{"fake-compiler": "g"}}
+	game := &domain.Game{ID: "g", DeployMode: domain.DeployCompile, SourceIDs: map[string]string{"fake-compiler": "g"}}
 
 	tests := []struct {
 		name string
@@ -214,10 +214,25 @@ func TestModHasPakMergeSource(t *testing.T) {
 	}
 
 	// #256: with no merge-compiler-capable source mapped, there is nothing
-	// to classify against - never true, regardless of FileIDs.
-	bare := &domain.Game{ID: "bare"}
+	// to classify against - never true, regardless of FileIDs. DeployCompile
+	// is set so this exercises the resolution-failure path, not the
+	// deploy-mode short-circuit.
+	bare := &domain.Game{ID: "bare", DeployMode: domain.DeployCompile}
 	if svc.ModHasPakMergeSource(bare, &domain.InstalledMod{FileIDs: []string{"pak"}}) {
 		t.Error("ModHasPakMergeSource must be false for a game with no MergeCompiler source")
+	}
+
+	// NOT gated on DeployMode: `lmm mod convert` persists the flag on
+	// non-compile games (advisory-only there), so a resolvable compiler
+	// still classifies - pre-#256 static behavior.
+	nonCompile := &domain.Game{ID: "g3", SourceIDs: map[string]string{"fake-compiler": "g3"}}
+	if !svc.ModHasPakMergeSource(nonCompile, &domain.InstalledMod{FileIDs: []string{"pak"}}) {
+		t.Error("ModHasPakMergeSource must classify for a non-DeployCompile game with a resolvable compiler")
+	}
+
+	// A nil game is false, never a panic.
+	if svc.ModHasPakMergeSource(nil, &domain.InstalledMod{FileIDs: []string{"pak"}}) {
+		t.Error("ModHasPakMergeSource must be false for a nil game")
 	}
 }
 

--- a/internal/core/merged_pak_test.go
+++ b/internal/core/merged_pak_test.go
@@ -211,6 +211,62 @@ func TestSyncMergedPak_ZeroEnabledMods_UninstallsExistingPak(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "disabling the last exmodz mod must remove the deployed merged pak")
 }
 
+// TestSyncMergedPak_ZeroEnabledMods_SecondZeroSyncSucceeds (#260 repro
+// shape 1): the first zero-pass uninstalls the pak AND deletes the merged
+// cache entry, so "zero sources + no merged entry" is the steady state after
+// disabling the last merge source. Every later mutation flow re-runs
+// syncMergedPak on that profile - the second zero-pass must succeed, not
+// fail on the absent entry. (The test above stops after the first zero-pass
+// and so never saw this.)
+func TestSyncMergedPak_ZeroEnabledMods_SecondZeroSyncSucceeds(t *testing.T) {
+	svc, game, _ := newMergedPakTestGame(t)
+	seedEnabledExmodzMod(t, svc, game, "fake-compiler", "bear-mount", "1.0", "exmodz-file", []byte("bear-bytes"))
+
+	_, err := svc.SyncMergedPak(context.Background(), game, "default")
+	require.NoError(t, err)
+
+	require.NoError(t, svc.SetModEnabled("fake-compiler", "bear-mount", game.ID, "default", false))
+
+	_, err = svc.SyncMergedPak(context.Background(), game, "default")
+	require.NoError(t, err, "first zero-pass: undeploys the pak and deletes the merged entry")
+
+	warnings, err := svc.SyncMergedPak(context.Background(), game, "default")
+	require.NoError(t, err, "second zero-pass must tolerate the already-absent merged entry")
+	require.Empty(t, warnings)
+}
+
+// TestSyncMergedPak_NeverMerged_ZeroSources (#260 repro shape 2): a fresh
+// DeployCompile game whose first synced profile has zero merge sources (e.g.
+// the first install is a plain non-pak file) has never had a merged-pak
+// cache entry at all - the very first sync must succeed.
+func TestSyncMergedPak_NeverMerged_ZeroSources(t *testing.T) {
+	svc, game, _ := newMergedPakTestGame(t)
+
+	warnings, err := svc.SyncMergedPak(context.Background(), game, "default")
+	require.NoError(t, err, "a profile that never merged has no entry to remove - not an error")
+	require.Empty(t, warnings)
+}
+
+// TestPurgeMergedPak_AbsentCacheEntry (#260 repro shape 3): PurgeMergedPak
+// routes through the same Installer.Uninstall and must likewise tolerate an
+// absent merged-pak cache entry (e.g. purge --uninstall already deleted it,
+// or the profile never merged).
+func TestPurgeMergedPak_AbsentCacheEntry(t *testing.T) {
+	svc, game, _ := newMergedPakTestGame(t)
+
+	require.NoError(t, svc.PurgeMergedPak(context.Background(), game, "default", true),
+		"purging a never-merged profile must be a no-op, not an error")
+
+	// And again after a full merge/purge cycle: --uninstall deletes the
+	// entry, so a repeat purge sees the same absent-entry state.
+	seedEnabledExmodzMod(t, svc, game, "fake-compiler", "bear-mount", "1.0", "exmodz-file", []byte("bear-bytes"))
+	_, err := svc.SyncMergedPak(context.Background(), game, "default")
+	require.NoError(t, err)
+	require.NoError(t, svc.PurgeMergedPak(context.Background(), game, "default", true))
+	require.NoError(t, svc.PurgeMergedPak(context.Background(), game, "default", true),
+		"a repeat purge after --uninstall must tolerate the already-deleted entry")
+}
+
 // TestSyncMergedPak_RegeneratesOnBaseHashChange proves a base-pak refresh
 // (the "Friday problem", generalized from #196 to the merged model) still
 // triggers regeneration.

--- a/internal/core/merged_pak_test.go
+++ b/internal/core/merged_pak_test.go
@@ -21,8 +21,13 @@ import (
 // skips a mod's fileIDs that have no retained source (a plain .pak).
 func TestEnabledMergeSources_OrderMatchesProfileLoadOrderAndSkipsDisabled(t *testing.T) {
 	svc := newFlowsTestService(t)
-	game := &domain.Game{ID: "icarus", ModPath: t.TempDir(), DeployMode: domain.DeployCompile}
+	// #256: enabledMergeSources classifies retained fileIDs via the game's
+	// MergeCompiler source instead of a static suffix test in core, so this
+	// fixture now maps and registers one.
+	game := &domain.Game{ID: "icarus", ModPath: t.TempDir(), DeployMode: domain.DeployCompile,
+		SourceIDs: map[string]string{"fake-compiler": "icarus"}}
 	require.NoError(t, svc.AddGame(game))
+	svc.RegisterSource(&fakeCompilerSource{})
 
 	gameCache := svc.GetGameCache(game)
 

--- a/internal/core/merged_pak_test.go
+++ b/internal/core/merged_pak_test.go
@@ -445,3 +445,137 @@ func TestReconcilePakManifests_RawFallbackPath_InstallFailureRetries(t *testing.
 	_, statErr = os.Stat(deployedPath)
 	require.NoError(t, statErr, "the retry must actually deploy the raw pak")
 }
+
+// TestReconcilePakManifests_RawFallback_RestoresPrunedDeployableCopy proves
+// the #250 heal: a cache entry damaged by a released version's prune - the
+// deployable pak copy missing, the retained source still present, the
+// manifest in the post-convert members=nil state - must be RESTORED by the
+// raw-fallback branch, not silently marked empty. Pre-fix, rawPakMembers
+// found no member to claim, reconcile recorded an empty member set, and
+// Install deployed nothing - silently, forever.
+//
+// The restored copy's name depends on the fileID's origin: an import-path
+// fileID IS the original archive filename (ingest names the deployable copy
+// identically), so it restores byte- and name-exact; a download-path fileID
+// (the literal icarus "pak") never carried the original name - the manifest
+// flip erased it and nothing else records it - so a deterministic mod-scoped
+// name in Icarus's "_P.pak" override convention is synthesized.
+func TestReconcilePakManifests_RawFallback_RestoresPrunedDeployableCopy(t *testing.T) {
+	cases := []struct {
+		name         string
+		fileID       string
+		restoredName string
+	}{
+		{"download-shape fileID synthesizes a mod-scoped name", "pak", "dmgmod_P.pak"},
+		{"import-shape fileID restores its own archive name", "DamagedMod.pak", "DamagedMod.pak"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, game, _ := newMergedPakTestGame(t)
+			// game.ConvertPaks stays false: the pak takes the raw-fallback
+			// branch (the issue's "user opts out of conversion" leg).
+			const (
+				sourceID = "fake-compiler"
+				modID    = "dmgmod"
+				version  = "1.0"
+			)
+			pakBytes := []byte("prebuilt-pak-bytes")
+
+			gameCache := svc.GetGameCache(game)
+			require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, cache.RetainedSourceName(tc.fileID), pakBytes))
+			versionDir := gameCache.ModPath(game.ID, sourceID, modID, version)
+			// The #250 damaged shape: converted manifest, no deployable copy.
+			require.NoError(t, cache.MarkFileCompleteWithMembers(versionDir, tc.fileID, nil))
+
+			require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+				Mod:          domain.Mod{ID: modID, SourceID: sourceID, Name: modID, Version: version, GameID: game.ID},
+				ProfileName:  "default",
+				Enabled:      true,
+				FileIDs:      []string{tc.fileID},
+				UpdatePolicy: domain.UpdateNotify,
+			}))
+			pm := svc.NewProfileManager()
+			require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: sourceID, ModID: modID, Version: version, FileIDs: []string{tc.fileID}}))
+
+			inst := core.NewInstaller(gameCache, linker.New(game.LinkMethod), nil)
+			_, err := svc.ReconcilePakManifestsForTest(context.Background(), game, "default", inst, nil)
+			require.NoError(t, err)
+
+			manifests, err := gameCache.FileManifests(game.ID, sourceID, modID, version)
+			require.NoError(t, err)
+			require.Equal(t, []string{tc.restoredName}, manifests[tc.fileID].Members,
+				"the healed manifest must claim the restored copy, never an empty member set (#250)")
+
+			restored, err := os.ReadFile(filepath.Join(versionDir, tc.restoredName))
+			require.NoError(t, err, "the deployable copy must be restored into the cache entry from the retained source")
+			require.Equal(t, pakBytes, restored)
+
+			deployed, err := os.ReadFile(filepath.Join(game.ModPath, tc.restoredName))
+			require.NoError(t, err, "the restored raw pak must actually deploy - the silent-empty deploy is the bug")
+			require.Equal(t, pakBytes, deployed)
+
+			// A second pass must converge as a no-op, not loop re-restoring.
+			_, err = svc.ReconcilePakManifestsForTest(context.Background(), game, "default", inst, nil)
+			require.NoError(t, err)
+			manifests, err = gameCache.FileManifests(game.ID, sourceID, modID, version)
+			require.NoError(t, err)
+			require.Equal(t, []string{tc.restoredName}, manifests[tc.fileID].Members, "the second pass must keep the healed claim stable")
+		})
+	}
+}
+
+// TestSyncMergedPak_OptOutAfterPrunedConvertedPak_RestoresRawDeploy is the
+// #250 heal driven through the full SyncMergedPak flow, matching the issue's
+// repro step 3 exactly: the user opts out of conversion game-wide AFTER a
+// released prune already deleted the converted pak's deployable copy. The
+// damaged state is seeded realistically: the merge DID happen once (that is
+// the only way the manifest flipped to members=nil), so the merged-pak
+// cache entry exists and its artifact is deployed. Zero merge sources
+// remain after the opt-out, so syncMergedPak takes its uninstall-to-zero
+// branch and reconciles - which must restore the raw deploy from the
+// retained source instead of deploying nothing. (An ABSENT merged entry in
+// this state trips the pre-existing, unrelated #260 instead.)
+func TestSyncMergedPak_OptOutAfterPrunedConvertedPak_RestoresRawDeploy(t *testing.T) {
+	svc, game, _ := newMergedPakTestGame(t)
+	// game.ConvertPaks stays false: opted out game-wide.
+
+	const (
+		sourceID = "fake-compiler"
+		modID    = "optout"
+		version  = "1.0"
+	)
+	pakBytes := []byte("prebuilt-pak-bytes")
+
+	gameCache := svc.GetGameCache(game)
+	require.NoError(t, gameCache.Store(game.ID, sourceID, modID, version, cache.RetainedSourceName("pak"), pakBytes))
+	versionDir := gameCache.ModPath(game.ID, sourceID, modID, version)
+	require.NoError(t, cache.MarkFileCompleteWithMembers(versionDir, "pak", nil))
+
+	// The prior successful merge's leftovers: a merged-pak cache entry and
+	// its deployed artifact (a symlink into the cache - the profile's
+	// effective link method here, matching what Install actually leaves).
+	require.NoError(t, gameCache.Store(game.ID, domain.SourceMerged, "merged-pak", "merged", "zzz_LMM_Merged_P.pak", []byte("merged-bytes")))
+	mergedDeployedPath := filepath.Join(game.ModPath, "zzz_LMM_Merged_P.pak")
+	require.NoError(t, os.Symlink(gameCache.GetFilePath(game.ID, domain.SourceMerged, "merged-pak", "merged", "zzz_LMM_Merged_P.pak"), mergedDeployedPath))
+
+	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
+		Mod:          domain.Mod{ID: modID, SourceID: sourceID, Name: modID, Version: version, GameID: game.ID},
+		ProfileName:  "default",
+		Enabled:      true,
+		FileIDs:      []string{"pak"},
+		UpdatePolicy: domain.UpdateNotify,
+	}))
+	pm := svc.NewProfileManager()
+	require.NoError(t, pm.UpsertMod(game.ID, "default", domain.ModReference{SourceID: sourceID, ModID: modID, Version: version, FileIDs: []string{"pak"}}))
+
+	warnings, err := svc.SyncMergedPak(context.Background(), game, "default")
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+
+	deployed, err := os.ReadFile(filepath.Join(game.ModPath, "optout_P.pak"))
+	require.NoError(t, err, "opting out after the prune must restore and deploy the raw pak (#250), not silently deploy nothing")
+	require.Equal(t, pakBytes, deployed)
+
+	_, err = os.Stat(mergedDeployedPath)
+	require.True(t, os.IsNotExist(err), "the opt-out must still remove the deployed merged pak (uninstall-to-zero)")
+}

--- a/internal/core/moddetail.go
+++ b/internal/core/moddetail.go
@@ -63,7 +63,7 @@ func (s *Service) ModDetail(ctx context.Context, game *domain.Game, profile, sou
 		Profile:      profile,
 		UpdatePolicy: installed.UpdatePolicy,
 	}
-	if game.DeployMode == domain.DeployCompile && s.ModHasPakMergeSource(installed) {
+	if game.DeployMode == domain.DeployCompile && s.ModHasPakMergeSource(game, installed) {
 		v := installed.ConvertPaks
 		info.ConvertPaks = &v
 	}

--- a/internal/core/moddetail_test.go
+++ b/internal/core/moddetail_test.go
@@ -20,9 +20,14 @@ import (
 func newModDetailTestService(t *testing.T) (*core.Service, *domain.Game, *mockSource) {
 	t.Helper()
 	svc := newFlowsTestService(t)
-	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink}
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), LinkMethod: domain.LinkSymlink,
+		// #256: ModHasPakMergeSource classifies fileIDs via the game's
+		// MergeCompiler source instead of a static suffix test in core, so
+		// the DeployCompile subtests need one mapped and registered.
+		SourceIDs: map[string]string{"fake-compiler": "testgame"}}
 	src := newMockSource("src")
 	svc.RegisterSource(src)
+	svc.RegisterSource(&fakeCompilerSource{})
 	return svc, game, src
 }
 

--- a/internal/core/pak_convert_e2e_test.go
+++ b/internal/core/pak_convert_e2e_test.go
@@ -80,9 +80,9 @@ func TestPakConvertEndToEnd(t *testing.T) {
 
 	require.Len(t, rec.lastSources, 2, "MergeCompile must receive both mods")
 	require.Equal(t, "fake-compiler:exmod", rec.lastSources[0].ModRef, "profile load order: exmod first")
-	require.Equal(t, source.MergeSourceExmodz, rec.lastSources[0].Kind)
+	require.Equal(t, "exmodz", rec.lastSources[0].Kind)
 	require.Equal(t, "fake-compiler:pakmod", rec.lastSources[1].ModRef, "profile load order: pakmod second")
-	require.Equal(t, source.MergeSourcePak, rec.lastSources[1].Kind)
+	require.Equal(t, "pak", rec.lastSources[1].Kind)
 
 	manifests, err := gameCache.FileManifests(game.ID, "fake-compiler", "pakmod", "1.0")
 	require.NoError(t, err)
@@ -202,12 +202,12 @@ func TestNoPakModsByteIdentical(t *testing.T) {
 	require.Equal(t, 1, rec.compileCalls)
 
 	require.Len(t, rec.lastSources, 1)
-	require.Equal(t, source.MergeSourceExmodz, rec.lastSources[0].Kind, "MergeCompile must receive Kind set even for a pure-exmodz profile (#221 regression net)")
+	require.Equal(t, "exmodz", rec.lastSources[0].Kind, "MergeCompile must receive Kind set even for a pure-exmodz profile (#221 regression net)")
 
 	outcomes, ok := svc.MergedPakOutcomes(game, "default")
 	require.True(t, ok)
 	require.Len(t, outcomes, 1)
-	require.Equal(t, source.MergeSourceExmodz, outcomes[0].Kind)
+	require.Equal(t, "exmodz", outcomes[0].Kind)
 	require.True(t, outcomes[0].Converted)
 	require.Empty(t, outcomes[0].FailReason)
 

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -128,16 +128,21 @@ func (s *Service) ValidateInstallFileSelection(sourceID string, files []domain.D
 	if !ok {
 		return nil
 	}
+	// The colliding filenames are captured for the error: naming the actual
+	// files keeps the message format-agnostic (the vocabulary comes from
+	// the selection itself, not a hardcoded format list) and tells the user
+	// WHICH two files collided, not just that a collision happened (#256).
 	var native, other bool
+	var nativeName, otherName string
 	for _, f := range files {
 		if mc.IsNativeMergeSource(f.FileName) {
-			native = true
+			native, nativeName = true, f.FileName
 		} else {
-			other = true
+			other, otherName = true, f.FileName
 		}
 	}
 	if native && other {
-		return fmt.Errorf("raw artifact and native merge archive are alternate forms of the same mod - select one")
+		return fmt.Errorf("%s and %s are alternate forms of the same mod - select one", otherName, nativeName)
 	}
 	return nil
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -1064,10 +1064,10 @@ func commitStagedCache(cachePath, stagePath string) error {
 // before "exmodz") - those must NOT be routed through this function's own
 // validate+retain branch as an exmodz, since MergeCompile expects an exmodz
 // diff, not a whole pak (#136 review, Task 13 fix round 1). A prebuilt pak
-// gets its OWN eligibility check instead - isConvertEligiblePakFile (#221) -
+// gets its OWN eligibility check instead - isConvertEligibleArtifact (#221) -
 // which the same validate+retain branch also widens for: a convert-eligible
 // pak still enters ingest's validate+retain machinery (a different
-// isExmodzFile-vs-isConvertEligiblePakFile Kind, not a different branch),
+// isExmodzFile-vs-isConvertEligibleArtifact Kind, not a different branch),
 // while a non-eligible pak (ConvertPaks off, or a non-DeployCompile game)
 // falls through to the pre-compile extract/copy logic unchanged, exactly as
 // if DeployMode were not DeployCompile at all.

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -204,7 +204,7 @@ func (s *Service) SourcesForGame(gameID string) ([]source.ModSource, error) {
 	return srcs, nil
 }
 
-// compilerSourceForGame resolves the sole Compiler-capable source
+// mergeCompilerSourceForGame resolves the sole MergeCompiler-capable source
 // registered for gameID (#173). The download path pins its MergeCompiler
 // check to the specific source a file was downloaded from
 // (DownloadModToCache's src.(source.MergeCompiler) check); Importer.Import

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -124,19 +124,20 @@ func (s *Service) ValidateInstallFileSelection(sourceID string, files []domain.D
 	if err != nil {
 		return nil
 	}
-	if _, ok := src.(source.MergeCompiler); !ok {
+	mc, ok := src.(source.MergeCompiler)
+	if !ok {
 		return nil
 	}
-	var exmodz, other bool
+	var native, other bool
 	for _, f := range files {
-		if isExmodzFile(f.FileName) {
-			exmodz = true
+		if mc.IsNativeMergeSource(f.FileName) {
+			native = true
 		} else {
 			other = true
 		}
 	}
-	if exmodz && other {
-		return fmt.Errorf("pak and exmodz are alternate forms of the same mod - select one")
+	if native && other {
+		return fmt.Errorf("raw pak and native merge archive are alternate forms of the same mod - select one")
 	}
 	return nil
 }
@@ -612,7 +613,7 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 	// hard-errors when src lacks MergeCompiler (see the !ok check below).
 	mc, isMergeCompiler := src.(source.MergeCompiler)
 	convertEligiblePak := isMergeCompiler && isConvertEligibleArtifact(game, mc, safeFileName)
-	if game.DeployMode == domain.DeployCompile && (isExmodzFile(safeFileName) || convertEligiblePak) {
+	if game.DeployMode == domain.DeployCompile && (s.isNativeMergeFile(game, mc, safeFileName) || convertEligiblePak) {
 		if !isMergeCompiler {
 			return nil, fmt.Errorf("source %q: game %q requires DeployCompile but source does not implement MergeCompiler", src.ID(), game.ID)
 		}
@@ -1058,21 +1059,34 @@ func commitStagedCache(cachePath, stagePath string) error {
 	return nil
 }
 
-// isExmodzFile reports whether fileName is a compile-eligible archive
-// (case-insensitive ".exmodz" suffix). DeployCompile games can also serve
-// plain, already-built ".pak" files (icarus.GetModFiles enumerates "pak"
-// before "exmodz") - those must NOT be routed through this function's own
-// validate+retain branch as an exmodz, since MergeCompile expects an exmodz
-// diff, not a whole pak (#136 review, Task 13 fix round 1). A prebuilt pak
-// gets its OWN eligibility check instead - isConvertEligibleArtifact (#221) -
-// which the same validate+retain branch also widens for: a convert-eligible
-// pak still enters ingest's validate+retain machinery (a different
-// isExmodzFile-vs-isConvertEligibleArtifact Kind, not a different branch),
-// while a non-eligible pak (ConvertPaks off, or a non-DeployCompile game)
-// falls through to the pre-compile extract/copy logic unchanged, exactly as
-// if DeployMode were not DeployCompile at all.
-func isExmodzFile(fileName string) bool {
-	return strings.HasSuffix(strings.ToLower(fileName), ".exmodz")
+// isNativeMergeFile reports whether fileName is the game's compile source's
+// NATIVE merge-source format (#256 - the seam-routed successor to the old
+// static isExmodzFile ".exmodz" test). DeployCompile games can also serve
+// plain, already-built raw paks (icarus.GetModFiles enumerates "pak"
+// before "exmodz") - those must NOT be routed through ingest's
+// validate+retain branch as a native archive, since MergeCompile expects a
+// native diff, not a whole pak (#136 review, Task 13 fix round 1); a
+// prebuilt pak gets its OWN eligibility check instead,
+// isConvertEligibleArtifact (#221), a different Kind through the same
+// validate+retain branch.
+//
+// mc is the file's own source's MergeCompiler view (nil when that source
+// doesn't implement it). When mc is nil, the GAME's sole compile source is
+// consulted instead, so the "native archive served by a non-compile-capable
+// source" hard error in DownloadModToCache stays reachable on mixed-source
+// games. With no compiler resolvable anywhere, nothing can define "native"
+// and this returns false - such files take the legacy extract/copy path,
+// where an unextractable native archive still fails loud
+// ("unsupported archive format"), just without the compile-specific message.
+func (s *Service) isNativeMergeFile(game *domain.Game, mc source.MergeCompiler, fileName string) bool {
+	if mc == nil {
+		gmc, err := s.mergeCompilerForGame(game)
+		if err != nil {
+			return false
+		}
+		mc = gmc
+	}
+	return mc.IsNativeMergeSource(fileName)
 }
 
 // isConvertEligibleArtifact reports whether fileName is a prebuilt raw

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -137,7 +137,7 @@ func (s *Service) ValidateInstallFileSelection(sourceID string, files []domain.D
 		}
 	}
 	if native && other {
-		return fmt.Errorf("raw pak and native merge archive are alternate forms of the same mod - select one")
+		return fmt.Errorf("raw artifact and native merge archive are alternate forms of the same mod - select one")
 	}
 	return nil
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -1076,8 +1076,15 @@ func commitStagedCache(cachePath, stagePath string) error {
 // source" hard error in DownloadModToCache stays reachable on mixed-source
 // games. With no compiler resolvable anywhere, nothing can define "native"
 // and this returns false - such files take the legacy extract/copy path,
-// where an unextractable native archive still fails loud
-// ("unsupported archive format"), just without the compile-specific message.
+// preserving #221 I1's protected download fall-through for the non-compile
+// source's paks and zips. Known residual, accepted deliberately: because
+// the legacy Extractor content-sniffs zip magic, a REAL native archive
+// downloaded in that doubly-broken state (a game whose SourceIDs map no
+// compiler at all - icarus is always registered, so only a hand-edited map
+// gets here - AND a foreign source serving native archives) is ingested as
+// a plain archive without ValidateSource. The import path has no such
+// residual: Importer.Import hard-errors on an unresolvable compiler, since
+// it has no per-archive source contract forcing a fall-through.
 func (s *Service) isNativeMergeFile(game *domain.Game, mc source.MergeCompiler, fileName string) bool {
 	if mc == nil {
 		gmc, err := s.mergeCompilerForGame(game)

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DonovanMods/go-unrealpak"
 	"github.com/DonovanMods/linux-mod-manager/internal/domain"
 	"github.com/DonovanMods/linux-mod-manager/internal/linker"
 	"github.com/DonovanMods/linux-mod-manager/internal/source"
@@ -204,9 +203,8 @@ func (s *Service) SourcesForGame(gameID string) ([]source.ModSource, error) {
 // check to the specific source a file was downloaded from
 // (DownloadModToCache's src.(source.MergeCompiler) check); Importer.Import
 // has no such per-archive source to key off of, so it resolves against
-// every source the game maps in its registry instead — matching
-// resolveBasePak's v1 scope of "Icarus only", at most one of a game's
-// configured sources implements MergeCompiler today. Zero is the expected
+// every source the game maps in its registry instead — at most one of a
+// game's configured sources implements MergeCompiler today. Zero is the expected
 // failure when the game (or its MergeCompiler source) isn't configured;
 // more than one is treated as ambiguous rather than picking arbitrarily —
 // both fail loud instead of letting an .exmodz import silently skip
@@ -222,6 +220,35 @@ func (s *Service) mergeCompilerSourceForGame(gameID string) (source.MergeCompile
 			compilers = append(compilers, c)
 		}
 	}
+	return soleMergeCompiler(gameID, compilers)
+}
+
+// mergeCompilerForGame is mergeCompilerSourceForGame for callers that
+// already hold the *domain.Game (#256): it resolves against the game
+// struct's own source map instead of re-looking the game up in s.games, so
+// merged-pak paths that always received their game as a parameter keep
+// working for a game value that was never registered with the service (a
+// distinction only tests exercise today). Same 0/1/many contract.
+func (s *Service) mergeCompilerForGame(game *domain.Game) (source.MergeCompiler, error) {
+	var compilers []source.MergeCompiler
+	for id := range game.SourceIDs {
+		src, err := s.registry.Get(id)
+		if err != nil {
+			continue // unregistered: silently skipped, matching SourcesForGame
+		}
+		if c, ok := src.(source.MergeCompiler); ok {
+			compilers = append(compilers, c)
+		}
+	}
+	return soleMergeCompiler(game.ID, compilers)
+}
+
+// soleMergeCompiler enforces the "exactly one compile-capable source per
+// game" contract shared by both resolvers above: zero is the expected
+// failure when the game's MergeCompiler source isn't configured; more than
+// one is treated as ambiguous rather than picking arbitrarily - both fail
+// loud instead of letting a compile-path operation silently skip.
+func soleMergeCompiler(gameID string, compilers []source.MergeCompiler) (source.MergeCompiler, error) {
 	switch len(compilers) {
 	case 0:
 		return nil, fmt.Errorf("game %q requires DeployCompile but has no merge-compiler-capable source configured (map a source implementing source.MergeCompiler in the game's sources)", gameID)
@@ -576,15 +603,15 @@ func (s *Service) DownloadModToCache(ctx context.Context, gameCache *cache.Cache
 
 	// convertEligiblePak requires BOTH the game's own eligibility (deploy
 	// mode + ConvertPaks) AND this specific src implementing MergeCompiler
-	// (#221 I1 fix): isConvertEligiblePakFile alone only checks game flags,
-	// so a .pak served by a source that does NOT implement MergeCompiler
+	// (#221 I1 fix): the game flags alone don't decide, so a raw pak served
+	// by a source that does NOT implement MergeCompiler
 	// (a mixed-source game, or a misconfigured/non-icarus source) must fall
 	// through to the legacy extract/copy path below - exactly as it did
 	// before #221 - rather than hard-erroring the whole download. Unlike a
 	// .exmodz file, which has no other valid interpretation and so still
 	// hard-errors when src lacks MergeCompiler (see the !ok check below).
 	mc, isMergeCompiler := src.(source.MergeCompiler)
-	convertEligiblePak := isMergeCompiler && isConvertEligiblePakFile(game, safeFileName)
+	convertEligiblePak := isMergeCompiler && isConvertEligibleArtifact(game, mc, safeFileName)
 	if game.DeployMode == domain.DeployCompile && (isExmodzFile(safeFileName) || convertEligiblePak) {
 		if !isMergeCompiler {
 			return nil, fmt.Errorf("source %q: game %q requires DeployCompile but source does not implement MergeCompiler", src.ID(), game.ID)
@@ -1048,53 +1075,21 @@ func isExmodzFile(fileName string) bool {
 	return strings.HasSuffix(strings.ToLower(fileName), ".exmodz")
 }
 
-// isConvertEligiblePakFile reports whether fileName is a prebuilt .pak that
-// should enter the merge-convert pipeline (#221): DeployCompile game with
-// convert_paks enabled. The per-MOD opt-out is consulted at merge-membership
-// time (enabledMergeSources), not here - ingest state is identical either
-// way (retained + raw-deployable), only participation differs. This checks
-// only game-level flags - callers (DownloadModToCache, Importer.Import) must
-// ALSO confirm the actual source/resolver implements source.MergeCompiler
-// before treating a pak as convert-eligible; a source that doesn't falls
-// through to the legacy extract/copy path instead (#221 I1 fix).
-func isConvertEligiblePakFile(game *domain.Game, fileName string) bool {
+// isConvertEligibleArtifact reports whether fileName is a prebuilt raw
+// artifact that should enter the merge-convert pipeline (#221): DeployCompile
+// game with convert_paks enabled, and a file the game's compile-capable
+// source says it can convert (mc.IsConvertibleArtifact - the format half of
+// the pre-#256 isConvertEligiblePakFile, now behind the MergeCompiler seam;
+// the policy half stays here). The per-MOD opt-out is consulted at
+// merge-membership time (enabledMergeSources), not here - ingest state is
+// identical either way (retained + raw-deployable), only participation
+// differs. mc must be the source/resolver actually serving the file: a
+// source that does not implement source.MergeCompiler falls through to the
+// legacy extract/copy path instead (#221 I1 fix), which callers express by
+// never reaching this check without one.
+func isConvertEligibleArtifact(game *domain.Game, mc source.MergeCompiler, fileName string) bool {
 	return game.DeployMode == domain.DeployCompile && game.ConvertPaks &&
-		strings.HasSuffix(strings.ToLower(fileName), ".pak")
-}
-
-// resolveBasePak locates the currently-installed game's base pak for
-// DeployCompile sources. v1 scope: Icarus only, one known pak filename
-// pattern — extend this if a second DeployCompile-using game is ever added
-// rather than generalizing speculatively now. The relative path below is
-// Task 1's empirically-confirmed finding (docs/plans/icarus-pak-format-findings.md),
-// recorded before this function was written, not an assumption made here: the
-// JSON data tables live in Content/Data/data.pak, NOT in the Content/Paks
-// pakchunks, which carry only cooked .uasset/.uexp assets and no JSON at all.
-//
-// This pak is also the direct source of base table *content* (#175): Compile
-// reads each patched table straight out of it via go-unrealpak, so a
-// compile is always week-correct by construction (there's no separate dump
-// to go stale relative to the install) and works entirely offline.
-func resolveBasePak(game *domain.Game) (string, error) {
-	candidate := filepath.Join(game.InstallPath, "Icarus", "Content", "Data", "data.pak")
-	if _, err := os.Stat(candidate); err != nil {
-		return "", fmt.Errorf("locating base pak for %q: %w", game.ID, err)
-	}
-	return candidate, nil
-}
-
-// basePakIndexHash opens basePakPath and returns its footer IndexHash
-// (#196) - cheap (footer + primary-index region only; unrealpak.Open never
-// reads a pak's actual file payloads), matching the base pak Compile itself
-// already opens to read patched tables from, so this adds no new I/O
-// pattern to the compile path.
-func basePakIndexHash(basePakPath string) (string, error) {
-	r, err := unrealpak.Open(basePakPath)
-	if err != nil {
-		return "", fmt.Errorf("reading base pak for compile fingerprint: %w", err)
-	}
-	defer r.Close() //nolint:errcheck
-	return r.IndexHash(), nil
+		mc.IsConvertibleArtifact(fileName)
 }
 
 // GetGame retrieves a game by ID

--- a/internal/core/service_icarus_compile_test.go
+++ b/internal/core/service_icarus_compile_test.go
@@ -37,6 +37,8 @@ func writeFakeBasePak(t *testing.T, path string) {
 // needs to prove Service validates and retains (never compiles a per-mod
 // pak) when DeployMode is DeployCompile (#197: merged-only).
 type fakeCompilerSource struct {
+	fakeMergeFormat // #256: the format-vocabulary half of source.MergeCompiler
+
 	downloadURL   string
 	compileCalls  int
 	validateCalls int

--- a/internal/core/service_import_compile_test.go
+++ b/internal/core/service_import_compile_test.go
@@ -176,20 +176,11 @@ func TestImportMod_DeployCompile_ZipPassthroughUnaffected(t *testing.T) {
 // TestImportMod_DeployCompile_NoCompilerSourceFailsLoud pins the "never
 // silently cache an unvalidated .exmodz" requirement (#173/#197): a
 // DeployCompile game with no MergeCompiler-capable source mapped in its
-// SourceIDs must fail loud, creating no cache entry.
-//
-// #256 amended WHICH loud failure this is: with the ".exmodz" test moved
-// behind the MergeCompiler seam (IsNativeMergeSource), a game whose
-// compiler cannot be resolved has nothing left that can define "native",
-// so the import falls through to the legacy path - where the
-// extension-keyed Extractor rejects the unknown ".exmodz" suffix as
-// "unsupported archive format" before anything is staged or cached. The
-// pre-#256 compiler-specific message required core itself to know the
-// extension, which is the leak #256 closes; the invariant that matters -
-// loud failure, nothing cached - is unchanged. (The resolver-nil variant
-// below, TestImportMod_DeployCompile_StandaloneImporterFailsLoud, keeps
-// its original message: a standalone Importer fails every DeployCompile
-// import up front, no format question needed.)
+// SourceIDs must fail loud with an actionable error instead of falling
+// through to extract/copy. (#256: the failure now happens up front - the
+// compiler is resolved for every DeployCompile import, since only it can
+// say which files are native - but the message still names the compiler
+// gap and nothing is ever cached, same as always.)
 func TestImportMod_DeployCompile_NoCompilerSourceFailsLoud(t *testing.T) {
 	installDir := t.TempDir()
 	basePak := filepath.Join(installDir, "Icarus", "Content", "Data", "data.pak")
@@ -214,37 +205,33 @@ func TestImportMod_DeployCompile_NoCompilerSourceFailsLoud(t *testing.T) {
 	result, err := importer.Import(context.Background(), archivePath, game, core.ImportOptions{})
 	require.Error(t, err)
 	require.Nil(t, result)
-	require.Contains(t, err.Error(), "unsupported archive format")
+	require.Contains(t, err.Error(), "compiler")
 
 	_, statErr := os.Stat(filepath.Join(cfg.CacheDir, game.ID))
 	require.True(t, os.IsNotExist(statErr), "no cache entry should have been created")
 }
 
-// TestImportMod_DeployCompile_PakNoCompilerSourceFallsThrough is the I1 fix
-// (final whole-branch review of #221) for the import path, mirroring
+// TestImportMod_DeployCompile_PakNoCompilerSourceFailsLoud mirrors
 // TestImportMod_DeployCompile_NoCompilerSourceFailsLoud's setup (a
-// DeployCompile game with NO MergeCompiler-capable source mapped) but for a
-// .pak filename instead of .exmodz: isConvertEligiblePakFile only checked
-// game flags (DeployMode + ConvertPaks), so this scenario used to enter the
-// validate+retain branch and hard-error on resolveMergeCompiler's failure -
-// exactly like the exmodz case above, even though a .pak (unlike an
-// .exmodz) has another valid interpretation once eligibility is properly
-// gated on actual resolver success.
+// DeployCompile game with NO MergeCompiler-capable source mapped) for a
+// .pak filename: like every other import into such a game, it must fail
+// loud on the compiler-resolution error, caching nothing.
 //
-// Unlike the download path (DownloadModToCache's copy fallback triggers
-// unconditionally whenever the file isn't a recognized archive, regardless
-// of deploy mode), Import has no such unconditional fallback outside
-// DeployCopy - a DeployCompile game importing any unrecognized, non-archive
-// format (a raw .pak included) has always ended in "unsupported archive
-// format" once it misses the compile branch, pre-#221 included (a .pak
-// import for Icarus simply wasn't a supported scenario before #221 existed
-// at all). So the observable fix here is not "the import now succeeds" (it
-// can't - Import genuinely has nothing else to do with a raw .pak) but "the
-// import fails with the SAME, accurate, pre-#221-consistent 'unsupported
-// archive format' error instead of a MISLEADING 'no merge-compiler-capable
-// source configured' one" - and, just as importantly, no cache entry or
-// retained source is created for a mod that was never actually ingested.
-func TestImportMod_DeployCompile_PakNoCompilerSourceFallsThrough(t *testing.T) {
+// History: #221 I1 made this exact case fall through to the legacy path
+// (whose "unsupported archive format" error it then reported), because the
+// resolver message was misleading while core could statically single out
+// .exmodz as the only file kind that truly REQUIRED the compiler. #256
+// moved that knowledge behind the seam (IsNativeMergeSource), which
+// removes the basis for the carve-out: with no resolvable compiler, core
+// cannot tell a raw pak from a native merge archive, and falling through
+// would let the legacy path's zip-content-sniffing extractor silently
+// ingest a real native archive unvalidated. Failing every import of a
+// compiler-less compile game with the actionable resolver message ("map a
+// source implementing source.MergeCompiler") is now both the safe and the
+// accurate behavior. The download path's I1 fall-through is unchanged -
+// it keys on the file's own source, a per-archive signal Import lacks
+// (TestDownloadPak_NonMergeCompilerSource_FallsThroughToLegacyPath).
+func TestImportMod_DeployCompile_PakNoCompilerSourceFailsLoud(t *testing.T) {
 	installDir := t.TempDir()
 	basePak := filepath.Join(installDir, "Icarus", "Content", "Data", "data.pak")
 	require.NoError(t, os.MkdirAll(filepath.Dir(basePak), 0o755))
@@ -268,8 +255,7 @@ func TestImportMod_DeployCompile_PakNoCompilerSourceFallsThrough(t *testing.T) {
 	result, err := importer.Import(context.Background(), archivePath, game, core.ImportOptions{})
 	require.Error(t, err)
 	require.Nil(t, result)
-	require.Contains(t, err.Error(), "unsupported archive format", "must fall through to the legacy path's own error, not the misleading MergeCompiler-resolution one")
-	require.NotContains(t, err.Error(), "compiler", "must NOT report a MergeCompiler-resolution failure once eligibility correctly fell through")
+	require.Contains(t, err.Error(), "merge-compiler-capable source", "must fail loud on the actionable compiler-resolution error, never reach the sniffing legacy path")
 
 	_, statErr := os.Stat(filepath.Join(cfg.CacheDir, game.ID))
 	require.True(t, os.IsNotExist(statErr), "no cache entry (and no retained source) should have been created")

--- a/internal/core/service_import_compile_test.go
+++ b/internal/core/service_import_compile_test.go
@@ -176,8 +176,20 @@ func TestImportMod_DeployCompile_ZipPassthroughUnaffected(t *testing.T) {
 // TestImportMod_DeployCompile_NoCompilerSourceFailsLoud pins the "never
 // silently cache an unvalidated .exmodz" requirement (#173/#197): a
 // DeployCompile game with no MergeCompiler-capable source mapped in its
-// SourceIDs must fail loud with an actionable error instead of falling
-// through to extract/copy.
+// SourceIDs must fail loud, creating no cache entry.
+//
+// #256 amended WHICH loud failure this is: with the ".exmodz" test moved
+// behind the MergeCompiler seam (IsNativeMergeSource), a game whose
+// compiler cannot be resolved has nothing left that can define "native",
+// so the import falls through to the legacy path - where the
+// extension-keyed Extractor rejects the unknown ".exmodz" suffix as
+// "unsupported archive format" before anything is staged or cached. The
+// pre-#256 compiler-specific message required core itself to know the
+// extension, which is the leak #256 closes; the invariant that matters -
+// loud failure, nothing cached - is unchanged. (The resolver-nil variant
+// below, TestImportMod_DeployCompile_StandaloneImporterFailsLoud, keeps
+// its original message: a standalone Importer fails every DeployCompile
+// import up front, no format question needed.)
 func TestImportMod_DeployCompile_NoCompilerSourceFailsLoud(t *testing.T) {
 	installDir := t.TempDir()
 	basePak := filepath.Join(installDir, "Icarus", "Content", "Data", "data.pak")
@@ -202,7 +214,7 @@ func TestImportMod_DeployCompile_NoCompilerSourceFailsLoud(t *testing.T) {
 	result, err := importer.Import(context.Background(), archivePath, game, core.ImportOptions{})
 	require.Error(t, err)
 	require.Nil(t, result)
-	require.Contains(t, err.Error(), "compiler")
+	require.Contains(t, err.Error(), "unsupported archive format")
 
 	_, statErr := os.Stat(filepath.Join(cfg.CacheDir, game.ID))
 	require.True(t, os.IsNotExist(statErr), "no cache entry should have been created")

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -1000,6 +1000,7 @@ func (m *mockSourceWithDownloads) Close() {
 // takes DownloadModToCache's ordinary copy path, and a later .exmodz
 // re-download that takes its validate+retain (#197) path.
 type compilerMockSource struct {
+	fakeMergeFormat // #256: the format-vocabulary half of source.MergeCompiler
 	*mockSourceWithDownloads
 }
 

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -787,6 +787,69 @@ func TestService_DownloadMod_OrganicPrune_PreConvergencePakClaimedThenExmodzReta
 	require.True(t, os.IsNotExist(err), "the unclaimed compiled pak must actually be gone from disk")
 }
 
+// TestService_DownloadMod_SiblingReingestKeepsConvertedPakCopy reproduces
+// #250: a converted pak's manifest is deliberately members=nil (the merged
+// pak claims its content - reconcilePakManifests' participating branch), so
+// its deployable cache copy is unclaimed by every recorded manifest. A later
+// ingest of a SIBLING file ID into the same version directory opens
+// PruneUnclaimed's gate (staging is seeded from the existing entry, every
+// marker reads Recorded, retained sources are present) - and pre-fix, the
+// converted pak's copy was deleted as if it were stale pre-#197 content.
+// It is not stale: it is the designated raw-fallback artifact, and pruning
+// it left a later opt-out or failed merge deploying nothing, silently.
+func TestService_DownloadMod_SiblingReingestKeepsConvertedPakCopy(t *testing.T) {
+	svc, err := core.NewService(core.ServiceConfig{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		CacheDir:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, svc.Close()) })
+
+	mock := &compilerMockSource{mockSourceWithDownloads: newMockSourceWithDownloads("test-compiler")}
+	defer mock.Close()
+	svc.RegisterSource(mock)
+
+	game := &domain.Game{ID: "testgame", Name: "Test Game", ModPath: t.TempDir(), DeployMode: domain.DeployCompile, ConvertPaks: true}
+	require.NoError(t, svc.AddGame(game))
+	mod := &domain.Mod{ID: "123", SourceID: "test-compiler", Name: "Mod", Version: "1.0.0", GameID: "testgame"}
+
+	gameCache := svc.GetGameCache(game)
+	dir := gameCache.ModPath(game.ID, mod.SourceID, mod.ID, mod.Version)
+
+	// Generation 1: the pak variant ingests via the validate+retain branch -
+	// a retained source plus a claimed deployable copy (#221's raw-deploy
+	// default state).
+	mock.AddDownload("pak", []byte("prebuilt-pak-bytes"))
+	_, err = svc.DownloadMod(context.Background(), "test-compiler", game, mod, &domain.DownloadableFile{ID: "pak", FileName: "Mod_P.pak"}, nil)
+	require.NoError(t, err)
+
+	manifests, err := gameCache.FileManifests(game.ID, mod.SourceID, mod.ID, mod.Version)
+	require.NoError(t, err)
+	require.Equal(t, []string{"Mod_P.pak"}, manifests["pak"].Members, "precondition: ingest claims the deployable pak copy")
+
+	// The first successful merge flips the pak's manifest to members=nil -
+	// the merged pak claims its content (reconcilePakManifests'
+	// participating branch). The copy is now unclaimed but NOT stale.
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "pak", nil))
+
+	// Generation 2: a sibling file ID of the same mod+version is ingested
+	// afterward (the issue's repro: an optional patch file, a verify --fix
+	// re-download, ...). This commit runs PruneUnclaimed with its gate open.
+	mock.AddDownload("exmodz", []byte("fake-exmodz-bytes"))
+	_, err = svc.DownloadMod(context.Background(), "test-compiler", game, mod, &domain.DownloadableFile{ID: "exmodz", FileName: "Mod.exmodz"}, nil)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "Mod_P.pak"))
+	require.NoError(t, err, "the converted pak's deployable copy is the designated raw-fallback artifact (#250) and must survive a sibling ingest's prune")
+	assert.Equal(t, "prebuilt-pak-bytes", string(data))
+
+	_, err = os.Stat(filepath.Join(dir, cache.RetainedSourceName("pak")))
+	require.NoError(t, err, "the pak's retained source must survive as before")
+	_, err = os.Stat(filepath.Join(dir, cache.RetainedSourceName("exmodz")))
+	require.NoError(t, err, "the sibling's retained source must survive as before")
+}
+
 // TestService_DownloadMod_ForgedCacheMarkerInArchiveIsRejected is the
 // integration-level guard for the #96 round 2 review finding, reproducing its
 // probe exactly: an archive downloaded for file1 that smuggles in a member

--- a/internal/source/icarus/format.go
+++ b/internal/source/icarus/format.go
@@ -118,3 +118,13 @@ func (s *Icarus) MergedArtifactName() string { return mergedPakFileName }
 // MergedArtifactLabel is the user-facing display name for the merged
 // artifact's synthetic mod row (verify/update output).
 func (s *Icarus) MergedArtifactLabel() string { return "Icarus Merged Pak" }
+
+// RestoredArtifactName names the deployable raw-fallback copy synthesized
+// when core heals a prune-damaged cache entry whose original artifact name
+// is unrecoverable (#250: download-path fileIDs never carried it - the
+// name came from the download URL's basename at ingest, and the convert
+// flip erased the manifest that recorded it). A deterministic mod-scoped
+// name in the "_P.pak" override convention (see mergedPakFileName's doc)
+// keeps healed installs stable: the same mod always restores to the same
+// name, which is on-disk state existing installs already depend on.
+func (s *Icarus) RestoredArtifactName(modID string) string { return modID + "_P.pak" }

--- a/internal/source/icarus/format.go
+++ b/internal/source/icarus/format.go
@@ -74,6 +74,16 @@ func (s *Icarus) FingerprintBase(baseArtifactPath string) (string, error) {
 	return r.IndexHash(), nil
 }
 
+// IsNativeMergeSource reports whether fileName names this source's NATIVE
+// merge-source format - a ".exmodz" archive (case-insensitive), the diff
+// format MergeCompile consumes directly without conversion. Pure format
+// test, the exact mirror of IsConvertibleArtifact (pre-#256 core's
+// isExmodzFile); core owns the DeployCompile policy gates and the
+// "native archive from a non-compile-capable source" hard error.
+func (s *Icarus) IsNativeMergeSource(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".exmodz")
+}
+
 // IsConvertibleArtifact reports whether fileName names a prebuilt .pak this
 // source can convert into a merge source (#221). Pure format test
 // (case-insensitive ".pak" suffix, mirroring pre-#256 core's

--- a/internal/source/icarus/format.go
+++ b/internal/source/icarus/format.go
@@ -1,0 +1,110 @@
+package icarus
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DonovanMods/go-unrealpak"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// This file implements source.MergeCompiler's format-vocabulary methods
+// (#256): everything lmm needs to know about Unreal paks and Icarus's disk
+// layout to orchestrate merges, moved here from internal/core so that core
+// asks the source instead of knowing the format itself. A second
+// DeployCompile game supplies its own answers to these questions in its own
+// source package; core never changes.
+
+// Merge-source kinds (#221; moved here from internal/source in #256 - they
+// are Icarus vocabulary, and core now treats kinds as opaque strings it
+// obtains from ClassifyMergeSource). An empty Kind means MergeSourceExmodz:
+// every pre-#221 constructor built exmodz-only sources and never set a kind,
+// and stored merge fingerprints from that era carry no Kind field.
+const (
+	MergeSourceExmodz = "exmodz"
+	MergeSourcePak    = "pak"
+)
+
+// mergedPakFileName names the single merged output pak. It sorts LAST among
+// files UE mounts from a profile's mods directory: paks mount in
+// filename-sort order and a later mount wins same-path conflicts (this
+// package's own icarusContentMountPoint doc comment, and #197's issue body,
+// both note this) - "zzz" is a long-standing UE-modding convention for
+// "load last, highest priority", so the merged pak's authoritative combined
+// table state can never be silently shadowed by a plain prebuilt .pak mod
+// that happens to also carry a table override. "LMM" makes the file
+// greppable as lmm-owned; "_P" is UE's override-pak suffix convention,
+// carried by the real prebuilt Icarus mod paks this package was built
+// against (#178).
+const mergedPakFileName = "zzz_LMM_Merged_P.pak"
+
+// ResolveBaseArtifact locates the currently-installed game's base pak - the
+// artifact every merge applies against. One known pak filename pattern: the
+// relative path below is Task 1's empirically-confirmed finding
+// (docs/plans/icarus-pak-format-findings.md), recorded before this function
+// was written, not an assumption made here: the JSON data tables live in
+// Content/Data/data.pak, NOT in the Content/Paks pakchunks, which carry
+// only cooked .uasset/.uexp assets and no JSON at all.
+//
+// This pak is also the direct source of base table *content* (#175):
+// MergeCompile reads each patched table straight out of it, so a compile is
+// always week-correct by construction (there's no separate dump to go stale
+// relative to the install) and works entirely offline.
+func (s *Icarus) ResolveBaseArtifact(game *domain.Game) (string, error) {
+	candidate := filepath.Join(game.InstallPath, "Icarus", "Content", "Data", "data.pak")
+	if _, err := os.Stat(candidate); err != nil {
+		return "", fmt.Errorf("locating base pak for %q: %w", game.ID, err)
+	}
+	return candidate, nil
+}
+
+// FingerprintBase opens the base pak and returns its footer IndexHash
+// (#196) as an opaque fingerprint - cheap (footer + primary-index region
+// only; unrealpak.Open never reads a pak's actual file payloads), matching
+// the base pak MergeCompile itself already opens to read patched tables
+// from, so this adds no new I/O pattern to the compile path.
+func (s *Icarus) FingerprintBase(baseArtifactPath string) (string, error) {
+	r, err := unrealpak.Open(baseArtifactPath)
+	if err != nil {
+		return "", fmt.Errorf("reading base pak for compile fingerprint: %w", err)
+	}
+	defer r.Close() //nolint:errcheck
+	return r.IndexHash(), nil
+}
+
+// IsConvertibleArtifact reports whether fileName names a prebuilt .pak this
+// source can convert into a merge source (#221). Pure format test
+// (case-insensitive ".pak" suffix, mirroring pre-#256 core's
+// isConvertEligiblePakFile) - core owns the DeployCompile/ConvertPaks
+// policy gates that decide whether a convertible file actually enters the
+// merge-convert pipeline.
+func (s *Icarus) IsConvertibleArtifact(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".pak")
+}
+
+// ClassifyMergeSource maps a retained-source identity to its merge-source
+// kind (#221) plus whether that kind is convertible (a raw prebuilt pak, as
+// opposed to a native .exmodz diff). id is a retained-source fileID -
+// download-path icarus fileIDs are literally "pak"/"exmodz", import-path
+// fileIDs are the archive's own filename - or a Kind string previously
+// recorded on a merge fingerprint (kind strings classify as themselves, and
+// a legacy pre-#221 entry's empty Kind classifies as exmodz, the only kind
+// that existed then). Unknown ids default to exmodz for the same reason.
+func (s *Icarus) ClassifyMergeSource(id string) (kind string, convertible bool) {
+	lower := strings.ToLower(id)
+	if lower == "pak" || strings.HasSuffix(lower, ".pak") {
+		return MergeSourcePak, true
+	}
+	return MergeSourceExmodz, false
+}
+
+// MergedArtifactName names the single merged output artifact deployed into
+// the game's mods directory - see mergedPakFileName for why this exact name
+// is a deploy contract.
+func (s *Icarus) MergedArtifactName() string { return mergedPakFileName }
+
+// MergedArtifactLabel is the user-facing display name for the merged
+// artifact's synthetic mod row (verify/update output).
+func (s *Icarus) MergedArtifactLabel() string { return "Icarus Merged Pak" }

--- a/internal/source/icarus/format_test.go
+++ b/internal/source/icarus/format_test.go
@@ -102,6 +102,25 @@ func TestIsConvertibleArtifact(t *testing.T) {
 	}
 }
 
+func TestIsNativeMergeSource(t *testing.T) {
+	tests := map[string]bool{
+		"Bear_Mount.exmodz": true,
+		"Bear_Mount.EXMODZ": true, // case-insensitive
+		"MyMod.pak":         false,
+		"MyMod.zip":         false,
+		// Bare "exmodz" is a download-path fileID, not a filename - this
+		// predicate backs ingest routing on FILENAMES (pre-#256 core's
+		// isExmodzFile), which was suffix-only, and stays that way.
+		"exmodz": false,
+	}
+	s := newFormatTestSource()
+	for fileName, want := range tests {
+		if got := s.IsNativeMergeSource(fileName); got != want {
+			t.Errorf("IsNativeMergeSource(%q) = %v, want %v", fileName, got, want)
+		}
+	}
+}
+
 func TestClassifyMergeSource(t *testing.T) {
 	tests := map[string]struct {
 		kind        string

--- a/internal/source/icarus/format_test.go
+++ b/internal/source/icarus/format_test.go
@@ -143,6 +143,16 @@ func TestClassifyMergeSource(t *testing.T) {
 	}
 }
 
+func TestRestoredArtifactName(t *testing.T) {
+	// The exact shape is on-disk state (#250): a heal-restored raw-fallback
+	// copy for existing installs is published under <mod-id>_P.pak, "_P"
+	// being UE's override-pak suffix convention - byte-identical names must
+	// come out of the seam or already-healed caches would orphan.
+	if got := newFormatTestSource().RestoredArtifactName("cool-mod"); got != "cool-mod_P.pak" {
+		t.Errorf("RestoredArtifactName = %q, want %q", got, "cool-mod_P.pak")
+	}
+}
+
 func TestMergedArtifactName(t *testing.T) {
 	// The exact name is a deploy contract (#197): it must sort last among
 	// mounted paks ("zzz"), be greppable as lmm-owned, and keep the "_P"

--- a/internal/source/icarus/format_test.go
+++ b/internal/source/icarus/format_test.go
@@ -1,0 +1,142 @@
+package icarus
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonovanMods/go-unrealpak"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// newFormatTestSource returns an *Icarus suitable for exercising the format
+// methods (#256) - none of them touch Firestore, so a nil HTTP client and a
+// dummy project ID are fine.
+func newFormatTestSource() *Icarus { return New(nil, "test-project") }
+
+func testGame(id, installPath string) *domain.Game {
+	return &domain.Game{ID: id, InstallPath: installPath}
+}
+
+func TestResolveBaseArtifact_FindsIcarusDataPak(t *testing.T) {
+	installDir := t.TempDir()
+	basePakDir := filepath.Join(installDir, "Icarus", "Content", "Data")
+	if err := os.MkdirAll(basePakDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	wantPath := filepath.Join(basePakDir, "data.pak")
+	if err := os.WriteFile(wantPath, []byte("stub"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := newFormatTestSource().ResolveBaseArtifact(testGame("icarus", installDir))
+	if err != nil {
+		t.Fatalf("ResolveBaseArtifact: %v", err)
+	}
+	if got != wantPath {
+		t.Errorf("ResolveBaseArtifact = %q, want %q", got, wantPath)
+	}
+}
+
+func TestResolveBaseArtifact_MissingPakErrors(t *testing.T) {
+	_, err := newFormatTestSource().ResolveBaseArtifact(testGame("icarus", t.TempDir()))
+	if err == nil {
+		t.Fatal("ResolveBaseArtifact must error when the base pak is absent")
+	}
+	// The error names the game, matching core's pre-#256 resolveBasePak
+	// wrapping ("locating base pak for %q: ...") which callers' messages
+	// were built around.
+	if want := `locating base pak for "icarus"`; !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain %q", err, want)
+	}
+}
+
+func TestFingerprintBase_MatchesPakIndexHash(t *testing.T) {
+	pakPath := writeTestBasePak(t, map[string][]byte{"Data/D_Fixture.json": []byte(`{"fixture":true}`)})
+
+	got, err := newFormatTestSource().FingerprintBase(pakPath)
+	if err != nil {
+		t.Fatalf("FingerprintBase: %v", err)
+	}
+
+	r, err := unrealpak.Open(pakPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close() //nolint:errcheck
+	if want := r.IndexHash(); got != want {
+		t.Errorf("FingerprintBase = %q, want the pak's IndexHash %q", got, want)
+	}
+	if got == "" {
+		t.Error("FingerprintBase must not be empty for a valid pak")
+	}
+}
+
+func TestFingerprintBase_InvalidPakErrors(t *testing.T) {
+	notAPak := filepath.Join(t.TempDir(), "data.pak")
+	if err := os.WriteFile(notAPak, []byte("not a pak"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newFormatTestSource().FingerprintBase(notAPak); err == nil {
+		t.Fatal("FingerprintBase must error on an unparseable pak")
+	}
+}
+
+func TestIsConvertibleArtifact(t *testing.T) {
+	tests := map[string]bool{
+		"MyMod.pak":    true,
+		"MyMod.PAK":    true, // case-insensitive
+		"MyMod.exmodz": false,
+		"MyMod.zip":    false,
+		// A bare "pak" is a download-path fileID, not a filename - the
+		// ingest predicate this backs (pre-#256 isConvertEligiblePakFile)
+		// was suffix-only, and stays that way.
+		"pak": false,
+	}
+	s := newFormatTestSource()
+	for fileName, want := range tests {
+		if got := s.IsConvertibleArtifact(fileName); got != want {
+			t.Errorf("IsConvertibleArtifact(%q) = %v, want %v", fileName, got, want)
+		}
+	}
+}
+
+func TestClassifyMergeSource(t *testing.T) {
+	tests := map[string]struct {
+		kind        string
+		convertible bool
+	}{
+		"pak":          {MergeSourcePak, true}, // download-path fileID
+		"MyMod.PAK":    {MergeSourcePak, true}, // import-path filename
+		"exmodz":       {MergeSourceExmodz, false},
+		"MyMod.exmodz": {MergeSourceExmodz, false},
+		"weird.zip":    {MergeSourceExmodz, false}, // unknown: exmodz, the only pre-#221 kind
+		"":             {MergeSourceExmodz, false}, // legacy fingerprint entries carry no Kind
+	}
+	s := newFormatTestSource()
+	for id, want := range tests {
+		kind, convertible := s.ClassifyMergeSource(id)
+		if kind != want.kind || convertible != want.convertible {
+			t.Errorf("ClassifyMergeSource(%q) = (%q, %v), want (%q, %v)",
+				id, kind, convertible, want.kind, want.convertible)
+		}
+	}
+}
+
+func TestMergedArtifactName(t *testing.T) {
+	// The exact name is a deploy contract (#197): it must sort last among
+	// mounted paks ("zzz"), be greppable as lmm-owned, and keep the "_P"
+	// override suffix - changing it would orphan already-deployed files.
+	if got := newFormatTestSource().MergedArtifactName(); got != "zzz_LMM_Merged_P.pak" {
+		t.Errorf("MergedArtifactName = %q, want %q", got, "zzz_LMM_Merged_P.pak")
+	}
+}
+
+func TestMergedArtifactLabel(t *testing.T) {
+	// User-facing display name for the merged artifact's synthetic mod row
+	// (verify/update output) - pre-#256 core hardcoded this string.
+	if got := newFormatTestSource().MergedArtifactLabel(); got != "Icarus Merged Pak" {
+		t.Errorf("MergedArtifactLabel = %q, want %q", got, "Icarus Merged Pak")
+	}
+}

--- a/internal/source/icarus/icarus.go
+++ b/internal/source/icarus/icarus.go
@@ -260,7 +260,7 @@ func mapDoc(d firestoreDoc) domain.Mod {
 // fileNameFromURL derives a download's file name from its URL, falling back
 // to a synthesized "mod.<fallbackExt>" name (never a bare, dot-less
 // fallbackExt) when the URL yields nothing usable. A dot-less fallback would
-// silently defeat isExmodzFile's case-insensitive ".exmodz" suffix check —
+// silently defeat IsNativeMergeSource's case-insensitive ".exmodz" suffix check —
 // a downloaded file named e.g. "exmodz" would never route through the
 // DeployCompile ingest branch (validate+retain, #197). A parsed basename
 // that exists but carries no extension of its own gets fallbackExt

--- a/internal/source/icarus/merge.go
+++ b/internal/source/icarus/merge.go
@@ -89,7 +89,7 @@ func MergeCompile(ctx context.Context, basePakPath string, sources []MergeSource
 		if label == "" {
 			label = src.ModRef
 		}
-		if src.Kind == source.MergeSourcePak {
+		if src.Kind == MergeSourcePak {
 			bundle, convWarnings, cerr := convertPakToBundle(src.SourcePath, base, baseFold)
 			if cerr != nil {
 				failed = append(failed, source.MergeFailure{ModRef: src.ModRef, Reason: cerr.Error()})

--- a/internal/source/icarus/merge_test.go
+++ b/internal/source/icarus/merge_test.go
@@ -322,7 +322,7 @@ func TestMergeCompilePakSource(t *testing.T) {
 	out := filepath.Join(dir, "merged.pak")
 
 	warnings, failed, err := MergeCompile(context.Background(), basePath, []MergeSource{
-		{ModRef: "icarus:pakmod", SourcePath: pakPath, Kind: source.MergeSourcePak},
+		{ModRef: "icarus:pakmod", SourcePath: pakPath, Kind: MergeSourcePak},
 	}, out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -360,8 +360,8 @@ func TestMergeCompilePakFailureSkipsModOnly(t *testing.T) {
 	out := filepath.Join(dir, "merged.pak")
 
 	warnings, failed, err := MergeCompile(context.Background(), basePath, []MergeSource{
-		{ModRef: "icarus:bad", SourcePath: badPak, Kind: source.MergeSourcePak},
-		{ModRef: "icarus:good", SourcePath: goodPak, Kind: source.MergeSourcePak},
+		{ModRef: "icarus:bad", SourcePath: badPak, Kind: MergeSourcePak},
+		{ModRef: "icarus:good", SourcePath: goodPak, Kind: MergeSourcePak},
 	}, out)
 	if err != nil {
 		t.Fatalf("per-mod failure must not be fatal: %v", err)
@@ -433,8 +433,8 @@ func TestMergeCompileWarningsPreferModName(t *testing.T) {
 	out := filepath.Join(dir, "merged.pak")
 
 	warnings, failed, err := MergeCompile(context.Background(), basePath, []MergeSource{
-		{ModRef: "icarus:pakmod", ModName: "Combined QOL", SourcePath: pakPath, Kind: source.MergeSourcePak},
-		{ModRef: "icarus:badmod", ModName: "Broken Mod", SourcePath: badPak, Kind: source.MergeSourcePak},
+		{ModRef: "icarus:pakmod", ModName: "Combined QOL", SourcePath: pakPath, Kind: MergeSourcePak},
+		{ModRef: "icarus:badmod", ModName: "Broken Mod", SourcePath: badPak, Kind: MergeSourcePak},
 	}, out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -150,6 +150,17 @@ type DownloadHeaderProvider interface {
 // mods patch the same table). Replaces #196's Compiler interface, which
 // this source no longer implements: there is no more per-mod compiled
 // artifact to produce.
+//
+// This interface is the complete contract a DeployCompile game must
+// implement (#256): the merge operations (ValidateSource, MergeCompile)
+// plus the format vocabulary core needs to orchestrate them without knowing
+// the game's artifact format itself - where the base artifact lives
+// (ResolveBaseArtifact), how to fingerprint it (FingerprintBase), which
+// files are convertible raw artifacts (IsConvertibleArtifact,
+// ClassifyMergeSource), and what the merged output is called
+// (MergedArtifactName, MergedArtifactLabel). A second compile-mode game is
+// a new source package implementing these methods plus one registration
+// line; internal/core never changes.
 type MergeCompiler interface {
 	// ValidateSource parses/validates sourceFilePath (the retained,
 	// not-yet-merged source archive) without compiling anything - called at
@@ -158,29 +169,63 @@ type MergeCompiler interface {
 	ValidateSource(sourceFilePath string) error
 
 	// MergeCompile applies every entry in sources, in order (profile load
-	// order), against basePakPath's tables, and writes the merged result to
-	// outputPakPath. Returns non-fatal warnings (e.g. same-path asset
-	// collisions - last-applied wins) alongside a nil error; a nil error
-	// with warnings is still a fully-written, deployable pak. Pak-kind
-	// sources that cannot be converted are skipped per-mod and reported in
-	// failed (#221) - only exmodz-source errors and I/O failures are fatal.
-	MergeCompile(ctx context.Context, basePakPath string, sources []MergeSource, outputPakPath string) (warnings []string, failed []MergeFailure, err error)
-}
+	// order), against the base artifact's tables, and writes the merged
+	// result to outputPath. Returns non-fatal warnings (e.g. same-path
+	// asset collisions - last-applied wins) alongside a nil error; a nil
+	// error with warnings is still a fully-written, deployable artifact.
+	// Convertible-kind sources that cannot be converted are skipped per-mod
+	// and reported in failed (#221) - only native-source errors and I/O
+	// failures are fatal.
+	MergeCompile(ctx context.Context, baseArtifactPath string, sources []MergeSource, outputPath string) (warnings []string, failed []MergeFailure, err error)
 
-// Merge-source kinds (#221). An empty Kind means MergeSourceExmodz - every
-// pre-#221 constructor built exmodz-only sources and never set a kind.
-const (
-	MergeSourceExmodz = "exmodz"
-	MergeSourcePak    = "pak"
-)
+	// ResolveBaseArtifact locates the installed game's base artifact - the
+	// input every merge applies against (Icarus: the game's own
+	// Content/Data/data.pak). Errors when the artifact cannot be found
+	// under the game's install path.
+	ResolveBaseArtifact(game *domain.Game) (string, error)
+
+	// FingerprintBase returns an opaque fingerprint of the base artifact at
+	// baseArtifactPath: cheap to compute, changing exactly when the base
+	// content changes. Core stores it in merge fingerprints to detect a
+	// game-update-invalidated merge; it never interprets the value.
+	FingerprintBase(baseArtifactPath string) (string, error)
+
+	// IsConvertibleArtifact reports whether fileName names a raw, prebuilt
+	// game artifact this source can convert into a merge source (#221;
+	// Icarus: a ".pak" file). Pure format test - core owns the
+	// DeployCompile/ConvertPaks policy gates that decide whether such a
+	// file actually enters the merge-convert pipeline.
+	IsConvertibleArtifact(fileName string) bool
+
+	// ClassifyMergeSource maps a retained-source identity - a fileID, an
+	// imported archive's filename, or a Kind string previously recorded on
+	// a merge fingerprint - to the source-defined kind string core
+	// round-trips (MergeSource.Kind, fingerprint entries) and whether that
+	// kind is a convertible raw artifact (subject to the ConvertPaks
+	// opt-out and per-mod conversion outcomes) as opposed to the source's
+	// native mergeable format. Must accept the empty string (legacy
+	// fingerprints recorded no Kind) and classify it as the native kind.
+	ClassifyMergeSource(id string) (kind string, convertible bool)
+
+	// MergedArtifactName names the single merged output artifact core
+	// deploys into the game's mod directory. The name is a deploy contract:
+	// it must stay stable across merges (core stats/replaces it by name),
+	// and any load-order significance it carries (Icarus: sorts last so it
+	// wins) is entirely the source's concern.
+	MergedArtifactName() string
+
+	// MergedArtifactLabel is the user-facing display name for the merged
+	// artifact's synthetic mod row (verify/update output).
+	MergedArtifactLabel() string
+}
 
 // MergeSource identifies one mod's contribution to a merge, in the order it
 // must be applied (profile load order).
 type MergeSource struct {
 	ModRef     string // "sourceID:modID" - machine identity (MergeFailure, ownership tracking)
 	ModName    string // display name preferred over ModRef in user-facing warnings; may be empty
-	SourcePath string // the retained source archive to read (.exmodz, or a raw .pak eligible for conversion - #221)
-	Kind       string // MergeSourceExmodz (default when empty) or MergeSourcePak
+	SourcePath string // the retained source archive to read (native diff, or a convertible raw artifact - #221)
+	Kind       string // source-defined kind from ClassifyMergeSource; empty means the source's native kind (#256)
 }
 
 // MergeFailure records one source that could not participate in a merge

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -226,6 +226,15 @@ type MergeCompiler interface {
 	// MergedArtifactLabel is the user-facing display name for the merged
 	// artifact's synthetic mod row (verify/update output).
 	MergedArtifactLabel() string
+
+	// RestoredArtifactName names the deployable raw-fallback copy core
+	// synthesizes when healing a prune-damaged cache entry whose original
+	// artifact name is unrecoverable (#250; Icarus: "<modID>_P.pak").
+	// Deterministic per mod - the same mod must always restore to the same
+	// name, since the name is on-disk state existing installs depend on.
+	// Core passes a path-safe (Base'd) modID and uses the result as a
+	// filename within the mod's own cache entry.
+	RestoredArtifactName(modID string) string
 }
 
 // MergeSource identifies one mod's contribution to a merge, in the order it

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -190,6 +190,14 @@ type MergeCompiler interface {
 	// game-update-invalidated merge; it never interprets the value.
 	FingerprintBase(baseArtifactPath string) (string, error)
 
+	// IsNativeMergeSource reports whether fileName names this source's
+	// NATIVE merge-source format (Icarus: a ".exmodz" archive) - the diff
+	// format MergeCompile consumes directly, with no other valid
+	// interpretation at ingest. Pure format test, the mirror of
+	// IsConvertibleArtifact - core owns the DeployCompile policy gates and
+	// routes native files into validate+retain instead of extract/copy.
+	IsNativeMergeSource(fileName string) bool
+
 	// IsConvertibleArtifact reports whether fileName names a raw, prebuilt
 	// game artifact this source can convert into a merge source (#221;
 	// Icarus: a ".pak" file). Pure format test - core owns the

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -158,8 +158,9 @@ type DownloadHeaderProvider interface {
 // (ResolveBaseArtifact), how to fingerprint it (FingerprintBase), which
 // files are the source's native merge format (IsNativeMergeSource), which
 // are convertible raw artifacts (IsConvertibleArtifact,
-// ClassifyMergeSource), and what the merged output is called
-// (MergedArtifactName, MergedArtifactLabel). A second compile-mode game is
+// ClassifyMergeSource), what the merged output is called
+// (MergedArtifactName, MergedArtifactLabel), and what a healed raw-fallback
+// copy is called (RestoredArtifactName). A second compile-mode game is
 // a new source package implementing these methods plus one registration
 // line; internal/core never changes.
 type MergeCompiler interface {

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -156,7 +156,8 @@ type DownloadHeaderProvider interface {
 // plus the format vocabulary core needs to orchestrate them without knowing
 // the game's artifact format itself - where the base artifact lives
 // (ResolveBaseArtifact), how to fingerprint it (FingerprintBase), which
-// files are convertible raw artifacts (IsConvertibleArtifact,
+// files are the source's native merge format (IsNativeMergeSource), which
+// are convertible raw artifacts (IsConvertibleArtifact,
 // ClassifyMergeSource), and what the merged output is called
 // (MergedArtifactName, MergedArtifactLabel). A second compile-mode game is
 // a new source package implementing these methods plus one registration

--- a/internal/storage/cache/cache.go
+++ b/internal/storage/cache/cache.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/fs"
@@ -323,6 +325,19 @@ func HasRetainedSource(versionDir string) (bool, error) {
 // versionDir makes the whole call a no-op. Reserved (ReservedPrefix) entries
 // are never candidates. Callers invoke it on a STAGING directory at commit
 // time, so a prune can never race a deploy.
+//
+// An unclaimed file whose content matches a retained source is EXEMPT
+// (#250): "unclaimed" has two distinct causes prune must tell apart.
+// Stale/superseded content - #210's actual target - matches no retained
+// source. A converted pak's deployable copy, by contrast, is unclaimed only
+// because a successful merge suppressed it (its manifest reads members=nil;
+// the merged pak claims its content), yet it remains the designated
+// raw-fallback artifact an opt-out or failed merge must be able to
+// redeploy. Content identity with the retained source is the one signal
+// that separates the two: ingest stages the deployable copy from the SAME
+// bytes as the retained source, and the convert flip erases the manifest
+// that once recorded the mapping (see internal/core's rawPakMembers, which
+// relies on the same attribution to find the way back to raw).
 func PruneUnclaimed(versionDir string) error {
 	manifests, err := fileManifestsAt(versionDir)
 	if err != nil {
@@ -346,11 +361,11 @@ func PruneUnclaimed(versionDir string) error {
 			claimed[member] = true
 		}
 	}
-	hasRetained, err := HasRetainedSource(versionDir)
+	retained, err := retainedSourceRefs(versionDir)
 	if err != nil {
 		return fmt.Errorf("checking retained source for prune: %w", err)
 	}
-	if !hasRetained {
+	if len(retained) == 0 {
 		return nil
 	}
 	files, err := walkEntries(versionDir, false) // same walker ListFiles uses
@@ -361,12 +376,104 @@ func PruneUnclaimed(versionDir string) error {
 		if claimed[f] {
 			continue
 		}
+		suppressed, err := matchesRetainedSource(filepath.Join(versionDir, f), retained)
+		if err != nil {
+			return fmt.Errorf("matching %s against retained sources for prune: %w", f, err)
+		}
+		if suppressed {
+			continue // a converted pak's raw-fallback copy, not stale debris (#250)
+		}
 		if err := os.Remove(filepath.Join(versionDir, f)); err != nil {
 			return fmt.Errorf("pruning unclaimed %s: %w", f, err)
 		}
 	}
 	removeEmptyDirs(versionDir)
 	return nil
+}
+
+// retainedSourceRef tracks one retained compile source during a prune pass:
+// full path, size, and its MD5, computed lazily (at most once, and only if
+// some unclaimed candidate's size matches - the common all-claimed entry
+// never hashes anything).
+type retainedSourceRef struct {
+	path string
+	size int64
+	sum  string
+}
+
+// retainedSourceRefs lists versionDir's retained compile sources (every
+// entry named by RetainedSourceName, for any fileID) with their sizes -
+// PruneUnclaimed's gate (#210: at least one must exist) and its #250
+// content-identity exemption both read from this. A missing versionDir is
+// not an error - it reports empty, same as an entry with none.
+func retainedSourceRefs(versionDir string) ([]retainedSourceRef, error) {
+	entries, err := os.ReadDir(versionDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var refs []retainedSourceRef
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), retainedSourcePrefix) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		refs = append(refs, retainedSourceRef{path: filepath.Join(versionDir, entry.Name()), size: info.Size()})
+	}
+	return refs, nil
+}
+
+// matchesRetainedSource reports whether the file at fullPath is
+// byte-identical to one of the entry's retained sources: size compared
+// first, MD5 only on a size match, each side hashed at most once. The MD5
+// (not a cryptographic guarantee - fine for self-owned cache bookkeeping)
+// mirrors internal/core's md5File attribution convention (#241).
+func matchesRetainedSource(fullPath string, retained []retainedSourceRef) (bool, error) {
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return false, err
+	}
+	var fileSum string
+	for i := range retained {
+		if info.Size() != retained[i].size {
+			continue
+		}
+		if retained[i].sum == "" {
+			if retained[i].sum, err = md5File(retained[i].path); err != nil {
+				return false, err
+			}
+		}
+		if fileSum == "" {
+			if fileSum, err = md5File(fullPath); err != nil {
+				return false, err
+			}
+		}
+		if fileSum == retained[i].sum {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// md5File returns the hex MD5 of path's content. Duplicates internal/core's
+// helper of the same name (core depends on this package, so importing it
+// back would cycle); used only for prune's content-identity check above.
+func md5File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close() //nolint:errcheck
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // removeEmptyDirs removes every empty subdirectory under versionDir

--- a/internal/storage/cache/cache_test.go
+++ b/internal/storage/cache/cache_test.go
@@ -633,3 +633,36 @@ func TestPruneUnclaimed_NeverTouchesReservedEntries(t *testing.T) {
 	_, err := os.Stat(filepath.Join(dir, cache.RetainedSourceName("exmodz")))
 	require.NoError(t, err, "reserved entries are never pruned")
 }
+
+// TestPruneUnclaimed_KeepsUnclaimedFileMatchingRetainedSource proves the
+// #250 fix: an unclaimed file whose content matches a retained source is
+// NOT stale debris - it is the retained source's own deployable copy,
+// currently suppressed because the merged pak claims its content
+// (members=nil), and it is still the designated raw-fallback artifact.
+// Pruning it left an opt-out/failed-merge fallback with nothing to deploy.
+// Content identity (not name, not size alone) is the test: the genuinely
+// stale file below has the SAME size as the retained pak source but
+// different bytes, and must still be pruned.
+func TestPruneUnclaimed_KeepsUnclaimedFileMatchingRetainedSource(t *testing.T) {
+	c := cache.New(t.TempDir())
+	pakBytes := []byte("prebuilt-pak-bytes")
+	staleBytes := []byte("stale-pak-bytes123") // same length as pakBytes, different content
+	require.Len(t, staleBytes, len(pakBytes), "fixture invariant: size alone must not distinguish the two")
+
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "SuperMod_P.pak", pakBytes)) // suppressed raw-fallback copy, unclaimed
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "stale.pak", staleBytes))    // genuine debris, unclaimed
+	require.NoError(t, c.Store("g", "s", "m", "1.0", "claimed.txt", []byte("sibling-content")))
+	dir := c.ModPath("g", "s", "m", "1.0")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("pak")), pakBytes, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, cache.RetainedSourceName("exmodz")), []byte("exmodz-zip"), 0o644))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "pak", nil)) // converted: the merged pak claims its content
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "exmodz", nil))
+	require.NoError(t, cache.MarkFileCompleteWithMembers(dir, "sibling", []string{"claimed.txt"}))
+
+	require.NoError(t, cache.PruneUnclaimed(dir))
+
+	files, err := c.ListFiles("g", "s", "m", "1.0")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"SuperMod_P.pak", "claimed.txt"}, files,
+		"the converted pak's deployable copy matches its retained source and must survive (#250); the same-size stale file must still be pruned")
+}

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -653,7 +653,10 @@ func (m Model) clampSelections() {
 // status text (rule 4): the outcome's own Message, plus its single warning
 // appended after an em dash, or an "(N warnings)" count suffix when there is
 // more than one — chosen so the status line never grows past one line
-// regardless of how many warnings a flow reports.
+// regardless of how many warnings a flow reports. The collapsed text isn't
+// lost: app.go's actionDoneMsg handler auto-opens the warnings info overlay
+// at the same "> 1" threshold (#253), so the count suffix stays the one-row
+// summary and the overlay carries the full text.
 func formatOutcomeStatus(outcome ActionOutcome) string {
 	switch len(outcome.Warnings) {
 	case 0:

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -211,12 +211,15 @@ type ActionOutcome struct {
 	// (mutations.go), the apply-updates batch's confirm-time body, populates
 	// this today - one "✓ <name> <from> → <to>" line per successful update,
 	// one "✗ <name>: <error>" line per failed one, in the SAME order the
-	// batch was applied. Every other ActionProvider call leaves this nil,
-	// same as ImportedProfile's own "" zero value above - app.go's
-	// actionDoneMsg handler treats a nil/empty ResultLines as "nothing to
-	// show" and opens no overlay for it. This is a TUI-side struct, not part
-	// of the ActionProvider interface itself, so adding it required no
-	// interface/method change on either provider (coreProvider/
+	// batch was applied, plus (#259) one trailing section - a blank
+	// separator, then one line per distinct success-emitted warning - when
+	// any successful update carried Warnings (see applyUpdatesSequentially's
+	// doc comment for why they must ride here). Every other ActionProvider
+	// call leaves this nil, same as ImportedProfile's own "" zero value
+	// above - app.go's actionDoneMsg handler treats a nil/empty ResultLines
+	// as "nothing to show" and opens no overlay for it. This is a TUI-side
+	// struct, not part of the ActionProvider interface itself, so adding it
+	// required no interface/method change on either provider (coreProvider/
 	// prototypeProvider): renderers besides the update batch's are free to
 	// ignore it entirely.
 	ResultLines []string
@@ -450,6 +453,28 @@ func (p *prototypeProvider) UninstallMod(_ context.Context, item ModItem) (Actio
 	return ActionOutcome{Message: fmt.Sprintf("Uninstalled %q", item.Name)}, nil
 }
 
+// prototypeMergeWarnings returns the canned merge-time diagnostics (#253),
+// surfaced on every prototype deploy AND every successful prototype update
+// (#259) so --prototype demo mode actually exercises both multi-warning
+// paths in actionDoneMsg (app.go): the auto-open warnings overlay (deploy)
+// and the update-results overlay's trailing warnings section (update batch -
+// applyUpdatesSequentially). Same rationale as prototypeAllSourcesWarning
+// (service.go): without these, no prototype mutation ever crosses
+// formatOutcomeStatus's "> 1" collapse threshold, leaving those states
+// unreachable in the one mode meant to demo every UI state. The strings
+// exist purely to exercise the rendering paths; they name assets no canned
+// mod actually bundles. Deliberately IDENTICAL on every call - like the real
+// profile-level merge diagnostics a per-update recompile re-emits verbatim -
+// so a multi-update prototype batch also demos the section's exact-text
+// dedupe (one section, not one copy per mod). Returns a fresh slice per
+// call so no caller ever aliases another outcome's Warnings.
+func prototypeMergeWarnings() []string {
+	return []string{
+		`asset "textures/armor/steel.dds" is bundled by both SkyUI and Ordinator - Ordinator wins (last-applied, per profile load order)`,
+		`asset "textures/armor/steel_n.dds" is bundled by both SkyUI and Ordinator - Ordinator wins (last-applied, per profile load order)`,
+	}
+}
+
 func (p *prototypeProvider) DeployProfile(_ context.Context) (ActionOutcome, error) {
 	deployed := 0
 	for _, mod := range p.activeMods() {
@@ -457,19 +482,7 @@ func (p *prototypeProvider) DeployProfile(_ context.Context) (ActionOutcome, err
 			deployed++
 		}
 	}
-	// Canned merge-time diagnostics (#253), surfaced on every prototype
-	// deploy so --prototype demo mode actually exercises the multi-warning
-	// auto-open overlay path (actionDoneMsg, app.go) - the same rationale as
-	// prototypeAllSourcesWarning (service.go): without these, no prototype
-	// mutation ever crosses formatOutcomeStatus's "> 1" collapse threshold,
-	// leaving the overlay unreachable in the one mode meant to demo every UI
-	// state. Like that constant, the strings exist purely to exercise the
-	// rendering path; they name assets no canned mod actually bundles.
-	warnings := []string{
-		`asset "textures/armor/steel.dds" is bundled by both SkyUI and Ordinator - Ordinator wins (last-applied, per profile load order)`,
-		`asset "textures/armor/steel_n.dds" is bundled by both SkyUI and Ordinator - Ordinator wins (last-applied, per profile load order)`,
-	}
-	return ActionOutcome{Message: fmt.Sprintf("Deployed %d mod(s)", deployed), Warnings: warnings}, nil
+	return ActionOutcome{Message: fmt.Sprintf("Deployed %d mod(s)", deployed), Warnings: prototypeMergeWarnings()}, nil
 }
 
 // activeProfileName returns the canned Profiles entry currently marked
@@ -784,7 +797,9 @@ func (p *prototypeProvider) CheckUpdates(_ context.Context) (UpdatesView, error)
 // ApplyUpdate emits the brief's own fake progress sequence, then bumps the
 // matching InstalledMods entry's Version to u.ToVersion and clears its
 // AvailableVersion - so a repeated CheckUpdates no longer reports it,
-// mirroring a real update's "already up to date" outcome.
+// mirroring a real update's "already up to date" outcome. The canned merge
+// warnings demo #259's results-overlay warnings section - see
+// prototypeMergeWarnings' doc comment.
 func (p *prototypeProvider) ApplyUpdate(_ context.Context, u UpdateItem, progress func(ActionProgress)) (ActionOutcome, error) {
 	idx := p.findInstalledIndex(u.Source, u.ID)
 	if idx < 0 {
@@ -798,7 +813,7 @@ func (p *prototypeProvider) ApplyUpdate(_ context.Context, u UpdateItem, progres
 	mods[idx].AvailableVersion = ""
 	mods[idx].Status = "installed"
 
-	return ActionOutcome{Message: fmt.Sprintf("Updated %q to %s", u.Name, u.ToVersion)}, nil
+	return ActionOutcome{Message: fmt.Sprintf("Updated %q to %s", u.Name, u.ToVersion), Warnings: prototypeMergeWarnings()}, nil
 }
 
 // isValidUpdatePolicy reports whether policy is one of the three strings

--- a/internal/tui/actions_provider.go
+++ b/internal/tui/actions_provider.go
@@ -457,7 +457,19 @@ func (p *prototypeProvider) DeployProfile(_ context.Context) (ActionOutcome, err
 			deployed++
 		}
 	}
-	return ActionOutcome{Message: fmt.Sprintf("Deployed %d mod(s)", deployed)}, nil
+	// Canned merge-time diagnostics (#253), surfaced on every prototype
+	// deploy so --prototype demo mode actually exercises the multi-warning
+	// auto-open overlay path (actionDoneMsg, app.go) - the same rationale as
+	// prototypeAllSourcesWarning (service.go): without these, no prototype
+	// mutation ever crosses formatOutcomeStatus's "> 1" collapse threshold,
+	// leaving the overlay unreachable in the one mode meant to demo every UI
+	// state. Like that constant, the strings exist purely to exercise the
+	// rendering path; they name assets no canned mod actually bundles.
+	warnings := []string{
+		`asset "textures/armor/steel.dds" is bundled by both SkyUI and Ordinator - Ordinator wins (last-applied, per profile load order)`,
+		`asset "textures/armor/steel_n.dds" is bundled by both SkyUI and Ordinator - Ordinator wins (last-applied, per profile load order)`,
+	}
+	return ActionOutcome{Message: fmt.Sprintf("Deployed %d mod(s)", deployed), Warnings: warnings}, nil
 }
 
 // activeProfileName returns the canned Profiles entry currently marked

--- a/internal/tui/actions_provider_test.go
+++ b/internal/tui/actions_provider_test.go
@@ -532,6 +532,35 @@ func TestPrototypeProviderActions_ApplyUpdate_UnknownModErrors(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestPrototypeProviderActions_ApplyUpdate_CannedMultiWarningDemo guards
+// #259's demo-mode parity, mirroring
+// TestPrototypeProviderActions_DeployProfile_CannedMultiWarningDemo (#253): a
+// successful prototype update must return MORE than one canned merge warning
+// so --prototype exercises the update-results overlay's trailing warnings
+// section (applyUpdatesSequentially) - and the SAME canned text on every
+// update, so a multi-update batch demos the exact-text dedupe too (one
+// section, not one copy per mod - exactly how a real per-update recompile
+// repeats the profile-level merge diagnostics).
+func TestPrototypeProviderActions_ApplyUpdate_CannedMultiWarningDemo(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	view, err := actions.CheckUpdates(context.Background())
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(view.Updates), 2, "the canned set has two available updates (see prototype/data.go)")
+
+	first, err := actions.ApplyUpdate(context.Background(), view.Updates[0], nil)
+	require.NoError(t, err)
+	assert.Greater(t, len(first.Warnings), 1,
+		"the prototype update must demo the multi-warning results section")
+
+	second, err := actions.ApplyUpdate(context.Background(), view.Updates[1], nil)
+	require.NoError(t, err)
+	assert.Equal(t, first.Warnings, second.Warnings,
+		"identical canned text per update, so a batch demos exact-text dedupe")
+}
+
 // TestPrototypeRollbackSwapsVersions covers Task 6's rollback demo: the
 // canned "skse-address-library" InstalledMods entry (see prototype/data.go's
 // PreviousVersion doc comment) has Version "11"/PreviousVersion "10" -
@@ -916,6 +945,12 @@ type recordingActions struct {
 	// mid-batch update failure (one mod in a multi-update apply fails,
 	// others succeed) without needing per-call outcome sequencing.
 	ApplyUpdateErrByID map[string]error
+
+	// ApplyUpdateOutcomeByID, if set, overrides ApplyUpdateOutcome for a
+	// specific UpdateItem.ID's successful return - lets a #259 test give
+	// each update in a batch its own Warnings without per-call outcome
+	// sequencing. ApplyUpdateErrByID still wins for an ID present in both.
+	ApplyUpdateOutcomeByID map[string]ActionOutcome
 }
 
 func (r *recordingActions) EnableMod(_ context.Context, item ModItem) (ActionOutcome, error) {
@@ -982,6 +1017,9 @@ func (r *recordingActions) ApplyUpdate(_ context.Context, u UpdateItem, progress
 	}
 	if err, ok := r.ApplyUpdateErrByID[u.ID]; ok {
 		return ActionOutcome{}, err
+	}
+	if out, ok := r.ApplyUpdateOutcomeByID[u.ID]; ok {
+		return out, nil
 	}
 	return r.ApplyUpdateOutcome, r.ApplyUpdateErr
 }

--- a/internal/tui/actions_provider_test.go
+++ b/internal/tui/actions_provider_test.go
@@ -129,6 +129,24 @@ func TestPrototypeProviderActions_DeployProfile_ReturnsPlausibleOutcome(t *testi
 	assert.NotEmpty(t, outcome.Message)
 }
 
+// TestPrototypeProviderActions_DeployProfile_CannedMultiWarningDemo guards
+// #253's demo-mode parity: the prototype deploy must return MORE than one
+// warning so --prototype actually exercises the multi-warning auto-open
+// overlay path (actionDoneMsg, app.go) - the same rationale as
+// prototypeAllSourcesWarning (service.go), without which no prototype
+// mutation would ever cross formatOutcomeStatus's collapse threshold and the
+// overlay would be unreachable in the one mode meant to demo every UI state.
+func TestPrototypeProviderActions_DeployProfile_CannedMultiWarningDemo(t *testing.T) {
+	t.Parallel()
+
+	actions := NewPrototypeProvider().(ActionProvider)
+
+	outcome, err := actions.DeployProfile(context.Background())
+	require.NoError(t, err)
+	assert.Greater(t, len(outcome.Warnings), 1,
+		"the prototype deploy must demo the multi-warning overlay threshold")
+}
+
 func TestPrototypeProviderActions_PlanProfileSwitch_ComputesFakeConsistentPlan(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -406,7 +406,12 @@ func TestActionDoneMultiWarningOutcomeReplacesStaleReadOnlyOverlay(t *testing.T)
 // priority when an outcome carries BOTH ResultLines and 2+ Warnings (today
 // only the apply-updates batch can): the pre-existing "update results"
 // overlay wins, and the warnings overlay defers rather than clobbering the
-// batch's per-item record.
+// batch's per-item record. This deferral is lossless since #259: the batch
+// embeds its success-emitted warnings inside ResultLines as a trailing
+// section (applyUpdatesSequentially), so the winning overlay already carries
+// them - this test's hand-built outcome deliberately omits that section
+// because the priority decision is what's pinned here, not the lines'
+// content.
 func TestActionDoneResultLinesKeepPriorityOverWarningsOverlay(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -374,6 +374,34 @@ func TestActionDoneSingleWarningOutcomeOpensNoOverlay(t *testing.T) {
 	require.Equal(t, `Enabled "SkyUI" — link method fell back to copy`, m.action.status)
 }
 
+// TestActionDoneMultiWarningOutcomeReplacesStaleReadOnlyOverlay guards the
+// Copilot PR #258 finding: a read-only overlay CAN be open when an action
+// settles (promptOverlay deliberately doesn't gate on m.action.running - the
+// Files overlay is the reachable case), and a plain m.overlay == nil guard
+// would silently drop the warnings overlay there, leaving the outcome stuck
+// at the unreadable "(N warnings)" count - the exact information loss #253
+// exists to fix. The warnings overlay must replace a stale read-only overlay;
+// it defers ONLY to the update-results overlay the same handler just opened.
+func TestActionDoneMultiWarningOutcomeReplacesStaleReadOnlyOverlay(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 1
+	model.action.running = true
+	model.overlay = &infoOverlay{title: "Files — SkyUI", lines: []string{"Data/SkyUI.esp"}}
+
+	warnings := []string{"warn a", "warn b"}
+	updated, _ := model.Update(actionDoneMsg{gen: 1, kind: actionDeploy, outcome: ActionOutcome{
+		Message:  "Deployed 2 mod(s)",
+		Warnings: warnings,
+	}})
+	m := updated.(Model)
+
+	require.NotNil(t, m.overlay)
+	require.Equal(t, "warnings", m.overlay.title, "a stale read-only overlay must not swallow the warnings")
+	require.Equal(t, warnings, m.overlay.lines)
+}
+
 // TestActionDoneResultLinesKeepPriorityOverWarningsOverlay pins the overlay
 // priority when an outcome carries BOTH ResultLines and 2+ Warnings (today
 // only the apply-updates batch can): the pre-existing "update results"

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -295,6 +295,108 @@ func TestFormatOutcomeStatusWarningSuffix(t *testing.T) {
 		formatOutcomeStatus(ActionOutcome{Message: "Deployed 3 mod(s)", Warnings: []string{"a", "b"}}))
 }
 
+// --- #253: multi-warning outcomes auto-open the warnings overlay ---
+
+// TestActionDoneMultiWarningOutcomeOpensWarningsOverlay is #253's decided
+// behavior end-to-end: an outcome whose Warnings crossed formatOutcomeStatus's
+// collapse threshold (> 1, where the status line degrades to a bare
+// "(N warnings)" count) auto-opens the info overlay listing every warning in
+// full - on a merged-pak game those collapsed warnings are the ONLY report of
+// a cross-mod asset conflict anywhere in the app, so they must stay readable.
+// The status line keeps the one-row count summary (the overlay is additive,
+// mirroring the update-results overlay), and dismissing the overlay has no
+// side effects: the mutation completed before it appeared.
+func TestActionDoneMultiWarningOutcomeOpensWarningsOverlay(t *testing.T) {
+	t.Parallel()
+
+	warnings := []string{
+		`asset "C_PlayerBlueprintGrowth.uasset" bundled by two mods - last wins`,
+		`asset "C_PlayerBlueprintGrowth.uexp" bundled by two mods - last wins`,
+	}
+	calls := 0
+	model := sizedModelWithActions(t, &recordingActions{}, 80, 24)
+	model.screen = ScreenDashboard
+	model, pa := model.buildAction(actionDeploy, "Deploy?", nil, "", func(context.Context, func(ActionProgress)) (ActionOutcome, error) {
+		calls++
+		return ActionOutcome{Message: "Deployed 2 mod(s)", Warnings: warnings}, nil
+	})
+	model = model.promptAction(pa)
+
+	confirmed, confirmCmd := model.Update(keyRunes("y"))
+	model = confirmed.(Model)
+	doneMsg := runActionCmd(t, confirmCmd)
+	require.IsType(t, actionDoneMsg{}, doneMsg)
+
+	updated, _ := model.Update(doneMsg)
+	model = updated.(Model)
+
+	require.NotNil(t, model.overlay, "a 2+-warning outcome must auto-open the warnings overlay")
+	require.Equal(t, "warnings", model.overlay.title)
+	require.Equal(t, warnings, model.overlay.lines, "every warning must be listed in full, in order")
+	require.Contains(t, model.action.status, "(2 warnings)", "the one-row count summary is kept, not replaced")
+	require.NotContains(t, model.action.status, "\n", "status must stay one line")
+
+	// The overlay renders at 80 columns within the content height budget.
+	view := model.overlayView()
+	require.Contains(t, view, "warnings")
+	for _, w := range warnings {
+		require.Contains(t, view, w)
+	}
+	require.LessOrEqual(t, lipgloss.Height(view), model.availableContentHeight(),
+		"overlay must never render taller than the content budget")
+
+	// Dismissal is side-effect free: the action already settled.
+	model = updateWithKeyType(t, model, tea.KeyEsc)
+	require.Nil(t, model.overlay)
+	require.Equal(t, 1, calls, "dismissing the overlay must not re-run the mutation")
+	require.False(t, model.action.running)
+	require.Contains(t, model.action.status, "(2 warnings)", "dismissal must leave the status summary alone")
+}
+
+// TestActionDoneSingleWarningOutcomeOpensNoOverlay is the other side of
+// #253's threshold: one warning still renders inline after the em dash
+// (fully readable, nothing unrecoverable), so no overlay opens - the guard
+// against throwing a modal at a lone benign note.
+func TestActionDoneSingleWarningOutcomeOpensNoOverlay(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 1
+	model.action.running = true
+
+	updated, _ := model.Update(actionDoneMsg{gen: 1, kind: actionEnable, outcome: ActionOutcome{
+		Message:  `Enabled "SkyUI"`,
+		Warnings: []string{"link method fell back to copy"},
+	}})
+	m := updated.(Model)
+
+	require.Nil(t, m.overlay, "a single-warning outcome renders inline and opens nothing")
+	require.Equal(t, `Enabled "SkyUI" — link method fell back to copy`, m.action.status)
+}
+
+// TestActionDoneResultLinesKeepPriorityOverWarningsOverlay pins the overlay
+// priority when an outcome carries BOTH ResultLines and 2+ Warnings (today
+// only the apply-updates batch can): the pre-existing "update results"
+// overlay wins, and the warnings overlay defers rather than clobbering the
+// batch's per-item record.
+func TestActionDoneResultLinesKeepPriorityOverWarningsOverlay(t *testing.T) {
+	t.Parallel()
+
+	model := modelWithActions(t, &recordingActions{})
+	model.action.gen = 1
+	model.action.running = true
+
+	updated, _ := model.Update(actionDoneMsg{gen: 1, kind: actionUpdate, outcome: ActionOutcome{
+		Message:     "Applied 1 update(s)",
+		Warnings:    []string{"warn a", "warn b"},
+		ResultLines: []string{"✓ SkyUI 5.2 → 5.3", "✗ USSEP: boom"},
+	}})
+	m := updated.(Model)
+
+	require.NotNil(t, m.overlay)
+	require.Equal(t, "update results", m.overlay.title, "the batch's per-item record keeps priority")
+}
+
 // --- Rule 5: actionFailedMsg staleness + partial-mutation contract ---
 
 func TestFreshActionFailedMsgShowsErrorRefreshesAndKeepsScreen(t *testing.T) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -587,12 +587,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// a scrollable info overlay titled "update results" listing each
 		// mod's own "✓ .../✗ ..." line. Placed AFTER the status-line
 		// assignment (the count summary is kept, not replaced) and guarded
-		// on m.overlay == nil, defensively, exactly like resolveChangelogPicked
-		// guards against clobbering an existing overlay - the modal/overlay
-		// machinery is idle whenever an action resolves, by construction, so
-		// this should never actually refuse, but costs nothing to check.
-		// The quit-drain path above already returned before this point, so
-		// draining never reaches here either.
+		// on m.overlay == nil, exactly like resolveChangelogPicked guards
+		// against clobbering an existing overlay. The MODAL machinery
+		// (pending/picker/inputModal) is idle whenever an action resolves,
+		// by construction - but a read-only overlay CAN be up, since
+		// promptOverlay deliberately doesn't gate on m.action.running (the
+		// Files overlay is the reachable case, Copilot PR #258), so this
+		// guard can genuinely refuse, leaving the overlay the user is
+		// reading in place. That tradeoff is acceptable here and NOT for
+		// the warnings block below - see its comment for why the stakes
+		// differ. The quit-drain path above already returned before this
+		// point, so draining never reaches here either.
 		openedResultsOverlay := false
 		if len(msg.outcome.ResultLines) > 0 && m.overlay == nil {
 			m.overlay = &infoOverlay{title: "update results", lines: msg.outcome.ResultLines}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -620,6 +620,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// gate on m.action.running - the Files overlay is the reachable
 		// case), and deferring to it would silently re-lose the warnings
 		// (Copilot PR #258 finding), so a stale overlay is replaced instead.
+		// This deferral loses nothing (#259): the update batch embeds its
+		// success-emitted warnings INSIDE ResultLines as a trailing section
+		// (applyUpdatesSequentially, mutations.go), so the overlay that wins
+		// already carries them.
 		if len(msg.outcome.Warnings) > 1 && !openedResultsOverlay {
 			m.overlay = &infoOverlay{title: "warnings", lines: msg.outcome.Warnings}
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -596,6 +596,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(msg.outcome.ResultLines) > 0 && m.overlay == nil {
 			m.overlay = &infoOverlay{title: "update results", lines: msg.outcome.ResultLines}
 		}
+		// #253: a multi-warning outcome auto-opens the same overlay listing
+		// every warning in full. The threshold is deliberately the SAME "> 1"
+		// formatOutcomeStatus collapses at, so the overlay opens exactly when
+		// the status line has degraded to a bare "(N warnings)" count and the
+		// text would otherwise be unrecoverable - on a merged-pak game those
+		// warnings are the ONLY report of a cross-mod asset conflict anywhere
+		// in the app. A single warning still renders inline after the em dash
+		// and opens nothing: that is the guard against throwing a modal at a
+		// lone benign note (mergeDiagnostics folds Notes in alongside real
+		// warnings), so no benign/severe classification is needed. The
+		// m.overlay == nil guard doubles as priority: an update batch's
+		// ResultLines overlay (above) keeps its per-item record, and the
+		// warnings defer to it.
+		if len(msg.outcome.Warnings) > 1 && m.overlay == nil {
+			m.overlay = &infoOverlay{title: "warnings", lines: msg.outcome.Warnings}
+		}
 		// A fresh switch's target must rebind the session's active-profile
 		// providers BEFORE the refresh below reads them (see rebindProfile
 		// and profileRebinder in actions.go) - otherwise Profiles() keeps

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -593,8 +593,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// this should never actually refuse, but costs nothing to check.
 		// The quit-drain path above already returned before this point, so
 		// draining never reaches here either.
+		openedResultsOverlay := false
 		if len(msg.outcome.ResultLines) > 0 && m.overlay == nil {
 			m.overlay = &infoOverlay{title: "update results", lines: msg.outcome.ResultLines}
+			openedResultsOverlay = true
 		}
 		// #253: a multi-warning outcome auto-opens the same overlay listing
 		// every warning in full. The threshold is deliberately the SAME "> 1"
@@ -606,10 +608,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// and opens nothing: that is the guard against throwing a modal at a
 		// lone benign note (mergeDiagnostics folds Notes in alongside real
 		// warnings), so no benign/severe classification is needed. The
-		// m.overlay == nil guard doubles as priority: an update batch's
-		// ResultLines overlay (above) keeps its per-item record, and the
-		// warnings defer to it.
-		if len(msg.outcome.Warnings) > 1 && m.overlay == nil {
+		// warnings defer ONLY to the ResultLines overlay this same handler
+		// just opened (the update batch's per-item record keeps priority) -
+		// NOT to any overlay that happens to be up: a read-only overlay CAN
+		// be open when an action settles (promptOverlay deliberately doesn't
+		// gate on m.action.running - the Files overlay is the reachable
+		// case), and deferring to it would silently re-lose the warnings
+		// (Copilot PR #258 finding), so a stale overlay is replaced instead.
+		if len(msg.outcome.Warnings) > 1 && !openedResultsOverlay {
 			m.overlay = &infoOverlay{title: "warnings", lines: msg.outcome.Warnings}
 		}
 		// A fresh switch's target must rebind the session's active-profile

--- a/internal/tui/merge_format_helpers_test.go
+++ b/internal/tui/merge_format_helpers_test.go
@@ -54,3 +54,5 @@ func (fakeMergeFormat) ClassifyMergeSource(id string) (string, bool) {
 
 func (fakeMergeFormat) MergedArtifactName() string  { return "zzz_LMM_Merged_P.pak" }
 func (fakeMergeFormat) MergedArtifactLabel() string { return "Icarus Merged Pak" }
+
+func (fakeMergeFormat) RestoredArtifactName(modID string) string { return modID + "_P.pak" }

--- a/internal/tui/merge_format_helpers_test.go
+++ b/internal/tui/merge_format_helpers_test.go
@@ -1,0 +1,52 @@
+package tui_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DonovanMods/go-unrealpak"
+	"github.com/DonovanMods/linux-mod-manager/internal/domain"
+)
+
+// fakeMergeFormat supplies source.MergeCompiler's format-vocabulary methods
+// (#256) for this package's compile-source fakes, mirroring the icarus
+// conventions the fixtures already encode (the Icarus/Content/Data/data.pak
+// base path, "pak"/"exmodz" fileIDs, the zzz_LMM_Merged_P.pak artifact
+// name). Embed it in any fake that needs to satisfy source.MergeCompiler.
+// Duplicated per test package by design - mirrors internal/core's identical
+// helper.
+type fakeMergeFormat struct{}
+
+func (fakeMergeFormat) ResolveBaseArtifact(game *domain.Game) (string, error) {
+	candidate := filepath.Join(game.InstallPath, "Icarus", "Content", "Data", "data.pak")
+	if _, err := os.Stat(candidate); err != nil {
+		return "", fmt.Errorf("locating base pak for %q: %w", game.ID, err)
+	}
+	return candidate, nil
+}
+
+func (fakeMergeFormat) FingerprintBase(basePakPath string) (string, error) {
+	r, err := unrealpak.Open(basePakPath)
+	if err != nil {
+		return "", fmt.Errorf("reading base pak for compile fingerprint: %w", err)
+	}
+	defer r.Close() //nolint:errcheck
+	return r.IndexHash(), nil
+}
+
+func (fakeMergeFormat) IsConvertibleArtifact(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".pak")
+}
+
+func (fakeMergeFormat) ClassifyMergeSource(id string) (string, bool) {
+	lower := strings.ToLower(id)
+	if lower == "pak" || strings.HasSuffix(lower, ".pak") {
+		return "pak", true
+	}
+	return "exmodz", false
+}
+
+func (fakeMergeFormat) MergedArtifactName() string  { return "zzz_LMM_Merged_P.pak" }
+func (fakeMergeFormat) MergedArtifactLabel() string { return "Icarus Merged Pak" }

--- a/internal/tui/merge_format_helpers_test.go
+++ b/internal/tui/merge_format_helpers_test.go
@@ -36,6 +36,10 @@ func (fakeMergeFormat) FingerprintBase(basePakPath string) (string, error) {
 	return r.IndexHash(), nil
 }
 
+func (fakeMergeFormat) IsNativeMergeSource(fileName string) bool {
+	return strings.HasSuffix(strings.ToLower(fileName), ".exmodz")
+}
+
 func (fakeMergeFormat) IsConvertibleArtifact(fileName string) bool {
 	return strings.HasSuffix(strings.ToLower(fileName), ".pak")
 }

--- a/internal/tui/mutations.go
+++ b/internal/tui/mutations.go
@@ -2297,10 +2297,29 @@ func (m Model) resolveChangelogPicked(msg changelogPickedMsg) (Model, tea.Cmd) {
 // behavior just above: those mods never ran, which isn't the same thing as
 // failing). app.go's actionDoneMsg handler renders these as a scrollable
 // info overlay titled "update results" once the batch resolves.
+//
+// #259: warnings emitted by SUCCESSFUL updates are appended to ResultLines
+// as one trailing section - a blank separator, then one line per distinct
+// warning - because the "update results" overlay keeps priority over #253's
+// warnings overlay (actionDoneMsg's openedResultsOverlay deferral), so any
+// warning NOT inside ResultLines would be unreadable: a success's own entry
+// is just its ✓ line. The section holds success-emitted warnings only - a
+// failure's synthesized "<name>: <error>" warning already has its ✗ line in
+// the same overlay and would render twice. These warnings are deduped on
+// EXACT text (first occurrence wins, batch order) in both the section and
+// the aggregate Warnings slice - keeping formatOutcomeStatus's "(N
+// warnings)" count in step with the section - because they are mostly
+// profile-LEVEL merge diagnostics ("asset X is bundled by both A and B"),
+// re-emitted verbatim by every update that re-runs the merge, not facts
+// about any one update; exact-match only, so distinct warnings that merely
+// share a prefix never collapse into each other. Failure warnings are never
+// deduped (their name prefix makes them distinct anyway).
 func applyUpdatesSequentially(ctx context.Context, actions ActionProvider, updates []UpdateItem, progress func(ActionProgress)) (ActionOutcome, error) {
 	applied := 0
 	var warnings []string
 	var resultLines []string
+	var successWarnings []string
+	seenSuccessWarnings := map[string]bool{}
 	for _, u := range updates {
 		if ctx.Err() != nil {
 			break
@@ -2325,8 +2344,19 @@ func applyUpdatesSequentially(ctx context.Context, actions ActionProvider, updat
 			continue
 		}
 		applied++
-		warnings = append(warnings, outcome.Warnings...)
+		for _, w := range outcome.Warnings {
+			if seenSuccessWarnings[w] {
+				continue
+			}
+			seenSuccessWarnings[w] = true
+			warnings = append(warnings, w)
+			successWarnings = append(successWarnings, w)
+		}
 		resultLines = append(resultLines, fmt.Sprintf("✓ %s %s", u.Name, u.VersionLabel()))
+	}
+	if len(successWarnings) > 0 {
+		resultLines = append(resultLines, "")
+		resultLines = append(resultLines, successWarnings...)
 	}
 	return ActionOutcome{
 		Message:     fmt.Sprintf("Applied %d update(s)", applied),

--- a/internal/tui/mutations_test.go
+++ b/internal/tui/mutations_test.go
@@ -2652,6 +2652,142 @@ func TestApplyUpdatesSequentiallyResultLines_CtxCancelledSkipsRemainder(t *testi
 	require.Equal(t, []string{"✓ SkyUI 5.2 → 5.3"}, outcome.ResultLines)
 }
 
+// --- #259: success-emitted warnings must be readable inside the results overlay ---
+
+// TestApplyUpdatesSequentially_SuccessWarningsAppendedAsSection guards #259's
+// fix. Warnings emitted by SUCCESSFUL updates (on a merged-pak game, the
+// merge-time asset-conflict diagnostics a recompile surfaces) used to be
+// folded into the aggregate Warnings slice only - unreadable, because the
+// "update results" overlay keeps priority over the warnings overlay (pinned
+// by TestActionDoneResultLinesKeepPriorityOverWarningsOverlay) and a success's
+// ResultLines entry is just its ✓ line. The batch must instead append them to
+// ResultLines as one trailing section - a blank separator, then one line per
+// distinct warning - so the ONE overlay the actionDoneMsg handler opens
+// carries them.
+func TestApplyUpdatesSequentially_SuccessWarningsAppendedAsSection(t *testing.T) {
+	t.Parallel()
+
+	updates := []UpdateItem{
+		{Source: "nexusmods", ID: "skyui", Name: "SkyUI", FromVersion: "5.2", ToVersion: "5.3"},
+		{Source: "nexusmods", ID: "ussep", Name: "USSEP", FromVersion: "4.3", ToVersion: "4.4"},
+	}
+	rec := &recordingActions{
+		UpdatesViewOut: UpdatesView{Updates: updates},
+		ApplyUpdateOutcomeByID: map[string]ActionOutcome{
+			"skyui": {Message: `Updated "SkyUI" to 5.3`, Warnings: []string{
+				`asset "a.uasset" is bundled by both SkyUI and Ordinator`,
+				`asset "b.uasset" is bundled by both SkyUI and Ordinator`,
+			}},
+			"ussep": {Message: `Updated "USSEP" to 4.4`, Warnings: []string{
+				`asset "c.uasset" is bundled by both USSEP and Ordinator`,
+			}},
+		},
+	}
+
+	outcome, err := applyUpdatesSequentially(context.Background(), rec, updates, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"✓ SkyUI 5.2 → 5.3",
+		"✓ USSEP 4.3 → 4.4",
+		"",
+		`asset "a.uasset" is bundled by both SkyUI and Ordinator`,
+		`asset "b.uasset" is bundled by both SkyUI and Ordinator`,
+		`asset "c.uasset" is bundled by both USSEP and Ordinator`,
+	}, outcome.ResultLines)
+	require.Equal(t, []string{
+		`asset "a.uasset" is bundled by both SkyUI and Ordinator`,
+		`asset "b.uasset" is bundled by both SkyUI and Ordinator`,
+		`asset "c.uasset" is bundled by both USSEP and Ordinator`,
+	}, outcome.Warnings, "the aggregate Warnings must keep the status line's '(N warnings)' count in step with the section")
+}
+
+// TestApplyUpdatesSequentially_FailuresAndSuccessWarningsBothReadable (#259):
+// a batch carrying BOTH ✗ failures and success-emitted warnings must render
+// both in ResultLines, without duplicating the failure text - a failure's
+// synthesized "<name>: <err>" warning stays OUT of the trailing section
+// (which holds success-emitted warnings only), because the failure already
+// has its own ✗ line in the same overlay.
+func TestApplyUpdatesSequentially_FailuresAndSuccessWarningsBothReadable(t *testing.T) {
+	t.Parallel()
+
+	updates := []UpdateItem{
+		{Source: "nexusmods", ID: "skyui", Name: "SkyUI", FromVersion: "5.2", ToVersion: "5.3"},
+		{Source: "nexusmods", ID: "ussep", Name: "USSEP", FromVersion: "4.3", ToVersion: "4.4"},
+	}
+	rec := &recordingActions{
+		UpdatesViewOut: UpdatesView{Updates: updates},
+		ApplyUpdateOutcomeByID: map[string]ActionOutcome{
+			"skyui": {Message: `Updated "SkyUI" to 5.3`, Warnings: []string{
+				`asset "a.uasset" is bundled by both SkyUI and Ordinator`,
+				`asset "b.uasset" is bundled by both SkyUI and Ordinator`,
+			}},
+		},
+		ApplyUpdateErrByID: map[string]error{"ussep": errors.New("connection refused")},
+	}
+
+	outcome, err := applyUpdatesSequentially(context.Background(), rec, updates, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"✓ SkyUI 5.2 → 5.3",
+		"✗ USSEP: connection refused",
+		"",
+		`asset "a.uasset" is bundled by both SkyUI and Ordinator`,
+		`asset "b.uasset" is bundled by both SkyUI and Ordinator`,
+	}, outcome.ResultLines)
+	require.Equal(t, []string{
+		`asset "a.uasset" is bundled by both SkyUI and Ordinator`,
+		`asset "b.uasset" is bundled by both SkyUI and Ordinator`,
+		"USSEP: connection refused",
+	}, outcome.Warnings, "the failure still reaches the aggregate Warnings exactly once, in batch order")
+}
+
+// TestApplyUpdatesSequentially_SuccessWarningsDedupedOnExactText (#259): a
+// multi-update batch on a merged-pak game re-runs the profile merge once per
+// update, so the SAME profile-level conflict text repeats once per successful
+// update. Dedupe on EXACT text (never a prefix or fuzzy match - a
+// genuinely-distinct warning must never collapse into an unrelated one) keeps
+// one line per distinct warning in first-occurrence order, in BOTH the
+// trailing section and the aggregate Warnings - so the status line's count
+// matches what the overlay shows.
+func TestApplyUpdatesSequentially_SuccessWarningsDedupedOnExactText(t *testing.T) {
+	t.Parallel()
+
+	updates := []UpdateItem{
+		{Source: "nexusmods", ID: "skyui", Name: "SkyUI", FromVersion: "5.2", ToVersion: "5.3"},
+		{Source: "nexusmods", ID: "ussep", Name: "USSEP", FromVersion: "4.3", ToVersion: "4.4"},
+	}
+	sharedA := `asset "a.uasset" is bundled by both SkyUI and Ordinator`
+	rec := &recordingActions{
+		UpdatesViewOut: UpdatesView{Updates: updates},
+		ApplyUpdateOutcomeByID: map[string]ActionOutcome{
+			"skyui": {Message: `Updated "SkyUI" to 5.3`, Warnings: []string{
+				sharedA,
+				`asset "a.uasset" is bundled by both SkyUI and Requiem`,
+			}},
+			"ussep": {Message: `Updated "USSEP" to 4.4`, Warnings: []string{
+				sharedA,
+				`asset "c.uasset" is bundled by both USSEP and Ordinator`,
+			}},
+		},
+	}
+
+	outcome, err := applyUpdatesSequentially(context.Background(), rec, updates, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"✓ SkyUI 5.2 → 5.3",
+		"✓ USSEP 4.3 → 4.4",
+		"",
+		sharedA,
+		`asset "a.uasset" is bundled by both SkyUI and Requiem`,
+		`asset "c.uasset" is bundled by both USSEP and Ordinator`,
+	}, outcome.ResultLines, "the repeated warning collapses to one line; near-identical text (same prefix, different tail) must NOT collapse")
+	require.Equal(t, []string{
+		sharedA,
+		`asset "a.uasset" is bundled by both SkyUI and Requiem`,
+		`asset "c.uasset" is bundled by both USSEP and Ordinator`,
+	}, outcome.Warnings)
+}
+
 // TestActionDoneOpensUpdateResultsOverlay is the end-to-end happy path:
 // confirming the apply-updates batch, once it resolves, opens a scrollable
 // info overlay titled "update results" listing each update's own outcome
@@ -3038,7 +3174,21 @@ func TestPrototypeUpdatesEndToEndKeyFlow(t *testing.T) {
 	updated, refreshCmd := model.Update(doneMsg)
 	model = updated.(Model)
 	require.NotNil(t, refreshCmd)
-	require.Equal(t, "Applied 2 update(s)", model.action.status)
+	// #259: each canned prototype update emits the same two merge warnings
+	// (prototypeMergeWarnings), deduped across the batch to exactly two -
+	// counted on the one-row status line, readable in full inside the
+	// results overlay's trailing section below.
+	require.Equal(t, "Applied 2 update(s) (2 warnings)", model.action.status)
+	require.NotContains(t, model.action.status, "\n", "status must stay one line")
+	require.NotNil(t, model.overlay)
+	require.Equal(t, "update results", model.overlay.title)
+	require.Equal(t, []string{
+		"✓ SkyUI 5.2 → 5.3",
+		"✓ USSEP 4.3 → 4.4",
+		"",
+		`asset "textures/armor/steel.dds" is bundled by both SkyUI and Ordinator - Ordinator wins (last-applied, per profile load order)`,
+		`asset "textures/armor/steel_n.dds" is bundled by both SkyUI and Ordinator - Ordinator wins (last-applied, per profile load order)`,
+	}, model.overlay.lines, "the per-mod record plus ONE deduped warnings section - not one copy per update")
 
 	loadedMsg := refreshCmd()
 	require.IsType(t, dataLoadedMsg{}, loadedMsg, "the updates flow never triggers the install-only search-refresh batching")

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -166,7 +166,7 @@ func (p *coreProvider) Overview(_ context.Context) (Summary, []ModItem, error) {
 			ConvertPaks:     mod.ConvertPaks,
 			CompileGame:     game.DeployMode == domain.DeployCompile,
 			GameConvertPaks: game.ConvertPaks,
-			HasPakSource:    p.svc.ModHasPakMergeSource(&mod),
+			HasPakSource:    p.svc.ModHasPakMergeSource(game, &mod),
 			// This row came from the installed-mods list, so its
 			// install-state fields above (Version/UpdatePolicy, plus
 			// Locked/LockedVersion set below) are genuine local install

--- a/internal/tui/service_core.go
+++ b/internal/tui/service_core.go
@@ -815,6 +815,18 @@ func (p *coreProvider) DeployProfile(ctx context.Context) (ActionOutcome, error)
 	if len(result.Skipped) > 0 {
 		msg += fmt.Sprintf(", %d failed", len(result.Skipped))
 	}
+	// #255: on a compile game the per-mod count alone misreads - most mods
+	// deploy nothing individually and one merged artifact carries them. The
+	// readout comes from DeployResult's own fields (progress is nil here, so
+	// there is no event stream) and stays in the one-row Message: routing it
+	// through Warnings would auto-open #253's 2+-warning overlay on every
+	// routine compile deploy.
+	if result.MergedArtifact != "" {
+		msg += fmt.Sprintf(" — merged %d → %s", result.MergedMods, result.MergedArtifact)
+		if result.RawFallbacks > 0 {
+			msg += fmt.Sprintf(" (%d raw)", result.RawFallbacks)
+		}
+	}
 	// result.Skipped carries one "<mod name>: <reason>" entry per mod that
 	// didn't deploy (see DeployResult.Skipped's doc comment); appended after
 	// the flow Warnings/Notes mergeDiagnostics already composed so the

--- a/internal/tui/service_core_convert_test.go
+++ b/internal/tui/service_core_convert_test.go
@@ -23,11 +23,11 @@ import (
 // the two independently constructed instances always observe the same
 // underlying DB/filesystem truth - letting this test mutate via one and
 // re-read via the other. Unlike newRecompileActionsFixture
-// (service_core_recompile_test.go), no merge-compiler source is registered
-// and no base pak is written: this test never deploys or merges anything,
-// so that machinery would be pure overhead - mirrors cmd/lmm/mod_convert_
-// test.go's setupDoModConvertTest, the CLI's own lightweight convert
-// fixture.
+// (service_core_recompile_test.go), no base pak is written: this test never
+// deploys or merges anything. A merge-compiler source IS registered (#256:
+// HasPakSource classification resolves the game's MergeCompiler source),
+// but stays otherwise inert - mirrors cmd/lmm/mod_convert_test.go's
+// setupDoModConvertTest, the CLI's own lightweight convert fixture.
 func newConvertActionsFixture(t *testing.T) (tui.ActionProvider, tui.DataProvider, *core.Service, *domain.Game) {
 	t.Helper()
 
@@ -47,8 +47,10 @@ func newConvertActionsFixture(t *testing.T) (tui.ActionProvider, tui.DataProvide
 		LinkMethod:  domain.LinkSymlink,
 		DeployMode:  domain.DeployCompile,
 		ConvertPaks: true,
+		SourceIDs:   map[string]string{"fake-compiler": "icarus"},
 	}
 	require.NoError(t, svc.AddGame(game))
+	svc.RegisterSource(&recompileFakeSource{})
 
 	pm := svc.NewProfileManager()
 	_, err = pm.Create(game.ID, "default")

--- a/internal/tui/service_core_deploy_compile_test.go
+++ b/internal/tui/service_core_deploy_compile_test.go
@@ -1,0 +1,31 @@
+package tui_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCoreProviderDeployProfile_CompileGame_NamesMergedArtifactInMessage is
+// #255's TUI parity test: coreProvider.DeployProfile passes nil progress
+// (no event stream), so the merge readout must come from DeployResult's own
+// fields and land in the one-row outcome Message - NOT in Warnings, whose
+// 2+-entry overlay (#253) would otherwise pop a modal on every routine
+// compile deploy. The fixture holds one enabled exmodz mod, so the merged
+// artifact carries exactly one mod.
+func TestCoreProviderDeployProfile_CompileGame_NamesMergedArtifactInMessage(t *testing.T) {
+	actions, _, mergedPakPath := newRecompileActionsFixture(t)
+
+	outcome, err := actions.DeployProfile(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, "Deployed 1 mod(s) — merged 1 → zzz_LMM_Merged_P.pak", outcome.Message,
+		"the one-row status message must name the merged artifact and its participant count")
+	require.Empty(t, outcome.Warnings,
+		"routine merge info must not ride the warnings channel (#253's overlay auto-opens on 2+ warnings)")
+
+	_, statErr := os.Stat(mergedPakPath)
+	require.NoError(t, statErr, "the merged artifact must actually be deployed")
+}

--- a/internal/tui/service_core_recompile_test.go
+++ b/internal/tui/service_core_recompile_test.go
@@ -20,6 +20,8 @@ import (
 // internal/core/service_icarus_compile_test.go's fakeCompilerSource at the
 // TUI layer.
 type recompileFakeSource struct {
+	fakeMergeFormat // #256: the format-vocabulary half of source.MergeCompiler
+
 	validateCalls int
 	compileCalls  int
 }

--- a/internal/tui/service_core_test.go
+++ b/internal/tui/service_core_test.go
@@ -2642,6 +2642,10 @@ func TestCoreProviderGetModDetails_NotInstalled(t *testing.T) {
 func TestCoreProviderGetModDetails_InstalledUsesPolicyToString(t *testing.T) {
 	provider, svc, game, netSrc := newCoreDetailsFixture(t)
 	game.DeployMode = domain.DeployCompile
+	// #256: the ConvertPaks detail field classifies pak-kind fileIDs via
+	// the game's MergeCompiler source, so this compile-game test maps one.
+	game.SourceIDs = map[string]string{"fake-compiler": game.ID}
+	svc.RegisterSource(&recompileFakeSource{})
 	netSrc.addMod(game.ID, &domain.Mod{ID: "modA", SourceID: "src", GameID: game.ID, Name: "Mod A", Version: "1.5"})
 	require.NoError(t, svc.SaveInstalledMod(&domain.InstalledMod{
 		Mod:          domain.Mod{ID: "modA", SourceID: "src", GameID: game.ID, Name: "Mod A", Version: "1.5"},


### PR DESCRIPTION
Release v1.30.1 — a fixes-only batch. **PATCH** per the versioning rules: no new commands, flags, or capabilities; five bug fixes plus one internal refactor.

## Contents

| Issue | PR | What |
|---|---|---|
| #250 | #261 | Cache pruning deleted a converted pak's raw-fallback copy, so a later conversion opt-out or merge failure deployed **nothing, silently**. Prune now exempts files matching a retained source, and the raw fallback self-heals entries already damaged by released versions. |
| #253 | #258 | TUI collapsed multi-warning outcomes to an unreadable `(N warnings)`. On merged-pak games those warnings are the *only* report of cross-mod asset conflicts anywhere in the app. |
| #255 | #264 | Compile-mode deploy presented merged mods as individual deployments and never named the merged pak. Now labels each mod `(merged)`/`(raw)`/plain and names the artifact. |
| #256 | #263 | All Unreal/Icarus format knowledge moved out of `internal/core` behind `source.MergeCompiler`. No user-visible change except a better mixed-selection error. |
| #259 | #265 | Warnings from *successful* updates in an apply-updates batch were unreachable; now rendered in the update-results overlay, deduped. |
| #260 | #262 | A `DeployCompile` profile with zero merge sources failed every subsequent sync/deploy/purge with a loud `no such file or directory`. Uninstall of an absent cache entry is now a no-op removal. |

## Prep commit

Single commit `163c69a`: version bump in `cmd/lmm/root.go`, `[Unreleased]` moved to a dated `[1.30.1]` section, comparison link added, `make man` regenerated (the genman test enforces this — verified passing).

## Verification

`go build ./... && go vet ./...` clean, `gofmt -l ./cmd ./internal` empty, `go test ./...` exits 0 across all packages, genman test green. Every constituent PR was independently verified and merged green, and #253/#255/#259 each passed a manual TUI smoke test before merge.

## Notes

#256 was the largest change — it widened `MergeCompiler` from 2 to 10 methods so a second `DeployCompile` game becomes a new source package plus one registration line. Two format leaks were caught during review that the original issue had not enumerated (`isExmodzFile`, and `.pak` naming reintroduced mid-flight by #261), both closed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
